### PR TITLE
fix(kmod): remove too much dmesg on kunit test

### DIFF
--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -30,6 +30,7 @@ static int agnocast_test_init(struct kunit * test)
 static void agnocast_test_exit(struct kunit * test)
 {
   agnocast_exit_free_data();
+  exit_memory_allocator();
 }
 
 static int agnocast_test_suite_init(struct kunit_suite * test_suite)
@@ -60,7 +61,6 @@ static void agnocast_test_suite_exit(struct kunit_suite * test_suite)
   agnocast_exit_kthread();
   agnocast_exit_kprobe();
   agnocast_exit_device();
-  exit_memory_allocator();
 }
 
 struct kunit_suite agnocast_test_suite = {

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1996,7 +1996,9 @@ void process_exit_cleanup(const pid_t pid)
     }
   }
 
+#ifndef KUNIT_BUILD
   dev_info(agnocast_device, "Process (pid=%d) has exited. (process_exit_cleanup)\n", pid);
+#endif
 }
 
 static int exit_worker_thread(void * data)


### PR DESCRIPTION
## Description

Removed too much dmesg on kunit test:
- removed `dev_info(agnocast_device, "Process (pid=%d) has exited. (process_exit_cleanup)\n", pid);` from kunit
- changed the timing of `exit_memory_allocator` from test suite exit to test exit
- refactored `test_case_new_shm_too_many` test so that only one `new_shm` call will fail.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
