### PR TITLE
fix: add maybe_unused

### DIFF
--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -46,8 +46,8 @@ public:
   using SharedPtr = std::shared_ptr<Publisher<MessageT>>;
 
   Publisher(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node, const std::string & topic_name,
-    const rclcpp::QoS & qos)
+    [[maybe_unused]] rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node, /* for CARET */
+    const std::string & topic_name, const rclcpp::QoS & qos)
   : topic_name_(topic_name), publisher_pid_(getpid()), qos_(qos)
   {
     initialize_publisher(publisher_pid_, topic_name_);


### PR DESCRIPTION
## Description

agnocast適用Autowareで `error: unused parameter ‘node’ [-Werror=unused-parameter]` のエラーが出ないように修正しました。

## Related links

https://star4.slack.com/archives/C07FL8616EM/p1736316546129739

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required) -> ビルドエラーが出ないことを確認

## Notes for reviewers
