### PR TITLE
fix(component container): enable parameter passing

### DIFF
--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -10,8 +10,9 @@ int main(int argc, char * argv[])
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
 
+  std::string node_name = "ComponentManager";
   auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
+    std::weak_ptr<rclcpp::Executor>(), node_name, options);
 
   const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
 

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -4,31 +4,30 @@
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
-
-  rclcpp::NodeOptions options;
-  options.allow_undeclared_parameters(true);
-  options.automatically_declare_parameters_from_overrides(true);
-  std::string node_name = "ComponentManager";
-  std::shared_ptr<rclcpp_components::ComponentManager> node;
-
   try {
-    node = std::make_shared<rclcpp_components::ComponentManager>(
-      std::weak_ptr<rclcpp::Executor>(), node_name, options);
+    rclcpp::init(argc, argv);
+
+    rclcpp::NodeOptions options;
+    options.allow_undeclared_parameters(true);
+    options.automatically_declare_parameters_from_overrides(true);
+
+    auto node = std::make_shared<rclcpp_components::ComponentManager>(
+      std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
+
+    const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
+
+    auto executor = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>(
+      rclcpp::ExecutorOptions{}, get_next_timeout_ms);
+
+    node->set_executor(executor);
+    executor->add_node(node);
+    executor->spin();
+
+    rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
     return EXIT_FAILURE;
   }
 
-  const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
-
-  auto executor = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>(
-    rclcpp::ExecutorOptions{}, get_next_timeout_ms);
-
-  node->set_executor(executor);
-  executor->add_node(node);
-  executor->spin();
-
-  rclcpp::shutdown();
   return 0;
 }

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -9,10 +9,16 @@ int main(int argc, char * argv[])
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
-
   std::string node_name = "ComponentManager";
-  auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+  std::shared_ptr<rclcpp_components::ComponentManager> node;
+
+  try {
+    node = std::make_shared<rclcpp_components::ComponentManager>(
+      std::weak_ptr<rclcpp::Executor>(), node_name, options);
+  } catch (rclcpp_components::ComponentManagerException & ex) {
+    std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 
   const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
 

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -26,9 +26,11 @@ int main(int argc, char * argv[])
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "Exception caught in main: " << ex.what() << std::endl;
+    close(agnocast_fd);
     return EXIT_FAILURE;
   } catch (...) {
     std::cerr << "Unknown exception caught in main: " << std::endl;
+    close(agnocast_fd);
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -9,10 +9,9 @@ int main(int argc, char * argv[])
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
-  std::string node_name = "component_manager" + std::to_string(getpid());
 
   auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+    std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
 
   const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
 

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -25,7 +25,10 @@ int main(int argc, char * argv[])
 
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
-    std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
+    std::cerr << "Exception caught in main: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "Unknown exception caught in main: " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -5,12 +5,16 @@
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<rclcpp_components::ComponentManager>();
 
-  const int get_next_timeout_ms =
-    (node->has_parameter("get_next_timeout_ms"))
-      ? static_cast<int>(node->get_parameter("get_next_timeout_ms").as_int())
-      : 50;
+  rclcpp::NodeOptions options;
+  options.allow_undeclared_parameters(true);
+  options.automatically_declare_parameters_from_overrides(true);
+  std::string node_name = "component_manager" + std::to_string(getpid());
+
+  auto node = std::make_shared<rclcpp_components::ComponentManager>(
+    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+
+  const int get_next_timeout_ms = node->get_parameter_or("get_next_timeout_ms", 50);
 
   auto executor = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>(
     rclcpp::ExecutorOptions{}, get_next_timeout_ms);

--- a/src/agnocastlib/src/agnocast_component_container.cpp
+++ b/src/agnocastlib/src/agnocast_component_container.cpp
@@ -26,11 +26,11 @@ int main(int argc, char * argv[])
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "Exception caught in main: " << ex.what() << std::endl;
-    close(agnocast_fd);
+    close(agnocast::agnocast_fd);
     return EXIT_FAILURE;
   } catch (...) {
     std::cerr << "Unknown exception caught in main: " << std::endl;
-    close(agnocast_fd);
+    close(agnocast::agnocast_fd);
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -6,9 +6,9 @@
 
 int main(int argc, char * argv[])
 {
-  using namespace std::chrono;
-
   try {
+    using namespace std::chrono;
+
     rclcpp::init(argc, argv);
 
     rclcpp::NodeOptions options;
@@ -37,7 +37,10 @@ int main(int argc, char * argv[])
 
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
-    std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
+    std::cerr << "Exception caught in main: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "Unknown exception caught in main: " << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -14,8 +14,9 @@ int main(int argc, char * argv[])
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
 
+  std::string node_name = "ComponentManager";
   auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
+    std::weak_ptr<rclcpp::Executor>(), node_name, options);
 
   const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
   const size_t number_of_agnocast_threads = node->get_parameter_or("number_of_agnocast_threads", 0);

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -13,10 +13,9 @@ int main(int argc, char * argv[])
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
-  std::string node_name = "component_manager" + std::to_string(getpid());
 
   auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+    std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
 
   const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
   const size_t number_of_agnocast_threads = node->get_parameter_or("number_of_agnocast_threads", 0);

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -38,11 +38,11 @@ int main(int argc, char * argv[])
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "Exception caught in main: " << ex.what() << std::endl;
-    close(agnocast_fd);
+    close(agnocast::agnocast_fd);
     return EXIT_FAILURE;
   } catch (...) {
     std::cerr << "Unknown exception caught in main: " << std::endl;
-    close(agnocast_fd);
+    close(agnocast::agnocast_fd);
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -38,9 +38,11 @@ int main(int argc, char * argv[])
     rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "Exception caught in main: " << ex.what() << std::endl;
+    close(agnocast_fd);
     return EXIT_FAILURE;
   } catch (...) {
     std::cerr << "Unknown exception caught in main: " << std::endl;
+    close(agnocast_fd);
     return EXIT_FAILURE;
   }
 

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -9,30 +9,26 @@ int main(int argc, char * argv[])
   using namespace std::chrono;
 
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<rclcpp_components::ComponentManager>();
 
-  const size_t number_of_ros2_threads = (node->has_parameter("number_of_ros2_threads"))
-                                          ? node->get_parameter("number_of_ros2_threads").as_int()
-                                          : 0;
-  const size_t number_of_agnocast_threads =
-    (node->has_parameter("number_of_agnocast_threads"))
-      ? node->get_parameter("number_of_agnocast_threads").as_int()
-      : 0;
-  const bool yield_before_execute = (node->has_parameter("yield_before_execute"))
-                                      ? node->get_parameter("yield_before_execute").as_bool()
-                                      : false;
-  const nanoseconds ros2_next_exec_timeout =
-    (node->has_parameter("ros2_next_exec_timeout_ms"))
-      ? nanoseconds(node->get_parameter("ros2_next_exec_timeout_ms").as_int() * 1000 * 1000)
-      : nanoseconds(10 * 1000 * 1000);
+  rclcpp::NodeOptions options;
+  options.allow_undeclared_parameters(true);
+  options.automatically_declare_parameters_from_overrides(true);
+  std::string node_name = "component_manager" + std::to_string(getpid());
+
+  auto node = std::make_shared<rclcpp_components::ComponentManager>(
+    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+
+  const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
+  const size_t number_of_agnocast_threads = node->get_parameter_or("number_of_agnocast_threads", 0);
+  const bool yield_before_execute = node->get_parameter_or("yield_before_execute", false);
+  const nanoseconds ros2_next_exec_timeout_ns =
+    nanoseconds(node->get_parameter_or("ros2_next_exec_timeout_ms", 10) * 1000 * 1000);
   const int agnocast_next_exec_timeout_ms =
-    (node->has_parameter("agnocast_next_exec_timeout_ms"))
-      ? static_cast<int>(node->get_parameter("agnocast_next_exec_timeout_ms").as_int())
-      : 10;
+    node->get_parameter_or("agnocast_next_exec_timeout_ms", 10);
 
   auto executor = std::make_shared<agnocast::MultiThreadedAgnocastExecutor>(
     rclcpp::ExecutorOptions{}, number_of_ros2_threads, number_of_agnocast_threads,
-    yield_before_execute, ros2_next_exec_timeout, agnocast_next_exec_timeout_ms);
+    yield_before_execute, ros2_next_exec_timeout_ns, agnocast_next_exec_timeout_ms);
 
   node->set_executor(executor);
   executor->add_node(node);

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -8,38 +8,38 @@ int main(int argc, char * argv[])
 {
   using namespace std::chrono;
 
-  rclcpp::init(argc, argv);
-
-  rclcpp::NodeOptions options;
-  options.allow_undeclared_parameters(true);
-  options.automatically_declare_parameters_from_overrides(true);
-  std::string node_name = "ComponentManager";
-  std::shared_ptr<rclcpp_components::ComponentManager> node;
-
   try {
-    node = std::make_shared<rclcpp_components::ComponentManager>(
-      std::weak_ptr<rclcpp::Executor>(), node_name, options);
+    rclcpp::init(argc, argv);
+
+    rclcpp::NodeOptions options;
+    options.allow_undeclared_parameters(true);
+    options.automatically_declare_parameters_from_overrides(true);
+
+    auto node = std::make_shared<rclcpp_components::ComponentManager>(
+      std::weak_ptr<rclcpp::Executor>(), "ComponentManager", options);
+
+    const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
+    const size_t number_of_agnocast_threads =
+      node->get_parameter_or("number_of_agnocast_threads", 0);
+    const bool yield_before_execute = node->get_parameter_or("yield_before_execute", false);
+    const nanoseconds ros2_next_exec_timeout_ns =
+      nanoseconds(node->get_parameter_or("ros2_next_exec_timeout_ms", 10) * 1000 * 1000);
+    const int agnocast_next_exec_timeout_ms =
+      node->get_parameter_or("agnocast_next_exec_timeout_ms", 10);
+
+    auto executor = std::make_shared<agnocast::MultiThreadedAgnocastExecutor>(
+      rclcpp::ExecutorOptions{}, number_of_ros2_threads, number_of_agnocast_threads,
+      yield_before_execute, ros2_next_exec_timeout_ns, agnocast_next_exec_timeout_ms);
+
+    node->set_executor(executor);
+    executor->add_node(node);
+    executor->spin();
+
+    rclcpp::shutdown();
   } catch (rclcpp_components::ComponentManagerException & ex) {
     std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
     return EXIT_FAILURE;
   }
 
-  const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
-  const size_t number_of_agnocast_threads = node->get_parameter_or("number_of_agnocast_threads", 0);
-  const bool yield_before_execute = node->get_parameter_or("yield_before_execute", false);
-  const nanoseconds ros2_next_exec_timeout_ns =
-    nanoseconds(node->get_parameter_or("ros2_next_exec_timeout_ms", 10) * 1000 * 1000);
-  const int agnocast_next_exec_timeout_ms =
-    node->get_parameter_or("agnocast_next_exec_timeout_ms", 10);
-
-  auto executor = std::make_shared<agnocast::MultiThreadedAgnocastExecutor>(
-    rclcpp::ExecutorOptions{}, number_of_ros2_threads, number_of_agnocast_threads,
-    yield_before_execute, ros2_next_exec_timeout_ns, agnocast_next_exec_timeout_ms);
-
-  node->set_executor(executor);
-  executor->add_node(node);
-  executor->spin();
-
-  rclcpp::shutdown();
   return 0;
 }

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -13,10 +13,16 @@ int main(int argc, char * argv[])
   rclcpp::NodeOptions options;
   options.allow_undeclared_parameters(true);
   options.automatically_declare_parameters_from_overrides(true);
-
   std::string node_name = "ComponentManager";
-  auto node = std::make_shared<rclcpp_components::ComponentManager>(
-    std::weak_ptr<rclcpp::Executor>(), node_name, options);
+  std::shared_ptr<rclcpp_components::ComponentManager> node;
+
+  try {
+    node = std::make_shared<rclcpp_components::ComponentManager>(
+      std::weak_ptr<rclcpp::Executor>(), node_name, options);
+  } catch (rclcpp_components::ComponentManagerException & ex) {
+    std::cerr << "ComponentManager exception: " << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 
   const size_t number_of_ros2_threads = node->get_parameter_or("number_of_ros2_threads", 0);
   const size_t number_of_agnocast_threads = node->get_parameter_or("number_of_agnocast_threads", 0);


### PR DESCRIPTION
## Description
実は今まで、AgnocastのComponent Containerには、パラメータを渡せないバグがあった。

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application
- [x] 各パラメータが適切に渡されていることのチェック

## Notes for reviewers
