### PR TITLE
fix(agnocast_heaphook): prepare stub to fix link error

### DIFF
--- a/agnocast_heaphook/build.rs
+++ b/agnocast_heaphook/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let status = std::process::Command::new("rustc")
-        .args(&[
+        .args([
             "--crate-type=cdylib",
             "stub/lib.rs",
             "-o",

--- a/agnocast_heaphook/build.rs
+++ b/agnocast_heaphook/build.rs
@@ -1,0 +1,20 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let status = std::process::Command::new("rustc")
+        .args(&[
+            "--crate-type=cdylib",
+            "stub/lib.rs",
+            "-o",
+            &format!("{}/libagnocast.so", out_dir.display()),
+        ])
+        .status()
+        .expect("failed to compile stub library");
+
+    assert!(status.success(), "rustc failed to compile stub library");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=dylib=agnocast");
+}

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 extern "C" {
+    fn initialize_agnocast(size: usize) -> *mut c_void;
     fn agnocast_get_borrowed_publisher_num() -> u32;
 }
 
@@ -101,10 +102,6 @@ static ORIGINAL_MEMALIGN: LazyLock<MemalignType> = LazyLock::new(|| {
 static MEMPOOL_START: AtomicUsize = AtomicUsize::new(0);
 static MEMPOOL_END: AtomicUsize = AtomicUsize::new(0);
 static IS_FORKED_CHILD: AtomicBool = AtomicBool::new(false);
-
-extern "C" {
-    fn initialize_agnocast(size: usize) -> *mut c_void;
-}
 
 extern "C" fn post_fork_handler_in_child() {
     IS_FORKED_CHILD.store(true, Ordering::Relaxed);

--- a/agnocast_heaphook/stub/lib.rs
+++ b/agnocast_heaphook/stub/lib.rs
@@ -1,0 +1,11 @@
+use std::os::raw::c_void;
+
+#[no_mangle]
+pub extern "C" fn initialize_agnocast(size: usize) -> *mut c_void {
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn agnocast_get_borrowed_publisher_num() -> u32 {
+    0
+}


### PR DESCRIPTION
## Description
v1.0.0リリースにて、agnocast_heaphookのビルド時にagnocatlibとリンクしないようにする変更を行なった (agnocast_heaphookはagnocastlibと独立した環境でリリースされるため、agnocast_heaphookビルド時のagnocastlibへの依存が不都合であったため)。
通常の動的リンクにおいては、未解決シンボルを探索するために、LD_LIBRARY_PATH等で指定されたパスを順番に探索して、最初にシンボルが見つかったライブラリに対してアドレスを解決する。
しかし、LD_PRELOADで指定したライブラリに関しては、そのライブラリで解決しないシンボルは、その時点でロードされているライブラリの中からしかシンボルを解決することができないという制約がある。つまり、探索パス上にlibagnocast.soが存在していたとしても、LD_PRELOADにagnocast_heaphook.soを指定したとき、agnocast_heaphook.so上で未解決になっているシンボルのアドレスを解決することはできない。
この問題に対処するためには、agnocast_heaphook.so ELFファイルのDT_NEEDEDにlibagnocast.soを記録すればいい。この場合は、LD_PRELOADで指定した場合にも、探索パスからlibagnocast.soを探し、未解決シンボルを解決してくれる。
これを実現するためには、ビルド時にlibagnocast.soと動的リンク ( `-lagnocast` ) すればいいが、これをしたくないからそもそもagnocast_heaphookのビルド時にagnocatlibとリンクしないようにする変更を行なったのであった。
ELFファイルのDT_NEEDEDは、soファイルへのパスではなく、単にファイル名を記録するだけであることに着目し、ちょっとテクニカルであるが、今回はstubファイルを用意することでこの問題を解決した。

## Related links

## How was this PR tested?

- [x] Autoware (required) 立ち上がるようにはなったが、機能が不全な気がする
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
v1.0.0リリース〜このPR直前まではAutowareは動作しない。
PointCloud Containerのみ正常に動作していたのは、agnocastlibが提供するバイナリそのものを使っていて、動的リンク時の探索パスからシンボル解決すること自体が不要だったからである。