### PR TITLE
fix: freeing memory when removing the kernel module

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1116,7 +1116,7 @@ unlock_mutex_and_return:
   return -EFAULT;
 }
 
-static char * agnocast_devnode(struct device * dev, umode_t * mode)
+static char * agnocast_devnode(const struct device * dev, umode_t * mode)
 {
   if (mode) {
     *mode = 0666;
@@ -1340,7 +1340,7 @@ static int agnocast_init(void)
   printk(KERN_INFO "Planted kprobe at %p\n", kp.addr);
 
   major = register_chrdev(0, "agnocast" /*device driver name*/, &fops);
-  agnocast_class = class_create(THIS_MODULE, "agnocast_class");
+  agnocast_class = class_create("agnocast_class");
   agnocast_class->devnode = agnocast_devnode;
   agnocast_device =
     device_create(agnocast_class, NULL, MKDEV(major, 0), NULL, "agnocast" /*file name*/);


### PR DESCRIPTION
## Description
rmmod時にカーネル内のメモリを正しく解放するための処理を実装。具体的にはfree_all_topics()を修正しました。
基本的には各プロセスのdo_exit時のハンドラでhash_tableのエントリは解放されているはずだが、何らかの理由で正しく解放されていなかった場合に有用。

## Related links
#39 

## How was this PR tested?
free_all_topics()の末尾にmsleep(10000)を追記し、10秒猶予を持たせてその間にcat /sys/modules/agnocast/status/allでhash_tableの状態を確認。
hash_tableにエントリが残存した状態での動作確認をしたいため、以下の2ケースで確認。
1. 各プロセスのdo_exitでの解放処理をコメントアウトしておき、sample application動作→停止後に確認。
2. sample application実行中に確認。

## Notes for reviewers
sample application実行中にrmmodすると、sample application側がうまく終了処理ができていない模様だがこれは別問題なので以下でissue化 しました。
#120 

あと、本PRとは本来直接関係ないですがinsmod時、rmmod時のprintkのメッセージも変更しておきました。
