### PR TITLE
Build heaphook under colcon

### DIFF
--- a/scripts/build_all
+++ b/scripts/build_all
@@ -1,4 +1,1 @@
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
-
-cd ./src/agnocast_heaphook
-cargo deb --install

--- a/src/agnocast_heaphook/CMakeLists.txt
+++ b/src/agnocast_heaphook/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5)
+project(agnocast_heaphook)
+
+find_package(ament_cmake REQUIRED)
+
+set(HEAPHOOK_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(HEAPHOOK_BUILD_DIR ${HEAPHOOK_SRC_DIR}/target/release)
+set(HEAPHOOK_OUTPUT ${HEAPHOOK_BUILD_DIR}/libagnocast_heaphook.so)
+
+add_custom_target(build_agnocast_heaphook ALL
+  COMMAND cargo build --release
+  WORKING_DIRECTORY ${HEAPHOOK_SRC_DIR}
+  BYPRODUCTS ${HEAPHOOK_OUTPUT}
+  COMMENT "Building agnocast_heaphook (Rust shared library)"
+)
+
+install(FILES ${HEAPHOOK_OUTPUT}
+  DESTINATION lib
+)
+
+ament_package()

--- a/src/agnocast_heaphook/package.xml
+++ b/src/agnocast_heaphook/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>agnocast_heaphook</name>
+  <version>0.0.0</version>
+  <description>Agnocast Heaphook</description>
+  <maintainer email="sykwer@gmail.com">sykwer</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>colcon-cmake</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description
apt packageとして配布するために、colconのビルドシステム下でビルドする必要がある。
package.xmlのメタデータは、リリース時に一斉に整備します。

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application
- [x] `bash scripts/build_all`

## Notes for reviewers
手元のシステムで、heaphookのインストール場所が変わるので注意。
- `/lib/libagnocast_heaphook.so` (変更前)
- `install/agnocast_heaphook/lib/libagnocast_heaphook.so` (変更後)
変更前の場所にあるsoファイルを消しておくこと。