### PR TITLE
fix: use load/store for atomic variables

### DIFF
--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -112,7 +112,7 @@ public:
 
       MqMsgAgnocast mq_msg;
 
-      while (is_running) {
+      while (is_running.load()) {
         union ioctl_receive_msg_args receive_args;
         receive_args.topic_name = topic_name_.c_str();
         receive_args.subscriber_pid = subscriber_pid_;

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -114,7 +114,7 @@ void * initialize_agnocast(const uint64_t shm_size)
 static void shutdown_agnocast()
 {
   fprintf(stdout, "[INFO] [Agnocast]: shutdown_agnocast started\n");
-  is_running = false;
+  is_running.store(false);
   /*
    * TODO:
    *   It might seem odd to re-acquire the PID and regenerate mq_name and shm_name.

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -45,7 +45,7 @@ void SubscriptionBase::wait_for_new_publisher(const pid_t subscriber_pid)
 
   // Create a thread that maps the areas for publishers afterwards
   auto th = std::thread([=]() {
-    while (is_running) {
+    while (is_running.load()) {
       MqMsgNewPublisher mq_msg;
       auto ret = mq_receive(mq, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), NULL);
       if (ret == -1) {


### PR DESCRIPTION
## Description

Use load/store for atomic variables.

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
