### PR TITLE
fix: match agnocast.h with agnocast_ioctl.h

### DIFF
--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -81,7 +81,7 @@ union ioctl_receive_msg_args {
   };
   struct
   {
-    uint32_t ret_len;
+    uint16_t ret_len;
     uint32_t ret_publisher_pids[MAX_QOS_DEPTH];
     uint64_t ret_timestamps[MAX_QOS_DEPTH];
     uint64_t ret_last_msg_addrs[MAX_QOS_DEPTH];


### PR DESCRIPTION
## Description
PR #203 で僕が入れてしまったバグです。動作確認では動いてしまい一度mergeしてしまったのですが、修正します。
現状、今回のagnocast.hの修正部分がagnocast_ioctl.hと一致していません。
[この修正](https://github.com/tier4/agnocast/pull/203#discussion_r1762274595)の修正の際に各整数型の表現範囲を踏まえて適切に扱うために、ret_lenをuint32_tをuint16_tにしてからint32_tへのキャストをしようという意図で行った変更がagnocast_ioctl.hにしか適用されていませんでした。

## Related links
https://github.com/tier4/agnocast/pull/203#discussion_r1762274595

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers
