### PR TITLE
fix(ioctl_wrapper): remove NOLINT

### DIFF
--- a/src/agnocast_ioctl_wrapper/src/node_info.cpp
+++ b/src/agnocast_ioctl_wrapper/src/node_info.cpp
@@ -21,23 +21,21 @@ char ** get_agnocast_sub_topics(const char * node_name, int * topic_count)
     return nullptr;
   }
 
-  // NOLINTBEGIN
   char * agnocast_topic_buffer =
     static_cast<char *>(malloc(MAX_TOPIC_NUM * TOPIC_NAME_BUFFER_SIZE));
-  // NOLINTEND
 
   union ioctl_node_info_args node_info_args = {};
   node_info_args.topic_name_buffer_addr = reinterpret_cast<uint64_t>(agnocast_topic_buffer);
   node_info_args.node_name = node_name;
   if (ioctl(fd, AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD, &node_info_args) < 0) {
     perror("AGNOCAST_TAKE_NODE_SUBSCRIBER_TOPICS_CMD failed");
-    free(agnocast_topic_buffer);  // NOLINT
+    free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
   }
 
   if (node_info_args.ret_topic_num == 0) {
-    free(agnocast_topic_buffer);  // NOLINT
+    free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
   }
@@ -47,28 +45,28 @@ char ** get_agnocast_sub_topics(const char * node_name, int * topic_count)
   std::vector<std::string> agnocast_sub_topics(*topic_count);
   for (uint32_t i = 0; i < *topic_count; i++) {
     agnocast_sub_topics[i] =
-      agnocast_topic_buffer + static_cast<size_t>(i) * TOPIC_NAME_BUFFER_SIZE;  // NOLINT
+      agnocast_topic_buffer + static_cast<size_t>(i) * TOPIC_NAME_BUFFER_SIZE;
   }
 
-  free(agnocast_topic_buffer);  // NOLINT
+  free(agnocast_topic_buffer);
   close(fd);
 
-  char ** topic_array = static_cast<char **>(malloc(*topic_count * sizeof(char *)));  // NOLINT
+  char ** topic_array = static_cast<char **>(malloc(*topic_count * sizeof(char *)));
   if (topic_array == nullptr) {
     return nullptr;
   }
 
   for (size_t i = 0; i < *topic_count; i++) {
-    topic_array[i] =                                                                    // NOLINT
-      static_cast<char *>(malloc((agnocast_sub_topics[i].size() + 1) * sizeof(char)));  // NOLINT
-    if (!topic_array[i]) {                                                              // NOLINT
+    topic_array[i] =
+      static_cast<char *>(malloc((agnocast_sub_topics[i].size() + 1) * sizeof(char)));
+    if (!topic_array[i]) {
       for (size_t j = 0; j < i; j++) {
-        free(topic_array[j]);  // NOLINT
+        free(topic_array[j]);
       }
-      free(topic_array);  // NOLINT
+      free(topic_array);
       return nullptr;
     }
-    std::strcpy(topic_array[i], agnocast_sub_topics[i].c_str());  // NOLINT
+    std::strcpy(topic_array[i], agnocast_sub_topics[i].c_str());
   }
   return topic_array;
 }
@@ -83,23 +81,21 @@ char ** get_agnocast_pub_topics(const char * node_name, int * topic_count)
     return nullptr;
   }
 
-  // NOLINTBEGIN
   char * agnocast_topic_buffer =
     static_cast<char *>(malloc(MAX_TOPIC_NUM * TOPIC_NAME_BUFFER_SIZE));
-  // NOLINTEND
 
   union ioctl_node_info_args node_info_args = {};
   node_info_args.topic_name_buffer_addr = reinterpret_cast<uint64_t>(agnocast_topic_buffer);
   node_info_args.node_name = node_name;
   if (ioctl(fd, AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD, &node_info_args) < 0) {
     perror("AGNOCAST_TAKE_NODE_PUBLISHER_TOPICS_CMD failed");
-    free(agnocast_topic_buffer);  // NOLINT
+    free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
   }
 
   if (node_info_args.ret_topic_num == 0) {
-    free(agnocast_topic_buffer);  // NOLINT
+    free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
   }
@@ -109,28 +105,28 @@ char ** get_agnocast_pub_topics(const char * node_name, int * topic_count)
   std::vector<std::string> agnocast_pub_topics(*topic_count);
   for (uint32_t i = 0; i < *topic_count; i++) {
     agnocast_pub_topics[i] =
-      agnocast_topic_buffer + static_cast<size_t>(i) * TOPIC_NAME_BUFFER_SIZE;  // NOLINT
+      agnocast_topic_buffer + static_cast<size_t>(i) * TOPIC_NAME_BUFFER_SIZE;
   }
 
-  free(agnocast_topic_buffer);  // NOLINT
+  free(agnocast_topic_buffer);
   close(fd);
 
-  char ** topic_array = static_cast<char **>(malloc(*topic_count * sizeof(char *)));  // NOLINT
+  char ** topic_array = static_cast<char **>(malloc(*topic_count * sizeof(char *)));
   if (topic_array == nullptr) {
     return nullptr;
   }
 
   for (size_t i = 0; i < *topic_count; i++) {
-    topic_array[i] =                                                                    // NOLINT
-      static_cast<char *>(malloc((agnocast_pub_topics[i].size() + 1) * sizeof(char)));  // NOLINT
-    if (!topic_array[i]) {                                                              // NOLINT
+    topic_array[i] =
+      static_cast<char *>(malloc((agnocast_pub_topics[i].size() + 1) * sizeof(char)));
+    if (!topic_array[i]) {
       for (size_t j = 0; j < i; j++) {
-        free(topic_array[j]);  // NOLINT
+        free(topic_array[j]);
       }
-      free(topic_array);  // NOLINT
+      free(topic_array);
       return nullptr;
     }
-    std::strcpy(topic_array[i], agnocast_pub_topics[i].c_str());  // NOLINT
+    std::strcpy(topic_array[i], agnocast_pub_topics[i].c_str());
   }
   return topic_array;
 }
@@ -142,8 +138,9 @@ void free_agnocast_topics(char ** topic_array, int topic_count)
   }
 
   for (int i = 0; i < topic_count; i++) {
-    free(topic_array[i]);  // NOLINT
+    free(topic_array[i]);
   }
-  free(topic_array);  // NOLINT
+  free(topic_array);
 }
-}
+
+}  // extern "C"


### PR DESCRIPTION
## Description

Remove `NOLINT` from agnocast_ioctl_wrapper, since they are no longer checked by clang-tidy.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
