### PR TITLE
fix(kmod): fix typo

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -240,7 +240,7 @@ static int insert_subscriber_info(
       if (!pub_info->qos_is_transient_local) {
         dev_warn(
           agnocast_device,
-          "Imcompatible QoS is set for the topic (topic_name=%s): subscriber is transient local "
+          "Incompatible QoS is set for the topic (topic_name=%s): subscriber is transient local "
           "but publisher is volatile. (insert_subscriber_info)\n",
           wrapper->key);
         break;
@@ -335,7 +335,7 @@ static int insert_publisher_info(
       if (sub_info->qos_is_transient_local) {
         dev_warn(
           agnocast_device,
-          "Imcompatible QoS is set for the topic (topic_name=%s): publisher is volatile "
+          "Incompatible QoS is set for the topic (topic_name=%s): publisher is volatile "
           "but subscriber is transient local. (insert_publisher_info)\n",
           wrapper->key);
         break;


### PR DESCRIPTION
## Description

Fixed typo of `Incompatible`

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
