### PR TITLE
refactor(heaphook): reduce mempool_ptr scope

### DIFF
--- a/src/agnocast_heaphook/src/preloaded.cpp
+++ b/src/agnocast_heaphook/src/preloaded.cpp
@@ -67,7 +67,7 @@ void initialize_mempool()
     exit(EXIT_FAILURE);
   }
 
-  const char * mempool_ptr = reinterpret_cast<char *>(ret);
+  char * mempool_ptr = reinterpret_cast<char *>(ret);
   memset(mempool_ptr, 0, mempool_size);
   init_memory_pool(mempool_size, mempool_ptr);  // tlsf library function
 


### PR DESCRIPTION
## Description

heaphook において `mempool_ptr` 変数が不必要に静的変数になっていたので、ローカル変数に修正しました

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
