### PR TITLE
fix: remove unnecessary ret in ioctl_update_entry_arg

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1143,7 +1143,7 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
   mutex_lock(&global_mutex);
   int ret = 0;
   char topic_name_buf[256];
-  union ioctl_update_entry_args entry_args;
+  struct ioctl_update_entry_args entry_args;
 
   switch (cmd) {
     case AGNOCAST_SUBSCRIBER_ADD_CMD:
@@ -1172,7 +1172,7 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
       break;
     case AGNOCAST_INCREMENT_RC_CMD:
       if (copy_from_user(
-            &entry_args, (union ioctl_update_entry_args __user *)arg, sizeof(entry_args)))
+            &entry_args, (struct ioctl_update_entry_args __user *)arg, sizeof(entry_args)))
         goto unlock_mutex_and_return;
       if (copy_from_user(
             topic_name_buf, (char __user *)entry_args.topic_name, sizeof(topic_name_buf)))
@@ -1182,7 +1182,7 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
       break;
     case AGNOCAST_DECREMENT_RC_CMD:
       if (copy_from_user(
-            &entry_args, (union ioctl_update_entry_args __user *)arg, sizeof(entry_args)))
+            &entry_args, (struct ioctl_update_entry_args __user *)arg, sizeof(entry_args)))
         goto unlock_mutex_and_return;
       if (copy_from_user(
             topic_name_buf, (char __user *)entry_args.topic_name, sizeof(topic_name_buf)))

--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -47,14 +47,11 @@ union ioctl_publisher_args {
   };
 };
 
-union ioctl_update_entry_args {
-  struct
-  {
-    const char * topic_name;
-    topic_local_id_t subscriber_id;
-    int64_t entry_id;
-  };
-  uint64_t ret;
+struct ioctl_update_entry_args
+{
+  const char * topic_name;
+  topic_local_id_t subscriber_id;
+  int64_t entry_id;
 };
 
 union ioctl_receive_msg_args {
@@ -121,8 +118,8 @@ union ioctl_get_subscriber_num_args {
 
 #define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW('S', 1, union ioctl_subscriber_args)
 #define AGNOCAST_PUBLISHER_ADD_CMD _IOW('P', 1, union ioctl_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, union ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, union ioctl_update_entry_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, struct ioctl_update_entry_args)
 #define AGNOCAST_RECEIVE_MSG_CMD _IOW('M', 3, union ioctl_receive_msg_args)
 #define AGNOCAST_PUBLISH_MSG_CMD _IOW('M', 4, union ioctl_publish_args)
 #define AGNOCAST_TAKE_MSG_CMD _IOW('M', 5, union ioctl_take_msg_args)

--- a/src/agnocastlib/include/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast_ioctl.hpp
@@ -61,14 +61,11 @@ union ioctl_publisher_args {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
-union ioctl_update_entry_args {
-  struct
-  {
-    const char * topic_name;
-    topic_local_id_t subscriber_id;
-    int64_t entry_id;
-  };
-  uint64_t ret;
+struct ioctl_update_entry_args
+{
+  const char * topic_name;
+  topic_local_id_t subscriber_id;
+  int64_t entry_id;
 };
 #pragma GCC diagnostic pop
 
@@ -148,8 +145,8 @@ union ioctl_get_subscriber_num_args {
 
 #define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW('S', 1, union ioctl_subscriber_args)
 #define AGNOCAST_PUBLISHER_ADD_CMD _IOW('P', 1, union ioctl_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, union ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, union ioctl_update_entry_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, struct ioctl_update_entry_args)
 #define AGNOCAST_RECEIVE_MSG_CMD _IOW('M', 3, union ioctl_receive_msg_args)
 #define AGNOCAST_PUBLISH_MSG_CMD _IOW('M', 4, union ioctl_publish_args)
 #define AGNOCAST_TAKE_MSG_CMD _IOW('M', 5, union ioctl_take_msg_args)

--- a/src/agnocastlib/src/agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/src/agnocast_smart_pointer.cpp
@@ -6,7 +6,7 @@ namespace agnocast
 void decrement_rc(
   const std::string & topic_name, const topic_local_id_t subscriber_id, const int64_t entry_id)
 {
-  union ioctl_update_entry_args entry_args = {};
+  struct ioctl_update_entry_args entry_args = {};
   entry_args.topic_name = topic_name.c_str();
   entry_args.subscriber_id = subscriber_id;
   entry_args.entry_id = entry_id;
@@ -20,7 +20,7 @@ void decrement_rc(
 void increment_rc_core(
   const std::string & topic_name, const topic_local_id_t subscriber_id, const int64_t entry_id)
 {
-  union ioctl_update_entry_args entry_args = {};
+  struct ioctl_update_entry_args entry_args = {};
   entry_args.topic_name = topic_name.c_str();
   entry_args.subscriber_id = subscriber_id;
   entry_args.entry_id = entry_id;


### PR DESCRIPTION
## Description

Removed unnecessary `uint64_t ret;` field in `ioctl_update_entry_args`.

## Related links

## How was this PR tested?

- [x] sample application (required)
- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub`
- [x] `bash scripts/e2e_test_2to2`

## Notes for reviewers
