### PR TITLE
refactor: force ros2_timeout and agnocast_timeout to be equal

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
@@ -21,8 +21,8 @@ class MultiThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   size_t number_of_agnocast_threads_;
 
   bool yield_before_execute_;
-  std::chrono::nanoseconds ros2_next_exec_timeout_;
-  const int agnocast_next_exec_timeout_ms_;
+  std::chrono::nanoseconds ros2_timeout_;
+  const int agnocast_timeout_ms_;
 
   void ros2_spin();
   void agnocast_spin();
@@ -33,8 +33,7 @@ public:
     const rclcpp::ExecutorOptions & options = rclcpp::ExecutorOptions(),
     size_t number_of_ros2_threads = 0, size_t number_of_agnocast_threads = 0,
     bool yield_before_execute = false,
-    std::chrono::nanoseconds ros2_next_exec_timeout = std::chrono::nanoseconds(10 * 1000 * 1000),
-    int agnocast_next_exec_timeout_ms = 10);
+    std::chrono::nanoseconds timeout = std::chrono::nanoseconds(10 * 1000 * 1000));
 
   RCLCPP_PUBLIC
   void spin() override;

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -21,18 +21,13 @@ int main(int argc, char * argv[])
   const bool yield_before_execute = (node->has_parameter("yield_before_execute"))
                                       ? node->get_parameter("yield_before_execute").as_bool()
                                       : false;
-  const nanoseconds ros2_next_exec_timeout =
-    (node->has_parameter("ros2_next_exec_timeout_ms"))
-      ? nanoseconds(node->get_parameter("ros2_next_exec_timeout_ms").as_int() * 1000 * 1000)
-      : nanoseconds(10 * 1000 * 1000);
-  const int agnocast_next_exec_timeout_ms =
-    (node->has_parameter("agnocast_next_exec_timeout_ms"))
-      ? static_cast<int>(node->get_parameter("agnocast_next_exec_timeout_ms").as_int())
-      : 1000;
+  const nanoseconds timeout = (node->has_parameter("timeout_ns"))
+                                ? nanoseconds(node->get_parameter("timeout_ns").as_int())
+                                : nanoseconds(10 * 1000 * 1000);
 
   auto executor = std::make_shared<agnocast::MultiThreadedAgnocastExecutor>(
     rclcpp::ExecutorOptions{}, number_of_ros2_threads, number_of_agnocast_threads,
-    yield_before_execute, ros2_next_exec_timeout, agnocast_next_exec_timeout_ms);
+    yield_before_execute, timeout);
 
   node->set_executor(executor);
   executor->add_node(node);

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -18,8 +18,8 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
   if (ros2_timeout_ == std::chrono::nanoseconds(-1)) {
     RCLCPP_ERROR(
       logger,
-      "If `timeout` is set to infinite, ros2 callbacks which share the callback group "
-      "with agnocast callbacks may not be executed. Set this parameter to be short enough");
+      "If `timeout` is set to infinite, agnocast callbacks which share the callback group with "
+      "ros2 callbacks may be blocked. Set this parameter to be short enough");
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
## Description

This forces `ros2_timeout` and `agnocast_timeout` to be equal for fairness scheduling in MultiThreadedAgnocastExecutor.

## Related links

## How was this PR tested?

- [ ] Autoware (required) -> Skipped, because this doesn't change the behavior. 
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
