### PR TITLE
fix(kmod): free node_name to avoid memory leak

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1828,6 +1828,7 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper, const pi
 
     const topic_local_id_t subscriber_id = sub_info->id;
     hash_del(&sub_info->node);
+    kfree(sub_info->node_name);
     kfree(sub_info);
 
     struct rb_root * root = &wrapper->topic.entries;
@@ -1861,6 +1862,7 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper, const pi
       pub_info->entries_num--;
       if (pub_info->entries_num == 0) {
         hash_del(&pub_info->node);
+        kfree(pub_info->node_name);
         kfree(pub_info);
       }
     }
@@ -1892,6 +1894,7 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper, const pid
 
     if (pub_info->entries_num == 0) {
       hash_del(&pub_info->node);
+      kfree(pub_info->node_name);
       kfree(pub_info);
     }
   }
@@ -2121,6 +2124,7 @@ static void remove_all_topics(void)
     hash_for_each_safe(wrapper->topic.pub_info_htable, bkt_pub_info, tmp_pub_info, pub_info, node)
     {
       hash_del(&pub_info->node);
+      kfree(pub_info->node_name);
       kfree(pub_info);
     }
 
@@ -2130,6 +2134,7 @@ static void remove_all_topics(void)
     hash_for_each_safe(wrapper->topic.sub_info_htable, bkt_sub_info, tmp_sub_info, sub_info, node)
     {
       hash_del(&sub_info->node);
+      kfree(sub_info->node_name);
       kfree(sub_info);
     }
 


### PR DESCRIPTION
## Description

Freed `node_name` s to avoid memory leak.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
