### PR TITLE
refactor: integrate create_name

### DIFF
--- a/src/agnocastlib/include/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast_utils.hpp
@@ -11,6 +11,8 @@ extern rclcpp::Logger logger;
 
 void validate_ld_preload();
 std::string create_mq_name(const std::string & topic_name, const uint32_t pid);
+std::string create_shm_name(const uint32_t pid);
+std::string create_mq_name_new_publisher(const uint32_t pid);
 uint64_t agnocast_get_timestamp();
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -42,7 +42,7 @@ bool already_mapped(const uint32_t pid)
 void * map_area(
   const uint32_t pid, const uint64_t shm_addr, const uint64_t shm_size, const bool writable)
 {
-  const std::string shm_name = "/agnocast@" + std::to_string(pid);
+  const std::string shm_name = create_shm_name(pid);
 
   int oflag = writable ? O_CREAT | O_RDWR : O_RDONLY;
   int shm_fd = shm_open(shm_name.c_str(), oflag, 0666);
@@ -139,7 +139,7 @@ static void shutdown_agnocast()
     }
   }
 
-  const std::string shm_name = "/agnocast@" + std::to_string(pid);
+  const std::string shm_name = create_shm_name(pid);
   if (shm_unlink(shm_name.c_str()) == -1) {
     perror("[ERROR] [Agnocast] shm_unlink failed");
   }
@@ -149,7 +149,7 @@ static void shutdown_agnocast()
       perror("[ERROR] [Agnocast] mq_close failed");
     }
 
-    const std::string mq_name = "/new_publisher@" + std::to_string(pid);
+    const std::string mq_name = create_mq_name_new_publisher(pid);
     if (mq_unlink(mq_name.c_str()) == -1) {
       perror("[ERROR] [Agnocast] mq_unlink failed");
     }

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -32,7 +32,7 @@ void initialize_publisher(uint32_t publisher_pid, const std::string & topic_name
         publisher_pid, topic_name.c_str());
       exit(EXIT_FAILURE);
     }
-    const std::string mq_name = "/new_publisher@" + std::to_string(pub_args.ret_subscriber_pids[i]);
+    const std::string mq_name = create_mq_name_new_publisher(pub_args.ret_subscriber_pids[i]);
     mqd_t mq = mq_open(mq_name.c_str(), O_WRONLY);
     if (mq == -1) {
       RCLCPP_ERROR(logger, "mq_open for new publisher failed: %s", strerror(errno));

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -29,7 +29,7 @@ void SubscriptionBase::wait_for_new_publisher(const pid_t subscriber_pid)
 
   pthread_mutex_unlock(&wait_newpub_mtx);
 
-  const std::string mq_name = "/new_publisher@" + std::to_string(subscriber_pid);
+  const std::string mq_name = create_mq_name_new_publisher(subscriber_pid);
 
   struct mq_attr attr;
   attr.mq_flags = 0;                            // Blocking queue

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -37,6 +37,16 @@ std::string create_mq_name(const std::string & topic_name, const uint32_t pid)
   return mq_name;
 }
 
+std::string create_shm_name(const uint32_t pid)
+{
+  return "/agnocast@" + std::to_string(pid);
+}
+
+std::string create_mq_name_new_publisher(const uint32_t pid)
+{
+  return "/new_publisher@" + std::to_string(pid);
+}
+
 uint64_t agnocast_get_timestamp()
 {
   auto now = std::chrono::system_clock::now();


### PR DESCRIPTION
## Description

shmやmqの命名関数をutilsに統合しました。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required) -> 不要と判断

## Notes for reviewers
