### PR TITLE
Refactor: use hlist for subscriber

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1440,9 +1440,7 @@ static int pre_handler_do_exit(struct kprobe * p, struct pt_regs * regs)
     pre_handler_subscriber_exit(wrapper);
 
     // Check if we can release the topic_wrapper
-    int pub_count = get_size_pub_info_htable(wrapper);
-    int sub_count = get_size_sub_info_htable(wrapper);
-    if (pub_count == 0 && sub_count == 0) {
+    if (get_size_pub_info_htable(wrapper) == 0 && get_size_sub_info_htable(wrapper) == 0) {
       hash_del(&wrapper->node);
       if (wrapper->key) {
         kfree(wrapper->key);


### PR DESCRIPTION
## Description
topicの持つsubscriber pidの配列をリスト化するPRです。subscriber infoという構造体を定義してリストで持つことで、subscriberのpidとそのsubscriberが受信した最後のtimestampを紐付けることが目的で、mq msgからtimestamp, publisher_pidを削除するPRに向けた準備作業になっています。(現段階ではsubscriber_infoにtimestampを紐付けてはいません。)

publisher_infoと対称的な設計になったので、リファクタリングも少し同時に行っています。具体的にはtopic_structからpub_info_numやsubscriber_numを削除し、それらが必要な箇所ではリストをループしてリストの持つノードの数を数えています(リストとそこに含まれるノードの数を別で管理することは、それが一致しない等のバグが起きる可能性がある。実際にpub_info_numやsubscriber_numの値が利用される箇所はパフォーマンスへの影響を考える必要のない数カ所のみだったので削除しました)。

## Related links
[mq msgからtimestamp, publisher_pidを削除する提案
](https://github.com/tier4/agnocast/issues/165)

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers
