### PR TITLE
fix(kmod): return type mismatch (unsigned to signed)

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -895,7 +895,7 @@ static int publisher_add(
   return 0;
 }
 
-static uint64_t release_msgs_to_meet_depth(
+static int release_msgs_to_meet_depth(
   struct topic_wrapper * wrapper, struct publisher_info * pub_info, const uint32_t qos_depth,
   union ioctl_enqueue_and_release_args * ioctl_ret)
 {
@@ -977,7 +977,7 @@ static uint64_t release_msgs_to_meet_depth(
   return 0;
 }
 
-static uint64_t enqueue_and_release(
+static int enqueue_and_release(
   const char * topic_name, const topic_local_id_t publisher_id, const uint32_t qos_depth,
   const uint64_t msg_virtual_address, const uint64_t timestamp,
   union ioctl_enqueue_and_release_args * ioctl_ret)


### PR DESCRIPTION
## Description

Fixed incorrect unsigned return type for functions with potential negative values

## Related links

## How was this PR tested?

No

- [ ] sample application (required)
- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub`
- [ ] `bash scripts/e2e_test_2to2`

## Notes for reviewers
