### PR TITLE
fix(kmod): init entry_id used in take_msg

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1207,7 +1207,7 @@ int take_msg(
 
   // These remains 0 if no message is found to take.
   ioctl_ret->ret_addr = 0;
-  ioctl_ret->ret_entry_id = 0;
+  ioctl_ret->ret_entry_id = -1;
 
   uint32_t searched_count = 0;
   struct entry_node * candidate_en = NULL;


### PR DESCRIPTION
## Description
fix entry_id init value to -1 so that it won't implies the actual entry_node.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
