### PR TITLE
fix(subscription): change initialize() into protected

### DIFF
--- a/src/agnocastlib/include/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast_subscription.hpp
@@ -48,11 +48,11 @@ protected:
   const pid_t subscriber_pid_;
   const std::string topic_name_;
   const rclcpp::QoS qos_;
+  union ioctl_subscriber_args initialize(bool is_take_sub);
 
 public:
   SubscriptionBase(
     const pid_t subscriber_pid, const std::string & topic_name, const rclcpp::QoS & qos);
-  union ioctl_subscriber_args initialize(bool is_take_sub);
 };
 
 template <typename MessageT>


### PR DESCRIPTION
## Description

SubscriptionBase::initialize()がpublicになっており、ユーザから呼び出せるようになっていたので、protectedに修正。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required) -> 不要と判断

## Notes for reviewers
