### PR TITLE
fix(MultiThreadedAgnocastExecutor): add mutex to preserve callback group rule

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -26,6 +26,7 @@ class AgnocastExecutor : public rclcpp::Executor
 protected:
   int epoll_fd_;
   pid_t my_pid_;
+  std::mutex wait_mutex_;
 
   void prepare_epoll();
   bool get_next_agnocast_executables(

--- a/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
@@ -12,8 +12,6 @@ class MultiThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
 {
   RCLCPP_DISABLE_COPY(MultiThreadedAgnocastExecutor)
 
-  std::mutex wait_mutex_;
-
   /*
   For performance, it is recommented to divide ROS 2's callbacks and Agnocast's callbacks into
   different callback groups. If divided, you can set `ros2_next_exec_timeout` to be long enough


### PR DESCRIPTION
## Description

ここでlockを取らないと、issueに記載通りのassertでのcrashや、Slackで共有したMutuallyExclusiveルール違反が発生するので、修正しました。

## Related links

- closes https://github.com/tier4/agnocast/issues/469
- solves https://star4.slack.com/archives/C07FL8616EM/p1741068179510049

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [x] 手元の統合テストでも正しく排他制御されるようになったことを確認

## Notes for reviewers

MultiThreadedAgnocastExecutorの設計を見直すという話がありますが、一旦これを修正した上での性能を見ようと思い、こちらのPRを出しました。