### PR TITLE
test(kmod): add missing test case for do_exit

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
@@ -9,6 +9,7 @@
     KUNIT_CASE(test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_exit),   \
     KUNIT_CASE(test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_exit),   \
     KUNIT_CASE(test_case_do_exit_with_entry),                                                    \
+    KUNIT_CASE(test_case_do_exit_with_entry_with_subscriber_reference),                          \
     KUNIT_CASE(test_case_do_exit_with_multi_references_publisher_exit_first),                    \
     KUNIT_CASE(test_case_do_exit_with_multi_references_subscriber_exit_first)
 
@@ -24,5 +25,6 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
 void test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_exit(
   struct kunit * test);
 void test_case_do_exit_with_entry(struct kunit * test);
+void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test);
 void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit * test);
 void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit * test);


### PR DESCRIPTION
## Description

There was no test case for `do_exit` to pass the following if branch

![Screenshot from 2025-03-26 14-48-00](https://github.com/user-attachments/assets/9e768f7a-f71d-42db-8721-e9992574a4ea)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
