### PR TITLE
fix(agnocastlib): fix bugprone-narrowing-conversions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,6 @@ Checks: "
 
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-narrowing-conversions,
 
   cert-*,
   -cert-err33-c,

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -58,7 +58,7 @@ void * map_area(
   }
 
   if (writable) {
-    if (ftruncate(shm_fd, shm_size) == -1) {
+    if (ftruncate(shm_fd, static_cast<off_t>(shm_size)) == -1) {
       perror("[ERROR] [Agnocast] ftruncate failed");
       close(agnocast_fd);
       return NULL;


### PR DESCRIPTION
## Description

以下の警告を解消し、clang-tidy において `bugprone-narrowing-conversions` を required にしました

```
agnocast/src/agnocastlib/src/agnocast.cpp:61:27: error: narrowing conversion from 'uint64_t' (aka 'unsigned long') to signed type '__off_t' (aka 'long') is implementation-defined [bugprone-narrowing-conversions,-warnings-as-errors]
    if (ftruncate(shm_fd, shm_size) == -1) {
                          ^
```

## Related links

## How was this PR tested?

ビルドのみ

## Notes for reviewers
