### PR TITLE
fix: delete sub_info in remove_all_topics

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1459,6 +1459,15 @@ static void remove_all_topics(void)
       kfree(pub_info);
     }
 
+    struct subscriber_info * sub_info;
+    int bkt_sub_info;
+    struct hlist_node * tmp_sub_info;
+    hash_for_each_safe(wrapper->topic.sub_info_htable, bkt_sub_info, tmp_sub_info, sub_info, node)
+    {
+      hash_del(&sub_info->node);
+      kfree(sub_info);
+    }
+
     hash_del(&wrapper->node);
     kfree(wrapper->key);
     kfree(wrapper);


### PR DESCRIPTION
## Description
remove_all_topics()時にsubscriber_infoの解放がされておらず、メモリリークが起きていたのでその修正。

## Related links
[Tier IV Internal Slack
](https://star4.slack.com/archives/C07FL8616EM/p1737514580700109)

## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)

## Notes for reviewers
