### PR TITLE
fix(heaphook_rust): panic in unsupported alloc

### DIFF
--- a/src/agnocast_heaphook_rust/src/lib.rs
+++ b/src/agnocast_heaphook_rust/src/lib.rs
@@ -313,12 +313,10 @@ pub extern "C" fn memalign(alignment: usize, size: usize) -> *mut c_void {
 
 #[no_mangle]
 pub extern "C" fn valloc(_size: usize) -> *mut c_void {
-    eprintln!("NOTE: valloc is not supported");
-    std::ptr::null_mut()
+    panic!("NOTE: valloc is not supported");
 }
 
 #[no_mangle]
 pub extern "C" fn pvalloc(_size: usize) -> *mut c_void {
-    eprintln!("NOTE: pvalloc is not supported");
-    std::ptr::null_mut()
+    panic!("NOTE: pvalloc is not supported");
 }


### PR DESCRIPTION
## Description

サポートしない valloc/pvalloc 命令がもし呼ばれた際に、エラーメッセージを出すだけでなく、panic するように変更しました。

## Related links

## How was this PR tested?

valloc, pvalloc が呼ばれるアプリケーションが見つけられていないのでテストできていませんが、panic するので大丈夫だと思います、、（valloc, pvalloc ってそもそも deplicated なので）
なお、Autoware に valloc, pvalloc は含まれていません。

- [ ] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
