### PR TITLE
fix(release): add arch in heaphook

### DIFF
--- a/agnocast_heaphook/debian/control
+++ b/agnocast_heaphook/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.6.1
 Homepage: https://github.com/tier4/agnocast
 
 Package: agnocast-heaphook
-Architecture: amd64
+Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: A heap runtime replacement for Agnocast.
  To achieve true zero-copy communication with Agnocast, message objects must be placed in shared memory. Therefore, all heap allocation and deallocation operations are intercepted and customized using LD_PRELOAD hooks.

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
             } else {
                 tlsf_reallocate_wrapped(addr, new_size)
             }
-        },
+        }
         None => tlsf_allocate_wrapped(0, new_size),
     }
 }


### PR DESCRIPTION
## Description
次のリリースから、x64以外でのパッケージも配布する (kmodではすでに配布しているが、heaphookではx64だけのままになっていた)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
