### PR TITLE
fix(clang-tidy): modernize-avoid-bind

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,6 @@ Checks: "
   misc-*,
 
   modernize-*,
-  -modernize-avoid-bind,
   -modernize-pass-by-value,
   -modernize-use-nullptr,
   -modernize-use-trailing-return-type,

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -50,12 +50,12 @@ void MultiThreadedAgnocastExecutor::spin()
     std::lock_guard wait_lock{wait_mutex_};
 
     for (size_t i = 0; i < number_of_ros2_threads_ - 1; i++) {
-      auto func = std::bind(&MultiThreadedAgnocastExecutor::ros2_spin, this);
+      auto func = [this] { ros2_spin(); };
       threads.emplace_back(func);
     }
 
     for (size_t i = 0; i < number_of_agnocast_threads_; i++) {
-      auto func = std::bind(&MultiThreadedAgnocastExecutor::agnocast_spin, this);
+      auto func = [this] { agnocast_spin(); };
       threads.emplace_back(func);
     }
   }


### PR DESCRIPTION
## Description

`std::bind` ではなく、ラムダ式を使えという警告の修正。

## Related links

## How was this PR tested?

- [x] sample application (required)

## Notes for reviewers
