### PR TITLE
fix: e2e test in restricted environments in terms of the number of cores

### DIFF
--- a/src/agnocast_e2e_test/test/test_2to2.py
+++ b/src/agnocast_e2e_test/test/test_2to2.py
@@ -73,6 +73,7 @@ def generate_test_description():
             executable='agnocast_component_container_mt',
             composable_node_descriptions=composable_nodes,
             output='screen',
+            parameters=[{'number_of_ros2_threads': 8, 'number_of_agnocast_threads': 8}],
             additional_env={
                 'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
                 'MEMPOOL_SIZE': '134217728',


### PR DESCRIPTION
## Description
クラウドのDocker環境など、ハードウェアのスレッド数が限られている場所では、2to2のテストが失敗する。
たとえば、物理スレッド数が2の環境では以下の理由で失敗する。

AgnocastMultiThreadedExecutorのデフォルト設定では、`ハードウェアのスレッド数 / 2` をスレッド数として、AgnocastとROS 2のスレッドプールを確保する。したがって、それぞれスレッド数は1。
そのため、 sleep 関数を呼び出すと、一つしかないスレッドの動作が停止し、全体が停止してしまう。

## Related links
[slack](https://star4.slack.com/archives/C07FL8616EM/p1742285136146179?thread_ts=1742273836.154089&cid=C07FL8616EM)

## How was this PR tested?

- [x] AWFのDocker環境 (物理スレッド数2) の環境でe2eテストが成功

## Notes for reviewers
https://github.com/tier4/agnocast/pull/538 がマージされないと、この設定変更は反映されない。