### PR TITLE
fix(agnocastlib): remove duplicate install

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -66,8 +66,6 @@ install(
   DESTINATION include
 )
 
-install(TARGETS agnocast DESTINATION lib/${PROJECT_NAME})
-
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_${PROJECT_NAME} test/test_agnocast_utils.cpp 


### PR DESCRIPTION
## Description

agnocastlib が二重で install されていたのを修正しました。

## Related links

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers
