### PR TITLE
fix: multiple reference count for single subscriber

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -255,17 +255,6 @@ static int get_referencing_subscriber_index(struct entry_node * en, uint32_t sub
   return -1;
 }
 
-static int insert_referencing_subscriber(struct entry_node * en, uint32_t subscriber_pid)
-{
-  for (int i = 0; i < MAX_SUBSCRIBER_NUM; i++) {
-    if (en->referencing_subscriber_pids[i] == 0) {
-      en->referencing_subscriber_pids[i] = subscriber_pid;
-      return i;
-    }
-  }
-  return -1;
-}
-
 static void remove_referencing_subscriber_by_index(struct entry_node * en, int index)
 {
   for (int i = index; i < MAX_SUBSCRIBER_NUM - 1; i++) {
@@ -282,7 +271,13 @@ static int increment_sub_rc(struct entry_node * en, uint32_t subscriber_pid)
 {
   int index = get_referencing_subscriber_index(en, subscriber_pid);
   if (index == -1) {
-    index = insert_referencing_subscriber(en, subscriber_pid);
+    for (int i = 0; i < MAX_SUBSCRIBER_NUM; i++) {
+      if (en->referencing_subscriber_pids[i] == 0) {
+        en->referencing_subscriber_pids[i] = subscriber_pid;
+        index = i;
+        break;
+      }
+    }
     if (index == -1) return -1;
   }
   en->subscriber_reference_count[index]++;


### PR DESCRIPTION
## Description
一つのsubscriberが複数のreference_countを持つ可能性があることを考慮できておらず、exitの際ににうまく解放できないというバグがあったのでその修正です。各subscriber_pidに対応するreference_countを持つような実装に変更しました。リンクドリストを利用するとincrement/decrementするごとにkmalloc, kfreeの必要があるので配列を利用しています。

## Related links

## How was this PR tested?
sample applications
Autoware

## Notes for reviewers
remove_publisher_infoも修正しました。subscriberのexit時にpublisher_infoを解放することがあるのですが、current->pidでpublisher_infoの構造体を探索してしまっていたのでその修正です。
