### PR TITLE
test: stress & long time test

### DIFF
--- a/scripts/e2e_test_stress
+++ b/scripts/e2e_test_stress
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+PERCENTAGES=($(seq 5 5 95)) # You can change this
+
+NUM_PERCENTAGES=${#PERCENTAGES[@]}
+MAX_MQ_NUM=$(cat /proc/sys/fs/mqueue/queues_max)
+declare -a MQ_PERCENT
+for ((i = 0; i < NUM_PERCENTAGES; i++)); do
+    MQ_PERCENT[$i]=$((MAX_MQ_NUM * ${PERCENTAGES[i]} / 100))
+done
+TIMEOUT=680s # based on the measurement time of e2e tests
+
+run-stress-ng() {
+    if [ $1 -lt $NUM_PERCENTAGES ]; then
+        echo "Run stress-ng with CPU load ${PERCENTAGES[$1]}%"
+        stress-ng --cpu $(nproc) --cpu-load ${PERCENTAGES[$1]} --timeout $TIMEOUT &
+
+    elif [ "$1" -lt "$((NUM_PERCENTAGES * 2))" ]; then
+        index=$(($1 - NUM_PERCENTAGES))
+        echo "Run stress-ng with VM ${PERCENTAGES[$index]}%"
+        stress-ng --vm 1 --vm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
+
+    elif [ "$1" -lt "$((NUM_PERCENTAGES * 3))" ]; then
+        index=$(($1 - NUM_PERCENTAGES * 2))
+        echo "Run stress-ng with SHM ${PERCENTAGES[$index]}%"
+        stress-ng --shm 1 --shm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
+
+    else
+        index=$(($1 - NUM_PERCENTAGES * 3))
+        echo "Run stress-ng with MQ ${MQ_PERCENT[$index]}"
+        stress-ng --mq ${MQ_PERCENT[$index]} --timeout $TIMEOUT &
+    fi
+}
+
+NUM_LOOP=$((NUM_PERCENTAGES * 4)) # cpu_load, vm, shm, mq
+for i in $(seq 1 $NUM_LOOP); do
+    echo "============================================================================"
+    echo "============================ Outer Loop $i / $NUM_LOOP ============================"
+    echo "============================================================================"
+
+    run-stress-ng $(($i - 1))
+    bash scripts/e2e_test_1to1_with_ros2sub -c
+    bash scripts/e2e_test_2to2 -c
+
+    wait
+done


### PR DESCRIPTION
## Description

負荷を変動させつつ、長時間e2eテストを実行するスクリプトを実装しました。

## Related links

## How was this PR tested?

bash scripts/e2e_test_stress

全ては見ていないですが、最初の数ループが正しく動作しているのを確認しました。

## Notes for reviewers

```bash
--cpu N               start N workers that perform CPU only loading
--cpu-load P          load CPU by P %, 0=sleep, 100=full load
--vm N                start N workers spinning on anonymous mmap
--vm-bytes N          allocate N bytes per vm worker (default 256MB)
--shm N               start N workers that exercise POSIX shared memory
--shm-bytes N         allocate/free N bytes of POSIX shared memory
--mq N                start N workers passing messages using POSIX
```