### PR TITLE
fix: choosing the deallocator when freeing

### DIFF
--- a/src/agnocast_heaphook/src/preloaded.cpp
+++ b/src/agnocast_heaphook/src/preloaded.cpp
@@ -118,7 +118,7 @@ static void * tlsf_allocate_internal(F allocate)
 
   size_t multiplier = 1;
   while (ret == NULL) {
-    char * addr = (char *)mmap(
+    void * addr = mmap(
       NULL, multiplier * ADDITIONAL_MEMPOOL_SIZE, PROT_READ | PROT_WRITE,
       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     add_new_area(addr, multiplier * ADDITIONAL_MEMPOOL_SIZE, mempool_ptr);  // tlsf library function


### PR DESCRIPTION
## Description
See issue: #31 
When freeing memory, you need to choose the deallocator based on which allocator was used to allocate it.
## Related links
#31

## How was this PR tested?

## Notes for reviewers
