### PR TITLE
feat(smart_pointer): indirection operator *

### DIFF
--- a/src/agnocastlib/include/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast_smart_pointer.hpp
@@ -104,12 +104,7 @@ public:
     exit(EXIT_FAILURE);
   }
 
-  T & operator*() const noexcept
-  {
-    std::cout << "[Error]: operator*() is not supported yet" << std::endl;
-    close(agnocast_fd);
-    exit(EXIT_FAILURE);
-  }
+  T & operator*() const noexcept { return *ptr_; }
 
   T * operator->() const noexcept { return ptr_; }
 

--- a/src/sample_application/src/minimal_publisher.cpp
+++ b/src/sample_application/src/minimal_publisher.cpp
@@ -18,6 +18,13 @@ uint64_t agnocast_get_timestamp()
 
 class MinimalPublisher : public rclcpp::Node
 {
+  void assign_data(sample_interfaces::msg::StaticSizeArray & data)
+  {
+    for (int i = 0; i < 1000; i++) {
+      data.data[i] = (i + count_) % 256;
+    }
+  }
+
   void timer_callback()
   {
     const auto timestamp = agnocast_get_timestamp();
@@ -38,9 +45,7 @@ class MinimalPublisher : public rclcpp::Node
         publisher_static_->borrow_loaned_message();
       message->id = count_;
       message->timestamp = timestamp;
-      for (int i = 0; i < 1000; i++) {
-        message->data[i] = (i + count_) % 256;
-      }
+      assign_data(*message);
       publisher_static_->publish(std::move(message));
     }
 


### PR DESCRIPTION
## Description

[こちらの PR](https://github.com/tier4/agnocast/commit/10a3c46f7370647ae1b24b603ec957bc80927ca3) で未使用という理由で削除した演算子オーバーロード `operator*` を復元し、sample application で動作確認しました。

Autoware 適用の際に必要になります。

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
