### PR TITLE
fix(kmod): avoid memory leak of pubsub info

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -206,6 +206,7 @@ static int insert_subscriber_info(
   char * node_name_copy = kstrdup(node_name, GFP_KERNEL);
   if (!node_name_copy) {
     dev_warn(agnocast_device, "kstrdup failed. (insert_subscriber_info)\n");
+    kfree(*new_info);
     return -ENOMEM;
   }
 
@@ -301,6 +302,7 @@ static int insert_publisher_info(
   char * node_name_copy = kstrdup(node_name, GFP_KERNEL);
   if (!node_name_copy) {
     dev_warn(agnocast_device, "kstrdup failed. (insert_publisher_info)\n");
+    kfree(*new_info);
     return -ENOMEM;
   }
 


### PR DESCRIPTION
## Description

Avoid memory leaks of publisher/subscriber info structure when inserting them.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
