### PR TITLE
feat(kmod): separete build for kunit

### DIFF
--- a/agnocast_kmod/.gitignore
+++ b/agnocast_kmod/.gitignore
@@ -7,4 +7,3 @@
 *.gcno
 Module.symvers
 modules.order
-agnocast_tmp_copied.c

--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -3,19 +3,19 @@ ccflags-y += -Wall -Werror
 ifneq ($(KUNIT_BUILD),y)
   obj-m := agnocast.o
 else
-  ifeq ($(CONFIG_KUNIT),y) and ($(CONFIG_GCOV_KERNEL),y)
+  ifeq ($(CONFIG_KUNIT)$(CONFIG_GCOV_KERNEL),yy)
     obj-m := agnocast_kunit.o
 	agnocast_kunit-m := agnocast_kunit_main.o agnocast.o \
-		agnocast_kunit/agnocast_kunit_subscriber_add.o \
-		agnocast_kunit/agnocast_kunit_publisher_add.o \
-		agnocast_kunit/agnocast_kunit_increment_rc.o \
-		agnocast_kunit/agnocast_kunit_decrement_rc.o \
-		agnocast_kunit/agnocast_kunit_receive_msg.o \
-		agnocast_kunit/agnocast_kunit_publish_msg.o \
-		agnocast_kunit/agnocast_kunit_take_msg.o \
-		agnocast_kunit/agnocast_kunit_new_shm.o \
-		agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
-		agnocast_kunit/agnocast_kunit_get_topic_list.o
+	  agnocast_kunit/agnocast_kunit_subscriber_add.o \
+	  agnocast_kunit/agnocast_kunit_publisher_add.o \
+	  agnocast_kunit/agnocast_kunit_increment_rc.o \
+	  agnocast_kunit/agnocast_kunit_decrement_rc.o \
+	  agnocast_kunit/agnocast_kunit_receive_msg.o \
+	  agnocast_kunit/agnocast_kunit_publish_msg.o \
+	  agnocast_kunit/agnocast_kunit_take_msg.o \
+	  agnocast_kunit/agnocast_kunit_new_shm.o \
+	  agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
+	  agnocast_kunit/agnocast_kunit_get_topic_list.o
 	ccflags-y += -DKUNIT_BUILD -fprofile-arcs -ftest-coverage
   else
     $(warning "CONFIG_KUNIT or CONFIG_GCOV_KERNEL is not set")
@@ -37,7 +37,6 @@ KERNEL_MINOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 2)
 ifeq ($(shell expr $(KERNEL_MAJOR) \< 5 \| $(KERNEL_MAJOR) = 5 \& $(KERNEL_MINOR) \<= 17), 1)
   ccflags-y += -std=gnu11
 endif
-
 
 # In Linux kernel versions v6.4 and earlier, the top-level Makefile includes
 # -Wdeclaration-after-statement, which requires all variables used within

--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -1,6 +1,26 @@
-obj-m := agnocast.o
-CFLAGS_agnocast.o := -Wall -Werror
-CFLAGS_agnocast_kunit.o := -Wall -Werror -DKUNIT_BUILD
+ccflags-y += -Wall -Werror
+
+ifneq ($(KUNIT_BUILD),y)
+  obj-m := agnocast.o
+else
+  ifeq ($(CONFIG_KUNIT),y) and ($(CONFIG_GCOV_KERNEL),y)
+    obj-m := agnocast_kunit.o
+	agnocast_kunit-m := agnocast_kunit_main.o agnocast.o \
+		agnocast_kunit/agnocast_kunit_subscriber_add.o \
+		agnocast_kunit/agnocast_kunit_publisher_add.o \
+		agnocast_kunit/agnocast_kunit_increment_rc.o \
+		agnocast_kunit/agnocast_kunit_decrement_rc.o \
+		agnocast_kunit/agnocast_kunit_receive_msg.o \
+		agnocast_kunit/agnocast_kunit_publish_msg.o \
+		agnocast_kunit/agnocast_kunit_take_msg.o \
+		agnocast_kunit/agnocast_kunit_new_shm.o \
+		agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
+		agnocast_kunit/agnocast_kunit_get_topic_list.o
+	ccflags-y += -DKUNIT_BUILD -fprofile-arcs -ftest-coverage
+  else
+    $(warning "CONFIG_KUNIT or CONFIG_GCOV_KERNEL is not set")
+  endif
+endif
 
 KERNEL_VERSION := $(shell uname -r)
 KERNEL_MAJOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 1)
@@ -15,9 +35,7 @@ KERNEL_MINOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 2)
 #   }
 # Therefore, add -std=gnu11 to suppress this error.
 ifeq ($(shell expr $(KERNEL_MAJOR) \< 5 \| $(KERNEL_MAJOR) = 5 \& $(KERNEL_MINOR) \<= 17), 1)
-  CFLAGS_agnocast.o += -std=gnu11
-  CFLAGS_agnocast_tmp_copied.o += -std=gnu11
-  CFLAGS_agnocast_kunit.o += -std=gnu11
+  ccflags-y += -std=gnu11
 endif
 
 
@@ -26,39 +44,16 @@ endif
 # a function to be declared at the beginning of the function. To suppress
 # this, we should add -Wno-declaration-after-statement.
 ifeq ($(shell expr $(KERNEL_MAJOR) \< 6 \| $(KERNEL_MAJOR) = 6 \& $(KERNEL_MINOR) \<= 4), 1)
-  CFLAGS_agnocast.o += -Wno-declaration-after-statement
-  CFLAGS_agnocast_tmp_copied.o += -Wno-declaration-after-statement
-  CFLAGS_agnocast_kunit.o += -Wno-declaration-after-statement
-endif
-
-ifeq ($(CONFIG_KUNIT),y)
-  obj-m += agnocast_kunit.o
-  agnocast_kunit-m := agnocast_kunit_main.o agnocast_tmp_copied.o \
-		agnocast_kunit/agnocast_kunit_subscriber_add.o \
-		agnocast_kunit/agnocast_kunit_publisher_add.o \
-		agnocast_kunit/agnocast_kunit_increment_rc.o \
-		agnocast_kunit/agnocast_kunit_decrement_rc.o \
-		agnocast_kunit/agnocast_kunit_receive_msg.o \
-		agnocast_kunit/agnocast_kunit_publish_msg.o \
-		agnocast_kunit/agnocast_kunit_take_msg.o \
-		agnocast_kunit/agnocast_kunit_new_shm.o \
-		agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
-		agnocast_kunit/agnocast_kunit_get_topic_list.o
-  $(foreach obj,$(agnocast_kunit-m),$(eval CFLAGS_$(obj) += -DKUNIT_BUILD))
-endif
-
-ifeq ($(CONFIG_GCOV_KERNEL),y)
-  CFLAGS_agnocast.o += -fprofile-arcs -ftest-coverage
-  CFLAGS_agnocast_tmp_copied.o += -fprofile-arcs -ftest-coverage
-  CFLAGS_agnocast_kunit.o += -fprofile-arcs -ftest-coverage
+  ccflags-y += -Wno-declaration-after-statement
 endif
 
 all:
-	# In order to build with different build options (KUNIT_BUILD),
-	# we need to temporarily copy the kernel module source.
-	cp agnocast.c agnocast_tmp_copied.c
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
+test:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) KUNIT_BUILD=y modules
+
 clean:
-	rm -f agnocast_tmp_copied.c
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+
+.PHONY: all test clean

--- a/scripts/run_kunit
+++ b/scripts/run_kunit
@@ -18,7 +18,7 @@ fi
 
 ### Check if agnocast.ko is not already loaded.
 ### Since agnocast_kunit.ko contains symbols from agnocast.ko,
-### symbol conflicts will ocurr if it is already loaded.
+### symbol conflicts will occur if it is already loaded.
 if lsmod | grep -q "agnocast"; then
     echo "Kernel module 'agnocast' is already loaded. Unload it before kunit test."
     exit 1
@@ -35,7 +35,7 @@ fi
 
 cd $AGNOCAST_KMOD_PATH
 make clean
-make
+make test
 sudo insmod $AGNOCAST_KMOD_PATH/agnocast_kunit.ko
 sleep 3 # HACK
 TOTALS_LINE=$(sudo dmesg | tail -n 10 | grep -E "# Totals: pass:[0-9]+ fail:[0-9]+")


### PR DESCRIPTION
## Description

Separeted the build command for agnocast_kmod:
- `make` creates `agnocast.ko`
- `make test` creates `agnocast_kunit.ko`

This PR also solved the following small problems:
- remove temporary file for agnocast.c
- enable all compile options for `agnocast_kunit/*.o` objects
- add `PHONY` directive

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
