### PR TITLE
fix(kmod): use larger hashtable for pub/sub

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -23,9 +23,10 @@ static DEFINE_MUTEX(global_mutex);
 // =========================================
 // data structure
 
-#define TOPIC_HASH_BITS 10  // hash table size : 2^TOPIC_HASH_BITS
-#define PUB_INFO_HASH_BITS 1
-#define SUB_INFO_HASH_BITS 3
+// hashtable size becomes 2^HASH_BITS
+#define TOPIC_HASH_BITS 10
+#define PUB_INFO_HASH_BITS 3
+#define SUB_INFO_HASH_BITS 5
 #define PROC_INFO_HASH_BITS 10
 
 // Maximum number of referencing Publisher/Subscriber per entry: +1 for the publisher


### PR DESCRIPTION
## Description

Use larger hashbits for publisher/subscriber tables.
Based on generative AI,
> It is common practice to allocate a number of buckets that is approximately 1.3 to 2 times the amount of data to be stored.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
