### PR TITLE
feat(kmod): add kunit test for too many mapping processes in take_msg and receive_msg

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -1,6 +1,7 @@
 #include "agnocast_kunit_receive_msg.h"
 
 #include "../agnocast.h"
+#include "../agnocast_memory_allocator.h"
 
 #include <kunit/test.h>
 
@@ -452,6 +453,64 @@ void test_case_receive_msg_twice(struct kunit * test)
 
 void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
 {
-  // TODO(Koichi98): Implement this test case
-  KUNIT_EXPECT_EQ(test, 0, 0);
+  // Arrange: create MAX_PROCESS_NUM_PER_MEMPOOL processes which map to the same memory pool
+  int ret;
+  union ioctl_subscriber_args subscriber_args;
+  union ioctl_publisher_args publisher_args;
+  const pid_t publisher_pid = 1000;
+  pid_t subscriber_pid = 2000;
+  const uint32_t qos_depth = 1;
+
+  union ioctl_new_shm_args new_shm_args;
+  ret = new_shm_addr(publisher_pid, PAGE_SIZE, &new_shm_args);
+  uint64_t msg_virtual_address = new_shm_args.ret_addr;
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  int mmap_process_num = 1;
+  for (int i = 0; i < MAX_PROCESS_NUM_PER_MEMPOOL / MAX_SUBSCRIBER_NUM + 1; i++) {
+    char topic_name[50];
+    snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
+    ret = publisher_add(
+      topic_name, NODE_NAME, publisher_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
+    KUNIT_ASSERT_EQ(test, ret, 0);
+    union ioctl_publish_args publish_ret;
+    ret = publish_msg(topic_name, publisher_args.ret_id, msg_virtual_address++, &publish_ret);
+    KUNIT_ASSERT_EQ(test, ret, 0);
+    for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
+      if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {
+        break;
+      }
+      ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+
+      ret = subscriber_add(
+        topic_name, NODE_NAME, subscriber_pid++, qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
+        &subscriber_args);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+      union ioctl_receive_msg_args receive_msg_ret;
+      ret = receive_msg(topic_name, subscriber_args.ret_id, &receive_msg_ret);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+      mmap_process_num++;
+    }
+  }
+  const char * topic_name = "/kunit_test_topic_1000";
+  ret = publisher_add(
+    topic_name, NODE_NAME, publisher_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), MAX_PROCESS_NUM_PER_MEMPOOL);
+
+  ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  ret = subscriber_add(
+    topic_name, NODE_NAME, subscriber_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
+    &subscriber_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // Act
+  union ioctl_receive_msg_args receive_msg_ret;
+  ret = receive_msg(topic_name, subscriber_args.ret_id, &receive_msg_ret);
+
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -510,7 +510,6 @@ void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
   union ioctl_receive_msg_args receive_msg_ret;
   ret = receive_msg(topic_name, subscriber_args.ret_id, &receive_msg_ret);
 
-
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -463,7 +463,6 @@ void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
 
   union ioctl_new_shm_args new_shm_args;
   ret = new_shm_addr(publisher_pid, PAGE_SIZE, &new_shm_args);
-  uint64_t msg_virtual_address = new_shm_args.ret_addr;
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   int mmap_process_num = 1;
@@ -472,9 +471,6 @@ void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
     snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
     ret = publisher_add(
       topic_name, NODE_NAME, publisher_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
-    KUNIT_ASSERT_EQ(test, ret, 0);
-    union ioctl_publish_args publish_ret;
-    ret = publish_msg(topic_name, publisher_args.ret_id, msg_virtual_address++, &publish_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
       if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -780,7 +780,6 @@ void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
 
   union ioctl_new_shm_args new_shm_args;
   ret = new_shm_addr(publisher_pid, PAGE_SIZE, &new_shm_args);
-  uint64_t msg_virtual_address = new_shm_args.ret_addr;
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   int mmap_process_num = 1;
@@ -789,9 +788,6 @@ void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
     snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
     ret = publisher_add(
       topic_name, NODE_NAME, publisher_pid, qos_depth, qos_transient_local, &publisher_args);
-    KUNIT_ASSERT_EQ(test, ret, 0);
-    union ioctl_publish_args publish_ret;
-    ret = publish_msg(topic_name, publisher_args.ret_id, msg_virtual_address++, &publish_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
       if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -1,6 +1,7 @@
 #include "agnocast_kunit_take_msg.h"
 
 #include "../agnocast.h"
+#include "../agnocast_memory_allocator.h"
 
 #include <kunit/test.h>
 
@@ -767,6 +768,66 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
 
 void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
 {
-  // TODO(Koichi98): Implement this test case
-  KUNIT_EXPECT_EQ(test, 0, 0);
+    // Arrange: create MAX_PROCESS_NUM_PER_MEMPOOL processes which map to the same memory pool
+  int ret;
+  union ioctl_subscriber_args subscriber_args;
+  union ioctl_publisher_args publisher_args;
+  const pid_t publisher_pid = 1000;
+  pid_t subscriber_pid = 2000;
+  const uint32_t qos_depth = 1;
+  const bool qos_transient_local = false;
+  const bool allow_same_message = true;
+
+  union ioctl_new_shm_args new_shm_args;
+  ret = new_shm_addr(publisher_pid, PAGE_SIZE, &new_shm_args);
+  uint64_t msg_virtual_address = new_shm_args.ret_addr;
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  int mmap_process_num = 1;
+  for (int i = 0; i < MAX_PROCESS_NUM_PER_MEMPOOL / MAX_SUBSCRIBER_NUM + 1; i++) {
+    char topic_name[50];
+    snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
+    ret = publisher_add(
+      topic_name, NODE_NAME, publisher_pid, qos_depth, qos_transient_local, &publisher_args);
+    KUNIT_ASSERT_EQ(test, ret, 0);
+    union ioctl_publish_args publish_ret;
+    ret = publish_msg(topic_name, publisher_args.ret_id, msg_virtual_address++, &publish_ret);
+    KUNIT_ASSERT_EQ(test, ret, 0);
+    for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
+      if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {
+        break;
+      }
+      ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+
+      ret = subscriber_add(
+        topic_name, NODE_NAME, subscriber_pid++, qos_depth, qos_transient_local, IS_TAKE_SUB,
+        &subscriber_args);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+      union ioctl_take_msg_args take_msg_ret;
+      ret = take_msg(topic_name, subscriber_args.ret_id, allow_same_message, &take_msg_ret);
+      KUNIT_ASSERT_EQ(test, ret, 0);
+      mmap_process_num++;
+    }
+  }
+  const char * topic_name = "/kunit_test_topic_1000";
+  ret = publisher_add(
+    topic_name, NODE_NAME, publisher_pid, qos_depth, qos_transient_local, &publisher_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), MAX_PROCESS_NUM_PER_MEMPOOL);
+
+  ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  ret = subscriber_add(
+    topic_name, NODE_NAME, subscriber_pid, qos_depth, qos_transient_local, IS_TAKE_SUB,
+    &subscriber_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // Act
+  union ioctl_take_msg_args take_msg_ret;
+  ret = take_msg(topic_name, subscriber_args.ret_id, allow_same_message, &take_msg_ret);
+
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -768,7 +768,7 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
 
 void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
 {
-    // Arrange: create MAX_PROCESS_NUM_PER_MEMPOOL processes which map to the same memory pool
+  // Arrange: create MAX_PROCESS_NUM_PER_MEMPOOL processes which map to the same memory pool
   int ret;
   union ioctl_subscriber_args subscriber_args;
   union ioctl_publisher_args publisher_args;
@@ -826,7 +826,6 @@ void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
   // Act
   union ioctl_take_msg_args take_msg_ret;
   ret = take_msg(topic_name, subscriber_args.ret_id, allow_same_message, &take_msg_ret);
-
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);


### PR DESCRIPTION
## Description
Added the missing test for too many mapping processes in take_msg  and receive_msg.
This is a revised version of PR #514 which was implemented for subscriber_add kunit tests previously.

## Related links
PR #514

## How was this PR tested?
Checked that the kunit test works.

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
