### PR TITLE
chore(ci): auto assign author to assignee

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,0 +1,12 @@
+name: auto assign author to assignee
+
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to assignee on PR
+        uses: technote-space/assign-author@v1


### PR DESCRIPTION
## Description

PR Open時に自動でauthorをassigneeにします。

## Related links

## How was this PR tested?

## Notes for reviewers
