### PR TITLE
fix: Reject a process if it tries to participate as both a publisher and a subscriber for the same topic

### DIFF
--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -57,7 +57,7 @@ public:
 
     // Send messages to subscribers to notify that a new publisher appears
     for (uint32_t i = 0; i < pub_args.ret_subscriber_len; i++) {
-      if (pub_args.ret_subscriber_pids == publisher_pid_) {
+      if (pub_args.ret_subscriber_pids[i] == publisher_pid_) {
         /*
          * NOTE: In ROS2, communication should work fine even if the same process exists as both a
          * publisher and a subscriber for a given topic. However, in Agnocast, to avoid applying
@@ -66,7 +66,7 @@ public:
          */
         std::cout << "[Error]: This process (pid=" << publisher_pid_
                   << ") already exists in the topic (topic_name=" << topic_name
-                  << ") as a publisher." << std::endl;
+                  << ") as a subscriber." << std::endl;
         exit(EXIT_FAILURE);
       }
       const std::string mq_name =

--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     for (uint32_t i = 0; i < subscriber_args.ret_publisher_num; i++) {
-      if (subscriber_args.ret_pids[i] == subscriber_pid) {
+      if ((pid_t)subscriber_args.ret_pids[i] == subscriber_pid) {
         /*
          * NOTE: In ROS2, communication should work fine even if the same process exists as both a
          * publisher and a subscriber for a given topic. However, in Agnocast, to avoid applying


### PR DESCRIPTION
## Description
CallbackSubscriptionでコメントアウトされていた以下のコメントがあったので、それに対応する処理を予め初期化時に行うコードを追加した。

```
 /*
if (subscriber_pid == mq_msg.publisher_pid) {
     return;
}
*/
```

ros2では問題なく送受信できるはずだが、Agnocastではcomponent container内のtopic通信に適用することを避けるために、初期化時に明示的に落ちるような処理とする。将来的にcomponent containerを利用せずにほとんどすべてのpub/subがプロセス間通信になった場合には、エラーで落とすのではなく、mmapを呼ばない処理を追加することにする。

sample applicationで意図的にこのエラーで落ちるようにすると、しっかり落ちはするもののshutdown_agnocastが終了しない。これは本件に限った問題ではないのでissuse #206でいずれまとめて対策。

## Related links
issue #206

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

エラーでしっかり落ちることを確認したのはsample applicationにおけるlisten_talkerのみ。
autowareではエラーが起きる状態での実験はしていないが、通常の動作確認のみを行った。

## Notes for reviewers
