### PR TITLE
improve: add warning if next_exec_timeout_ms is large

### DIFF
--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -11,6 +11,13 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
   const rclcpp::ExecutorOptions & options, int next_exec_timeout_ms)
 : agnocast::AgnocastExecutor(options), next_exec_timeout_ms_(next_exec_timeout_ms)
 {
+  const int next_exec_timeout_ms_threshold = 500;  // Rough value
+  if (next_exec_timeout_ms_ > next_exec_timeout_ms_threshold) {
+    RCLCPP_WARN(
+      logger,
+      "Due to the large next_exec_timeout_ms value, the callbacks registered after spin and ROS 2 "
+      "callbacks may be extremely slow to execute.");
+  }
 }
 
 void SingleThreadedAgnocastExecutor::spin()


### PR DESCRIPTION
## Description

https://star4.slack.com/archives/C07FL8616EM/p1740458748816689

## Related links

## How was this PR tested?

警告の追加のみなので、テストしていません。

## Notes for reviewers

しきい値はエイヤで決めました。
