### PR TITLE
test(kmod): add increment_rc negative tets

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.h
@@ -1,6 +1,12 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_INCREMENT_RC KUNIT_CASE(test_case_increment_rc)
+#define TEST_CASES_INCREMENT_RC                                                         \
+  KUNIT_CASE(test_case_increment_rc), KUNIT_CASE(test_case_increment_rc_without_topic), \
+    KUNIT_CASE(test_case_increment_rc_without_entry),                                   \
+    KUNIT_CASE(test_case_increment_rc_by_publisher)
 
 void test_case_increment_rc(struct kunit * test);
+void test_case_increment_rc_without_topic(struct kunit * test);
+void test_case_increment_rc_without_entry(struct kunit * test);
+void test_case_increment_rc_by_publisher(struct kunit * test);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -415,7 +415,7 @@ int increment_message_entry_rc(
     dev_warn(
       agnocast_device, "Topic (topic_name=%s) not found. (increment_message_entry_rc)\n",
       topic_name);
-    return -1;
+    return -EINVAL;
   }
 
   struct entry_node * en = find_message_entry(wrapper, entry_id);
@@ -425,7 +425,7 @@ int increment_message_entry_rc(
       "Message entry (topic_name=%s entry_id=%lld) not found. "
       "(increment_message_entry_rc)\n",
       topic_name, entry_id);
-    return -1;
+    return -EINVAL;
   }
 
   if (en->publisher_id == pubsub_id) {
@@ -434,12 +434,12 @@ int increment_message_entry_rc(
       "Incrementing publisher's rc is not allowed. (topic_name=%s entry_id=%lld pubsub_id=%d) "
       "(increment_message_entry_rc)\n",
       wrapper->key, entry_id, pubsub_id);
-    return -1;
-  } else {
-    int ret = increment_sub_rc(en, pubsub_id);
-    if (ret < 0) {
-      return ret;
-    }
+    return -EINVAL;
+  }
+
+  int ret = increment_sub_rc(en, pubsub_id);
+  if (ret < 0) {
+    return ret;
   }
 
   return 0;


### PR DESCRIPTION
## Description

Add negative kunit tests for `increment_message_entry_rc` 

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
