### PR TITLE
fix(clang-tidy): cppcoreguidelines-prefer-member-initializer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: "
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
-  -cppcoreguidelines-prefer-member-initializer,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -10,16 +10,15 @@ namespace agnocast
 AgnocastExecutor::AgnocastExecutor(
   const rclcpp::ExecutorOptions & options,
   std::chrono::nanoseconds agnocast_callback_group_wait_time)
-: rclcpp::Executor(options), agnocast_callback_group_wait_time_(agnocast_callback_group_wait_time)
+: rclcpp::Executor(options),
+  agnocast_callback_group_wait_time_(agnocast_callback_group_wait_time),
+  my_pid_(getpid()),
+  epoll_fd_(epoll_create1(0))
 {
-  epoll_fd_ = epoll_create1(0);
-
   if (epoll_fd_ == -1) {
     RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));
     exit(EXIT_FAILURE);
   }
-
-  my_pid_ = getpid();
 }
 
 AgnocastExecutor::~AgnocastExecutor()


### PR DESCRIPTION
## Description

初期化リストを使えという警告の修正。

## Related links

## How was this PR tested?

ビルドのみ

## Notes for reviewers
