### PR TITLE
fix(ci): version of upload-artifact

### DIFF
--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload Cppcheck report
         if: ${{ steps.add-kmod.outputs.filtered-full-paths != '' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cppcheck-report
           path: cppcheck-report.txt


### PR DESCRIPTION
## Description

actions/upload-artifact@v2がdeprecatedでエラーが出ていたためv3に更新。

## Related links

## How was this PR tested?

## Notes for reviewers
