### PR TITLE
fix: decrement_borrowed_publisher_num before calling publish_core

### DIFF
--- a/src/agnocastlib/include/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast_publisher.hpp
@@ -84,13 +84,13 @@ public:
 
   void publish(ipc_shared_ptr<MessageT> && message)
   {
-    decrement_borrowed_publisher_num();
-
     if (!message || topic_name_ != message.get_topic_name()) {
       RCLCPP_ERROR(logger, "Invalid message to publish.");
       close(agnocast_fd);
       exit(EXIT_FAILURE);
     }
+
+    decrement_borrowed_publisher_num();
 
     const union ioctl_publish_args publish_args = publish_core(
       topic_name_, id_, static_cast<uint32_t>(qos_.depth()),


### PR DESCRIPTION
## Description
publish_coreでの実行後にdecrement_borrowed_publisher_numをするような実装になっていましたが、実際はpublish_core内で確保されるメモリを共有メモリにする必要はないのでpublish()直後に移動させる修正です。

## Related links
[TIER IV Internal Slack
](https://star4.slack.com/archives/C07FL8616EM/p1738228254517849)
## How was this PR tested?

- [x] sample application (required)
- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub`
- [x] `bash scripts/e2e_test_2to2`

## Notes for reviewers
