### PR TITLE
fix(clang-tidy): readability-braces-around-statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,8 +49,7 @@ Checks: "
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-convert-member-functions-to-static,
-  -readability-make-member-function-const,
-  -readability-braces-around-statements"
+  -readability-make-member-function-const"
 
 
 WarningsAsErrors: "

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -90,8 +90,12 @@ void * map_writable_area(const uint32_t pid, const uint64_t shm_addr, const uint
 
 void map_read_only_area(const uint32_t pid, const uint64_t shm_addr, const uint64_t shm_size)
 {
-  if (already_mapped(pid)) return;
-  if (map_area(pid, shm_addr, shm_size, false) == NULL) exit(EXIT_FAILURE);
+  if (already_mapped(pid)) {
+    return;
+  }
+  if (map_area(pid, shm_addr, shm_size, false) == NULL) {
+    exit(EXIT_FAILURE);
+  }
 }
 
 // NOTE: Avoid heap allocation inside initialize_agnocast. TLSF is not initialized yet.

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -35,12 +35,18 @@ void AgnocastExecutor::prepare_epoll()
   for (auto it = id2_topic_mq_info.begin(); it != id2_topic_mq_info.end(); it++) {
     const uint32_t topic_local_id = it->first;
     AgnocastTopicInfo & topic_info = it->second;
-    if (!topic_info.need_epoll_update) continue;
+    if (!topic_info.need_epoll_update) {
+      continue;
+    }
 
     for (const auto & [weak_group, _] : rclcpp::Executor::weak_groups_to_nodes_) {
       const auto group = weak_group.lock();
-      if (!group) continue;
-      if (group != topic_info.callback_group) continue;
+      if (!group) {
+        continue;
+      }
+      if (group != topic_info.callback_group) {
+        continue;
+      }
 
       struct epoll_event ev;
       ev.events = EPOLLIN;
@@ -77,7 +83,9 @@ bool AgnocastExecutor::get_next_agnocast_executables(
   }
 
   // timeout
-  if (nfds == 0) return false;
+  if (nfds == 0) {
+    return false;
+  }
 
   const uint32_t topic_local_id = event.data.u32;
   AgnocastTopicInfo topic_info;

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -62,7 +62,9 @@ void MultiThreadedAgnocastExecutor::spin()
 
   ros2_spin();
 
-  for (auto & thread : threads) thread.join();
+  for (auto & thread : threads) {
+    thread.join();
+  }
 }
 
 void MultiThreadedAgnocastExecutor::ros2_spin()
@@ -73,11 +75,17 @@ void MultiThreadedAgnocastExecutor::ros2_spin()
     {
       std::lock_guard wait_lock{wait_mutex_};
 
-      if (!rclcpp::ok(this->context_) || !agnocast::ok()) return;
-      if (!get_next_executable(any_executable, ros2_next_exec_timeout_)) continue;
+      if (!rclcpp::ok(this->context_) || !agnocast::ok()) {
+        return;
+      }
+      if (!get_next_executable(any_executable, ros2_next_exec_timeout_)) {
+        continue;
+      }
     }
 
-    if (ros2_yield_before_execute_) std::this_thread::yield();
+    if (ros2_yield_before_execute_) {
+      std::this_thread::yield();
+    }
 
     execute_any_executable(any_executable);
 
@@ -103,7 +111,9 @@ void MultiThreadedAgnocastExecutor::agnocast_spin()
     // timeout. However, since we need to periodically check for epoll updates, we should implement
     // a long timeout period instead of an infinite block.
     if (get_next_agnocast_executables(agnocast_executables, 1000 /*ms timed-blocking*/)) {
-      if (ros2_yield_before_execute_) std::this_thread::yield();
+      if (ros2_yield_before_execute_) {
+        std::this_thread::yield();
+      }
 
       execute_agnocast_executables(agnocast_executables);
     }

--- a/src/agnocastlib/src/agnocast_topic_info.cpp
+++ b/src/agnocastlib/src/agnocast_topic_info.cpp
@@ -20,7 +20,9 @@ std::shared_ptr<std::function<void()>> create_callable(
     std::lock_guard<std::mutex> lock(id2_topic_mq_info_mtx);
     auto it = id2_topic_mq_info.find(topic_local_id);
     found = it != id2_topic_mq_info.end();
-    if (found) info = &it->second;
+    if (found) {
+      info = &it->second;
+    }
   }
 
   if (!found) {


### PR DESCRIPTION
## Description

blockは {} で囲めという警告の修正。

## Related links

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers
