### PR TITLE
fix(clang-tidy): modernize-use-nullptr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks: "
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
-  -cppcoreguidelines-special-member-functions,
   -cppcoreguidelines-avoid-non-const-global-variables,
 
   google-*,
@@ -33,7 +32,6 @@ Checks: "
   modernize-*,
   -modernize-avoid-bind,
   -modernize-pass-by-value,
-  -modernize-use-nullptr,
   -modernize-use-trailing-return-type,
 
   performance-*,

--- a/docs/clang_tidy_suppression.md
+++ b/docs/clang_tidy_suppression.md
@@ -14,6 +14,14 @@ This is difficult to avoid, as it requires a major change to the implementation.
 
 In the current logic, `reinterpret-cast` is essential.
 
+## cppcoreguidelines-pro-type-vararg, hicpp-vararg
+
+These cannot be resolved while using `ioctl`.
+
+## cppcoreguidelines-pro-type-union-access
+
+This is difficult to avoid, as it prohibits the use of `union`.
+
 ## google-build-using-namespace
 
 This cannot be resolved while using gmock-global. This is due to [this issue](https://github.com/apriorit/gmock-global/issues/5).

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -46,7 +46,7 @@ void * map_area(
   if (shm_fd == -1) {
     RCLCPP_ERROR(logger, "shm_open failed: %s", strerror(errno));
     close(agnocast_fd);
-    return NULL;
+    return nullptr;
   }
 
   {
@@ -58,7 +58,7 @@ void * map_area(
     if (ftruncate(shm_fd, static_cast<off_t>(shm_size)) == -1) {
       RCLCPP_ERROR(logger, "ftruncate failed: %s", strerror(errno));
       close(agnocast_fd);
-      return NULL;
+      return nullptr;
     }
   }
 
@@ -70,7 +70,7 @@ void * map_area(
   if (ret == MAP_FAILED) {
     RCLCPP_ERROR(logger, "mmap failed: %s", strerror(errno));
     close(agnocast_fd);
-    return NULL;
+    return nullptr;
   }
 
   return ret;
@@ -81,7 +81,7 @@ void * map_writable_area(const uint32_t pid, const uint64_t shm_addr, const uint
   if (already_mapped(pid)) {
     RCLCPP_ERROR(logger, "map_writeable_area failed");
     close(agnocast_fd);
-    return NULL;
+    return nullptr;
   }
 
   return map_area(pid, shm_addr, shm_size, true);
@@ -92,7 +92,7 @@ void map_read_only_area(const uint32_t pid, const uint64_t shm_addr, const uint6
   if (already_mapped(pid)) {
     return;
   }
-  if (map_area(pid, shm_addr, shm_size, false) == NULL) {
+  if (map_area(pid, shm_addr, shm_size, false) == nullptr) {
     exit(EXIT_FAILURE);
   }
 }
@@ -102,13 +102,13 @@ void * initialize_agnocast(const uint64_t shm_size)
 {
   if (agnocast_fd >= 0) {
     RCLCPP_ERROR(logger, "Agnocast is already open");
-    return NULL;
+    return nullptr;
   }
 
   agnocast_fd = open("/dev/agnocast", O_RDWR);
   if (agnocast_fd < 0) {
     RCLCPP_ERROR(logger, "Failed to open the device: %s", strerror(errno));
-    return NULL;
+    return nullptr;
   }
 
   const uint32_t pid = getpid();
@@ -119,7 +119,7 @@ void * initialize_agnocast(const uint64_t shm_size)
   if (ioctl(agnocast_fd, AGNOCAST_NEW_SHM_CMD, &new_shm_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_NEW_SHM_CMD failed");
     close(agnocast_fd);
-    return NULL;
+    return nullptr;
   }
   return map_writable_area(pid, new_shm_args.ret_addr, shm_size);
 }

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -106,7 +106,8 @@ bool AgnocastExecutor::get_next_agnocast_executables(
   MqMsgAgnocast mq_msg = {};
 
   // non-blocking
-  auto ret = mq_receive(topic_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), NULL);
+  auto ret =
+    mq_receive(topic_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), nullptr);
   if (ret < 0) {
     if (errno != EAGAIN) {
       RCLCPP_ERROR(logger, "mq_receive failed: %s", strerror(errno));

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -49,7 +49,7 @@ void SubscriptionBase::wait_for_new_publisher() const
   auto th = std::thread([=]() {
     while (agnocast::ok()) {
       MqMsgNewPublisher mq_msg = {};
-      auto ret = mq_receive(mq, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), NULL);
+      auto ret = mq_receive(mq, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), nullptr);
       if (ret == -1) {
         RCLCPP_ERROR(logger, "mq_receive for new publisher failed: %s", strerror(errno));
         close(agnocast_fd);


### PR DESCRIPTION
## Description

`NULL` ではなく、`nullptr` を使えという警告を修正。その他既に解決されている警告の削除及び、解決困難な警告の追記。

## Related links

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers
