### PR TITLE
fix(kmod): restore decrement_rc kunit test

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_decrement_rc.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_decrement_rc.c
@@ -94,39 +94,37 @@ void test_case_decrement_rc_last_reference(struct kunit * test)
 
 void test_case_decrement_rc_multi_reference(struct kunit * test)
 {
-  // KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
 
-  // // Arrange
-  // topic_local_id_t ret_publisher_id;
-  // uint64_t ret_addr;
-  // setup_one_publisher(test, &ret_publisher_id, &ret_addr);
+  // Arrange
+  topic_local_id_t ret_publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &ret_publisher_id, &ret_addr);
 
-  // union ioctl_publish_args publish_args;
-  // int ret1 = publish_msg(TOPIC_NAME, ret_publisher_id, ret_addr, &publish_args);
-  // KUNIT_ASSERT_EQ(test, ret1, 0);
+  union ioctl_publish_args publish_args;
+  int ret1 = publish_msg(TOPIC_NAME, ret_publisher_id, ret_addr, &publish_args);
+  KUNIT_ASSERT_EQ(test, ret1, 0);
 
-  // const pid_t subscriber_pid = 1000;
-  // union ioctl_new_shm_args new_shm_args;
-  // int ret2 = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
-  // union ioctl_subscriber_args subscriber_args;
-  // int ret3 = subscriber_add(
-  //   TOPIC_NAME, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, false,
-  //   &subscriber_args);
+  const pid_t subscriber_pid = 1000;
+  union ioctl_new_shm_args new_shm_args;
+  int ret2 = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
+  KUNIT_ASSERT_EQ(test, ret2, 0);
 
-  // KUNIT_ASSERT_EQ(test, subscriber_args.ret_transient_local_num, 1);
-  // KUNIT_ASSERT_EQ(test, ret2, 0);
-  // KUNIT_ASSERT_EQ(test, ret3, 0);
+  union ioctl_subscriber_args subscriber_args;
+  int ret3 = subscriber_add(
+    TOPIC_NAME, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, false,
+    &subscriber_args);
+  KUNIT_ASSERT_EQ(test, ret3, 0);
 
-  // int ret4 = increment_message_entry_rc(
-  //   TOPIC_NAME, subscriber_args.ret_id, subscriber_args.ret_entry_ids[0]);
-  // KUNIT_ASSERT_EQ(test, ret4, 0);
+  int ret4 =
+    increment_message_entry_rc(TOPIC_NAME, subscriber_args.ret_id, publish_args.ret_entry_id);
+  KUNIT_ASSERT_EQ(test, ret4, 0);
 
-  // // Act
-  // int ret_sut = decrement_message_entry_rc(
-  //   TOPIC_NAME, subscriber_args.ret_id, subscriber_args.ret_entry_ids[0]);
+  // Act
+  int ret_sut =
+    decrement_message_entry_rc(TOPIC_NAME, subscriber_args.ret_id, publish_args.ret_entry_id);
 
-  // // Assert
-  // KUNIT_EXPECT_EQ(test, ret_sut, 0);
-  // KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, publish_args.ret_entry_id, ret_publisher_id),
-  // 1);
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret_sut, 0);
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, publish_args.ret_entry_id, ret_publisher_id), 1);
 }


### PR DESCRIPTION
## Description

Restored `test_case_decrement_rc_multi_reference` kunit test, which was previously commented out in https://github.com/tier4/agnocast/pull/520

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
