### PR TITLE
improve: stress test

### DIFF
--- a/scripts/e2e_test_1to1_with_ros2sub
+++ b/scripts/e2e_test_1to1_with_ros2sub
@@ -51,9 +51,9 @@ source install/setup.bash
 # Run test
 CONFIG_FILE="src/agnocast_e2e_test/test/config_test_1to1_with_ros2sub.yaml"
 show_config() {
-    echo "----------------------------------------------"
-    cat $CONFIG_FILE
-    echo "----------------------------------------------"
+    echo "----------------------------------------------" | sudo tee /dev/kmsg
+    cat $CONFIG_FILE | sudo tee /dev/kmsg
+    echo "----------------------------------------------" | sudo tee /dev/kmsg
 }
 
 FAILURE_COUNT=0
@@ -61,7 +61,7 @@ if [ "$RUN_SINGLE" = true ]; then
     show_config
     launch_test src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
     if [ $? -ne 0 ]; then
-        echo "Test failed"
+        echo "Test failed" | sudo tee /dev/kmsg
         exit 1
     fi
 else
@@ -86,12 +86,12 @@ else
                             sed -i "s/sub_qos_depth:.*/sub_qos_depth: $sub_qos_depth/g" $CONFIG_FILE
                             sed -i "s/sub_transient_local:.*/sub_transient_local: $sub_transient_local/g" $CONFIG_FILE
                             sed -i "s/use_take_sub:.*/use_take_sub: $use_take_sub/g" $CONFIG_FILE
-                            echo "====================== $COUNT / 64 ======================"
+                            echo "====================== $COUNT / 64 ======================" | sudo tee /dev/kmsg
                             show_config
                             launch_test src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
 
                             if [ $? -ne 0 ]; then
-                                echo "Test failed."
+                                echo "Test failed." | sudo tee /dev/kmsg
                                 if [ "$CONTINUE_ON_FAILURE" = true ]; then
                                     FAILURE_COUNT=$((FAILURE_COUNT + 1))
                                 else
@@ -107,10 +107,10 @@ else
 fi
 
 if [ "$FAILURE_COUNT" -gt 0 ]; then
-    echo "$FAILURE_COUNT / $COUNT tests failed"
+    echo "$FAILURE_COUNT / $COUNT tests failed" | sudo tee /dev/kmsg
     exit 1
 else
-    echo "All tests passed!!"
+    echo "All tests passed!!" | sudo tee /dev/kmsg
 fi
 
 # Reset config file

--- a/scripts/e2e_test_2to2
+++ b/scripts/e2e_test_2to2
@@ -51,9 +51,9 @@ source install/setup.bash
 # Run test
 CONFIG_FILE=src/agnocast_e2e_test/test/config_test_2to2.yaml
 show_config() {
-    echo "----------------------------------------------"
-    cat $CONFIG_FILE
-    echo "----------------------------------------------"
+    echo "----------------------------------------------" | sudo tee /dev/kmsg
+    cat $CONFIG_FILE | sudo tee /dev/kmsg
+    echo "----------------------------------------------" | sudo tee /dev/kmsg
 }
 
 FAILURE_COUNT=0
@@ -61,7 +61,7 @@ if [ "$RUN_SINGLE" = true ]; then
     show_config
     launch_test src/agnocast_e2e_test/test/test_2to2.py
     if [ $? -ne 0 ]; then
-        echo "Test failed"
+        echo "Test failed" | sudo tee /dev/kmsg
         exit 1
     fi
 else
@@ -81,12 +81,12 @@ else
             sed -i "s|^container$i:.*|container$i: [$list]|" "$CONFIG_FILE"
         done
 
-        echo "====================== $COUNT / 8 ======================"
+        echo "====================== $COUNT / 8 ======================" | sudo tee /dev/kmsg
         show_config
         launch_test src/agnocast_e2e_test/test/test_2to2.py
 
         if [ $? -ne 0 ]; then
-            echo "Test failed"
+            echo "Test failed" | sudo tee /dev/kmsg
             if [ "$CONTINUE_ON_FAILURE" = true ]; then
                 FAILURE_COUNT=$((FAILURE_COUNT + 1))
             else
@@ -97,10 +97,10 @@ else
 fi
 
 if [ "$FAILURE_COUNT" -gt 0 ]; then
-    echo "$FAILURE_COUNT / $COUNT tests failed"
+    echo "$FAILURE_COUNT / $COUNT tests failed" | sudo tee /dev/kmsg
     exit 1
 else
-    echo "All tests passed!!"
+    echo "All tests passed!!" | sudo tee /dev/kmsg
 fi
 
 # Reset config file

--- a/scripts/e2e_test_stress
+++ b/scripts/e2e_test_stress
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PERCENTAGES=($(seq 5 5 95)) # You can change this
+PERCENTAGES=($(seq 5 5 95))   # You can change this
+TIMEOUT_EACH_TEST_CASE_S="60" # You can change this
 
 NUM_PERCENTAGES=${#PERCENTAGES[@]}
 MAX_MQ_NUM=$(cat /proc/sys/fs/mqueue/queues_max)
@@ -12,35 +13,35 @@ TIMEOUT=680s # based on the measurement time of e2e tests
 
 run-stress-ng() {
     if [ $1 -lt $NUM_PERCENTAGES ]; then
-        echo "Run stress-ng with CPU load ${PERCENTAGES[$1]}%"
+        echo "Run stress-ng with CPU load ${PERCENTAGES[$1]}%" | sudo tee /dev/kmsg
         stress-ng --cpu $(nproc) --cpu-load ${PERCENTAGES[$1]} --timeout $TIMEOUT &
 
     elif [ "$1" -lt "$((NUM_PERCENTAGES * 2))" ]; then
         index=$(($1 - NUM_PERCENTAGES))
-        echo "Run stress-ng with VM ${PERCENTAGES[$index]}%"
+        echo "Run stress-ng with VM ${PERCENTAGES[$index]}%" | sudo tee /dev/kmsg
         stress-ng --vm 1 --vm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
 
     elif [ "$1" -lt "$((NUM_PERCENTAGES * 3))" ]; then
         index=$(($1 - NUM_PERCENTAGES * 2))
-        echo "Run stress-ng with SHM ${PERCENTAGES[$index]}%"
+        echo "Run stress-ng with SHM ${PERCENTAGES[$index]}%" | sudo tee /dev/kmsg
         stress-ng --shm 1 --shm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
 
     else
         index=$(($1 - NUM_PERCENTAGES * 3))
-        echo "Run stress-ng with MQ ${MQ_PERCENT[$index]}"
+        echo "Run stress-ng with MQ ${MQ_PERCENT[$index]}" | sudo tee /dev/kmsg
         stress-ng --mq ${MQ_PERCENT[$index]} --timeout $TIMEOUT &
     fi
 }
 
 NUM_LOOP=$((NUM_PERCENTAGES * 4)) # cpu_load, vm, shm, mq
 for i in $(seq 1 $NUM_LOOP); do
-    echo "============================================================================"
-    echo "============================ Outer Loop $i / $NUM_LOOP ============================"
-    echo "============================================================================"
+    echo "============================================================================" | sudo tee /dev/kmsg
+    echo "============================ Outer Loop $i / $NUM_LOOP ============================" | sudo tee /dev/kmsg
+    echo "============================================================================" | sudo tee /dev/kmsg
 
     run-stress-ng $(($i - 1))
-    bash scripts/e2e_test_1to1_with_ros2sub -c
-    bash scripts/e2e_test_2to2 -c
+    STRESS_TEST_TIMEOUT=$TIMEOUT_EACH_TEST_CASE_S ./scripts/e2e_test_1to1_with_ros2sub -c
+    STRESS_TEST_TIMEOUT=$TIMEOUT_EACH_TEST_CASE_S ./scripts/e2e_test_2to2 -c
 
     wait
 done

--- a/src/agnocast_e2e_test/src/test_publisher.cpp
+++ b/src/agnocast_e2e_test/src/test_publisher.cpp
@@ -16,6 +16,7 @@ class TestPublisher : public rclcpp::Node
   int64_t planned_sub_count_;
   size_t planned_pub_count_;
   bool is_ready_ = false;
+  bool forever_;
 
   bool is_ready()
   {
@@ -47,11 +48,13 @@ class TestPublisher : public rclcpp::Node
     count_++;
 
     if (count_ == target_pub_num_) {
-      timer_->cancel();
       RCLCPP_INFO(this->get_logger(), "All messages published. Shutting down.");
       std::cout << std::flush;
       sleep(3);  // HACK: wait for other nodes in the same container
-      rclcpp::shutdown();
+
+      if (!forever_) {
+        rclcpp::shutdown();
+      }
     }
   }
 
@@ -64,12 +67,14 @@ public:
     this->declare_parameter<int64_t>("pub_num", 10);
     this->declare_parameter<int64_t>("planned_sub_count", 1);
     this->declare_parameter<int64_t>("planned_pub_count", 1);
+    this->declare_parameter<bool>("forever", false);
     int64_t qos_depth = this->get_parameter("qos_depth").as_int();
     bool transient_local = this->get_parameter("transient_local").as_bool();
     int64_t init_pub_num = this->get_parameter("init_pub_num").as_int();
     int64_t pub_num = this->get_parameter("pub_num").as_int();
     planned_sub_count_ = this->get_parameter("planned_sub_count").as_int();
     planned_pub_count_ = static_cast<size_t>(this->get_parameter("planned_pub_count").as_int());
+    forever_ = this->get_parameter("forever").as_bool();
 
     rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(qos_depth));
     if (transient_local) {

--- a/src/agnocast_e2e_test/src/test_ros2_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_ros2_subscriber.cpp
@@ -9,6 +9,7 @@ class TestROS2Subscriber : public rclcpp::Node
   rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr sub_;
   int64_t count_;
   int64_t sub_num_;
+  bool forever_;
 
   void callback(const std_msgs::msg::Int64 & message)
   {
@@ -18,7 +19,10 @@ class TestROS2Subscriber : public rclcpp::Node
     if (count_ == sub_num_) {
       RCLCPP_INFO(this->get_logger(), "All messages received. Shutting down.");
       std::cout << std::flush;
-      rclcpp::shutdown();
+
+      if (!forever_) {
+        rclcpp::shutdown();
+      }
     }
   }
 
@@ -29,8 +33,10 @@ public:
     this->declare_parameter<int64_t>("qos_depth", 10);
     this->declare_parameter<bool>("transient_local", true);
     this->declare_parameter<int64_t>("sub_num", 10);
+    this->declare_parameter<bool>("forever", false);
     int64_t qos_depth = this->get_parameter("qos_depth").as_int();
     bool transient_local = this->get_parameter("transient_local").as_bool();
+    forever_ = this->get_parameter("forever").as_bool();
 
     rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(qos_depth));
     if (transient_local) {

--- a/src/agnocast_e2e_test/src/test_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_subscriber.cpp
@@ -10,6 +10,7 @@ class TestSubscriber : public rclcpp::Node
   agnocast::Subscription<std_msgs::msg::Int64>::SharedPtr sub_;
   uint64_t count_;
   uint64_t target_sub_num_;
+  bool forever_;
 
   void callback(const agnocast::ipc_shared_ptr<std_msgs::msg::Int64> & message)
   {
@@ -20,7 +21,10 @@ class TestSubscriber : public rclcpp::Node
       RCLCPP_INFO(this->get_logger(), "All messages received. Shutting down.");
       std::cout << std::flush;
       sleep(3);  // HACK: wait for other nodes in the same container
-      rclcpp::shutdown();
+
+      if (!forever_) {
+        rclcpp::shutdown();
+      }
     }
   }
 
@@ -30,6 +34,8 @@ public:
     this->declare_parameter<int64_t>("qos_depth", 10);
     this->declare_parameter<bool>("transient_local", true);
     this->declare_parameter<int64_t>("sub_num", 10);
+    this->declare_parameter<bool>("forever", false);
+    forever_ = this->get_parameter("forever").as_bool();
 
     int64_t qos_depth = this->get_parameter("qos_depth").as_int();
     rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(qos_depth));

--- a/src/agnocast_e2e_test/src/test_take_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_take_subscriber.cpp
@@ -12,6 +12,7 @@ class TestTakeSubscriber : public rclcpp::Node
   agnocast::TakeSubscription<std_msgs::msg::Int64>::SharedPtr sub_;
   uint64_t count_;
   uint64_t sub_num_;
+  bool forever_;
 
   void timer_callback()
   {
@@ -24,8 +25,12 @@ class TestTakeSubscriber : public rclcpp::Node
     if (count_ == sub_num_) {
       RCLCPP_INFO(this->get_logger(), "All messages received. Shutting down.");
       std::cout << std::flush;
-      timer_->cancel();
-      rclcpp::shutdown();
+
+      if (!forever_) {
+        rclcpp::shutdown();
+      } else {
+        count_++;
+      }
     }
   }
 
@@ -36,6 +41,8 @@ public:
     this->declare_parameter<int64_t>("qos_depth", 10);
     this->declare_parameter<bool>("transient_local", true);
     this->declare_parameter<int64_t>("sub_num", 10);
+    this->declare_parameter<bool>("forever", false);
+    forever_ = this->get_parameter("forever").as_bool();
 
     int64_t qos_depth = this->get_parameter("qos_depth").as_int();
     rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(qos_depth));

--- a/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
+++ b/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
@@ -19,6 +19,9 @@ EXPECT_SUB_NUM: int
 EXPECT_INIT_ROS2_SUB_NUM: int
 EXPECT_ROS2_SUB_NUM: int
 
+TIMEOUT = os.environ.get('STRESS_TEST_TIMEOUT')
+FOREVER = True if (os.environ.get('STRESS_TEST_TIMEOUT')) else False
+
 
 def calc_expect_pub_sub_num(config: dict) -> None:
     global EXPECT_PUB_NUM, EXPECT_INIT_PUB_NUM, EXPECT_INIT_SUB_NUM, EXPECT_SUB_NUM, EXPECT_INIT_ROS2_SUB_NUM, EXPECT_ROS2_SUB_NUM
@@ -43,7 +46,7 @@ def calc_action_delays(config: dict) -> tuple:
     unit_delay = 1.0
     pub_delay = 0.0 if config['launch_pub_before_sub'] else unit_delay
     sub_delay = 0.01 * EXPECT_INIT_PUB_NUM + unit_delay if config['launch_pub_before_sub'] else 0.0
-    ready_delay = pub_delay + sub_delay + 7.0
+    ready_delay = float(TIMEOUT) if TIMEOUT else pub_delay + sub_delay + 7.0
     return pub_delay, sub_delay, ready_delay
 
 
@@ -72,7 +75,8 @@ def generate_test_description():
                                 "qos_depth": config['pub_qos_depth'],
                                 "transient_local": config['pub_transient_local'],
                                 "init_pub_num": EXPECT_INIT_PUB_NUM,
-                                "pub_num": EXPECT_PUB_NUM
+                                "pub_num": EXPECT_PUB_NUM,
+                                "forever": FOREVER
                             }
                         ],
                     )
@@ -98,11 +102,12 @@ def generate_test_description():
                         plugin='TestROS2Subscriber',
                         name='test_ros2_listener_node',
                         parameters=[
-                            {"qos_depth": config['sub_qos_depth'],
-                             "transient_local": config
-                             ['sub_transient_local']
-                             if config['pub_transient_local'] else False,
-                             "sub_num": EXPECT_INIT_ROS2_SUB_NUM + EXPECT_ROS2_SUB_NUM}
+                            {
+                                "qos_depth": config['sub_qos_depth'],
+                                "transient_local": config['sub_transient_local'] if config['pub_transient_local'] else False,
+                                "sub_num": EXPECT_INIT_ROS2_SUB_NUM + EXPECT_ROS2_SUB_NUM,
+                                "forever": FOREVER
+                            }
                         ],
                     )
             ],
@@ -125,7 +130,8 @@ def generate_test_description():
                             {
                                 "qos_depth": config['sub_qos_depth'],
                                 "transient_local": config['sub_transient_local'],
-                                "sub_num": EXPECT_INIT_SUB_NUM + EXPECT_SUB_NUM
+                                "sub_num": EXPECT_INIT_SUB_NUM + EXPECT_SUB_NUM,
+                                "forever": FOREVER
                             }
                         ],
                     )
@@ -153,7 +159,8 @@ def generate_test_description():
                             {
                                 "qos_depth": config['sub_qos_depth'],
                                 "transient_local": config['sub_transient_local'],
-                                "sub_num": EXPECT_INIT_SUB_NUM + EXPECT_SUB_NUM
+                                "sub_num": EXPECT_INIT_SUB_NUM + EXPECT_SUB_NUM,
+                                "forever": FOREVER
                             }
                         ],
                     )
@@ -188,7 +195,6 @@ def generate_test_description():
     )
 
 
-@launch_testing.post_shutdown_test()
 class Test1To1(unittest.TestCase):
 
     def test_pub(self, proc_output, test_pub):

--- a/src/agnocast_e2e_test/test/test_2to2.py
+++ b/src/agnocast_e2e_test/test/test_2to2.py
@@ -15,6 +15,8 @@ with open(CONFIG_PATH, 'r') as f:
     CONFIG = yaml.safe_load(f)
 QOS_DEPTH = 10
 PUB_NUM = int(QOS_DEPTH / 2)
+TIMEOUT = float(os.environ.get('STRESS_TEST_TIMEOUT', 8.0))
+FOREVER = True if (os.environ.get('STRESS_TEST_TIMEOUT')) else False
 
 
 @launch_testing.markers.keep_alive
@@ -39,7 +41,8 @@ def generate_test_description():
                                 "init_pub_num": 0,
                                 "pub_num": PUB_NUM,
                                 "planned_pub_count": 2,
-                                "planned_sub_count": 2
+                                "planned_sub_count": 2,
+                                "forever": FOREVER,
                             }
                         ],
                     )
@@ -57,6 +60,7 @@ def generate_test_description():
                                 "qos_depth": QOS_DEPTH,
                                 "transient_local": False,
                                 "sub_num": QOS_DEPTH,
+                                "forever": FOREVER,
                             }
                         ],
                     )
@@ -83,13 +87,12 @@ def generate_test_description():
             [
                 SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '0'),
                 *containers,
-                TimerAction(period=8.0, actions=[launch_testing.actions.ReadyToTest()])
+                TimerAction(period=TIMEOUT, actions=[launch_testing.actions.ReadyToTest()])
             ]
         ), testing_processes
     )
 
 
-@launch_testing.post_shutdown_test()
 class Test2To2(unittest.TestCase):
     pub_i_ = 0
     sub_i_ = 0


### PR DESCRIPTION
## Description

- e2e testの各テストケースのtimeout時間を設定可能に
- ログを /dev/kmsg に書き込むようにした

## Related links

https://star4.slack.com/archives/C07FL8616EM/p1741312400130989

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
