### PR TITLE
refactor(Subscription): remove backward compatibility

### DIFF
--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -74,16 +74,14 @@ public:
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = options.callback_group;
 
-    if (ros2_node_base_ != nullptr /* for backward compatibility */) {
-      if (callback_group) {
-        if (!ros2_node_base_->callback_group_in_node(callback_group)) {
-          RCLCPP_ERROR(logger, "Cannot create agnocast subscription, callback group not in node.");
-          close(agnocast_fd);
-          exit(EXIT_FAILURE);
-        }
-      } else {
-        callback_group = ros2_node_base_->get_default_callback_group();
+    if (callback_group) {
+      if (!ros2_node_base_->callback_group_in_node(callback_group)) {
+        RCLCPP_ERROR(logger, "Cannot create agnocast subscription, callback group not in node.");
+        close(agnocast_fd);
+        exit(EXIT_FAILURE);
       }
+    } else {
+      callback_group = ros2_node_base_->get_default_callback_group();
     }
 
     union ioctl_subscriber_args subscriber_args = initialize(false);


### PR DESCRIPTION
## Description

後方互換性のための分岐が残っていたので、削除しました。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required) -> 不要と判断

## Notes for reviewers
