### PR TITLE
ci: remove cache precedures

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -10,8 +10,6 @@
 #include <fstream>
 #include <set>
 
-// TODO: delete
-
 namespace agnocast
 {
 


### PR DESCRIPTION
## Description
actions/cache が古いと警告が出ていたので。
https://github.com/tier4/agnocast/actions/runs/11677045626
![Screenshot from 2024-11-05 14-06-49](https://github.com/user-attachments/assets/827719ae-f784-4ffd-a261-88fdd4212c3b)

そもそもキャッシュ関連の処理をいったんすべて消すということになりました
slack: https://star4.slack.com/archives/C07FL8616EM/p1730783653911299

## Related links

## How was this PR tested?

- [ ] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
