### PR TITLE
chore: add info prefix for log

### DIFF
--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -112,7 +112,7 @@ public:
 
     // Create a thread that handles the messages to execute the callback
     auto th = std::thread([=]() {
-      std::cout << "callback thread for " << topic_name << " has been started" << std::endl;
+      std::cout << "[Info]: callback thread for " << topic_name << " has been started" << std::endl;
 
       // If there are messages available and the transient local is enabled, immediately call the
       // callback.

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -195,7 +195,7 @@ size_t read_mq_msgmax()
 
 static void shutdown_agnocast()
 {
-  std::cout << "shutdown_agnocast started" << std::endl;
+  std::cout << "[Info]: shutdown_agnocast started" << std::endl;
   is_running = false;
   /*
    * TODO:
@@ -231,7 +231,7 @@ static void shutdown_agnocast()
     th.join();
   }
 
-  std::cout << "shutdown_agnocast completed" << std::endl;
+  std::cout << "[Info]: shutdown_agnocast completed" << std::endl;
 }
 
 class Cleanup


### PR DESCRIPTION
## Description

ログ情報の接頭辞として `[Info]` を追加します。

## Related links

[Slack](https://star4.slack.com/archives/C07FL8616EM/p1724372081307429?thread_ts=1724328576.218259&cid=C07FL8616EM)

## How was this PR tested?

メッセージの変更のみなので、テストしていません。

## Notes for reviewers
