### PR TITLE
fix(kmod): refine return values

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -436,8 +436,9 @@ int increment_message_entry_rc(
       wrapper->key, entry_id, pubsub_id);
     return -1;
   } else {
-    if (increment_sub_rc(en, pubsub_id) == -1) {
-      return -1;
+    int ret = increment_sub_rc(en, pubsub_id);
+    if (ret < 0) {
+      return ret;
     }
   }
 
@@ -1112,8 +1113,9 @@ int receive_and_check_new_publisher(
       break;
     }
 
-    if (increment_sub_rc(en, subscriber_id) == -1) {
-      return -1;
+    int ret = increment_sub_rc(en, subscriber_id);
+    if (ret < 0) {
+      return ret;
     }
 
     ioctl_ret->ret_entry_ids[ioctl_ret->ret_entry_num] = en->entry_id;
@@ -1221,8 +1223,9 @@ int take_msg(
   }
 
   if (candidate_en) {
-    if (increment_sub_rc(candidate_en, subscriber_id) == -1) {
-      return -1;
+    int ret = increment_sub_rc(candidate_en, subscriber_id);
+    if (ret < 0) {
+      return ret;
     }
 
     ioctl_ret->ret_addr = candidate_en->msg_virtual_address;

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -832,7 +832,7 @@ static int set_publisher_shm_info(
     dev_warn(
       agnocast_device, "Process Info (pid=%d) not found. (set_publisher_shm_info)\n",
       subscriber_pid);
-    return -EINVAL;
+    return -ESRCH;
   }
 
   uint32_t publisher_num = 0;
@@ -849,7 +849,7 @@ static int set_publisher_shm_info(
       dev_warn(
         agnocast_device, "Process Info (pid=%d) not found. (set_publisher_shm_info)\n",
         pub_info->pid);
-      return -EINVAL;
+      return -ESRCH;
     }
 
     int ret = reference_memory(proc_info->mempool_entry, sub_proc_info->pid);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -383,7 +383,7 @@ static int increment_sub_rc(struct entry_node * en, const topic_local_id_t id)
     "(increment_sub_rc)\n",
     MAX_REFERENCING_PUBSUB_NUM_PER_ENTRY);
 
-  return -1;
+  return -ENOBUFS;
 }
 
 static struct entry_node * find_message_entry(
@@ -830,7 +830,7 @@ static int set_publisher_shm_info(
     dev_warn(
       agnocast_device, "Process Info (pid=%d) not found. (set_publisher_shm_info)\n",
       subscriber_pid);
-    return -1;
+    return -EINVAL;
   }
 
   uint32_t publisher_num = 0;
@@ -847,7 +847,7 @@ static int set_publisher_shm_info(
       dev_warn(
         agnocast_device, "Process Info (pid=%d) not found. (set_publisher_shm_info)\n",
         pub_info->pid);
-      return -1;
+      return -EINVAL;
     }
 
     int ret = reference_memory(proc_info->mempool_entry, sub_proc_info->pid);
@@ -878,7 +878,7 @@ static int set_publisher_shm_info(
         "returned at once in a call from this subscriber process (topic_name=%s, "
         "subscriber_pid=%d). (set_publisher_shm_info)\n",
         wrapper->key, sub_proc_info->pid);
-      return -1;
+      return -ENOBUFS;
     }
 
     pub_shm_info->publisher_pids[publisher_num] = pub_info->pid;
@@ -921,8 +921,9 @@ int subscriber_add(
 
   ioctl_ret->ret_id = sub_info->id;
 
-  if (set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info) == -1) {
-    return -1;
+  ret = set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info);
+  if (ret < 0) {
+    return ret;
   }
 
   ioctl_ret->ret_transient_local_num = 0;
@@ -937,8 +938,9 @@ int subscriber_add(
 
     struct entry_node * en = container_of(node, struct entry_node, node);
 
-    if (increment_sub_rc(en, sub_info->id) == -1) {
-      return -1;
+    ret = increment_sub_rc(en, sub_info->id);
+    if (ret < 0) {
+      return ret;
     }
 
     ioctl_ret->ret_entry_ids[ioctl_ret->ret_transient_local_num] = en->entry_id;
@@ -1130,8 +1132,9 @@ int receive_and_check_new_publisher(
     return 0;
   }
 
-  if (set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info) == -1) {
-    return -1;
+  int ret = set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info);
+  if (ret < 0) {
+    return ret;
   }
 
   sub_info->new_publisher = false;
@@ -1234,8 +1237,9 @@ int take_msg(
     return 0;
   }
 
-  if (set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info) == -1) {
-    return -1;
+  int ret = set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info);
+  if (ret < 0) {
+    return ret;
   }
 
   sub_info->new_publisher = false;

--- a/agnocast_kmod/agnocast_memory_allocator.h
+++ b/agnocast_kmod/agnocast_memory_allocator.h
@@ -3,7 +3,7 @@
 #include <linux/types.h>
 
 // Maximum number of processes that can be mapped to a memory pool
-#define MAX_PROCESS_NUM_PER_MEMPOOL 16
+#define MAX_PROCESS_NUM_PER_MEMPOOL 32
 
 struct mempool_entry
 {


### PR DESCRIPTION
## Description

Refined `subscriber_add` related functions' return values.

Actually, there was a bug in `subscriber_add`:
when `set_publisher_shm_info` failed with exit code other than -1, `subscriber_add` does not fail since it cheks in the following way
```
  if (set_publisher_shm_info(wrapper, sub_info->pid, &ioctl_ret->ret_pub_shm_info) == -1) {
    return -1;
  }
```
This is why `MAX_PROCESS_NUM_PER_MEMPOOL` is changed to 32.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
