### PR TITLE
fix(kmod): skip transient_local procedures on take subscriber addition

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -228,7 +228,7 @@ static int insert_subscriber_info(
     new_id, subscriber_pid, wrapper->key);
 
   // Check if the topic has any volatile publishers.
-  if (qos_is_transient_local) {
+  if (!is_take_sub && qos_is_transient_local) {
     struct publisher_info * pub_info;
     int bkt_pub_info;
     hash_for_each(wrapper->topic.pub_info_htable, bkt_pub_info, pub_info, node)
@@ -930,12 +930,11 @@ int subscriber_add(
   }
 
   ioctl_ret->ret_transient_local_num = 0;
-  if (!qos_is_transient_local) {
+  if (is_take_sub || !qos_is_transient_local) {
     return 0;
   }
 
   // Return qos_depth messages in order from newest to oldest for transient local
-  bool sub_info_updated = false;
   for (struct rb_node * node = rb_last(&wrapper->topic.entries); node; node = rb_prev(node)) {
     if (qos_depth <= ioctl_ret->ret_transient_local_num) break;
 
@@ -949,11 +948,6 @@ int subscriber_add(
     ioctl_ret->ret_entry_ids[ioctl_ret->ret_transient_local_num] = en->entry_id;
     ioctl_ret->ret_entry_addrs[ioctl_ret->ret_transient_local_num] = en->msg_virtual_address;
     ioctl_ret->ret_transient_local_num++;
-
-    if (!sub_info_updated) {
-      sub_info->latest_received_entry_id = en->entry_id;
-      sub_info_updated = true;
-    }
   }
 
   return 0;

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -128,11 +128,6 @@ public:
       dummy_cb_symbols.c_str(), topic_name_.c_str(), qos.depth(), 0);
 #endif
 
-    if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
-      RCLCPP_WARN(
-        logger, "The transient local is not supported by TakeSubscription, so it is ignored.");
-    }
-
     union ioctl_subscriber_args subscriber_args =
       initialize(qos, true, node->get_fully_qualified_name());
 


### PR DESCRIPTION
## Description

- skip transient local procedures on take subscription addition
- stop updating `sub_info->latest_received_entry_id` on transient_local, and use dummy entry_id

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
