### PR TITLE
fix: checking spinning in MultiThreadedAgnocastExecutor

### DIFF
--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -76,6 +76,9 @@ void MultiThreadedAgnocastExecutor::ros2_spin()
     {
       std::lock_guard wait_lock{wait_mutex_};
 
+      if (!rclcpp::ok(this->context_) || !spinning.load()) {
+        return;
+      }
       if (!get_next_executable(any_executable, ros2_next_exec_timeout_)) {
         continue;
       }
@@ -102,6 +105,10 @@ void MultiThreadedAgnocastExecutor::agnocast_spin()
     }
 
     agnocast::AgnocastExecutables agnocast_executables;
+
+    if (!rclcpp::ok(this->context_) || !spinning.load()) {
+      return;
+    }
 
     // Unlike a single-threaded executor, in a multi-threaded executor, each thread is dedicated to
     // handling either ROS 2 callbacks or Agnocast callbacks exclusively.

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -70,15 +70,12 @@ void MultiThreadedAgnocastExecutor::spin()
 
 void MultiThreadedAgnocastExecutor::ros2_spin()
 {
-  while (true) {
+  while (rclcpp::ok(this->context_) && spinning.load()) {
     rclcpp::AnyExecutable any_executable;
 
     {
       std::lock_guard wait_lock{wait_mutex_};
 
-      if (!rclcpp::ok(this->context_)) {
-        return;
-      }
       if (!get_next_executable(any_executable, ros2_next_exec_timeout_)) {
         continue;
       }
@@ -99,16 +96,12 @@ void MultiThreadedAgnocastExecutor::ros2_spin()
 
 void MultiThreadedAgnocastExecutor::agnocast_spin()
 {
-  while (true) {
+  while (rclcpp::ok(this->context_) && spinning.load()) {
     if (need_epoll_updates.exchange(false)) {
       prepare_epoll();
     }
 
     agnocast::AgnocastExecutables agnocast_executables;
-
-    if (!rclcpp::ok(this->context_)) {
-      return;
-    }
 
     // Unlike a single-threaded executor, in a multi-threaded executor, each thread is dedicated to
     // handling either ROS 2 callbacks or Agnocast callbacks exclusively.


### PR DESCRIPTION
## Description

MultiThreadedAgnocastExecutorのspin()内で、spinning変数のチェックが漏れていたので追加しました。また、チェック方法をSingleThreadedAgnocastExecutorと揃えました。

https://github.com/tier4/agnocast/blob/3db26d5181ab6e8de126098701b04c0d9d664a96/src/agnocastlib/src/agnocast_single_threaded_executor.cpp#L35

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
