### PR TITLE
feat(kmod): free process_info in agnocast_exit

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1354,10 +1354,21 @@ static void remove_all_topics(void)
   }
 }
 
+static void remove_all_process_info(void)
+{
+  struct process_info * proc_info = proc_info_list;
+  while (proc_info) {
+    struct process_info * next = proc_info->next;
+    kfree(proc_info);
+    proc_info = next;
+  }
+}
+
 static void agnocast_exit(void)
 {
   mutex_lock(&global_mutex);
   remove_all_topics();
+  remove_all_process_info();
   mutex_unlock(&global_mutex);
 
   // Decrement reference count


### PR DESCRIPTION
## Description

process_info 構造体を agnocast_exit 時に完全に free されるようにしました。

各プロセスが exit してから rmmod agnocast すればこの処理が呼ばれることはないが、プロセス exit する前に rmmod agnocast などをしてしまった際にメモリリークするのを防いでいます。

## Related links

https://github.com/tier4/agnocast/issues/170 に関連して追加したデータ構造である

## How was this PR tested?

sample app

## Notes for reviewers
