### PR TITLE
fix(clang-tidy): remove hicpp-braces-around-statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,6 @@ Checks: "
   hicpp-*,
   -hicpp-member-init,
   -hicpp-vararg,
-  -hicpp-braces-around-statements,
   -hicpp-no-array-decay,
   -hicpp-special-member-functions,
 


### PR DESCRIPTION
## Description

https://github.com/tier4/agnocast/pull/293 で同時に解決されていたので、抑制を解除。

## Related links

## How was this PR tested?

ビルドのみ

## Notes for reviewers
