### PR TITLE
refactor(heaphook): reduce variable scopes

### DIFF
--- a/src/agnocast_heaphook/src/preloaded.cpp
+++ b/src/agnocast_heaphook/src/preloaded.cpp
@@ -44,11 +44,11 @@ void initialize_mempool()
   static pthread_mutex_t init_mtx = PTHREAD_MUTEX_INITIALIZER;
   static std::atomic<bool> mempool_initialized = false;
 
-  // cppcheck-suppress identicalConditionAfterEarlyExit
   if (mempool_initialized) return;
 
   pthread_mutex_lock(&init_mtx);
 
+  // cppcheck-suppress identicalConditionAfterEarlyExit
   if (mempool_initialized) {
     pthread_mutex_unlock(&init_mtx);
     return;


### PR DESCRIPTION
## Description

heaphook において、`init_mtx` と `mempool_initialized` 変数はどちらも `initialize_mempool` 関数でしか使われない静的変数なので、スコープを正しくした。

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
