### PR TITLE
fix: close fd

### DIFF
--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -53,6 +53,7 @@ void subscribe_topic_agnocast(const char* topic_name, std::function<void(const a
     mq = mq_open(mq_name.c_str(), O_CREAT | O_RDONLY, 0666, &attr);
     if (mq == -1) {
       perror("mq_open");
+      close(agnocast_fd);
       exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
追加で、map_area 中に exit してしまったら、その呼び出し元で fd を close する必要がある気がするんですが、今そうなってないんですよね。これは map_area が成功したかの返り値を返すようにして、agnocastlib 側でエラーハンドリングしたほうが良いですかね？

```
void map_area(const char * shm_name, const uint64_t shm_addr, const bool writable) {
  int oflag = writable ? O_CREAT | O_RDWR : O_RDONLY;
  int shm_fd = shm_open(shm_name, oflag, 0666);
  if (shm_fd == -1) {
    fprintf(stderr, "heaphook: shm_open failed in map_area\n");
    exit(EXIT_FAILURE);
  }

  if (writable) {
    if (ftruncate(shm_fd, INITIAL_MEMPOOL_SIZE) == -1) {
      fprintf(stderr, "heaphook: ftruncate failed in map_area\n");
      exit(EXIT_FAILURE);
    }
  }

  int prot = PROT_READ | MAP_FIXED;
  if (writable) prot |= PROT_WRITE;

  void* ret = mmap(reinterpret_cast<void*>(shm_addr), INITIAL_MEMPOOL_SIZE, prot, MAP_SHARED | MAP_FIXED, shm_fd, 0);

  if (ret == MAP_FAILED) {
    fprintf(stderr, "heaphook: mmap failed in map_area\n");
    exit(EXIT_FAILURE);
  }

  if (writable) {
    mempool_ptr = reinterpret_cast<char*>(ret);
  }
}
```