### PR TITLE
fix(agnocastlib): remove iostream related comments

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -89,6 +89,7 @@ void map_read_only_area(const uint32_t pid, const uint64_t shm_addr, const uint6
   if (map_area(pid, shm_addr, shm_size, false) == NULL) exit(EXIT_FAILURE);
 }
 
+// NOTE: Avoid heap allocation inside initialize_agnocast. TLSF is not initialized yet.
 void * initialize_agnocast(const uint64_t shm_size)
 {
   if (agnocast_fd >= 0) {


### PR DESCRIPTION
## Description

以下の issue を再確認したところ、std::cout を初期化時に呼んでも問題ないことがわかったので、不要なコメントを削除しました。
pid を global 変数にするのは別に実装しなくていいかなと思ったので、そのコメントも消しています。
https://github.com/tier4/agnocast/issues/116

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
