### PR TITLE
fix(kmod): fix comment for MAX_RELEASE_NUM

### DIFF
--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -6,7 +6,7 @@
 #define MAX_PUBLISHER_NUM 4   // At least 4 is required for sample application
 #define MAX_SUBSCRIBER_NUM 8  // At least 6 is required for pointcloud topic in Autoware
 #define MAX_QOS_DEPTH 10      // Maximum depth of transient local usage part in Autoware
-#define MAX_RELEASE_NUM 3     // Max to keep union size equal to 32 bytes
+#define MAX_RELEASE_NUM 3     // Maximum number of entry_nodes that can be released at once
 #define MAX_MAP_NUM 8         // Max number of read-only shared memory regions mappable per process
 
 typedef int32_t topic_local_id_t;


### PR DESCRIPTION
## Description
Fixed comment for MAX_RELEASE_NUM since it is no longer true.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
