### PR TITLE
fix(ci): fix bug in cppcheck workflow

### DIFF
--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Add kmod to paths
         id: add-kmod
         run: |
-          target_paths="${{ steps.add-header-paths.outputs.filtered-full-paths }}"
+          target_paths="${{ steps.add-header-paths.outputs.target-paths }}"
           target_paths="$target_paths $(realpath agnocast_kmod/agnocast_main.c)"
           target_paths="$target_paths $(realpath agnocast_kmod/agnocast.h)"
           target_paths="$target_paths $(realpath agnocast_kmod/agnocast_memory_allocator.c)"

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -3,8 +3,6 @@
 namespace agnocast
 {
 
-// dummy
-
 std::mutex id2_callback_info_mtx;
 const int callback_map_bkt_cnt = 100;  // arbitrary size to prevent rehash
 std::unordered_map<uint32_t, CallbackInfo> id2_callback_info(callback_map_bkt_cnt);

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -3,6 +3,8 @@
 namespace agnocast
 {
 
+// dummy
+
 std::mutex id2_callback_info_mtx;
 const int callback_map_bkt_cnt = 100;  // arbitrary size to prevent rehash
 std::unordered_map<uint32_t, CallbackInfo> id2_callback_info(callback_map_bkt_cnt);


### PR DESCRIPTION
## Description

Fixed cppcheck workflow bug: cppcheck was running for only kmod files.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
