### PR TITLE
chore: reduce array size in StaticSizeArray.msg

### DIFF
--- a/src/sample_interfaces/msg/StaticSizeArray.msg
+++ b/src/sample_interfaces/msg/StaticSizeArray.msg
@@ -1,3 +1,3 @@
 int64 id
 int64 timestamp
-uint8[2147483648] data
+uint8[1000] data


### PR DESCRIPTION
## Description

CIにビルドテストを追加する際に、構造体のサイズが大きすぎて `MemoryError` が出るので、StaticSizeArrayのサイズを小さくしました。

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
