### PR TITLE
fix(clang-tidy): hicpp-special-member-functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,9 +26,7 @@ Checks: "
   -google-build-using-namespace,
 
   hicpp-*,
-  -hicpp-member-init,
   -hicpp-vararg,
-  -hicpp-special-member-functions,
 
   misc-*,
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -166,6 +166,12 @@ static void shutdown_agnocast()
 class Cleanup
 {
 public:
+  Cleanup(const Cleanup &) = delete;
+  Cleanup & operator=(const Cleanup &) = delete;
+  Cleanup(Cleanup &&) = delete;
+  Cleanup & operator=(Cleanup &&) = delete;
+
+  Cleanup() = default;
   ~Cleanup() { shutdown_agnocast(); }
 };
 


### PR DESCRIPTION
## Description

C++の規則では、非デフォルトのデストラクタを定義すると、コピーやムーブに関連するメンバー関数が暗黙的に生成されなくなるため、それらを明示的に定義または禁止する必要があるらしく、それを修正。
https://en.cppreference.com/w/cpp/language/rule_of_three

hicpp-member-initは既に解決していたので、消しました。

## Related links

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers
