### PR TITLE
feat: all warnings are treated as errors in kernel module

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -1,5 +1,5 @@
 obj-m := agnocast.o
-CFLAGS_agnocast.o :=
+CFLAGS_agnocast.o := -Wall -Werror
 
 KERNEL_VERSION := $(shell uname -r)
 KERNEL_MAJOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 1)


### PR DESCRIPTION
## Description

カーネルモジュールのコンパイルオプションを追加し、warning をエラーとして扱うようにしました。

## Related links

close https://github.com/tier4/agnocast/issues/140

## How was this PR tested?

## Notes for reviewers
