### PR TITLE
fix: remove unused remove_topic function

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -94,11 +94,6 @@ static struct topic_wrapper *find_topic(const char *topic_name) {
 	return NULL;
 }
 
-// TODO: free all memory
-static void remove_topic(struct topic_wrapper *wrapper) {
-	hash_del(&wrapper->node);
-}
-
 static void insert_subscriber_pid(const char *topic_name, uint32_t pid) {
 	struct topic_wrapper *wrapper = find_topic(topic_name);
 	if (!wrapper) {


### PR DESCRIPTION
Compiler warning
```
agnocast/kmod/agnocast.c:98:13: warning: ‘remove_topic’ defined but not used [-Wunused-function]
   98 | static void remove_topic(struct topic_wrapper *wrapper) {
      |             ^~~~~~~~~~~~
```