### PR TITLE
fix(agnocastlib): fix array decay

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,9 +17,7 @@ Checks: "
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-init-variables,
-  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
-  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,
@@ -33,7 +31,6 @@ Checks: "
   hicpp-*,
   -hicpp-member-init,
   -hicpp-vararg,
-  -hicpp-no-array-decay,
   -hicpp-special-member-functions,
 
   misc-*,

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -110,8 +110,11 @@ std::vector<uint64_t> borrow_loaned_message_core(
     exit(EXIT_FAILURE);
   }
 
-  return std::vector<uint64_t>(
-    ioctl_args.ret_released_addrs, ioctl_args.ret_released_addrs + ioctl_args.ret_len);
+  std::vector<uint64_t> addresses(ioctl_args.ret_len);
+  std::copy_n(
+    static_cast<const uint64_t *>(ioctl_args.ret_released_addrs), ioctl_args.ret_len,
+    addresses.begin());
+  return addresses;
 }
 
 uint32_t get_subscription_count_core(const std::string & topic_name)


### PR DESCRIPTION
## Description

暗黙的な変換をやめて、明示的に型変換と vector への変換を行ないました！

メモリ確保回数もコピー回数もともに一回なので、パフォーマンスは変わっていないと思います。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
