### PR TITLE
fix(cppcheck): suppress uninitvar for kernel module

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -1,5 +1,7 @@
 *:*/test/*
 
+uninitvar:kmod/agnocast.c
+
 checkersReport
 missingInclude
 missingIncludeSystem


### PR DESCRIPTION
## Description

Suppress `uninitvar` cppcheck for agnocast.c

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
