### PR TITLE
ci: add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,7 @@ Checks: "
 
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  // -bugprone-narrowing-conversions,
+  -bugprone-narrowing-conversions,
 
   cert-*,
   -cert-err33-c,

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  size_t number_of_ros2_threads = 1;
+  size_t number_of_ros2_threads = 0;
   size_t number_of_agnocast_threads = 0;
   bool ros2_yield_before_execute = false;
   std::chrono::nanoseconds ros2_next_exec_timeout = std::chrono::nanoseconds(10 * 1000 * 1000);


### PR DESCRIPTION
## Description

clang-tidy による静的解析を agnocastlib に対して追加しました。

CI 実行時間に関しては、
ROS 2 環境構築: 4m 12s
ビルド: 1m 13s
clang-tidy: 3m 29s

## Related links

AWF の clang-tidy ワークフローを参考にしています
https://github.com/autowarefoundation/autoware-github-actions/blob/main/clang-tidy/action.yaml

また、clang-tidy で有効にできるチェック一覧は以下を参照
https://clang.llvm.org/extra/clang-tidy/

## How was this PR tested?

警告がある場合に CI が fail することを確認
https://github.com/tier4/agnocast/actions/runs/11887648269/job/33120753988

## Notes for reviewers

.clang-tidy ファイルの読み方ですが、

- `-*` : 一旦すべてのチェックを無効にす
- `bugprone-*` : bugprone- で始まる項目をすべて有効にする
- `-bugprone-hoge` : 今の agnocastlib には bugprone-hoge という警告が発生するので、CI がブロックされないようにチェックを無効にしている