### PR TITLE
fix(clang-tidy): cppcoreguidelines-pro-type-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,9 +2,10 @@ Checks: "
   -*,
 
   bugprone-*,
-  -bugprone-easily-swappable-parameters, /* This is a bit excessive. */
+  -bugprone-easily-swappable-parameters,
 
   cert-*,
+  -cert-err58-cpp,
 
   clang-analyzer-*,
 
@@ -14,16 +15,15 @@ Checks: "
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-pro-bounds-constant-array-index,
-  -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-special-member-functions,
-  -cppcoreguidelines-avoid-non-const-global-variables, /* This is hard to avoid. */
+  -cppcoreguidelines-avoid-non-const-global-variables,
 
   google-*,
   -google-default-arguments,
-  -google-build-using-namespace, /* This cannot be resolved while using gmock-global. */
+  -google-build-using-namespace,
 
   hicpp-*,
   -hicpp-member-init,

--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ If you want to disable pre-commit, please execute `pre-commit uninstall`.
 - [message queue](./docs/message_queue.md)
 - [Autoware integration](./docs/autoware_integration.md)
 - [Memory format in heaphook](./docs/heaphook_alignment.md)
+- [Clang-tidy Suppressions](./docs/clang_tidy_suppression.md)

--- a/docs/clang_tidy_suppression.md
+++ b/docs/clang_tidy_suppression.md
@@ -1,0 +1,19 @@
+# Clang-tidy Suppression
+
+This document explains why the warnings are suppressed in [.clang-tidy](../.clang-tidy).
+
+## bugprone-easily-swappable-parameters
+
+We think this is a bit excessive, as it requires a change in the way arguments are passed.
+
+## cppcoreguidelines-avoid-non-const-global-variables
+
+This is difficult to avoid, as it requires a major change to the implementation.
+
+## cppcoreguidelines-pro-type-reinterpret-cast
+
+In the current logic, `reinterpret-cast` is essential.
+
+## google-build-using-namespace
+
+This cannot be resolved while using gmock-global. This is due to [this issue](https://github.com/apriorit/gmock-global/issues/5).

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -113,7 +113,7 @@ void * initialize_agnocast(const uint64_t shm_size)
 
   const uint32_t pid = getpid();
 
-  union ioctl_new_shm_args new_shm_args;
+  union ioctl_new_shm_args new_shm_args = {};
   new_shm_args.pid = pid;
   new_shm_args.shm_size = shm_size;
   if (ioctl(agnocast_fd, AGNOCAST_NEW_SHM_CMD, &new_shm_args) < 0) {

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -48,7 +48,7 @@ void AgnocastExecutor::prepare_epoll()
         continue;
       }
 
-      struct epoll_event ev;
+      struct epoll_event ev = {};
       ev.events = EPOLLIN;
       ev.data.u32 = topic_local_id;
 
@@ -67,7 +67,7 @@ void AgnocastExecutor::prepare_epoll()
 bool AgnocastExecutor::get_next_agnocast_executables(
   AgnocastExecutables & agnocast_executables, const int timeout_ms) const
 {
-  struct epoll_event event;
+  struct epoll_event event = {};
 
   // blocking with timeout
   const int nfds = epoll_wait(epoll_fd_, &event, 1 /*maxevents*/, timeout_ms);
@@ -103,7 +103,7 @@ bool AgnocastExecutor::get_next_agnocast_executables(
     topic_info = it->second;
   }
 
-  MqMsgAgnocast mq_msg;
+  MqMsgAgnocast mq_msg = {};
 
   // non-blocking
   auto ret = mq_receive(topic_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), NULL);
@@ -117,7 +117,7 @@ bool AgnocastExecutor::get_next_agnocast_executables(
     return false;
   }
 
-  union ioctl_receive_msg_args receive_args;
+  union ioctl_receive_msg_args receive_args = {};
   receive_args.topic_name = topic_info.topic_name.c_str();
   receive_args.subscriber_pid = my_pid_;
   receive_args.qos_depth = topic_info.qos_depth;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -6,7 +6,7 @@ void initialize_publisher(uint32_t publisher_pid, const std::string & topic_name
 {
   validate_ld_preload();
 
-  union ioctl_publisher_args pub_args;
+  union ioctl_publisher_args pub_args = {};
   pub_args.publisher_pid = publisher_pid;
   pub_args.topic_name = topic_name.c_str();
   if (ioctl(agnocast_fd, AGNOCAST_PUBLISHER_ADD_CMD, &pub_args) < 0) {
@@ -39,7 +39,7 @@ void initialize_publisher(uint32_t publisher_pid, const std::string & topic_name
       exit(EXIT_FAILURE);
     }
 
-    MqMsgNewPublisher mq_msg;
+    MqMsgNewPublisher mq_msg = {};
     mq_msg.publisher_pid = publisher_pid;
     mq_msg.shm_addr = pub_args.ret_shm_addr;
     mq_msg.shm_size = pub_args.ret_shm_size;
@@ -55,7 +55,7 @@ void publish_core(
   const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp,
   std::unordered_map<std::string, mqd_t> & opened_mqs)
 {
-  union ioctl_publish_args publish_args;
+  union ioctl_publish_args publish_args = {};
   publish_args.topic_name = topic_name.c_str();
   publish_args.publisher_pid = publisher_pid;
   publish_args.msg_timestamp = timestamp;
@@ -81,7 +81,7 @@ void publish_core(
       opened_mqs.insert({mq_name, mq});
     }
 
-    struct MqMsgAgnocast mq_msg;
+    struct MqMsgAgnocast mq_msg = {};
     if (mq_send(mq, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), 0) == -1) {
       // If it returns EAGAIN, it means mq_send has already been executed, but the subscriber
       // hasn't received it yet. Thus, there's no need to send it again since the notification has
@@ -97,7 +97,7 @@ std::vector<uint64_t> borrow_loaned_message_core(
   const std::string & topic_name, uint32_t publisher_pid, uint32_t qos_depth,
   uint64_t msg_virtual_address, uint64_t timestamp)
 {
-  union ioctl_enqueue_and_release_args ioctl_args;
+  union ioctl_enqueue_and_release_args ioctl_args = {};
   ioctl_args.topic_name = topic_name.c_str();
   ioctl_args.publisher_pid = publisher_pid;
   ioctl_args.qos_depth = qos_depth;
@@ -118,7 +118,7 @@ std::vector<uint64_t> borrow_loaned_message_core(
 
 uint32_t get_subscription_count_core(const std::string & topic_name)
 {
-  union ioctl_get_subscriber_num_args get_subscriber_count_args;
+  union ioctl_get_subscriber_num_args get_subscriber_count_args = {};
   get_subscriber_count_args.topic_name = topic_name.c_str();
   if (ioctl(agnocast_fd, AGNOCAST_GET_SUBSCRIBER_NUM_CMD, &get_subscriber_count_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));

--- a/src/agnocastlib/src/agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/src/agnocast_smart_pointer.cpp
@@ -4,7 +4,7 @@ using namespace agnocast;
 
 void decrement_rc(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp)
 {
-  union ioctl_update_entry_args entry_args;
+  union ioctl_update_entry_args entry_args = {};
   entry_args.topic_name = topic_name.c_str();
   entry_args.subscriber_pid = getpid();
   entry_args.publisher_pid = publisher_pid;
@@ -18,7 +18,7 @@ void decrement_rc(const std::string & topic_name, uint32_t publisher_pid, uint64
 
 void increment_rc_core(const std::string & topic_name, uint32_t publisher_pid, uint64_t timestamp)
 {
-  union ioctl_update_entry_args entry_args;
+  union ioctl_update_entry_args entry_args = {};
   entry_args.topic_name = topic_name.c_str();
   entry_args.subscriber_pid = getpid();
   entry_args.publisher_pid = publisher_pid;

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -31,7 +31,7 @@ void SubscriptionBase::wait_for_new_publisher() const
 
   const std::string mq_name = create_mq_name_new_publisher(subscriber_pid_);
 
-  struct mq_attr attr;
+  struct mq_attr attr = {};
   attr.mq_flags = 0;                            // Blocking queue
   attr.mq_maxmsg = 10;                          // Maximum number of messages in the queue
   attr.mq_msgsize = sizeof(MqMsgNewPublisher);  // Maximum message size
@@ -48,7 +48,7 @@ void SubscriptionBase::wait_for_new_publisher() const
   // Create a thread that maps the areas for publishers afterwards
   auto th = std::thread([=]() {
     while (agnocast::ok()) {
-      MqMsgNewPublisher mq_msg;
+      MqMsgNewPublisher mq_msg = {};
       auto ret = mq_receive(mq, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), NULL);
       if (ret == -1) {
         RCLCPP_ERROR(logger, "mq_receive for new publisher failed: %s", strerror(errno));
@@ -73,7 +73,7 @@ union ioctl_subscriber_args SubscriptionBase::initialize(bool is_take_sub)
 
   // Register topic and subscriber info with the kernel module, and receive the publisher's shared
   // memory information along with messages needed to achieve transient local, if neccessary.
-  union ioctl_subscriber_args subscriber_args;
+  union ioctl_subscriber_args subscriber_args = {};
   subscriber_args.topic_name = topic_name_.c_str();
   subscriber_args.qos_depth = (qos_.durability() == rclcpp::DurabilityPolicy::TransientLocal)
                                 ? static_cast<uint32_t>(qos_.depth())
@@ -116,7 +116,7 @@ mqd_t open_mq_for_subscription(
   std::pair<mqd_t, std::string> & mq_subscription)
 {
   std::string mq_name = create_mq_name(topic_name, subscriber_pid);
-  struct mq_attr attr;
+  struct mq_attr attr = {};
   attr.mq_flags = 0;                        // Blocking queue
   attr.mq_msgsize = sizeof(MqMsgAgnocast);  // Maximum message size
   attr.mq_curmsgs = 0;  // Number of messages currently in the queue (not set by mq_open)


### PR DESCRIPTION
## Description

構造体を初期化しろという警告を修正しました。また、.clang-tidyファイルにコメントを書くのが良く無さそうだったので、別でドキュメントを用意しました。あと、https://github.com/tier4/agnocast/pull/304/files で消した cert-err58-cpp が復活してきたので、再度加えました :bow: 

## Related links

## How was this PR tested?

ビルドのみ

## Notes for reviewers

今後将来的に抑制しそうな警告を見つけたら、clang-tidy-suppression.mdに追記してください。