### PR TITLE
fix: error handling when subscriber qos_depth is larger than MAX_QOS_DEPTH

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -171,6 +171,15 @@ static int insert_subscriber_info(
   const uint32_t qos_depth, const bool qos_is_transient_local, const bool is_take_sub,
   struct subscriber_info ** new_info)
 {
+  if (qos_depth > MAX_QOS_DEPTH) {
+    dev_warn(
+      agnocast_device,
+      "Subscriber's (topic_local_id=%s, pid=%d, qos_depth=%d) qos_depth can't be larger than "
+      "MAX_QOS_DEPTH(=%d). (insert_subscriber_info)\n",
+      wrapper->key, subscriber_pid, qos_depth, MAX_QOS_DEPTH);
+    return -EINVAL;
+  }
+
   int count = get_size_sub_info_htable(wrapper);
   if (count == MAX_SUBSCRIBER_NUM) {
     dev_warn(
@@ -199,14 +208,6 @@ static int insert_subscriber_info(
 
   (*new_info)->id = new_id;
   (*new_info)->pid = subscriber_pid;
-  if (qos_depth > MAX_QOS_DEPTH) {
-    dev_warn(
-      agnocast_device,
-      "Subscriber's (topic_local_id=%s, pid=%d, qos_depth=%d) qos_depth can't be larger than "
-      "MAX_QOS_DEPTH(=%d). (insert_subscriber_info)\n",
-      wrapper->key, subscriber_pid, qos_depth, MAX_QOS_DEPTH);
-    return -EINVAL;
-  }
   (*new_info)->qos_depth = qos_depth;
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
   (*new_info)->latest_received_entry_id = wrapper->current_entry_id++;


### PR DESCRIPTION
## Description
I've implemented error handling for the case where the number of receiving messages exceeds MAX_QOS_DEPTH in receive_and_check_new_publisher and subscriber_add . The root cause of the issue is not the lack of error handling at this point, but rather that we can prevent this problem by ensuring the subscriber's qos_depth doesn't exceed MAX_QOS_DEPTH, which is what my implementation addresses.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
Since this doesn't seem to affect Autoware behavior, I skipped the test.