### PR TITLE
refactor: uninstall agnocast_heaphook before test_and_create_report 

### DIFF
--- a/scripts/test_and_create_report
+++ b/scripts/test_and_create_report
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Remove agnocast-heaphook if it is installed, for unit tests
-HEAP_HOOK_FOUND=0
+HEAPHOOK_FOUND=0
 if ls "/usr/lib/" | grep -q "libagnocast_heaphook.so"; then
     sudo apt-get -y remove agnocast-heaphook
-    HEAP_HOOK_FOUND=1
+    HEAPHOOK_FOUND=1
 fi
 
 rm -rf build install log
@@ -18,7 +18,7 @@ rm -rf coverage.info coverage_filtered.info
 echo "Please open coverage_report_agnocastlib/index.html"
 
 # Reinstall agnocast-heaphook if it was installed
-if [ $HEAP_HOOK_FOUND -eq 1 ]; then
+if [ $HEAPHOOK_FOUND -eq 1 ]; then
     cd src/agnocast_heaphook
     cargo deb --install
 fi


### PR DESCRIPTION
## Description

agnocast-heaphookがインストールされている、かつ、kmodがinsmodされていない状態だと、単体テストがfailしてしまうので、もしagnocast-heaphookがインストールされている場合は

1. uninstall
2. テスト実行
3. 再install

となるようにスクリプトを修正しました。ついでにテスト結果の詳細もコンソールに出るようにしました。

## Related links

https://star4.slack.com/archives/C07FL8616EM/p1738287186688019

## How was this PR tested?

ローカルで動作確認。

## Notes for reviewers
