### PR TITLE
fix: remove unnecessary procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,8 @@ bash scripts/setup
 Build.
 
 ```bash
-bash scripts/build_all
-```
-
-Check if there is a `libagnocast_heaphook.so` in `/usr/lib`.
-
-```bash
-$ ls /usr/lib | grep libagnocast_heaphook
-libagnocast_heaphook.so
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 ## Run

--- a/scripts/build_all
+++ b/scripts/build_all
@@ -1,1 +1,0 @@
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/scripts/setup
+++ b/scripts/setup
@@ -11,4 +11,3 @@ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 rustup toolchain install nightly-2024-08-13
 rustup default nightly-2024-08-13
 rustup component add clippy rustfmt
-cargo install cargo-deb


### PR DESCRIPTION
## Description

- Removed `build_all` script
- Removed cargo-deb installation
- Updated README

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
