### PR TITLE
feat: introduce move constructor

### DIFF
--- a/src/agnocastlib/include/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast_smart_pointer.hpp
@@ -90,11 +90,10 @@ public:
   : ptr_(r.ptr_),
     topic_name_(r.topic_name_),
     publisher_pid_(r.publisher_pid_),
-    timestamp_(r.timestamp_)
+    timestamp_(r.timestamp_),
+    need_rc_update_(r.need_rc_update_)
   {
-    std::cout << "[Error]: move constructor is not supported yet" << std::endl;
-    close(agnocast_fd);
-    exit(EXIT_FAILURE);
+    r.ptr_ = nullptr;
   }
 
   message_ptr & operator=(message_ptr && r)

--- a/src/sample_application/src/minimal_publisher.cpp
+++ b/src/sample_application/src/minimal_publisher.cpp
@@ -30,7 +30,11 @@ class MinimalPublisher : public rclcpp::Node
       for (size_t i = 0; i < MESSAGE_SIZE / sizeof(uint64_t); i++) {
         message->data.push_back(i + count_);
       }
-      publisher_dynamic_->publish(std::move(message));
+
+      // In order to test move constructor
+      auto moved_message = std::move(message);
+
+      publisher_dynamic_->publish(std::move(moved_message));
     }
 
     {


### PR DESCRIPTION
## Description

PR https://github.com/tier4/agnocast/commit/10a3c46f7370647ae1b24b603ec957bc80927ca3 によって削除された move constructor を復元しました。
sample app でも move constructor が呼ばれるように、publisher のコードを少し編集しました。

## Related links

## How was this PR tested?

sample application

## Notes for reviewers
