### PR TITLE
feat(kunit): divide agnocast exit

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -1753,26 +1753,47 @@ static void remove_all_process_info(void)
   }
 }
 
-static void agnocast_exit(void)
+static void agnocast_exit_free_data(void)
 {
   mutex_lock(&global_mutex);
   remove_all_topics();
   remove_all_process_info();
   mutex_unlock(&global_mutex);
+}
 
-  dev_info(agnocast_device, "Agnocast removed!\n");
-
+static void agnocast_exit_sysfs(void)
+{
   // Decrement reference count
   kobject_put(status_kobj);
+}
 
+static void agnocast_exit_kthread(void)
+{
+  wake_up_interruptible(&worker_wait);
+  kthread_stop(worker_task);
+}
+
+static void agnocast_exit_kprobe(void)
+{
+  unregister_kprobe(&kp);
+}
+
+static void agnocast_exit_device(void)
+{
   device_destroy(agnocast_class, MKDEV(major, 0));
   class_destroy(agnocast_class);
   unregister_chrdev(major, "agnocast");
+}
 
-  wake_up_interruptible(&worker_wait);
-  kthread_stop(worker_task);
+static void agnocast_exit(void)
+{
+  agnocast_exit_sysfs();
+  agnocast_exit_kthread();
+  agnocast_exit_kprobe();
 
-  unregister_kprobe(&kp);
+  agnocast_exit_free_data();
+  dev_info(agnocast_device, "Agnocast removed!\n");
+  agnocast_exit_device();
 }
 
 module_init(agnocast_init) module_exit(agnocast_exit)


### PR DESCRIPTION
## Description
背景はドキュメントを参考に。
データ構造のfreeは、未来の実装で解放忘れが発生しないように、なるべく最後にまわした。

## Related links
[TIER IV internal document](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3513517457)

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
