### PR TITLE
fix(agnocastlib): close mqs that are no longer needed

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -32,7 +32,7 @@ topic_local_id_t initialize_publisher(
 union ioctl_publish_args publish_core(
   [[maybe_unused]] const void * publisher_handle, /* for CARET */ const std::string & topic_name,
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<std::string, mqd_t> & opened_mqs);
+  std::unordered_map<std::string, std::tuple<mqd_t, bool>> & opened_mqs);
 uint32_t get_subscription_count_core(const std::string & topic_name);
 void increment_borrowed_publisher_num();
 void decrement_borrowed_publisher_num();
@@ -55,7 +55,7 @@ class Publisher
   topic_local_id_t id_ = -1;
   std::string topic_name_;
   pid_t publisher_pid_;
-  std::unordered_map<std::string, mqd_t> opened_mqs_;
+  std::unordered_map<std::string, std::tuple<mqd_t, bool>> opened_mqs_;
   PublisherOptions options_;
 
   // ROS2 publish related variables

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -55,8 +55,6 @@ class Publisher
   topic_local_id_t id_ = -1;
   std::string topic_name_;
   pid_t publisher_pid_;
-  // TODO(Koichi98): The mq should be closed when a subscriber unsubscribes the topic, but this is
-  // not currently implemented.
   std::unordered_map<std::string, mqd_t> opened_mqs_;
   PublisherOptions options_;
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -52,7 +52,7 @@ topic_local_id_t initialize_publisher(
 union ioctl_publish_args publish_core(
   [[maybe_unused]] const void * publisher_handle /* for CARET */, const std::string & topic_name,
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<std::string, mqd_t> & opened_mqs)
+  std::unordered_map<std::string, std::tuple<mqd_t, bool>> & opened_mqs)
 {
   union ioctl_publish_args publish_args = {};
   publish_args.topic_name = topic_name.c_str();
@@ -76,14 +76,19 @@ union ioctl_publish_args publish_core(
     const std::string mq_name = create_mq_name_for_agnocast_publish(topic_name, subscriber_id);
     mqd_t mq = 0;
     if (opened_mqs.find(mq_name) != opened_mqs.end()) {
-      mq = opened_mqs[mq_name];
+      std::tuple<mqd_t, bool> & t = opened_mqs[mq_name];
+      mq = std::get<0>(t);
+      // The boolean in the tuple indicates whether the mq is used in this publication round.
+      // An unused mq means that its corresponding subscribers have exited, so we close such mqs
+      // later.
+      std::get<1>(t) = true;
     } else {
       mq = mq_open(mq_name.c_str(), O_WRONLY | O_NONBLOCK);
       if (mq == -1) {
         RCLCPP_ERROR(logger, "mq_open failed: %s", strerror(errno));
         continue;
       }
-      opened_mqs.insert({mq_name, mq});
+      opened_mqs.insert({mq_name, {mq, true}});
     }
 
     struct MqMsgAgnocast mq_msg = {};
@@ -96,20 +101,20 @@ union ioctl_publish_args publish_core(
         RCLCPP_ERROR(logger, "mq_send failed: %s", strerror(errno));
       }
     }
-
-    // Invert the sign of the mqs that should be retained
-    opened_mqs[mq_name] = -opened_mqs[mq_name];
   }
 
   // Close mqs that are no longer needed and update `opened_mqs`
   for (auto it = opened_mqs.begin(); it != opened_mqs.end();) {
-    if (it->second > 0) {
-      if (mq_close(it->second) == -1) {
+    bool & keep = std::get<1>(it->second);
+    if (!keep) {
+      mqd_t mq = std::get<0>(it->second);
+      if (mq_close(mq) == -1) {
         RCLCPP_ERROR(logger, "mq_close failed: %s", strerror(errno));
       }
       it = opened_mqs.erase(it);
     } else {
-      it->second = -it->second;
+      // Update the value for the next publication round
+      keep = false;
       ++it;
     }
   }


### PR DESCRIPTION
closes #463 

## Description
This PR enables closing message queues (mqs) that are no longer needed.

A publisher no longer need an mq when the corresponding subscriber has exited. In this case, we close that mq.

### Key points of the implementation
`opened_mqs` の型を `unordered_map<string, mqd_t>` から `unordered_map<string, tuple<mqd_t, bool>>` に変更しました。毎回の `publish_core` 関数の呼び出しでその mq が使われたかどうかを、導入した `bool` で管理します。もし使われていなければ、その mq は close します。

### Why this implementation over others

ランタイムの allocation/deallocation を避けるため、情報（mq を close するかどうか）は `Publisher` のデータメンバに持たせる必要がありました。新しいデータメンバを用意するのは大袈裟だと思ったので、`opened_mqs_` が `bool` も保持できるようにすることで対応しました。

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

I confirmed that the sample talker closes the message queue when the sample listener is terminated first.

## Notes for reviewers
Since I am a beginner in C++, I might be making mistakes regarding resource management.