### PR TITLE
refactor: apply hlist_node for proc_info

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -912,7 +912,7 @@ static int new_shm_addr(uint32_t pid, uint64_t shm_size, union ioctl_new_shm_arg
   new_proc_info->shm_size = shm_size;
 
   INIT_HLIST_NODE(&new_proc_info->node);
-  uint32_t hash_val = hash_min(pid, PROC_INFO_HASH_BITS);
+  uint32_t hash_val = hash_min(new_proc_info->pid, PROC_INFO_HASH_BITS);
   hash_add(proc_info_htable, &new_proc_info->node, hash_val);
 
   allocatable_addr += shm_size;


### PR DESCRIPTION
## Description
PR #193 に引き続き、proc_infoのリストをhlist_nodeを利用した実装に置き換えるリファクタリングです。

## Related links

## How was this PR tested?
sample applications

## Notes for reviewers
