### PR TITLE
fix: decrement borrowed_publisher_num before ros2 publish

### DIFF
--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -97,14 +97,18 @@ public:
       exit(EXIT_FAILURE);
     }
 
+    publish_core(topic_name_, publisher_pid_, message.get_timestamp(), opened_mqs_);
+    // We need to decrement borrowed_publisher_num before ros2_publish, otherwise the buffers used
+    // for ROS2 serialization will also use shared memory. Since we don't need to store any
+    // additional data in shared memory after the agnocast publish operation, here is the ideal
+    // point to decrement.
+    decrement_borrowed_publisher_num();
+
     if (do_always_ros2_publish_ || ros2_publisher_->get_subscription_count() > 0) {
       const MessageT * raw = message.get();
       ros2_publisher_->publish(*raw);
     }
-
-    publish_core(topic_name_, publisher_pid_, message.get_timestamp(), opened_mqs_);
     message.reset();
-    decrement_borrowed_publisher_num();
   }
 
   uint32_t get_subscription_count() const


### PR DESCRIPTION
## Description
borrowed_publisher_numのデクリメントはros2 publishよりも前に行うことで、ros2 publish時に起きるシリアライゼーション等のメモリの確保が共有メモリ上に行われてしまうのを避けるようにしました。

## Related links

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers