### PR TITLE
fix: delete agnocast initialize from application code

### DIFF
--- a/src/agnocastlib/include/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast.hpp
@@ -16,6 +16,7 @@
 
 namespace agnocast {
 
+__attribute__((constructor))
 void initialize_agnocast();
 
 template<typename MessageT>

--- a/src/sample_application/src/minimal_publisher.cpp
+++ b/src/sample_application/src/minimal_publisher.cpp
@@ -70,7 +70,6 @@ public:
 };
 
 int main(int argc, char * argv[]) {
-  agnocast::initialize_agnocast();
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<MinimalPublisher>());
   rclcpp::shutdown();

--- a/src/sample_application/src/minimal_pubsub.cpp
+++ b/src/sample_application/src/minimal_pubsub.cpp
@@ -77,7 +77,6 @@ public:
 };
 
 int main(int argc, char * argv[]) {
-  agnocast::initialize_agnocast();
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<MinimalPubSub>());
   rclcpp::shutdown();

--- a/src/sample_application/src/minimal_subscriber.cpp
+++ b/src/sample_application/src/minimal_subscriber.cpp
@@ -63,7 +63,6 @@ public:
 };
 
 int main(int argc, char * argv[]) {
-  agnocast::initialize_agnocast();
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<MinimalSubscriber>());
   rclcpp::shutdown();


### PR DESCRIPTION
## Description

There is no need anymore to call `agnocast::initialize_agnocast();` from application programs!!

## Related links

Issue: https://github.com/tier4/agnocast/issues/17

## How was this PR tested?

sample application

## Notes for reviewers
