### PR TITLE
fix(ci): add modernize clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,12 @@ Checks: "
 
   misc-*,
 
+  modernize-*,
+  -modernize-avoid-bind,
+  -modernize-pass-by-value,
+  -modernize-use-nullptr,
+  -modernize-use-trailing-return-type,
+
   performance-*,
   -performance-no-int-to-ptr,
 
@@ -51,6 +57,7 @@ WarningsAsErrors: "
   google-*,
   hicpp-*,
   misc-*,
+  modernize-*,
   performance-*,
   portability-*,
   readability-*"

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -32,9 +32,9 @@ void AgnocastExecutor::prepare_epoll()
   std::lock_guard<std::mutex> lock2(rclcpp::Executor::mutex_);  // weak_groups_to_nodes_
 
   // Check if each callback's callback_group is included in this executor
-  for (auto it = id2_topic_mq_info.begin(); it != id2_topic_mq_info.end(); it++) {
-    const uint32_t topic_local_id = it->first;
-    AgnocastTopicInfo & topic_info = it->second;
+  for (auto & it : id2_topic_mq_info) {
+    const uint32_t topic_local_id = it.first;
+    AgnocastTopicInfo & topic_info = it.second;
     if (!topic_info.need_epoll_update) {
       continue;
     }


### PR DESCRIPTION
## Description

clang-tidy の modernize プレフィックスのチェックを追加しました。
```
    modernize-avoid-c-arrays
    modernize-concat-nested-namespaces
    modernize-deprecated-headers
    modernize-deprecated-ios-base-aliases
    modernize-loop-convert
    modernize-make-shared
    modernize-make-unique
    modernize-raw-string-literal
    modernize-redundant-void-arg
    modernize-replace-auto-ptr
    modernize-replace-disallow-copy-and-assign-macro
    modernize-replace-random-shuffle
    modernize-return-braced-init-list
    modernize-shrink-to-fit
    modernize-unary-static-assert
    modernize-use-auto
    modernize-use-bool-literals
    modernize-use-default-member-init
    modernize-use-emplace
    modernize-use-equals-default
    modernize-use-equals-delete
    modernize-use-nodiscard
    modernize-use-noexcept
    modernize-use-override
    modernize-use-transparent-functors
    modernize-use-uncaught-exceptions
    modernize-use-using
```

また、`modernize-loop-convert` 警告を修正しました。
```
src/agnocastlib/src/agnocast_executor.cpp:35:3: error: use range-based for loop instead [modernize-loop-convert,-warnings-as-errors]
  for (auto it = id2_topic_mq_info.begin(); it != id2_topic_mq_info.end(); it++) {
  ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      (auto & it : id2_topic_mq_info)
```

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)

## Notes for reviewers
