### PR TITLE
fix(kmod): update kernel module macros

### DIFF
--- a/kmod/agnocast.c
+++ b/kmod/agnocast.c
@@ -26,6 +26,9 @@ static DEFINE_MUTEX(global_mutex);
 // Maximum number of referencing Publisher/Subscriber per entry: +1 for the publisher
 #define MAX_REFERENCING_PUBSUB_NUM_PER_ENTRY (MAX_SUBSCRIBER_NUM + 1)
 
+// Maximum number of read-only shared memory regions mappable per process
+#define MAX_MAP_NUM 8
+
 // Maximum length of topic name: 256 characters
 #define TOPIC_NAME_BUFFER_SIZE 256
 #define NODE_NAME_BUFFER_SIZE 256

--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -2,12 +2,11 @@
 
 #include <linux/types.h>
 
-// TODO: should be made larger when applied for Autoware
-#define MAX_PUBLISHER_NUM 4   // At least 4 is required for sample application
-#define MAX_SUBSCRIBER_NUM 8  // At least 6 is required for pointcloud topic in Autoware
-#define MAX_QOS_DEPTH 10      // Maximum depth of transient local usage part in Autoware
-#define MAX_RELEASE_NUM 3     // Maximum number of entry_nodes that can be released at once
-#define MAX_MAP_NUM 8         // Max number of read-only shared memory regions mappable per process
+#define MAX_PUBLISHER_NUM 4   // Maximum number of publishers per topic
+#define MAX_SUBSCRIBER_NUM 8  // Maximum number of subscribers per topic
+#define MAX_QOS_DEPTH 10      // Maximum QoS depth for each publisher/subscriber
+#define MAX_RELEASE_NUM 3     // Maximum number of entries that can be released at one ioctl
+#define MAX_MAP_NUM 8         // Maximum number of read-only shared memory regions mappable per process
 
 typedef int32_t topic_local_id_t;
 struct publisher_shm_info

--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -6,7 +6,6 @@
 #define MAX_SUBSCRIBER_NUM 16  // Maximum number of subscribers per topic
 #define MAX_QOS_DEPTH 10       // Maximum QoS depth for each publisher/subscriber
 #define MAX_RELEASE_NUM 3      // Maximum number of entries that can be released at one ioctl
-#define MAX_MAP_NUM 8  // Maximum number of read-only shared memory regions mappable per process
 
 typedef int32_t topic_local_id_t;
 struct publisher_shm_info

--- a/kmod/agnocast.h
+++ b/kmod/agnocast.h
@@ -2,11 +2,11 @@
 
 #include <linux/types.h>
 
-#define MAX_PUBLISHER_NUM 4   // Maximum number of publishers per topic
-#define MAX_SUBSCRIBER_NUM 8  // Maximum number of subscribers per topic
-#define MAX_QOS_DEPTH 10      // Maximum QoS depth for each publisher/subscriber
-#define MAX_RELEASE_NUM 3     // Maximum number of entries that can be released at one ioctl
-#define MAX_MAP_NUM 8         // Maximum number of read-only shared memory regions mappable per process
+#define MAX_PUBLISHER_NUM 4    // Maximum number of publishers per topic
+#define MAX_SUBSCRIBER_NUM 16  // Maximum number of subscribers per topic
+#define MAX_QOS_DEPTH 10       // Maximum QoS depth for each publisher/subscriber
+#define MAX_RELEASE_NUM 3      // Maximum number of entries that can be released at one ioctl
+#define MAX_MAP_NUM 8  // Maximum number of read-only shared memory regions mappable per process
 
 typedef int32_t topic_local_id_t;
 struct publisher_shm_info

--- a/src/agnocastlib/include/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast_ioctl.hpp
@@ -12,7 +12,6 @@ namespace agnocast
 #define MAX_SUBSCRIBER_NUM 16  // Maximum number of subscribers per topic
 #define MAX_QOS_DEPTH 10       // Maximum QoS depth for each publisher/subscriber
 #define MAX_RELEASE_NUM 3      // Maximum number of entries that can be released at one ioctl
-#define MAX_MAP_NUM 8  // Maximum number of read-only shared memory regions mappable per process
 
 using topic_local_id_t = int32_t;
 struct publisher_shm_info

--- a/src/agnocastlib/include/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast_ioctl.hpp
@@ -8,11 +8,11 @@
 namespace agnocast
 {
 
-// TODO: should be made larger when applied for Autoware
-#define MAX_PUBLISHER_NUM 4   // At least 4 is required for sample application
-#define MAX_SUBSCRIBER_NUM 8  // At least 6 is required for pointcloud topic in Autoware
-#define MAX_QOS_DEPTH 10      // Maximum depth of transient local usage part in Autoware
-#define MAX_RELEASE_NUM 3     // Max to keep union size equal to 32 bytes
+#define MAX_PUBLISHER_NUM 4    // Maximum number of publishers per topic
+#define MAX_SUBSCRIBER_NUM 16  // Maximum number of subscribers per topic
+#define MAX_QOS_DEPTH 10       // Maximum QoS depth for each publisher/subscriber
+#define MAX_RELEASE_NUM 3      // Maximum number of entries that can be released at one ioctl
+#define MAX_MAP_NUM 8  // Maximum number of read-only shared memory regions mappable per process
 
 using topic_local_id_t = int32_t;
 struct publisher_shm_info


### PR DESCRIPTION
## Description

- updated `MAX_SUBSCRIBER_NUM` from 8 to 16, considering Autoware topics
- updated comments for `MAX_...` macros
- moved `MAX_MAP_NUM` from header to .c file

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
