### PR TITLE
chore: suppress readability-avoid-const-params-in-decls

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,7 +38,8 @@ Checks: "
 
   readability-*,
   -readability-function-cognitive-complexity,
-  -readability-identifier-length"
+  -readability-identifier-length,
+  -readability-avoid-const-params-in-decls"
 
 WarningsAsErrors: "
   bugprone-*,

--- a/docs/clang_tidy_suppression.md
+++ b/docs/clang_tidy_suppression.md
@@ -50,6 +50,10 @@ This is a bit excessive, such as
         ^
 ```
 
+## readability-avoid-const-params-in-decls
+
+We think it is better for a function declaration to convey the function's exact signature.
+
 ## TODO
 
 - [ ] cert-err58-cpp


### PR DESCRIPTION
## Description

> Parameter 'publisher_pid' is const-qualified in the function declaration; const-qualification of parameters only has an effect in function definitions

このようなエラーが出ないようにします。

## Related links
- [readability-avoid-const-params-in-decls - clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
