### PR TITLE
fix(kmod): fix get_topic_entries_num bug

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -228,7 +228,7 @@ void process_exit_cleanup(const pid_t pid);
 #ifdef KUNIT_BUILD
 int get_proc_info_htable_size(void);
 bool is_in_proc_info_htable(const pid_t pid);
-int get_topic_entries_num(char * topic_name);
+int get_topic_entries_num(const char * topic_name);
 bool is_in_topic_entries(char * topic_name, int64_t entry_id);
 int get_publisher_num(const char * topic_name);
 bool is_in_publisher_htable(const char * topic_name, const topic_local_id_t publisher_id);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1761,16 +1761,13 @@ int get_topic_entries_num(char * topic_name)
 {
   struct topic_wrapper * wrapper = find_topic(topic_name);
   if (!wrapper) {
-    dev_warn(
-      agnocast_device, "Topic (topic_name=%s) not found. (get_topic_entries_num)\n", topic_name);
-    return -1;
+    return 0;
   }
 
   struct rb_root * root = &wrapper->topic.entries;
-  struct rb_node ** new = &(root->rb_node);
+  struct rb_node * node;
   int count = 0;
-  while (*new) {
-    new = &((*new)->rb_right);
+  for (node = rb_first(root); node; node = rb_next(node)) {
     count++;
   }
   return count;

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1757,7 +1757,7 @@ bool is_in_proc_info_htable(const pid_t pid)
   return false;
 }
 
-int get_topic_entries_num(char * topic_name)
+int get_topic_entries_num(const char * topic_name)
 {
   struct topic_wrapper * wrapper = find_topic(topic_name);
   if (!wrapper) {


### PR DESCRIPTION
## Description

Fixed `get_topic_entries_num` bug: it didn't properly calculate the total count of entries.

## Related links

## How was this PR tested?

kunit tests pass

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
