### PR TITLE
fix(kmod): remove invalid test

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -419,43 +419,6 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 0);
 }
 
-void test_case_take_msg_too_many_rc(struct kunit * test)
-{
-  // Arrange
-  topic_local_id_t publisher_id;
-  uint64_t ret_addr;
-  const pid_t publisher_pid = 1000;
-  const uint32_t publisher_qos_depth = MAX_QOS_DEPTH;
-  const bool publisher_transient_local = false;
-  setup_one_publisher(
-    test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
-  topic_local_id_t subscriber_id;
-  const pid_t subscriber_pid = 2000;
-  const uint32_t subscriber_qos_depth = 1;
-  const bool subscriber_transient_local = false;
-  setup_one_subscriber(
-    test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
-
-  union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-
-  for (int i = 0; i < MAX_SUBSCRIBER_NUM; i++) {
-    int ret = increment_message_entry_rc(
-      TOPIC_NAME, subscriber_id + i + 1, ioctl_publish_msg_ret1.ret_entry_id);
-    KUNIT_ASSERT_EQ(test, ret, 0);
-  }
-
-  const bool allow_same_message = true;
-  union ioctl_take_msg_args ioctl_take_msg_ret;
-
-  // Act
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
-
-  // Assert
-  KUNIT_EXPECT_EQ(test, ret2, -ENOBUFS);
-}
-
 void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
   struct kunit * test)
 {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -16,7 +16,6 @@
       test_case_take_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_publish_num),     \
     KUNIT_CASE(                                                                                  \
       test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_max_qos_depth), \
-    KUNIT_CASE(test_case_take_msg_too_many_rc),                                                  \
     KUNIT_CASE(                                                                                  \
       test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal),     \
     KUNIT_CASE(                                                                                  \
@@ -46,7 +45,6 @@ void test_case_take_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_pu
   struct kunit * test);
 void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_max_qos_depth(
   struct kunit * test);
-void test_case_take_msg_too_many_rc(struct kunit * test);
 void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
   struct kunit * test);
 void test_case_take_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(


### PR DESCRIPTION
## Description

Removed `test_case_take_msg_too_many_rc` since incrementing reference count of invalid subscriber is no longer acceptable.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
