### PR TITLE
test(kmod): add missing test case for receive_msg

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -18,6 +18,7 @@
     KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                       \
     KUNIT_CASE(test_case_receive_msg_2pub_in_same_process),                                         \
     KUNIT_CASE(test_case_receive_msg_2sub_in_same_process),                                         \
+    KUNIT_CASE(test_case_receive_msg_twice),                                                        \
     KUNIT_CASE(test_case_receive_msg_too_many_mapping_processes)
 
 void test_case_receive_msg_no_topic_when_receive(struct kunit * test);
@@ -36,4 +37,5 @@ void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);
 void test_case_receive_msg_2pub_in_same_process(struct kunit * test);
 void test_case_receive_msg_2sub_in_same_process(struct kunit * test);
+void test_case_receive_msg_twice(struct kunit * test);
 void test_case_receive_msg_too_many_mapping_processes(struct kunit * test);


### PR DESCRIPTION
## Description

There was no test case for receive_msg which pass the following if branch

![Screenshot from 2025-03-26 13-36-57](https://github.com/user-attachments/assets/9a4fbe26-760a-485f-83cd-5c3a8f473d6a)


## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
