### PR TITLE
test: fix not to check messages order in ROS 2 sub

### DIFF
--- a/src/e2e_test/test/test_1to1_with_ros2sub.py
+++ b/src/e2e_test/test/test_1to1_with_ros2sub.py
@@ -212,7 +212,7 @@ class Test1To1(unittest.TestCase):
         with launch_testing.asserts.assertSequentialStdout(proc_output, process=test_ros2_sub) as cm:
             stdout_content = "".join(cm._output)
 
-            # In ROS 2 subscription, not check the order of messages received
+            # No checking of the order of messages received in ROS 2 subscription
             for i in range(EXPECT_INIT_PUB_NUM - EXPECT_INIT_ROS2_SUB_NUM, EXPECT_ROS2_SUB_NUM):
                 self.assertIn(f"Receiving {i}.", stdout_content)
             self.assertIn("All messages received. Shutting down.", stdout_content)


### PR DESCRIPTION
## Description

https://star4.slack.com/archives/C07FL8616EM/p1738645049888409

## Related links

## How was this PR tested?

- [ ] sample application (required)
- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub`
- [ ] `bash scripts/e2e_test_2to2`

## Notes for reviewers
