### PR TITLE
test: fix error & fail workflow when git diff is failed

### DIFF
--- a/.github/workflows/build-and-test-cpp.yaml
+++ b/.github/workflows/build-and-test-cpp.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Check for .cpp or .hpp file changes
       id: check_changes_cpp
       run: |
+        set -e
         if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -E '(agnocastlib|agnocast_ioctl_wrapper)/.*\.(cpp|hpp)$'; then
           echo ".cpp or .hpp files changed"
           echo "cpp_changed=true" >> $GITHUB_OUTPUT

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -22,7 +22,7 @@ MOCK_GLOBAL_FUNC3(
 MOCK_GLOBAL_FUNC5(
   publish_core_mock, union ioctl_publish_args(
                        const void *, const std::string &, const topic_local_id_t, const uint64_t,
-                       std::unordered_map<std::string, mqd_t> &));
+                       std::unordered_map<std::string, std::tuple<mqd_t, bool>> &));
 
 namespace agnocast
 {
@@ -43,7 +43,7 @@ topic_local_id_t initialize_publisher(
 union ioctl_publish_args publish_core(
   const void * publisher_handle, const std::string & topic_name,
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<std::string, mqd_t> & opened_mqs)
+  std::unordered_map<std::string, std::tuple<mqd_t, bool>> & opened_mqs)
 {
   return publish_core_mock(
     publisher_handle, topic_name, publisher_id, msg_virtual_address, opened_mqs);


### PR DESCRIPTION
## Description

https://github.com/tier4/agnocast/pull/476 でテストがfailするようになっていたので、修正しました。これは、 `git diff` が失敗しても添付画像のようにworkflowがpassしてしまうことに起因していたので、それを修正しました。

![image](https://github.com/user-attachments/assets/5650c1fe-196b-4f29-a0ca-6d04f046e41a)


## Related links

## How was this PR tested?

test

## Notes for reviewers
