### PR TITLE
feat: exit when two publishers are created for one topic

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -165,7 +165,6 @@ static int insert_publisher_queue(const char *topic_name, uint32_t publisher_pid
 
 	if (!new_node) {
 		printk(KERN_WARNING "kmalloc failed (insert_publisher_queue)\n");
-		kfree(new_node);
 		return -1;
 	}
 


### PR DESCRIPTION
Confirmed by a small 2 piblishers - 1 subscriber demo

The second publisher process log
```
$ bash scripts/run_listen_talker 
[INFO] [launch]: All log files can be found below /home/veqcc/.ros/log/2024-07-23-13-26-03-497427-dpc2206003-22580
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [listen_talker-1]: process started with pid [22581]
[listen_talker-1] AGNOCAST_PUBLISHER_ADD_CMD failed: Operation not permitted
[listen_talker-1] shutting down agnocast..
[ERROR] [listen_talker-1]: process has died [pid 22581, exit code -11, cmd '/home/veqcc/work/agnocast/install/sample_application/lib/sample_application/listen_talker --ros-args -r __node:=listern_talker_node'].
```