### PR TITLE
fix(heaphook): fix typo

### DIFF
--- a/agnocast_heaphook/Cargo.toml
+++ b/agnocast_heaphook/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agnocast_heaphook"
 version = "1.0.0"
 edition = "2021"
-license = "Apatch-2.0"
+license = "Apache-2.0"
 authors = [
     "Takahiro Ishikawa-Aso <sykwer@gmail.com>",
     "Ryuta Kambe <ryuta.kambe@tier4.jp>",


### PR DESCRIPTION
## Description

Fixed typo of `Apache-2.0`

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
