### PR TITLE
fix: for CallbackGroupType::Reentrant

### DIFF
--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -169,6 +169,10 @@ void AgnocastExecutor::execute_agnocast_executables(AgnocastExecutables & agnoca
     while (!agnocast_executables.callback_group->can_be_taken_from().exchange(false)) {
       std::this_thread::sleep_for(std::chrono::nanoseconds(agnocast_callback_group_wait_time_));
     }
+  } else if (agnocast_executables.callback_group->type() == rclcpp::CallbackGroupType::Reentrant) {
+    while (!agnocast_executables.callback_group->can_be_taken_from().load()) {
+      std::this_thread::sleep_for(std::chrono::nanoseconds(agnocast_callback_group_wait_time_));
+    }
   }
 
   while (!agnocast_executables.callable_queue.empty()) {

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -163,10 +163,12 @@ bool AgnocastExecutor::get_next_agnocast_executables(
 
 void AgnocastExecutor::execute_agnocast_executables(AgnocastExecutables & agnocast_executables)
 {
-  // In a single-threaded executor, it never sleeps here.
-  // For multi-threaded executor, it's workaround to preserve the callback group rule.
-  while (!agnocast_executables.callback_group->can_be_taken_from().exchange(false)) {
-    std::this_thread::sleep_for(std::chrono::nanoseconds(agnocast_callback_group_wait_time_));
+  if (agnocast_executables.callback_group->type() == rclcpp::CallbackGroupType::MutuallyExclusive) {
+    // In a single-threaded executor, it never sleeps here.
+    // For multi-threaded executor, it's workaround to preserve the callback group rule.
+    while (!agnocast_executables.callback_group->can_be_taken_from().exchange(false)) {
+      std::this_thread::sleep_for(std::chrono::nanoseconds(agnocast_callback_group_wait_time_));
+    }
   }
 
   while (!agnocast_executables.callable_queue.empty()) {
@@ -181,7 +183,9 @@ void AgnocastExecutor::execute_agnocast_executables(AgnocastExecutables & agnoca
 #endif
   }
 
-  agnocast_executables.callback_group->can_be_taken_from().store(true);
+  if (agnocast_executables.callback_group->type() == rclcpp::CallbackGroupType::MutuallyExclusive) {
+    agnocast_executables.callback_group->can_be_taken_from().store(true);
+  }
 }
 
 void AgnocastExecutor::add_node(rclcpp::Node::SharedPtr node, bool notify)


### PR DESCRIPTION
## Description

This fixes the bug that Agnocast's executor doesn't consider `CallbackGroupType::Reentrant`.

## Related links

## How was this PR tested?

- [ ] Autoware (required) -> skip
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers

As far as I examined, `can_be_taken_from` is never false in `Reentrant`, but I am also checking in `Reentrant` just to be sure.