### PR TITLE
refactor: add base class for Subscription

### DIFF
--- a/src/agnocast_bridge/src/bridge_node.cpp
+++ b/src/agnocast_bridge/src/bridge_node.cpp
@@ -6,7 +6,7 @@ using std::placeholders::_1;
 
 class BridgeNode : public rclcpp::Node
 {
-  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::DynamicSizeArray>>
+  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::DynamicSizeArray>>
     agnocast_subscriber_;
   rclcpp::Publisher<sample_interfaces::msg::DynamicSizeArray>::SharedPtr publisher_;
 

--- a/src/agnocastlib/include/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast.hpp
@@ -50,19 +50,19 @@ std::shared_ptr<Publisher<MessageT>> create_publisher(
 }
 
 template <typename MessageT>
-std::shared_ptr<Subscription<MessageT>> create_subscription(
+std::shared_ptr<CallbackSubscription<MessageT>> create_subscription(
   const char * topic_name, const rclcpp::QoS & qos,
   std::function<void(const agnocast::message_ptr<MessageT> &)> callback)
 {
-  return std::make_shared<Subscription<MessageT>>(topic_name, qos, callback);
+  return std::make_shared<CallbackSubscription<MessageT>>(topic_name, qos, callback);
 }
 
 template <typename MessageT>
-std::shared_ptr<Subscription<MessageT>> create_subscription(
+std::shared_ptr<CallbackSubscription<MessageT>> create_subscription(
   const char * topic_name, size_t qos_history_depth,
   std::function<void(const agnocast::message_ptr<MessageT> &)> callback)
 {
-  return std::make_shared<Subscription<MessageT>>(
+  return std::make_shared<CallbackSubscription<MessageT>>(
     topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), callback);
 }
 

--- a/src/sample_application/src/minimal_pubsub.cpp
+++ b/src/sample_application/src/minimal_pubsub.cpp
@@ -44,7 +44,8 @@ class MinimalPubSub : public rclcpp::Node
   }
 
   std::shared_ptr<agnocast::Publisher<sample_interfaces::msg::DynamicSizeArray>> publisher_dynamic_;
-  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::StaticSizeArray>> sub_static_;
+  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::StaticSizeArray>>
+    sub_static_;
   int count_;
 
   std::vector<uint64_t> timestamps_;

--- a/src/sample_application/src/minimal_subscriber.cpp
+++ b/src/sample_application/src/minimal_subscriber.cpp
@@ -21,8 +21,10 @@ class MinimalSubscriber : public rclcpp::Node
   std::vector<uint64_t> timestamp_ids_;
   int timestamp_idx_ = 0;
 
-  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::DynamicSizeArray>> sub_dynamic_;
-  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::StaticSizeArray>> sub_static_;
+  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::DynamicSizeArray>>
+    sub_dynamic_;
+  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::StaticSizeArray>>
+    sub_static_;
 
   void callback_dynamic(
     const agnocast::message_ptr<sample_interfaces::msg::DynamicSizeArray> & message)


### PR DESCRIPTION
## Description

`take()` を使用する `Subscription` 実装に先立って、共通処理を `SubscriptionBase` クラスに移します。

## Related links

[Design Document](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3254157998/take+API)

## How was this PR tested?

sample application

## Notes for reviewers
