### PR TITLE
fix: added management of mqd using unordered_map in the publisher

### DIFF
--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -28,7 +28,7 @@ class Publisher {
   std::string topic_name_cpp_;
   uint32_t publisher_pid_;
   rclcpp::QoS qos_;
-  std::unordered_map<std::string, mqd_t> opened_mqs; // TODO: The mq should be closed when a subscriber unsubscribes from the topic, but this is not currently implemented.
+  std::unordered_map<std::string, mqd_t> opened_mqs; // TODO: The mq should be closed when a subscriber unsubscribes the topic, but this is not currently implemented.
 
 public:
 
@@ -118,10 +118,10 @@ public:
         mq = opened_mqs[mq_name];
       } else {
         mq = mq_open(mq_name.c_str(), O_WRONLY);
-          if (mq == -1) {
-            perror("mq_open failed");
-            continue;
-          }
+        if (mq == -1) {
+          perror("mq_open failed");
+          continue;
+        }
         opened_mqs.insert({mq_name, mq});
       }
 


### PR DESCRIPTION
## Description
Currently, the mq descriptor is opened for all subscribers each time a message is published, but it is not closed. Since the number of file descriptors a single process can open is limited, this poses a problem.
As a temporary solution, we will close the descriptor each time after use. If the repeated calls to mq_open and mq_close affect performance, consider storing the opened descriptors in a hash map.
## Related links

## How was this PR tested?

## Notes for reviewers
