### PR TITLE
fix(agnocastlib): remove unnecessary mq

### DIFF
--- a/src/agnocastlib/include/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast_mq.hpp
@@ -1,16 +1,7 @@
 #pragma once
 
-#include <cstdint>
-
 namespace agnocast
 {
-
-struct MqMsgNewPublisher
-{
-  pid_t publisher_pid;
-  uint64_t shm_addr;
-  uint64_t shm_size;
-};
 
 struct MqMsgAgnocast
 {


### PR DESCRIPTION
## Description

Removed `MqMsgNewPublisher`, which is no longer used.

## Related links

`MqMsgNewPublisher` became unused in https://github.com/tier4/agnocast/pull/359

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
