### PR TITLE
improve(MultiThreadedAgnocastExecutor): remove unnecessary check

### DIFF
--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -25,6 +25,12 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
 void MultiThreadedAgnocastExecutor::validate_callback_group(
   const rclcpp::CallbackGroup::SharedPtr & group) const
 {
+  if (!group) {
+    RCLCPP_ERROR(logger, "Callback group is nullptr. The node may have been destructed.");
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+
   if (group->type() == rclcpp::CallbackGroupType::Reentrant) {
     return;
   }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -23,7 +23,11 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
 void SingleThreadedAgnocastExecutor::validate_callback_group(
   [[maybe_unused]] const rclcpp::CallbackGroup::SharedPtr & group) const
 {
-  // Do nothing
+  if (!group) {
+    RCLCPP_ERROR(logger, "Callback group is nullptr. The node may have been destructed.");
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
 }
 
 void SingleThreadedAgnocastExecutor::spin()

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -21,7 +21,7 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
 }
 
 void SingleThreadedAgnocastExecutor::validate_callback_group(
-  [[maybe_unused]] const rclcpp::CallbackGroup::SharedPtr & group) const
+  const rclcpp::CallbackGroup::SharedPtr & group) const
 {
   if (!group) {
     RCLCPP_ERROR(logger, "Callback group is nullptr. The node may have been destructed.");


### PR DESCRIPTION
## Description

https://github.com/tier4/agnocast/pull/515 により、このチェックは不要になりました。nullptrチェックのみ残しました。

## Related links

https://star4.slack.com/archives/C07FL8616EM/p1741934476490689?thread_ts=1741917956.704529&cid=C07FL8616EM

## How was this PR tested?

- [x] Autoware (required) -> これで動くようになることを神戸さんが確認している
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
