### PR TITLE
feat(agnocastlib): allow process-internal Agnocast communication

### DIFF
--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -94,18 +94,7 @@ union ioctl_subscriber_args SubscriptionBase::initialize(bool is_take_sub)
 
   for (uint32_t i = 0; i < subscriber_args.ret_publisher_num; i++) {
     if (static_cast<pid_t>(subscriber_args.ret_pids[i]) == subscriber_pid_) {
-      /*
-       * NOTE: In ROS2, communication should work fine even if the same process exists as both a
-       * publisher and a subscriber for a given topic. However, in Agnocast, to avoid applying
-       * Agnocast to topic communication within a component container, the system will explicitly
-       * fail with an error during initialization.
-       */
-      RCLCPP_ERROR(
-        logger,
-        "This process (pid=%d) already exists in the topic (topic_name=%s) "
-        "as a publisher.",
-        subscriber_pid_, topic_name_.c_str());
-      exit(EXIT_FAILURE);
+      continue;
     }
     const uint32_t pid = subscriber_args.ret_pids[i];
     const uint64_t addr = subscriber_args.ret_shm_addrs[i];


### PR DESCRIPTION
## Description

同一プロセス内での Agnocast 通信を可能にしました。

## Related links

[TIER IV INTERNAL](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3450535971/Publisher+Subscription)

## How was this PR tested?

- [x] sample application (required)
プロセス内通信するような pub/sub を追加しました。

- [x] Autoware (required)
現状の適用箇所にプロセス内での Agnocast 通信は存在しないので、既存の適用箇所が従来どおり動いているかのみ確認しました。

## Notes for reviewers
