### PR TITLE
fix(clang-tidy): google-readability-todo

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,7 +30,6 @@ Checks: "
   google-*,
   -google-readability-casting,
   -google-default-arguments,
-  -google-readability-todo,
   -google-readability-avoid-underscore-in-googletest-name,
 
   hicpp-*,

--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -38,8 +38,8 @@ class Publisher
   std::string topic_name_;
   uint32_t publisher_pid_;
   rclcpp::QoS qos_;
-  // TODO: The mq should be closed when a subscriber unsubscribes the topic, but this is not
-  // currently implemented.
+  // TODO(Koichi98): The mq should be closed when a subscriber unsubscribes the topic, but this is
+  // not currently implemented.
   std::unordered_map<std::string, mqd_t> opened_mqs_;
 
 public:

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -42,7 +42,7 @@ void MultiThreadedAgnocastExecutor::spin()
 
   RCPPUTILS_SCOPE_EXIT(this->spinning.store(false););
 
-  // TODO: Transient Local
+  // TODO(sykwer): Transient Local
 
   std::vector<std::thread> threads;
 

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -23,7 +23,7 @@ void SingleThreadedAgnocastExecutor::spin()
 
   RCPPUTILS_SCOPE_EXIT(this->spinning.store(false););
 
-  // TODO: Transient local
+  // TODO(sykwer): Transient local
 
   while (rclcpp::ok(this->context_) && agnocast::ok() && spinning.load()) {
     if (need_epoll_updates.exchange(false)) {


### PR DESCRIPTION
## Description

TODOコメントにusernameを追加しろという警告の修正。

## Related links

## How was this PR tested?

ビルドのみ

## Notes for reviewers
