### PR TITLE
fix: workaround for launch_testing timeout configuration

### DIFF
--- a/scripts/e2e_test_stress
+++ b/scripts/e2e_test_stress
@@ -12,6 +12,7 @@ done
 TIMEOUT=680s # based on the measurement time of e2e tests
 
 # Workaround for launch_testing timeout configuration
+# This is because it is hard coded in https://github.com/ros2/launch/blob/f31c1ff13fcbed3653d1a0e26438cb739e96d751/launch_testing/launch_testing/test_runner.py#L184.
 SED_TARGET_FILE=$(dirname "$(python3 -c 'import launch_testing; print(launch_testing.__file__)')")/test_runner.py
 sudo cp $SED_TARGET_FILE $SED_TARGET_FILE.bak
 TIMEOUT_WITH_BUFFER=$((TIMEOUT_EACH_TEST_CASE_S + 10))

--- a/scripts/e2e_test_stress
+++ b/scripts/e2e_test_stress
@@ -11,7 +11,14 @@ for ((i = 0; i < NUM_PERCENTAGES; i++)); do
 done
 TIMEOUT=680s # based on the measurement time of e2e tests
 
+# Workaround for launch_testing timeout configuration
+SED_TARGET_FILE=$(dirname "$(python3 -c 'import launch_testing; print(launch_testing.__file__)')")/test_runner.py
+sudo cp $SED_TARGET_FILE $SED_TARGET_FILE.bak
+TIMEOUT_WITH_BUFFER=$((TIMEOUT_EACH_TEST_CASE_S + 10))
+sudo sed -i '/if not self._processes_launched.wait/s/\(timeout=\)[0-9]\+/\1'"$TIMEOUT_WITH_BUFFER"'/' "$SED_TARGET_FILE"
+
 cleanup() {
+    sudo cp $SED_TARGET_FILE.bak $SED_TARGET_FILE
     echo "Stopping stress-ng..."
     pkill -P $$ # Kill all child processes
     exit 1


### PR DESCRIPTION
## Description

launch_testingではReadyToTest()が呼ばれたタイミングか、テストが終了したタイミングで対象プロセスがkillされてしまいます。なので、今回の用途ではReadyToTest()の遅延 (TimerActionのperiod) を伸ばすしかないのですが、
https://github.com/ros2/launch/blob/f31c1ff13fcbed3653d1a0e26438cb739e96d751/launch_testing/launch_testing/test_runner.py#L184 でこの値の上限がハードコーディングされているので、これをsedで書き換えるworkaroundを実装しました。

## Related links

solves https://star4.slack.com/archives/C07FL8616EM/p1741861357582109?thread_ts=1741859385.045249&cid=C07FL8616EM

## How was this PR tested?

`bash scripts/e2e_test_stress`

## Notes for reviewers
