### PR TITLE
fix(kmod): remove publisher reference on publisher exit

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1972,7 +1972,16 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper, const pid
     while (node) {
       struct entry_node * en = rb_entry(node, struct entry_node, node);
       node = rb_next(node);
-      if (en->publisher_id == publisher_id && !is_referenced(en)) {
+
+      if (en->publisher_id != publisher_id) continue;
+
+      for (int i = 0; i < MAX_REFERENCING_PUBSUB_NUM_PER_ENTRY; i++) {
+        if (en->referencing_ids[i] == publisher_id) {
+          remove_reference_by_index(en, i);
+        }
+      }
+
+      if (!is_referenced(en)) {
         pub_info->entries_num--;
         remove_entry_node(wrapper, en);
       }


### PR DESCRIPTION
## Description

Fixed bug on publisher exit: remove self reference of entry on publisher exit.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
