### PR TITLE
fix(kmod): fix publish_msg return value

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -48,7 +48,7 @@ static void setup_one_publisher(
 }
 
 // Expect to fail at find_topic()
-void test_case_no_topic(struct kunit * test)
+void test_case_publish_msg_no_topic(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id = 0;
@@ -59,11 +59,11 @@ void test_case_no_topic(struct kunit * test)
   int ret = publish_msg(topic_name, publisher_id, msg_virtual_address, &ioctl_publish_ret);
 
   // Assert
-  KUNIT_EXPECT_EQ(test, ret, -1);
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
 }
 
 // Expect to fail at find_publisher_info
-void test_case_no_publisher(struct kunit * test)
+void test_case_publish_msg_no_publisher(struct kunit * test)
 {
   // Arrange
   topic_local_id_t subscriber_id;
@@ -77,10 +77,10 @@ void test_case_no_publisher(struct kunit * test)
   int ret = publish_msg(topic_name, publisher_id, msg_virtual_address, &ioctl_publish_msg_ret);
 
   // Assert
-  KUNIT_ASSERT_EQ(test, ret, -1);
+  KUNIT_ASSERT_EQ(test, ret, -EINVAL);
 }
 
-void test_case_simple_publish_without_any_release(struct kunit * test)
+void test_case_publish_msg_simple_publish_without_any_release(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;
@@ -100,7 +100,7 @@ void test_case_simple_publish_without_any_release(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 1);
 }
 
-void test_case_different_publisher_no_release(struct kunit * test)
+void test_case_publish_msg_different_publisher_no_release(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id1, publisher_id2;
@@ -129,7 +129,7 @@ void test_case_different_publisher_no_release(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
 }
 
-void test_case_referenced_node_not_released(struct kunit * test)
+void test_case_publish_msg_referenced_node_not_released(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;
@@ -154,7 +154,7 @@ void test_case_referenced_node_not_released(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
 }
 
-void test_case_single_release_return(struct kunit * test)
+void test_case_publish_msg_single_release_return(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;
@@ -184,7 +184,7 @@ void test_case_single_release_return(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 1);
 }
 
-void test_case_excessive_release_count(struct kunit * test)
+void test_case_publish_msg_excessive_release_count(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;
@@ -217,7 +217,7 @@ void test_case_excessive_release_count(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
 }
 
-void test_case_ret_one_subscriber(struct kunit * test)
+void test_case_publish_msg_ret_one_subscriber(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id, subscriber_id;
@@ -237,7 +237,7 @@ void test_case_ret_one_subscriber(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_ids[0], subscriber_id);
 }
 
-void test_case_ret_many_subscribers(struct kunit * test)
+void test_case_publish_msg_ret_many_subscribers(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -1,20 +1,22 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_PUBLISH_MSG                                                                  \
-  KUNIT_CASE(test_case_no_topic), KUNIT_CASE(test_case_no_publisher),                           \
-    KUNIT_CASE(test_case_simple_publish_without_any_release),                                   \
-    KUNIT_CASE(test_case_different_publisher_no_release),                                       \
-    KUNIT_CASE(test_case_referenced_node_not_released),                                         \
-    KUNIT_CASE(test_case_single_release_return), KUNIT_CASE(test_case_excessive_release_count), \
-    KUNIT_CASE(test_case_ret_one_subscriber), KUNIT_CASE(test_case_ret_many_subscribers)
+#define TEST_CASES_PUBLISH_MSG                                                                \
+  KUNIT_CASE(test_case_publish_msg_no_topic), KUNIT_CASE(test_case_publish_msg_no_publisher), \
+    KUNIT_CASE(test_case_publish_msg_simple_publish_without_any_release),                     \
+    KUNIT_CASE(test_case_publish_msg_different_publisher_no_release),                         \
+    KUNIT_CASE(test_case_publish_msg_referenced_node_not_released),                           \
+    KUNIT_CASE(test_case_publish_msg_single_release_return),                                  \
+    KUNIT_CASE(test_case_publish_msg_excessive_release_count),                                \
+    KUNIT_CASE(test_case_publish_msg_ret_one_subscriber),                                     \
+    KUNIT_CASE(test_case_publish_msg_ret_many_subscribers)
 
-void test_case_no_topic(struct kunit * test);
-void test_case_no_publisher(struct kunit * test);
-void test_case_simple_publish_without_any_release(struct kunit * test);
-void test_case_different_publisher_no_release(struct kunit * test);
-void test_case_referenced_node_not_released(struct kunit * test);
-void test_case_single_release_return(struct kunit * test);
-void test_case_excessive_release_count(struct kunit * test);
-void test_case_ret_one_subscriber(struct kunit * test);
-void test_case_ret_many_subscribers(struct kunit * test);
+void test_case_publish_msg_no_topic(struct kunit * test);
+void test_case_publish_msg_no_publisher(struct kunit * test);
+void test_case_publish_msg_simple_publish_without_any_release(struct kunit * test);
+void test_case_publish_msg_different_publisher_no_release(struct kunit * test);
+void test_case_publish_msg_referenced_node_not_released(struct kunit * test);
+void test_case_publish_msg_single_release_return(struct kunit * test);
+void test_case_publish_msg_excessive_release_count(struct kunit * test);
+void test_case_publish_msg_ret_one_subscriber(struct kunit * test);
+void test_case_publish_msg_ret_many_subscribers(struct kunit * test);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -548,9 +548,7 @@ static int insert_message_entry(
       dev_warn(
         agnocast_device,
         "Unreachable: New message entry (entry_id=%lld) does not have the largest entry_id in the "
-        "topic "
-        "(topic_name=%s). "
-        "(insert_message_entry)\n",
+        "topic (topic_name=%s). (insert_message_entry)\n",
         new_node->entry_id, wrapper->key);
       kfree(new_node);
       return -ECANCELED;

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -521,7 +521,7 @@ static int insert_message_entry(
   struct entry_node * new_node = kmalloc(sizeof(struct entry_node), GFP_KERNEL);
   if (!new_node) {
     dev_warn(agnocast_device, "kmalloc failed. (insert_message_entry)\n");
-    return -1;
+    return -ENOMEM;
   }
 
   new_node->entry_id = wrapper->current_entry_id++;
@@ -547,12 +547,13 @@ static int insert_message_entry(
     } else {
       dev_warn(
         agnocast_device,
-        "New message entry (entry_id=%lld) does not have the largest entry_id in the topic "
+        "Unreachable: New message entry (entry_id=%lld) does not have the largest entry_id in the "
+        "topic "
         "(topic_name=%s). "
         "(insert_message_entry)\n",
         new_node->entry_id, wrapper->key);
       kfree(new_node);
-      return -1;
+      return -ECANCELED;
     }
   }
 
@@ -1005,9 +1006,10 @@ static int release_msgs_to_meet_depth(
   if (!node) {
     dev_warn(
       agnocast_device,
-      "Failed to get message entries in publisher (id=%d). (release_msgs_to_meet_depth)\n",
+      "Unreachable: Failed to get message entries in publisher (id=%d). "
+      "(release_msgs_to_meet_depth)\n",
       pub_info->id);
-    return -1;
+    return -ENODATA;
   }
 
   // Number of entries exceeding qos_depth
@@ -1031,9 +1033,9 @@ static int release_msgs_to_meet_depth(
     if (!node) {
       dev_warn(
         agnocast_device,
-        "entries_num is inconsistent with actual message entry num. "
+        "Unreachable: entries_num is inconsistent with actual message entry num. "
         "(release_msgs_to_meet_depth)\n");
-      return -1;
+      return -ENODATA;
     }
 
     if (en->publisher_id != pub_info->id) continue;
@@ -1131,7 +1133,7 @@ int publish_msg(
   struct topic_wrapper * wrapper = find_topic(topic_name);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (publish_msg)\n", topic_name);
-    return -1;
+    return -EINVAL;
   }
 
   struct publisher_info * pub_info = find_publisher_info(wrapper, publisher_id);
@@ -1139,15 +1141,17 @@ int publish_msg(
     dev_warn(
       agnocast_device, "Publisher (id=%d) not found in the topic (topic_name=%s). (publish_msg)\n",
       publisher_id, topic_name);
-    return -1;
+    return -EINVAL;
   }
 
-  if (insert_message_entry(wrapper, pub_info, msg_virtual_address, ioctl_ret) == -1) {
-    return -1;
+  int ret = insert_message_entry(wrapper, pub_info, msg_virtual_address, ioctl_ret);
+  if (ret < 0) {
+    return ret;
   }
 
-  if (release_msgs_to_meet_depth(wrapper, pub_info, ioctl_ret) == -1) {
-    return -1;
+  ret = release_msgs_to_meet_depth(wrapper, pub_info, ioctl_ret);
+  if (ret < 0) {
+    return ret;
   }
 
   int subscriber_num = 0;


### PR DESCRIPTION
## Description
publish_msgにおけるreturn valueに適切なerrnoを設定しました。
加えて、

- Unreachableなら"Unreachable:" の記載
- 本変更によるKunitテストの修正
- kunitテストの名前をtest_case_***からtest_case_publish_msg_***に変更

## Related links
close #379 

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
