### PR TITLE
fix: do shm_unlink in kernel module

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -2005,7 +2005,7 @@ void process_exit_cleanup(const pid_t pid)
 
 #ifndef KUNIT_BUILD
   // Unlink /dev/shm/agnocast@PID
-  char filename_buffer[30]; // Larger enough than when pid is 4,194,304 (Linux default pid_max).
+  char filename_buffer[30];  // Larger enough than when pid is 4,194,304 (Linux default pid_max).
   scnprintf(filename_buffer, sizeof(filename_buffer), "/dev/shm/agnocast@%d", pid);
 
   struct filename * filename = getname_kernel(filename_buffer);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -2110,7 +2110,7 @@ static struct kprobe kp = {
   .pre_handler = pre_handler_do_exit,
 };
 
-/* Look up and set optee_invoke_func using kprobe */
+/* Look up and set do_unlinkat using kprobe */
 unsigned long lookup_do_unlinkat(void)
 {
   struct kprobe kp_do_unlinkat;

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -36,7 +36,6 @@ static DEFINE_MUTEX(global_mutex);
 #define MAX_TOPIC_INFO_RET_NUM max(MAX_PUBLISHER_NUM, MAX_SUBSCRIBER_NUM)
 
 #ifndef KUNIT_BUILD
-static int set_do_unlinkat(void);
 static int (*do_unlinkat)(int, struct filename *);
 #endif
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -99,15 +99,11 @@ void * initialize_agnocast(const uint64_t shm_size)
 
 static void shutdown_agnocast()
 {
-  const pid_t pid = getpid();
-
-  {
-    std::lock_guard<std::mutex> lock(shm_fds_mtx);
-    for (int fd : shm_fds) {
+  std::lock_guard<std::mutex> lock(shm_fds_mtx);
+  for (int fd : shm_fds) {
       if (close(fd) == -1) {
-        perror("[ERROR] [Agnocast] close shm_fd failed");
+      perror("[ERROR] [Agnocast] close shm_fd failed");
       }
-    }
   }
 }
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -101,9 +101,9 @@ static void shutdown_agnocast()
 {
   std::lock_guard<std::mutex> lock(shm_fds_mtx);
   for (int fd : shm_fds) {
-      if (close(fd) == -1) {
+    if (close(fd) == -1) {
       perror("[ERROR] [Agnocast] close shm_fd failed");
-      }
+    }
   }
 }
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -109,11 +109,6 @@ static void shutdown_agnocast()
       }
     }
   }
-
-  const std::string shm_name = create_shm_name(pid);
-  if (shm_unlink(shm_name.c_str()) == -1) {
-    perror("[ERROR] [Agnocast] shm_unlink failed");
-  }
 }
 
 class Cleanup


### PR DESCRIPTION
## Description

#### 概要
shm_unlinkをstruct Cleanupのデストラクタで行っているとAutowareの異常終了時にSIGABRTなどで終了される際に呼ばれないのでこれを解決するためにkernel moduleにおけるexit_handler内で行うように変更。また、kunitテスト時にはunlinkする必要はないので今回の追加はすべて#ifndef KUNIT_BUILDの元で実装している。

##### 詳細
shm_unlinkは内部でunlinkat(2)を呼び出しているのでunlinkatに該当するカーネル内部の関数を直接呼び出す。
具体的にはそれは以下のdo_unlinkat()
https://elixir.bootlin.com/linux/v6.10.1/source/fs/namei.c#L4377
do_unlinkatはEXPORTされていないので、これを呼び出すためregister_kprobeを利用してdo_unlinkatのアドレスを直接取得している。

unlinkat(2)の定義
https://elixir.bootlin.com/linux/v6.10.1/source/fs/namei.c#L4449

ファイル名の文字列からstruct filenameを取得するgetnameの、カーネル内部呼び出し版のgetname_kernel
https://elixir.bootlin.com/linux/v6.10.1/source/fs/namei.c#L222


## Related links
[TIER IV Internal Doc
](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3603006119/dev+shm+dev+mqueue?force_transition=493ed30d-7f4b-464d-87fa-544b6f325efe)

## How was this PR tested?
実際に/dev/shmにはAutowareの異常終了時にも何も残らないことを確認した。

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

/dev/shmをアンマウントしてから、ext4ファイルシステムを作成したダミーファイルにマウントし、このとき正しいエラーメッセージとともにfailすることを確認した。

## Notes for reviewers

- 本PRで利用されているLinux kernel内部の関数(do_unlinkat, getname_kernel, kern_path, vfs_statfs)のAPIがLinux kernel v5.0 - 6.10の間で変更がないことを確認(将来的にも修正は入りにくい場所)

- /dev/shmが共有メモリ(TMPFS_MAGIC)としてマウントされていることを確認するコードを追加し、共有メモリとして利用できないのであればfailするように変更