### PR TITLE
feat(agnocastlib): implement copy assignment operator

### DIFF
--- a/src/agnocastlib/include/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast_smart_pointer.hpp
@@ -35,7 +35,6 @@ class ipc_shared_ptr
   int64_t entry_id_ = -1;
 
   // Unimplemented operators. If these are called, a compile error is raised.
-  ipc_shared_ptr & operator=(const ipc_shared_ptr & r) = delete;
   bool operator==(const ipc_shared_ptr & r) const = delete;
   bool operator!=(const ipc_shared_ptr & r) const = delete;
 
@@ -43,6 +42,7 @@ public:
   using element_type = T;
 
   const std::string get_topic_name() const { return topic_name_; }
+  topic_local_id_t get_pubsub_id() const { return pubsub_id_; }
   int64_t get_entry_id() const { return entry_id_; }
   void set_entry_id(const int64_t entry_id) { entry_id_ = entry_id; }
 
@@ -66,6 +66,19 @@ public:
   : ptr_(r.ptr_), topic_name_(r.topic_name_), pubsub_id_(r.pubsub_id_), entry_id_(r.entry_id_)
   {
     increment_rc(topic_name_, pubsub_id_, entry_id_);
+  }
+
+  ipc_shared_ptr & operator=(const ipc_shared_ptr & r)
+  {
+    if (this != &r) {
+      reset();
+      ptr_ = r.ptr_;
+      topic_name_ = r.topic_name_;
+      pubsub_id_ = r.pubsub_id_;
+      entry_id_ = r.entry_id_;
+      increment_rc(topic_name_, pubsub_id_, entry_id_);
+    }
+    return *this;
   }
 
   ipc_shared_ptr(ipc_shared_ptr && r)

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -194,6 +194,59 @@ TEST_F(AgnocastSmartPointerTest, copy_constructor_empty)
   EXPECT_NO_THROW(agnocast::ipc_shared_ptr<int> sut2{sut});
 }
 
+TEST_F(AgnocastSmartPointerTest, copy_assignment_normal)
+{
+  int * ptr = new int(0);
+  int * ptr2 = new int(1);
+  std::string dummy_tn2 = "dummy2";
+  topic_local_id_t dummy_pubsub_id2 = 2;
+  int64_t dummy_entry_id2 = 3;
+
+  EXPECT_GLOBAL_CALL(
+    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
+    .Times(1);
+  EXPECT_GLOBAL_CALL(
+    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
+    .Times(2);
+  EXPECT_GLOBAL_CALL(
+    increment_rc_mock, increment_rc_mock(dummy_tn2, dummy_pubsub_id2, dummy_entry_id2))
+    .Times(0);
+  EXPECT_GLOBAL_CALL(
+    decrement_rc_mock, decrement_rc_mock(dummy_tn2, dummy_pubsub_id2, dummy_entry_id2))
+    .Times(1);
+
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+  agnocast::ipc_shared_ptr<int> sut2{ptr2, dummy_tn2, dummy_pubsub_id2, dummy_entry_id2};
+
+  sut2 = sut;
+
+  EXPECT_EQ(ptr, sut2.get());
+  EXPECT_EQ(dummy_tn, sut2.get_topic_name());
+  EXPECT_EQ(dummy_pubsub_id, sut2.get_pubsub_id());
+  EXPECT_EQ(dummy_entry_id, sut2.get_entry_id());
+}
+
+TEST_F(AgnocastSmartPointerTest, copy_assignment_self)
+{
+  int * ptr = new int(0);
+
+  EXPECT_GLOBAL_CALL(
+    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
+    .Times(0);
+  EXPECT_GLOBAL_CALL(
+    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
+    .Times(1);
+
+  agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+
+  sut = sut;
+
+  EXPECT_EQ(ptr, sut.get());
+  EXPECT_EQ(dummy_tn, sut.get_topic_name());
+  EXPECT_EQ(dummy_pubsub_id, sut.get_pubsub_id());
+  EXPECT_EQ(dummy_entry_id, sut.get_entry_id());
+}
+
 TEST_F(AgnocastSmartPointerTest, move_constructor_normal)
 {
   int * ptr = new int(0);


### PR DESCRIPTION
## Description

Added copy assignment operator of ipc_shared_ptr.

## Related links

## How was this PR tested?

Skipped all tests since all of them do not use copy assignment operator currently.

Instead, I wrote a brief sample app to call copy assignment in sample listener, and it worked:
```
  void callback(const agnocast::ipc_shared_ptr<sample_interfaces::msg::DynamicSizeArray> & message)
  {
    agnocast::ipc_shared_ptr<sample_interfaces::msg::DynamicSizeArray> msg;
    msg = message;
    RCLCPP_INFO(this->get_logger(), "subscribe message: id=%ld", msg->id);
  }
```

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
