### PR TITLE
feat: add validation if agnocast cb and ros2 cb belong to same MutuallyExclusive cbg in MultiThreadedAgnocastExecutor

### DIFF
--- a/src/agnocast_e2e_test/src/test_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_subscriber.cpp
@@ -45,8 +45,12 @@ public:
 
     count_ = 0;
     target_sub_num_ = this->get_parameter("sub_num").as_int();
+
+    auto cbg = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    agnocast::SubscriptionOptions sub_options;
+    sub_options.callback_group = cbg;
     sub_ = agnocast::create_subscription<std_msgs::msg::Int64>(
-      this, "/test_topic", qos, std::bind(&TestSubscriber::callback, this, _1));
+      this, "/test_topic", qos, std::bind(&TestSubscriber::callback, this, _1), sub_options);
   }
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -21,13 +21,10 @@ class AgnocastExecutor : public rclcpp::Executor
 
   std::mutex ready_agnocast_executables_mutex_;
   std::vector<AgnocastExecutable> ready_agnocast_executables_;
-  std::mutex is_shared_with_ros2_cache_mutex_;
-  std::unordered_map<rclcpp::CallbackGroup *, bool>
-    is_shared_with_ros2_cache_;  // to reduce acquiring CallbackGroup->mutex_
 
-  bool is_shared_with_ros2(const rclcpp::CallbackGroup::SharedPtr & group);
   void wait_and_handle_epoll_event(const int timeout_ms);
   bool get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable);
+  virtual void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const = 0;
 
 protected:
   int epoll_fd_;

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -19,18 +19,23 @@ class AgnocastExecutor : public rclcpp::Executor
   // prevent objects from being destructed by keeping reference count
   std::vector<rclcpp::Node::SharedPtr> nodes_;
 
+  std::mutex ready_agnocast_executables_mutex_;
   std::vector<AgnocastExecutable> ready_agnocast_executables_;
+  std::mutex is_shared_with_ros2_cache_mutex_;
+  std::unordered_map<rclcpp::CallbackGroup *, bool>
+    is_shared_with_ros2_cache_;  // to reduce acquiring CallbackGroup->mutex_
+
+  bool is_shared_with_ros2(const rclcpp::CallbackGroup::SharedPtr & group);
+  void wait_and_handle_epoll_event(const int timeout_ms);
+  bool get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable);
 
 protected:
   int epoll_fd_;
   pid_t my_pid_;
   std::mutex wait_mutex_;
-  std::mutex ready_agnocast_executables_mutex_;
 
   void prepare_epoll();
   bool get_next_agnocast_executable(AgnocastExecutable & agnocast_executable, const int timeout_ms);
-  void wait_and_handle_epoll_event(const int timeout_ms);
-  bool get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable);
   static void execute_agnocast_executable(AgnocastExecutable & agnocast_executable);
 
 public:

--- a/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
@@ -21,6 +21,7 @@ class MultiThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
 
   void ros2_spin();
   void agnocast_spin();
+  void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
 
 public:
   RCLCPP_PUBLIC

--- a/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
@@ -12,11 +12,6 @@ class MultiThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
 {
   RCLCPP_DISABLE_COPY(MultiThreadedAgnocastExecutor)
 
-  /*
-  For performance, it is recommented to divide ROS 2's callbacks and Agnocast's callbacks into
-  different callback groups. If divided, you can set `ros2_next_exec_timeout` to be long enough
-  because we do not have to assume `can_be_taken_from` is changed outside of rclcpp.
-  */
   size_t number_of_ros2_threads_;
   size_t number_of_agnocast_threads_;
 

--- a/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
@@ -12,6 +12,7 @@ class SingleThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   RCLCPP_DISABLE_COPY(SingleThreadedAgnocastExecutor)
 
   const int next_exec_timeout_ms_;
+  void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
 
 public:
   RCLCPP_PUBLIC

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -28,7 +28,7 @@ int main(int argc, char * argv[])
   const int agnocast_next_exec_timeout_ms =
     (node->has_parameter("agnocast_next_exec_timeout_ms"))
       ? static_cast<int>(node->get_parameter("agnocast_next_exec_timeout_ms").as_int())
-      : 1000;
+      : 10;
 
   auto executor = std::make_shared<agnocast::MultiThreadedAgnocastExecutor>(
     rclcpp::ExecutorOptions{}, number_of_ros2_threads, number_of_agnocast_threads,

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -171,20 +171,20 @@ void AgnocastExecutor::wait_and_handle_epoll_event(const int timeout_ms)
 
 bool AgnocastExecutor::get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable)
 {
-  std::scoped_lock ready_wait_lock{ready_agnocast_executables_mutex_, wait_mutex_};
+  std::scoped_lock ready_wait_lock{ready_agnocast_executables_mutex_};
 
   for (auto it = ready_agnocast_executables_.begin(); it != ready_agnocast_executables_.end();
        ++it) {
-    if (it->callback_group->can_be_taken_from().load()) {
-      if (it->callback_group->type() == rclcpp::CallbackGroupType::MutuallyExclusive) {
-        it->callback_group->can_be_taken_from().store(false);
-      }
-
-      agnocast_executable = *it;
-      ready_agnocast_executables_.erase(it);
-
-      return true;
+    if (
+      it->callback_group->type() == rclcpp::CallbackGroupType::MutuallyExclusive &&
+      !it->callback_group->can_be_taken_from().exchange(false)) {
+      continue;
     }
+
+    agnocast_executable = *it;
+    ready_agnocast_executables_.erase(it);
+
+    return true;
   }
 
   return false;

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -22,6 +22,50 @@ AgnocastExecutor::~AgnocastExecutor()
   close(epoll_fd_);
 }
 
+bool AgnocastExecutor::is_shared_with_ros2(const rclcpp::CallbackGroup::SharedPtr & group)
+{
+  // Check the cache
+  {
+    std::lock_guard<std::mutex> lock(is_shared_with_ros2_cache_mutex_);
+    const auto it = is_shared_with_ros2_cache_.find(group.get());
+    if (it != is_shared_with_ros2_cache_.end()) {
+      return it->second;
+    }
+  }
+
+  // If not found in the cache, access the group internals
+  bool shared = false;
+  group->collect_all_ptrs(
+    [&](const rclcpp::SubscriptionBase::SharedPtr &) {
+      shared = true;
+      return;
+    },
+    [&](const rclcpp::ServiceBase::SharedPtr &) {
+      shared = true;
+      return;
+    },
+    [&](const rclcpp::ClientBase::SharedPtr &) {
+      shared = true;
+      return;
+    },
+    [&](const rclcpp::TimerBase::SharedPtr &) {
+      shared = true;
+      return;
+    },
+    [&](const rclcpp::Waitable::SharedPtr &) {
+      shared = true;
+      return;
+    });
+
+  // Cache the result
+  {
+    std::lock_guard<std::mutex> lock(is_shared_with_ros2_cache_mutex_);
+    is_shared_with_ros2_cache_[group.get()] = shared;
+  }
+
+  return shared;
+}
+
 void AgnocastExecutor::prepare_epoll()
 {
   // For added callback groups after calling spin().
@@ -45,6 +89,15 @@ void AgnocastExecutor::prepare_epoll()
       }
       if (group != callback_info.callback_group) {
         continue;
+      }
+
+      if (is_shared_with_ros2(group)) {
+        RCLCPP_WARN(
+          logger,
+          "The Agnocast callback and the rclcpp callback belong to the same callback group. In "
+          "this case, the AgnocastExecutor will schedule them without considering their arrival "
+          "order. Furthermore, performance is also degraded due to the overhead of mutual "
+          "exclusion. If you want to avoid this, assign them to separate callback groups.");
       }
 
       struct epoll_event ev = {};

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -32,6 +32,49 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
                                   : std::thread::hardware_concurrency() / 2;
 }
 
+void MultiThreadedAgnocastExecutor::validate_callback_group(
+  const rclcpp::CallbackGroup::SharedPtr & group) const
+{
+  if (group->type() == rclcpp::CallbackGroupType::Reentrant) {
+    return;
+  }
+
+  bool is_shared_with_ros2 = false;
+  group->collect_all_ptrs(
+    [&](const rclcpp::SubscriptionBase::SharedPtr &) {
+      is_shared_with_ros2 = true;
+      return;
+    },
+    [&](const rclcpp::ServiceBase::SharedPtr &) {
+      is_shared_with_ros2 = true;
+      return;
+    },
+    [&](const rclcpp::ClientBase::SharedPtr &) {
+      is_shared_with_ros2 = true;
+      return;
+    },
+    [&](const rclcpp::TimerBase::SharedPtr &) {
+      is_shared_with_ros2 = true;
+      return;
+    },
+    [&](const rclcpp::Waitable::SharedPtr &) {
+      is_shared_with_ros2 = true;
+      return;
+    });
+
+  if (is_shared_with_ros2) {
+    RCLCPP_ERROR(
+      logger,
+      "To prevent performance degradation, MultiThreadedAgnocastExecutor prohibits the agnocast "
+      "callback and the ros2 callback from belonging to the same MutuallyExclusive callback group "
+      ". If mutual exclusion between callbacks is not required, consider using `Reentrant`. If "
+      "mutual exclusion is required, separate them into different callback groups and use a mutex "
+      "or other synchronization mechanism.");
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+}
+
 void MultiThreadedAgnocastExecutor::spin()
 {
   if (spinning.exchange(true)) {

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -67,9 +67,9 @@ void MultiThreadedAgnocastExecutor::validate_callback_group(
       logger,
       "To prevent performance degradation, MultiThreadedAgnocastExecutor prohibits the agnocast "
       "callback and the ros2 callback from belonging to the same MutuallyExclusive callback group "
-      ". If mutual exclusion between callbacks is not required, consider using `Reentrant`. If "
-      "mutual exclusion is required, separate them into different callback groups and use a mutex "
-      "or other synchronization mechanism.");
+      ". If mutual exclusion between callbacks is not required, consider using Reentrant callback "
+      "group. If mutual exclusion is required, separate them into different callback groups and "
+      "use a mutex or other synchronization mechanism.");
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -20,6 +20,12 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
   }
 }
 
+void SingleThreadedAgnocastExecutor::validate_callback_group(
+  [[maybe_unused]] const rclcpp::CallbackGroup::SharedPtr & group) const
+{
+  // Do nothing
+}
+
 void SingleThreadedAgnocastExecutor::spin()
 {
   if (spinning.exchange(true)) {


### PR DESCRIPTION
## Description

MultiThreadedAgnocastExecutorにて、agnocast callbackとros2 callbackが同一のMutuallyExclusive callback groupに属している時に**エラーで落ちる**ようにしました。prepare_epoll()時にチェックしているのは、executorがspin()した後でないと、callback groupへの登録が済んでいないケースがあるためです。厳密にはspin()後にもros2 callbackが参加してくる可能性がありますが、それはレアケースであるのと、callback実行時に毎回チェックするのはオーバヘッドが大きいので、現状の実装になっています。

これに伴い、 `get_next_ready_agnocast_executable()` で `wait_mutex_` を取らなくて良くなったので、ロジックを修正しました。また、e2eテストにおけるcbg分離も行いました。

## Related links

- [CallbackGroup::collect_all_ptrs()](https://github.com/ros2/rclcpp/blob/19773973a80d753c6fa028b0b548462fbbef122d/rclcpp/src/rclcpp/callback_group.cpp#L57)
- [Discussion in Slack](https://star4.slack.com/archives/C07FL8616EM/p1741820412275869?thread_ts=1741756781.258029&cid=C07FL8616EM)

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers

以下の凡ミスも修正しています

- protected -> private に変更できるものの移動
- パラメータのデフォルト値変更漏れ
