### PR TITLE
tests(ci): run test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,6 +52,7 @@ jobs:
     
     - name: run tests
       run: |
+        source /opt/ros/humble/setup.bash
         colcon test --event-handlers console_cohesion+
         colcon test-result --verbose
 


### PR DESCRIPTION
## Description

CIで `colcon test` を実行するようにしました。今まで存在した `build test` にstepを追加する形で実装しています。

## Related links

## How was this PR tested?

本PRの[CIのlog](https://github.com/tier4/agnocast/actions/runs/10768611131/job/29858077722?pr=192)を見て、単体テストが実行されていることを確認。

## Notes for reviewers
