### PR TITLE
feat: make sysfs debug work well

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -436,6 +436,7 @@ static ssize_t store_value(
   return count;
 }
 
+#define BUFFER_SIZE 30
 static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, char * buf)
 {
   // at least 500 bytes would be needed as an initial buffer size
@@ -458,10 +459,10 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
     strcat(local_buf, " subscriber_pids:");
     buf_len += 17;
     for (int i = 0; i < entry->topic.subscriber_num; i++) {
-      char num_str[20];
+      char num_str[BUFFER_SIZE];
       scnprintf(num_str, sizeof(num_str), " %u", entry->topic.subscriber_pids[i]);
       strcat(local_buf, num_str);
-      buf_len += 20;
+      buf_len += BUFFER_SIZE;
     }
     strcat(local_buf, "\n");
     buf_len += 1;
@@ -471,10 +472,10 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
 
     struct publisher_queue_node * pub_node = entry->topic.publisher_queues;
     while (pub_node) {
-      char num_str[20];
+      char num_str[BUFFER_SIZE];
       scnprintf(num_str, sizeof(num_str), "  pid=%u:\n", pub_node->pid);
       strcat(local_buf, num_str);
-      buf_len += 20;
+      buf_len += BUFFER_SIZE;
 
       struct rb_root * root = &pub_node->entries;
       struct rb_node * node;
@@ -484,26 +485,26 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
         strcat(local_buf, "   entry: ");
         buf_len += 10;
 
-        char num_str_timestamp[30];
+        char num_str_timestamp[BUFFER_SIZE];
         scnprintf(num_str_timestamp, sizeof(num_str_timestamp), "time=%lld ", en->timestamp);
         strcat(local_buf, num_str_timestamp);
-        buf_len += 30;
+        buf_len += BUFFER_SIZE;
 
-        char num_str_msg_addr[30];
+        char num_str_msg_addr[BUFFER_SIZE];
         scnprintf(
           num_str_msg_addr, sizeof(num_str_msg_addr), "addr=%lld ", en->msg_virtual_address);
         strcat(local_buf, num_str_msg_addr);
-        buf_len += 30;
+        buf_len += BUFFER_SIZE;
 
-        char num_str_rc[10];
+        char num_str_rc[BUFFER_SIZE];
         scnprintf(num_str_rc, sizeof(num_str_rc), "rc=%d ", en->reference_count);
         strcat(local_buf, num_str_rc);
-        buf_len += 10;
+        buf_len += BUFFER_SIZE;
 
-        char num_str_usc[10];
+        char num_str_usc[BUFFER_SIZE];
         scnprintf(num_str_usc, sizeof(num_str_usc), "usc=%d\n", en->unreceived_subscriber_count);
         strcat(local_buf, num_str_usc);
-        buf_len += 10;
+        buf_len += BUFFER_SIZE;
 
         if (buf_len * 2 > buf_size) {
           buf_size *= 2;


### PR DESCRIPTION
## Description

`cat /sys/module/agnocast/status/all` の機能を、まともに使えるようにした。

sample application 実行中の status all の内容↓

```
$ cat /sys/module/agnocast/status/all
/my_dynamic_topic
 subscriber_pids: 16647
 publishers:
  pid=16677:
   entry: time=1722935476153644185 addr=4432418590352 rc=0 usc=0
   entry: time=1722935476253681368 addr=4432420657792 rc=0 usc=0
   entry: time=1722935476353678327 addr=4432420657840 rc=0 usc=0
   entry: time=1722935476453691390 addr=4432410133280 rc=0 usc=0
   entry: time=1722935476553681704 addr=4432410143520 rc=0 usc=0
   entry: time=1722935476653683937 addr=4432410132352 rc=0 usc=0
   entry: time=1722935476753681309 addr=4432410133328 rc=0 usc=0
   entry: time=1722935476853680889 addr=4432410102624 rc=0 usc=0
   entry: time=1722935476953689446 addr=4432410132400 rc=0 usc=0
   entry: time=1722935477053700825 addr=4432416522816 rc=0 usc=0
   entry: time=1722935477153690638 addr=4432416522864 rc=0 usc=0
  pid=16618:
   entry: time=1722935476154769755 addr=4398060911120 rc=0 usc=0
   entry: time=1722935476254819196 addr=4398060911168 rc=0 usc=0
   entry: time=1722935476354841015 addr=4398050530592 rc=0 usc=0
   entry: time=1722935476454845414 addr=4398050560768 rc=0 usc=0
   entry: time=1722935476554823130 addr=4398050565072 rc=0 usc=0
   entry: time=1722935476654819597 addr=4398050565120 rc=0 usc=0
   entry: time=1722935476754826642 addr=4398054711920 rc=0 usc=0
   entry: time=1722935476854821530 addr=4398054711968 rc=0 usc=0
   entry: time=1722935476954828638 addr=4398056778320 rc=0 usc=0
   entry: time=1722935477054844950 addr=4398056778368 rc=0 usc=0
   entry: time=1722935477154828752 addr=4398058844720 rc=0 usc=0

/my_static_topic
 subscriber_pids: 16618 16647
 publishers:
  pid=16677:
   entry: time=1722935476154542988 addr=4432421690544 rc=0 usc=0
   entry: time=1722935476254582124 addr=4432421692032 rc=0 usc=0
   entry: time=1722935476354584224 addr=4432421693072 rc=0 usc=0
   entry: time=1722935476454591766 addr=4432410158464 rc=0 usc=0
   entry: time=1722935476554581540 addr=4432421694112 rc=0 usc=0
   entry: time=1722935476654581309 addr=4432414454128 rc=0 usc=0
   entry: time=1722935476754580364 addr=4432421695152 rc=0 usc=0
   entry: time=1722935476854582093 addr=4432416521776 rc=0 usc=0
   entry: time=1722935476954588795 addr=4432421696192 rc=0 usc=0
   entry: time=1722935477054598896 addr=4432418589264 rc=0 usc=0
   entry: time=1722935477154587961 addr=4432421697232 rc=0 usc=0
```

## Related links

TIER IV INTERNAL: https://tier4.atlassian.net/browse/RT2-1757

## How was this PR tested?

## Notes for reviewers
