### PR TITLE
fix(ci): minor changes in clang-tidy-ci

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -75,7 +75,6 @@ jobs:
     - name: Run clang-tidy for agnocastlib
       if: steps.check_changes_cpp.outputs.cpp_changed == 'true'
       run: |
-        echo $(nproc)
         export FILES=($(find src/agnocastlib/ -name '*.cpp' -not -path '*/test/*'))
         run-clang-tidy -j $(nproc) -p build/ "${FILES[@]}"
     

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -17,7 +17,7 @@ int main(int argc, char * argv[])
 
   auto node = std::make_shared<rclcpp_components::ComponentManager>();
 
-  if (node->has_parameter("number_of_ros2_threadsa")) {
+  if (node->has_parameter("number_of_ros2_threads")) {
     number_of_ros2_threads = node->get_parameter("number_of_ros2_threads").as_int();
   }
 


### PR DESCRIPTION
## Description

clang-tidy に関する小さな修正をいくつか行ないました
 - test ディレクトリが対象外になったため、`google-readability-avoid-underscore-in-googletest-name` が必要なくなった
 - `hicpp-braces-around-statements` が被っていたので片方を消した
 - clang-tidy は .hpp を解析しないため、そもそもフィルタから `-name '*.hpp'` を消した
 - run-clang-tidy の並列数を 16 ではなくシステムの最大並列数にした `run-clang-tidy -j $(nproc)`
   - 実際に CI 上で並列数を確認したところ、2 であった。

## Related links

## How was this PR tested?

## Notes for reviewers
