### PR TITLE
fix(kmod): fix is_subscriber_referencing bug

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -260,7 +260,7 @@ static struct publisher_info * insert_publisher_info(
 static bool is_subscriber_referencing(struct entry_node * en)
 {
   // The referencing_subscriber_ids array is always populated starting from the smallest index.
-  // Therefore, an empty element at index 0 is equivalent to a non-existent referencing subscriber.
+  // Therefore, the value -1 at index 0 is equivalent to a non-existent referencing subscriber.
   return (en->referencing_subscriber_ids[0] != -1);
 }
 


### PR DESCRIPTION
## Description

Fixed `is_subscriber_referencing` bug and updated its comment.

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub`
- [x] `bash scripts/e2e_test_2to2`

## Notes for reviewers
