### PR TITLE
fix(agnocastlib): fix readability-implicit-bool-conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: "
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
-  -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-prefer-member-initializer,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
@@ -53,9 +52,7 @@ Checks: "
   readability-*,
   -readability-magic-numbers,
   -readability-function-cognitive-complexity,
-  -readability-implicit-bool-conversion,
   -readability-identifier-length,
-  -readability-braces-around-statements,
   -readability-convert-member-functions-to-static,
   -readability-make-member-function-const,
   -readability-braces-around-statements"

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -11,7 +11,7 @@ rclcpp::Logger logger = rclcpp::get_logger("Agnocast");
 void validate_ld_preload()
 {
   const char * ld_preload = getenv("LD_PRELOAD");
-  if (!ld_preload || std::strcmp(ld_preload, "libpreloaded.so") != 0) {
+  if (ld_preload == nullptr || std::strcmp(ld_preload, "libpreloaded.so") != 0) {
     RCLCPP_ERROR(logger, "LD_PRELOAD is not set to libpreloaded.so");
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
## Description

`readability-implicit-bool-conversion` 警告を修正し、required にしました。

また、`cppcoreguidelines-narrowing-conversions` は以前の PR で解決済み、`readability-braces-around-statements` は二重で suppress してしまっていたため、ついでに削除しました

## Related links

## How was this PR tested?

launch から LD_PRELOAD を削除したときに、
```
<launch>
    <node pkg="sample_application" exec="talker" name="talker_node" output="screen">
        <env name="MEMPOOL_SIZE" value="67108864" />  <!-- 64MB-->
    </node>
</launch>
```

想定通りエラー処理されることを確認

```
$ bash scripts/run_talker 
[INFO] [launch]: All log files can be found below /home/veqcc/.ros/log/2024-11-19-10-09-11-964717-dpc2206003-16144
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [talker-1]: process started with pid [16145]
[talker-1] [ERROR] [1731978552.089212281] [Agnocast]: LD_PRELOAD is not set to libpreloaded.so
[talker-1] [ERROR] [Agnocast] shm_unlink failed: No such file or directory
[talker-1] [INFO] [Agnocast]: shutdown_agnocast started
[talker-1] [INFO] [Agnocast]: shutdown_agnocast completed
[ERROR] [talker-1]: process has died [pid 16145, exit code 1, cmd '/home/veqcc/work/agnocast/install/sample_application/lib/sample_application/talker --ros-args -r __node:=talker_node'].
```

## Notes for reviewers
