### PR TITLE
fix(agnocast_heaphook): delete dlclose

### DIFF
--- a/src/agnocast_heaphook/src/lib.rs
+++ b/src/agnocast_heaphook/src/lib.rs
@@ -121,8 +121,6 @@ static TLSF: LazyLock<Mutex<TlsfType>> = LazyLock::new(|| {
 
     let mempool_ptr: *mut c_void = unsafe { initialize_agnocast(aligned_size) };
 
-    unsafe { libc::dlclose(agnocast_lib) };
-
     let pool: &mut [MaybeUninit<u8>] = unsafe {
         std::slice::from_raw_parts_mut(mempool_ptr as *mut MaybeUninit<u8>, mempool_size)
     };


### PR DESCRIPTION
## Description

dlclose を削除しました。理由は [slack](https://star4.slack.com/archives/C07FL8616EM/p1732784394214039?thread_ts=1732771511.659719&cid=C07FL8616EM) を参照。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers
