### PR TITLE
feat: exit handler for subscriber after pub_queue unified 

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1094,6 +1094,7 @@ static void remove_publisher_info(struct topic_wrapper * wrapper)
 
     prev_pub_info->next = pub_info->next;
     kfree(pub_info);
+    wrapper->topic.pub_info_num--;
     break;
   }
   wrapper->topic.pub_info_list = dummy_head.next;
@@ -1118,7 +1119,6 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper)
 
   if (pub_info->entries_num == 0) {
     remove_publisher_info(wrapper);
-    wrapper->topic.pub_info_num--;
   }
 
   dev_info(
@@ -1134,6 +1134,7 @@ static bool remove_if_subscriber(struct topic_wrapper * wrapper)
   for (int i = 0; i < wrapper->topic.subscriber_num; i++) {
     if (wrapper->topic.subscriber_pids[i] == current->pid) {
       is_subscriber = true;
+      wrapper->topic.subscriber_num--;
     }
     if (is_subscriber && i < MAX_SUBSCRIBER_NUM - 1) {
       wrapper->topic.subscriber_pids[i] = wrapper->topic.subscriber_pids[i + 1];
@@ -1161,8 +1162,6 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper)
 {
   if (!remove_if_subscriber(wrapper)) return;
 
-  wrapper->topic.subscriber_num--;
-
   // Decrement the reference count, then free the entry node if it reaches zero and publisher has
   // already exited.
   for (struct rb_node * node = rb_first(&wrapper->topic.entries); node; node = rb_next(node)) {
@@ -1187,7 +1186,6 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper)
     remove_entry_node(wrapper, en);
     if (pub_info->entries_num == 0) {
       remove_publisher_info(wrapper);
-      wrapper->topic.pub_info_num--;
     }
   }
 


### PR DESCRIPTION
## Description
PR #167 に続いて、publisher_queue_node の統一PR #163 に伴って削除された、subscriberのexit handlerの実装の追加です。

## Related links
PR #163 #167
issue #130 

## How was this PR tested?
talker, listen_talker, listenerを実行後に任意の順でSIGINTする。その後
```
cat /sys/module/agnocast/status/all
```
を実行して空になっていることを確認。

## Notes for reviewers
