### PR TITLE
fix(kmod): KUNIT_BUILD applied only for kunit tests objects files

### DIFF
--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -44,7 +44,7 @@ ifeq ($(CONFIG_KUNIT),y)
 		agnocast_kunit/agnocast_kunit_new_shm.o \
 		agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
 		agnocast_kunit/agnocast_kunit_get_topic_list.o
-  ccflags-y += -DKUNIT_BUILD
+  $(foreach obj,$(agnocast_kunit-m),$(eval CFLAGS_$(obj) += -DKUNIT_BUILD))
 endif
 
 ifeq ($(CONFIG_GCOV_KERNEL),y)


### PR DESCRIPTION
## Description
agnocast.koもKUNIT_BUILDフラグでビルドされてしまっていたのでその修正。

## Related links
#453 

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
