### PR TITLE
add shm_unlink to delete shm

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -198,11 +198,13 @@ static void shutdown_agnocast()
   std::cout << "shutdown_agnocast started" << std::endl;
   is_running = false;
   /*
-    It might seem odd to re-acquire the PID and regenerate mq_name and shm_name.
-    However, this approach was taken because storing mq_name and shm_name as
-    global variables didn't work. The issue likely stems from code within
-    initialize_agnocast() that interacts with heap-allocated memory.
-  */
+   * TODO:
+   *   It might seem odd to re-acquire the PID and regenerate mq_name and shm_name.
+   *   However, this approach was taken because the code that stored the `mq_name`
+   *   and `shm_name` strings as global variables didn't work. The reason it didn't
+   *   work is likely related to the fact that initialize_agnocast() cannot use heap
+   *   memory. Once this issue is resolved, this implementation will be revised.
+   */
   const uint32_t pid = getpid();
 
   for (int fd : shm_fds) {


### PR DESCRIPTION
## Description
shm_unlinkをしておらず、agnocastによる通信を終了してもシステム上に共有メモリは残存しているのでそれを解放するための実装。

## Related links
issue #42 

## How was this PR tested?
run_talker, run_listenerをそれぞれ立ち上げ、run_talker, run_listenerの順に停止した際にunlinkされて/dev/shmから削除されていることを確認。(PR #118 同様、 issue #114 によりlistenerから停止するとshutdown_agnocast()が呼ばれないのでunlinkされない。)

## Notes for reviewers
PR　#118 同様、これもshutdown_agnocast()で改めてgetpid()をしてpidを取得してshm_nameを生成する。
(PR #118 で矢野さんに質問いただいて、ソースコード中のコメントがあまりにわかりずらいと思ったので変更しました。)
