### PR TITLE
fix(topic_add_sub): bug of uninitialized ret_len

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -663,11 +663,11 @@ union ioctl_get_shm_args {
 
 #define AGNOCAST_TOPIC_ADD_SUB_CMD _IOW('T', 2, union ioctl_add_topic_sub_args)
 void topic_add_sub(const char *topic_name, uint32_t qos_depth, union ioctl_add_topic_sub_args *ioctl_ret) {
+	ioctl_ret->ret_len = 0;
 	struct topic_wrapper *wrapper = find_topic(topic_name);
 	if (wrapper) {
 		printk(KERN_INFO "Topic %s already exists (topic_add)\n", topic_name);
 
-		ioctl_ret->ret_len = 0;
 		if (qos_depth == 0) return;  // transient local is disabled
 
 		struct publisher_queue_node *pubq = wrapper->topic.publisher_queues;


### PR DESCRIPTION
## Description

https://github.com/tier4/agnocast/blob/4b3b84fbfbd0f565e51124ab4cf2ee66c0f38dc9/kmod/agnocast.c#L664
この関数で、wrapper が存在しない（初めての topic）の場合に、ret_len の値が未初期化になっており、後の参照時に落ちてしまう問題を修正します。

## Related links

## How was this PR tested?

sample applicationで最初に `bash script/run_listener` を実行し、落ちないことを確認しました。

## Notes for reviewers
