### PR TITLE
fix: reduce maximum publisher/subscriber size

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -20,9 +20,9 @@ static int major;
 static struct class * agnocast_class;
 static struct device * agnocast_device;
 
-// TODO: These values should be reconsidered
-#define MAX_PUBLISHER_NUM 2
-#define MAX_SUBSCRIBER_NUM 8
+// TODO: should be made larger when applied for Autoware
+#define MAX_PUBLISHER_NUM 2   // At least 2 is required for sample application
+#define MAX_SUBSCRIBER_NUM 8  // At least 6 is required for pointcloud topic in Autoware
 
 // =========================================
 // data structure

--- a/src/agnocastlib/include/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast_ioctl.hpp
@@ -7,9 +7,9 @@
 namespace agnocast
 {
 
-// TODO: These values should be reconsidered
-#define MAX_PUBLISHER_NUM 2
-#define MAX_SUBSCRIBER_NUM 8
+// TODO: should be made larger when applied for Autoware
+#define MAX_PUBLISHER_NUM 2   // At least 2 is required for sample application
+#define MAX_SUBSCRIBER_NUM 8  // At least 6 is required for pointcloud topic in Autoware
 
 #define MAX_QOS_DEPTH 10  // Maximum depth of transient local usage part in Autoware
 


### PR DESCRIPTION
## Description

`MAX_PUBLISHER_NUM` と `MAX_SUBSCRIBER_NUM` の値を減らしました。
この変更によって、一旦 issue https://github.com/tier4/agnocast/issues/113 を回避できます。（今後本質的な対応が必要になるかもしれないが）

## Related links

close https://github.com/tier4/agnocast/issues/113

## How was this PR tested?

sample application

## Notes for reviewers

publisher 側を 2 にしたのは、
 - sample application で最低限 2 以上であることが必要
 - Autoware 適用にあたっては、複数 publisher に適用するのは相当先になると思われるため

subscriber 側を 8 にしたのは、
 - Autoware 適用にあたって直近の pointcloud を見据えると、（たしか）6 subscriber くらいいたので、2べきで一番近い 8 にした