### PR TITLE
fix(agnocastlib): include cstring for std::strcmp

### DIFF
--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -1,5 +1,7 @@
 #include "agnocast_utils.hpp"
 
+#include <cstring>
+
 namespace agnocast
 {
 


### PR DESCRIPTION
## Description

`std::strcmp` には cstring が必要らしい。ローカルではこれまで問題なかったが、XX1 ベンチでビルドが失敗した。

## Related links

## How was this PR tested?

- [ ] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
