### PR TITLE
test(ipc_shared_ptr): unit test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: "
   google-*,
   -google-readability-casting,
   -google-default-arguments,
+  -google-build-using-namespace,
 
   hicpp-*,
   -hicpp-member-init,

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -67,11 +67,22 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(test_${PROJECT_NAME} test/test_agnocast_utils.cpp 
-    test/test_agnocast_topic_info.cpp test/test_agnocast_subscription.cpp)
+  # For gmock-global
+  include(FetchContent)
+  FetchContent_Declare(
+    gmock-global
+    GIT_REPOSITORY https://github.com/apriorit/gmock-global.git
+    GIT_TAG        master
+  )
+  FetchContent_MakeAvailable(gmock-global)
+  include_directories(${gmock-global_SOURCE_DIR}/include)
+
+  find_package(ament_cmake_gmock REQUIRED)
+  ament_add_gmock(test_${PROJECT_NAME} test/test_agnocast_utils.cpp 
+    test/test_agnocast_topic_info.cpp test/test_agnocast_subscription.cpp
+    test/test_agnocast_smart_pointer.cpp)
   target_include_directories(test_${PROJECT_NAME} PRIVATE include)
-  target_link_libraries(test_${PROJECT_NAME} agnocast)
+  target_link_libraries(test_${PROJECT_NAME} gmock-global agnocast)
   set_tests_properties(test_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )

--- a/src/agnocastlib/include/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast_smart_pointer.hpp
@@ -15,14 +15,14 @@
 #include <cstdlib>
 #include <cstring>
 
+// These are cut out of the class for information hiding.
+void decrement_rc(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp);
+void increment_rc_core(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp);
+
 namespace agnocast
 {
 
 extern int agnocast_fd;
-
-// These are cut out of the class for information hiding.
-void decrement_rc(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp);
-void increment_rc_core(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp);
 
 template <typename T>
 class ipc_shared_ptr
@@ -49,7 +49,10 @@ class ipc_shared_ptr
     increment_rc_core(topic_name_, publisher_pid_, timestamp_);
   }
 
+  // Unimplemented operators. If these are called, a compile error is raised.
   ipc_shared_ptr & operator=(const ipc_shared_ptr & r) = delete;
+  bool operator==(const ipc_shared_ptr & r) const = delete;
+  bool operator!=(const ipc_shared_ptr & r) const = delete;
 
 public:
   using element_type = T;

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -12,7 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/agnocastlib/src/agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/src/agnocast_smart_pointer.cpp
@@ -1,7 +1,6 @@
 #include "agnocast_smart_pointer.hpp"
 
-namespace agnocast
-{
+using namespace agnocast;
 
 void decrement_rc(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp)
 {
@@ -30,5 +29,3 @@ void increment_rc_core(const std::string & topic_name, uint32_t publisher_pid, u
     exit(EXIT_FAILURE);
   }
 }
-
-}  // namespace agnocast

--- a/src/agnocastlib/test/test_agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/test/test_agnocast_smart_pointer.cpp
@@ -1,0 +1,157 @@
+#include "agnocast_smart_pointer.hpp"
+
+#include <gmock-global/gmock-global.h>
+#include <gmock/gmock.h>
+
+MOCK_GLOBAL_FUNC3(decrement_rc, void(const std::string &, uint32_t, uint64_t));
+MOCK_GLOBAL_FUNC3(increment_rc_core, void(const std::string &, uint32_t, uint64_t));
+
+class AgnocastSmartPointerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    dummy_tn = "dummy";
+    dummy_pid = 0;
+    dummy_ts = 0;
+  }
+
+  std::string dummy_tn;
+  uint32_t dummy_pid;
+  uint64_t dummy_ts;
+};
+
+TEST_F(AgnocastSmartPointerTest, deconstructor_normal)
+{
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, true};
+}
+
+TEST_F(AgnocastSmartPointerTest, deconstructor_dont_need_rc_update)
+{
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, false};
+}
+
+TEST_F(AgnocastSmartPointerTest, deconstructor_nullptr)
+{
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc("", 0, 0)).Times(0);
+  std::shared_ptr<agnocast::ipc_shared_ptr<int>> sut;
+}
+
+TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)
+{
+  EXPECT_GLOBAL_CALL(increment_rc_core, increment_rc_core(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(2);
+  agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, true};
+
+  agnocast::ipc_shared_ptr<int> sut2 = sut;
+
+  EXPECT_EQ(sut.get(), sut2.get());
+  EXPECT_EQ(sut.get_topic_name(), sut2.get_topic_name());
+  EXPECT_EQ(sut.get_publisher_pid(), sut2.get_publisher_pid());
+  EXPECT_EQ(sut.get_timestamp(), sut2.get_timestamp());
+}
+
+TEST_F(AgnocastSmartPointerTest, copy_constructor_dont_need_rc_update)
+{
+  EXPECT_GLOBAL_CALL(increment_rc_core, increment_rc_core(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, false};
+
+  agnocast::ipc_shared_ptr<int> sut2 = sut;
+
+  EXPECT_EQ(sut.get(), sut2.get());
+  EXPECT_EQ(sut.get_topic_name(), sut2.get_topic_name());
+  EXPECT_EQ(sut.get_publisher_pid(), sut2.get_publisher_pid());
+  EXPECT_EQ(sut.get_timestamp(), sut2.get_timestamp());
+}
+
+TEST_F(AgnocastSmartPointerTest, move_constructor_normal)
+{
+  int * ptr = new int(0);
+  EXPECT_GLOBAL_CALL(increment_rc_core, increment_rc_core(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pid, dummy_ts, true};
+
+  agnocast::ipc_shared_ptr<int> sut2 = std::move(sut);
+
+  EXPECT_EQ(nullptr, sut.get());
+  EXPECT_EQ(ptr, sut2.get());
+  EXPECT_EQ(dummy_tn, sut2.get_topic_name());
+  EXPECT_EQ(dummy_pid, sut2.get_publisher_pid());
+  EXPECT_EQ(dummy_ts, sut2.get_timestamp());
+}
+
+TEST_F(AgnocastSmartPointerTest, move_assignment_normal)
+{
+  int * ptr = new int(0);
+  EXPECT_GLOBAL_CALL(increment_rc_core, increment_rc_core(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pid, dummy_ts, true};
+
+  agnocast::ipc_shared_ptr<int> sut2;
+  sut2 = std::move(sut);
+
+  EXPECT_EQ(nullptr, sut.get());
+  EXPECT_EQ(ptr, sut2.get());
+  EXPECT_EQ(dummy_tn, sut2.get_topic_name());
+  EXPECT_EQ(dummy_pid, sut2.get_publisher_pid());
+  EXPECT_EQ(dummy_ts, sut2.get_timestamp());
+}
+
+TEST_F(AgnocastSmartPointerTest, move_assignment_self)
+{
+  int * ptr = new int(0);
+  EXPECT_GLOBAL_CALL(increment_rc_core, increment_rc_core(dummy_tn, dummy_pid, dummy_ts)).Times(0);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pid, dummy_ts, true};
+
+  sut = std::move(sut);
+
+  EXPECT_EQ(ptr, sut.get());
+  EXPECT_EQ(dummy_tn, sut.get_topic_name());
+  EXPECT_EQ(dummy_pid, sut.get_publisher_pid());
+  EXPECT_EQ(dummy_ts, sut.get_timestamp());
+}
+
+TEST_F(AgnocastSmartPointerTest, dereference_operator)
+{
+  int * ptr = new int(0);
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pid, dummy_ts, true};
+
+  int & result = *sut;
+
+  EXPECT_EQ(ptr, &result);
+}
+
+TEST_F(AgnocastSmartPointerTest, arrow_operator)
+{
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<std::vector<int>> sut{
+    new std::vector<int>{0}, dummy_tn, dummy_pid, dummy_ts, true};
+
+  size_t result = sut->size();
+
+  EXPECT_EQ(1, result);
+}
+
+TEST_F(AgnocastSmartPointerTest, bool_operator_true)
+{
+  EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
+  agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, true};
+
+  bool result = static_cast<bool>(sut);
+
+  EXPECT_TRUE(result);
+}
+
+TEST_F(AgnocastSmartPointerTest, bool_operator_false)
+{
+  agnocast::ipc_shared_ptr<int> sut;
+
+  bool result = static_cast<bool>(sut);
+
+  EXPECT_FALSE(result);
+}


### PR DESCRIPTION
## Description

ipc_shared_ptrへの単体テストを実装しました。Mockにはサードパーティの gmock-global を使用しています。gmock-globalの[このissue](https://github.com/apriorit/gmock-global/issues/5)の関係上、Mockする関数をnamespace agnocastの外に出しました。これによってclang-tidyの警告に引っかかるようになってしまったのですが、どうしても回避できなかったのでご了承ください :bow: 

## Related links

- [gmock-globalを使う理由](https://star4.slack.com/archives/C07FL8616EM/p1732236909655929)

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers