### PR TITLE
test: add callback group validation into integration test

### DIFF
--- a/src/agnocastlib/test/integration/include/node_for_no_starvation_test.hpp
+++ b/src/agnocastlib/test/integration/include/node_for_no_starvation_test.hpp
@@ -8,10 +8,11 @@
 class NodeForNoStarvation : public rclcpp::Node
 {
 private:
-  rclcpp::CallbackGroup::SharedPtr common_cbg_ = nullptr;
   std::chrono::milliseconds cb_exec_time_;
 
   // For Agnocast
+  std::mutex mutex_for_agnocast_cbg_;
+  bool is_mutually_exclusive_agnocast_ = true;
   rclcpp::CallbackGroup::SharedPtr agnocast_common_cbg_ = nullptr;
   rclcpp::TimerBase::SharedPtr agnocast_timer_;
   std::vector<bool> agnocast_sub_cbs_called_;
@@ -27,6 +28,8 @@ private:
   void agnocast_sub_cb(const agnocast::ipc_shared_ptr<std_msgs::msg::Bool> & msg, int64_t cb_i);
 
   // For ROS 2
+  std::mutex mutex_for_ros2_cbg_;
+  bool is_mutually_exclusive_ros2_ = true;
   rclcpp::CallbackGroup::SharedPtr ros2_common_cbg_ = nullptr;
   rclcpp::TimerBase::SharedPtr ros2_timer_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr ros2_pub_;
@@ -47,4 +50,6 @@ public:
 
   bool is_all_ros2_sub_cbs_called() const;
   bool is_all_agnocast_sub_cbs_called() const;
+  bool is_mutually_exclusive_agnocast() const;
+  bool is_mutually_exclusive_ros2() const;
 };

--- a/src/agnocastlib/test/integration/test_agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_multi_threaded_executor.cpp
@@ -83,6 +83,9 @@ TEST_P(MultiThreadedAgnocastExecutorNoStarvationTest, test_no_starvation)
   // Assert
   EXPECT_TRUE(test_node_->is_all_ros2_sub_cbs_called());
   EXPECT_TRUE(test_node_->is_all_agnocast_sub_cbs_called());
+
+  // The success rate of subsequent tests depends on the number of callbacks and CPU utilization.
+  // With the current configuration, the test is almost certain to pass.
   if (cbg_type_ == "mutually_exclusive") {
     EXPECT_TRUE(test_node_->is_mutually_exclusive_agnocast());
     EXPECT_TRUE(test_node_->is_mutually_exclusive_ros2());


### PR DESCRIPTION
## Description

`MultiThreadedAgnocastExecutor` の統合テストにcallback groupの仕様が守られているかのテストも加えました。当初はテストファイルやテスト用のノードをstarvationの検証と分けようと思っていたのですが、そのまま追加した方が実装が楽だったので、追加する形にしました。これに伴うもろもろのリネームは[別PR](https://github.com/tier4/agnocast/pull/543/files)で行います。

## Related links

## How was this PR tested?

tests

## Notes for reviewers
