### PR TITLE
feat(ipc_shared_ptr): reset

### DIFF
--- a/src/agnocastlib/test/test_agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/test/test_agnocast_smart_pointer.cpp
@@ -21,22 +21,31 @@ protected:
   uint64_t dummy_ts;
 };
 
-TEST_F(AgnocastSmartPointerTest, deconstructor_normal)
+TEST_F(AgnocastSmartPointerTest, reset_normal)
 {
   EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(1);
   agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, true};
+
+  sut.reset();
+
+  EXPECT_EQ(nullptr, sut.get());
 }
 
-TEST_F(AgnocastSmartPointerTest, deconstructor_dont_need_rc_update)
+TEST_F(AgnocastSmartPointerTest, reset_dont_need_rc_update)
 {
   EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc(dummy_tn, dummy_pid, dummy_ts)).Times(0);
   agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pid, dummy_ts, false};
+
+  sut.reset();
+
+  EXPECT_EQ(nullptr, sut.get());
 }
 
-TEST_F(AgnocastSmartPointerTest, deconstructor_nullptr)
+TEST_F(AgnocastSmartPointerTest, reset_nullptr)
 {
   EXPECT_GLOBAL_CALL(decrement_rc, decrement_rc("", 0, 0)).Times(0);
   std::shared_ptr<agnocast::ipc_shared_ptr<int>> sut;
+  sut.reset();
 }
 
 TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)


### PR DESCRIPTION
## Description

https://star4.slack.com/archives/C07FL8616EM/p1732271168667669 に対応するために、publish関数内でptrをnullptrにしたく、そのためのreset関数を実装しました。命名はC++のshared_ptrを参考にしています。実装したと言っても、既存のrelease関数をリネームし、必ずnullptrにセットするようにし、publicにしたのみです。テストは、destructorに対するテストだったものを流用しました。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [x] pass unit test

## Notes for reviewers
