### PR TITLE
feat: debug function in kernel module

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -401,7 +401,7 @@ static ssize_t store_value(
   return count;
 }
 
-#define BUFFER_SIZE 30
+#define BUFFER_UNIT_SIZE 30
 static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, char * buf)
 {
   mutex_lock(&global_mutex);
@@ -426,10 +426,10 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
     strcat(local_buf, " subscriber_pids:");
     buf_len += 17;
     for (int i = 0; i < wrapper->topic.subscriber_num; i++) {
-      char num_str[BUFFER_SIZE];
+      char num_str[BUFFER_UNIT_SIZE];
       scnprintf(num_str, sizeof(num_str), " %u", wrapper->topic.subscriber_pids[i]);
       strcat(local_buf, num_str);
-      buf_len += BUFFER_SIZE;
+      buf_len += BUFFER_UNIT_SIZE;
     }
     strcat(local_buf, "\n");
     buf_len += 1;
@@ -439,12 +439,12 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
 
     struct publisher_info * pub_info = wrapper->topic.pub_info_list;
     while (pub_info) {
-      char num_str[BUFFER_SIZE * 3];
+      char num_str[BUFFER_UNIT_SIZE * 3];
       scnprintf(
         num_str, sizeof(num_str), "  pid=%u, entries_num=%u, exited=%d\n", pub_info->pid,
         pub_info->entries_num, pub_info->exited);
       strcat(local_buf, num_str);
-      buf_len += BUFFER_SIZE * 3;
+      buf_len += BUFFER_UNIT_SIZE * 3;
 
       pub_info = pub_info->next;
     }
@@ -457,12 +457,12 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
     for (node = rb_first(root); node; node = rb_next(node)) {
       struct entry_node * en = container_of(node, struct entry_node, node);
 
-      char num_str[BUFFER_SIZE * 4];
+      char num_str[BUFFER_UNIT_SIZE * 4];
       scnprintf(
         num_str, sizeof(num_str), "  time=%lld, pid=%u, addr=%lld, published=%d, ", en->timestamp,
         en->publisher_pid, en->msg_virtual_address, en->published);
       strcat(local_buf, num_str);
-      buf_len += BUFFER_SIZE * 4;
+      buf_len += BUFFER_UNIT_SIZE * 4;
 
       strcat(local_buf, "referencing:=[");
       buf_len += 14;
@@ -472,10 +472,10 @@ static ssize_t show_all(struct kobject * kobj, struct kobj_attribute * attr, cha
           buf_len += 2;
         }
 
-        char num_str[BUFFER_SIZE];
+        char num_str[BUFFER_UNIT_SIZE];
         scnprintf(num_str, sizeof(num_str), "%u", en->referencing_subscriber_pids[i]);
         strcat(local_buf, num_str);
-        buf_len += BUFFER_SIZE;
+        buf_len += BUFFER_UNIT_SIZE;
       }
       strcat(local_buf, "]\n");
       buf_len += 2;


### PR DESCRIPTION
## Description

publisher queue 統一後の、show_all 関数の実装

## Related links

## How was this PR tested?

sample application

## Notes for reviewers

以下のように表示される

```
$ cat /sys/module/agnocast/status/all 
/my_dynamic_topic
 subscriber_pids: 11519
 publishers:
  pid=11481, entries_num=10, exited=0
  pid=11454, entries_num=10, exited=0
 entries:
  time=1725332435609964743, pid=11454, addr=4398060856416, published=1, referencing:=[]
  time=1725332435610838567, pid=11481, addr=4415237726048, published=1, referencing:=[]
  time=1725332435709957682, pid=11454, addr=4398050331776, published=1, referencing:=[]
  time=1725332435710838099, pid=11481, addr=4415237726096, published=1, referencing:=[]
  time=1725332435809962372, pid=11454, addr=4398049986960, published=1, referencing:=[]
  time=1725332435810832224, pid=11481, addr=4415240825696, published=1, referencing:=[]
  time=1725332435909946919, pid=11454, addr=4398050331824, published=1, referencing:=[]
  time=1725332435910829690, pid=11481, addr=4415240825744, published=1, referencing:=[]
  time=1725332436009947862, pid=11454, addr=4398060938464, published=1, referencing:=[]
  time=1725332436010863564, pid=11481, addr=4415240969584, published=1, referencing:=[]
  time=1725332436109950952, pid=11454, addr=4398046679600, published=1, referencing:=[]
  time=1725332436110870671, pid=11481, addr=4415230275392, published=1, referencing:=[]
  time=1725332436209971319, pid=11454, addr=4398050364064, published=1, referencing:=[]
  time=1725332436210890247, pid=11481, addr=4415229816704, published=1, referencing:=[]
  time=1725332436309971557, pid=11454, addr=4398050364560, published=1, referencing:=[]
  time=1725332436310896946, pid=11481, addr=4415230275440, published=1, referencing:=[]
  time=1725332436409964416, pid=11454, addr=4398060935856, published=1, referencing:=[]
  time=1725332436410805101, pid=11481, addr=4415230302560, published=1, referencing:=[]
  time=1725332436509964922, pid=11454, addr=4398050243392, published=1, referencing:=[]
  time=1725332436510785377, pid=11481, addr=4415230299408, published=0, referencing:=[]

/my_static_topic
 subscriber_pids: 11481 11519
 publishers:
  pid=11454, entries_num=10, exited=0
 entries:
  time=1725332435610592724, pid=11454, addr=4398061057456, published=1, referencing:=[]
  time=1725332435710576438, pid=11454, addr=4398060970224, published=1, referencing:=[]
  time=1725332435810576211, pid=11454, addr=4398060976544, published=1, referencing:=[]
  time=1725332435910576980, pid=11454, addr=4398060966208, published=1, referencing:=[]
  time=1725332436010575895, pid=11454, addr=4398061058496, published=1, referencing:=[]
  time=1725332436110569739, pid=11454, addr=4398060967248, published=1, referencing:=[]
  time=1725332436210605752, pid=11454, addr=4398060973488, published=1, referencing:=[]
  time=1725332436310608683, pid=11454, addr=4398061054912, published=1, referencing:=[]
  time=1725332436410588925, pid=11454, addr=4398060974528, published=1, referencing:=[]
  time=1725332436510577646, pid=11454, addr=4398061055952, published=1, referencing:=[11481]
```
