### PR TITLE
Build kmod under colcon

### DIFF
--- a/kmod/CMakeLists.txt
+++ b/kmod/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+project(agnocast_kmod)
+
+find_package(ament_cmake REQUIRED)
+
+set(KMOD_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(KMOD_OUTPUT ${KMOD_SRC_DIR}/agnocast.ko)
+
+add_custom_target(build_agnocast_kmod ALL
+  COMMAND make -C ${KMOD_SRC_DIR}
+  BYPRODUCTS ${KMOD_OUTPUT}
+  WORKING_DIRECTORY ${KMOD_SRC_DIR}
+  COMMENT "Building agnocast kernel module"
+)
+
+# Install the module inside colcon install directory instead of system directories
+install(FILES ${KMOD_OUTPUT}
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/kmod/package.xml
+++ b/kmod/package.xml
@@ -1,0 +1,10 @@
+<package format="3">
+  <name>agnocast_kmod</name>
+  <version>0.0.0</version>
+  <description>Agnocast kernel module</description>
+  <maintainer email="sykwer@gmail.com">sykwer</maintainer>
+  <license>Dual BSD/GPL</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>colcon-cmake</exec_depend>
+</package>

--- a/scripts/build_all
+++ b/scripts/build_all
@@ -1,7 +1,4 @@
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-cd kmod
-make
-
-cd ../src/agnocast_heaphook
+cd ./src/agnocast_heaphook
 cargo deb --install


### PR DESCRIPTION
## Description
apt packageとして配布するために、colconのビルドシステム下でビルドする必要がある。

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application
- [x] `bash scripts/build_all`

## Notes for reviewers
