### PR TITLE
refactor: rename CallbackSubscription into Subscription

### DIFF
--- a/src/agnocast_bridge/src/bridge_node.cpp
+++ b/src/agnocast_bridge/src/bridge_node.cpp
@@ -6,7 +6,7 @@ using std::placeholders::_1;
 
 class BridgeNode : public rclcpp::Node
 {
-  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::DynamicSizeArray>>
+  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::DynamicSizeArray>>
     agnocast_subscriber_;
   rclcpp::Publisher<sample_interfaces::msg::DynamicSizeArray>::SharedPtr publisher_;
 

--- a/src/agnocastlib/include/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast.hpp
@@ -49,19 +49,19 @@ std::shared_ptr<Publisher<MessageT>> create_publisher(
 }
 
 template <typename MessageT>
-std::shared_ptr<CallbackSubscription<MessageT>> create_subscription(
+std::shared_ptr<Subscription<MessageT>> create_subscription(
   const std::string & topic_name, const rclcpp::QoS & qos,
   std::function<void(const agnocast::message_ptr<MessageT> &)> callback)
 {
-  return std::make_shared<CallbackSubscription<MessageT>>(topic_name, qos, callback);
+  return std::make_shared<Subscription<MessageT>>(topic_name, qos, callback);
 }
 
 template <typename MessageT>
-std::shared_ptr<CallbackSubscription<MessageT>> create_subscription(
+std::shared_ptr<Subscription<MessageT>> create_subscription(
   const std::string & topic_name, const size_t qos_history_depth,
   std::function<void(const agnocast::message_ptr<MessageT> &)> callback)
 {
-  return std::make_shared<CallbackSubscription<MessageT>>(
+  return std::make_shared<Subscription<MessageT>>(
     topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), callback);
 }
 

--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -96,12 +96,12 @@ public:
 };
 
 template <typename MessageT>
-class CallbackSubscription : public SubscriptionBase
+class Subscription : public SubscriptionBase
 {
   std::pair<mqd_t, std::string> mq_subscription;
 
 public:
-  CallbackSubscription(
+  Subscription(
     const std::string & topic_name, const rclcpp::QoS & qos,
     std::function<void(const agnocast::message_ptr<MessageT> &)> callback)
   {
@@ -183,7 +183,7 @@ public:
     threads.push_back(std::move(th));
   }
 
-  ~CallbackSubscription()
+  ~Subscription()
   {
     /* It's best to notify the publisher and have it call mq_close, but currently
     this is not being done. The message queue is destroyed when the publisher process exits. */

--- a/src/sample_application/src/minimal_pubsub.cpp
+++ b/src/sample_application/src/minimal_pubsub.cpp
@@ -44,8 +44,7 @@ class MinimalPubSub : public rclcpp::Node
   }
 
   std::shared_ptr<agnocast::Publisher<sample_interfaces::msg::DynamicSizeArray>> publisher_dynamic_;
-  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::StaticSizeArray>>
-    sub_static_;
+  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::StaticSizeArray>> sub_static_;
   int count_;
 
   std::vector<uint64_t> timestamps_;

--- a/src/sample_application/src/minimal_subscriber.cpp
+++ b/src/sample_application/src/minimal_subscriber.cpp
@@ -24,10 +24,8 @@ class MinimalSubscriber : public rclcpp::Node
   int timestamp_idx_ = 0;
   pthread_mutex_t timestamp_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::DynamicSizeArray>>
-    sub_dynamic_;
-  std::shared_ptr<agnocast::CallbackSubscription<sample_interfaces::msg::StaticSizeArray>>
-    sub_static_;
+  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::DynamicSizeArray>> sub_dynamic_;
+  std::shared_ptr<agnocast::Subscription<sample_interfaces::msg::StaticSizeArray>> sub_static_;
 
   void callback_dynamic(
     const agnocast::message_ptr<sample_interfaces::msg::DynamicSizeArray> & message)


### PR DESCRIPTION
## Description

Autoware適用で手間になるので、タイトルの通りのリネームをしました

## Related links

[Slack](https://star4.slack.com/archives/C07FL8616EM/p1726219885564459?thread_ts=1726219729.772219&cid=C07FL8616EM)

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers
