### PR TITLE
fix: size of ioctl_add_topic_sub_args

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -680,7 +680,7 @@ int topic_add_pub(const char * topic_name)
   return 0;
 }
 
-#define MAX_QOS_DEPTH 100  // TODO: should be reconsidered
+#define MAX_QOS_DEPTH 10  // Maximum depth of transient local usage part in Autoware
 
 union ioctl_add_topic_sub_args {
   struct

--- a/src/agnocastlib/include/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast_ioctl.hpp
@@ -11,7 +11,7 @@ namespace agnocast
 #define MAX_PUBLISHER_NUM 16
 #define MAX_SUBSCRIBER_NUM 16
 
-#define MAX_QOS_DEPTH 100  // TODO: should be reconsidered
+#define MAX_QOS_DEPTH 10  // Maximum depth of transient local usage part in Autoware
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"


### PR DESCRIPTION
## Description

`union ioctl_add_topic_sub_args` のサイズが大きすぎてコンパイル時警告が出ていたので、修正。
`MAX_QOS_DEPTH` はAutowareのTransient local使用部分の最大Queue sizeにしています。

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
