### PR TITLE
refactor(kmod): unified magic number for ioctl

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -122,15 +122,15 @@ union ioctl_get_subscriber_num_args {
   uint32_t ret_subscriber_num;
 };
 
-#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW('S', 1, union ioctl_subscriber_args)
-#define AGNOCAST_PUBLISHER_ADD_CMD _IOW('P', 1, union ioctl_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, struct ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOW('M', 3, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOW('M', 4, union ioctl_publish_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOW('M', 5, union ioctl_take_msg_args)
-#define AGNOCAST_NEW_SHM_CMD _IOW('I', 1, union ioctl_new_shm_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW('G', 1, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW(0xA6, 1, union ioctl_subscriber_args)
+#define AGNOCAST_PUBLISHER_ADD_CMD _IOW(0xA6, 2, union ioctl_publisher_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOW(0xA6, 5, union ioctl_receive_msg_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
+#define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 9, union ioctl_get_subscriber_num_args)
 
 // ================================================
 // ros2cli ioctls
@@ -167,11 +167,11 @@ union ioctl_topic_info_args {
   uint32_t ret_topic_info_ret_num;
 };
 
-#define AGNOCAST_GET_TOPIC_LIST_CMD _IOR('R', 1, union ioctl_topic_list_args)
-#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOR('R', 2, union ioctl_topic_info_args)
-#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOR('R', 3, union ioctl_topic_info_args)
-#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOR('R', 4, union ioctl_node_info_args)
-#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOR('R', 5, union ioctl_node_info_args)
+#define AGNOCAST_GET_TOPIC_LIST_CMD _IOR(0xA6, 20, union ioctl_topic_list_args)
+#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOR(0xA6, 21, union ioctl_topic_info_args)
+#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOR(0xA6, 22, union ioctl_topic_info_args)
+#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOR(0xA6, 23, union ioctl_node_info_args)
+#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOR(0xA6, 24, union ioctl_node_info_args)
 
 // ================================================
 // public macros and functions in agnocast_main.c

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -130,7 +130,8 @@ union ioctl_get_subscriber_num_args {
 #define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
 #define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
 #define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 9, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_GET_VERSION_CMD _IOW(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 10, union ioctl_get_subscriber_num_args)
 
 // ================================================
 // ros2cli ioctls

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -127,16 +127,16 @@ union ioctl_get_subscriber_num_args {
   uint32_t ret_subscriber_num;
 };
 
-#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW(0xA6, 1, union ioctl_subscriber_args)
-#define AGNOCAST_PUBLISHER_ADD_CMD _IOW(0xA6, 2, union ioctl_publisher_args)
+#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOWR(0xA6, 1, union ioctl_subscriber_args)
+#define AGNOCAST_PUBLISHER_ADD_CMD _IOWR(0xA6, 2, union ioctl_publisher_args)
 #define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
 #define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOW(0xA6, 5, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
-#define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
-#define AGNOCAST_GET_VERSION_CMD _IOW(0xA6, 9, struct ioctl_get_version_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 10, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 5, union ioctl_receive_msg_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 6, union ioctl_publish_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 7, union ioctl_take_msg_args)
+#define AGNOCAST_NEW_SHM_CMD _IOWR(0xA6, 8, union ioctl_new_shm_args)
+#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOWR(0xA6, 10, union ioctl_get_subscriber_num_args)
 
 // ================================================
 // ros2cli ioctls

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -173,11 +173,11 @@ union ioctl_topic_info_args {
   uint32_t ret_topic_info_ret_num;
 };
 
-#define AGNOCAST_GET_TOPIC_LIST_CMD _IOR(0xA6, 20, union ioctl_topic_list_args)
-#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOR(0xA6, 21, union ioctl_topic_info_args)
-#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOR(0xA6, 22, union ioctl_topic_info_args)
-#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOR(0xA6, 23, union ioctl_node_info_args)
-#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOR(0xA6, 24, union ioctl_node_info_args)
+#define AGNOCAST_GET_TOPIC_LIST_CMD _IOWR(0xA6, 20, union ioctl_topic_list_args)
+#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOWR(0xA6, 21, union ioctl_topic_info_args)
+#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOWR(0xA6, 22, union ioctl_topic_info_args)
+#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOWR(0xA6, 23, union ioctl_node_info_args)
+#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOWR(0xA6, 24, union ioctl_node_info_args)
 
 // ================================================
 // public macros and functions in agnocast_main.c

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1569,8 +1569,6 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
       goto return_EFAULT;
     topic_name_buf[entry_args.topic_name.len] = '\0';
     ret = increment_message_entry_rc(topic_name_buf, entry_args.pubsub_id, entry_args.entry_id);
-    if (copy_to_user((struct ioctl_update_entry_args __user *)arg, &entry_args, sizeof(entry_args)))
-      goto return_EFAULT;
   } else if (cmd == AGNOCAST_DECREMENT_RC_CMD) {
     struct ioctl_update_entry_args entry_args;
     char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
@@ -1583,8 +1581,6 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
       goto return_EFAULT;
     topic_name_buf[entry_args.topic_name.len] = '\0';
     ret = decrement_message_entry_rc(topic_name_buf, entry_args.pubsub_id, entry_args.entry_id);
-    if (copy_to_user((struct ioctl_update_entry_args __user *)arg, &entry_args, sizeof(entry_args)))
-      goto return_EFAULT;
   } else if (cmd == AGNOCAST_RECEIVE_MSG_CMD) {
     union ioctl_receive_msg_args receive_msg_args;
     char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -51,8 +51,8 @@ union ioctl_topic_info_args {
 };
 #pragma GCC diagnostic pop
 
-#define AGNOCAST_GET_TOPIC_LIST_CMD _IOR('R', 1, union ioctl_topic_list_args)
-#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOR('R', 2, union ioctl_topic_info_args)
-#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOR('R', 3, union ioctl_topic_info_args)
-#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOR('R', 4, union ioctl_node_info_args)
-#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOR('R', 5, union ioctl_node_info_args)
+#define AGNOCAST_GET_TOPIC_LIST_CMD _IOWR(0xA6, 20, union ioctl_topic_list_args)
+#define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOWR(0xA6, 21, union ioctl_topic_info_args)
+#define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOWR(0xA6, 22, union ioctl_topic_info_args)
+#define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOWR(0xA6, 23, union ioctl_node_info_args)
+#define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOWR(0xA6, 24, union ioctl_node_info_args)

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -155,6 +155,7 @@ union ioctl_get_subscriber_num_args {
 #define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
 #define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
 #define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 9, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_GET_VERSION_CMD _IOW(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 10, union ioctl_get_subscriber_num_args)
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -147,14 +147,14 @@ union ioctl_get_subscriber_num_args {
   uint32_t ret_subscriber_num;
 };
 
-#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW('S', 1, union ioctl_subscriber_args)
-#define AGNOCAST_PUBLISHER_ADD_CMD _IOW('P', 1, union ioctl_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW('M', 1, struct ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW('M', 2, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOW('M', 3, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOW('M', 4, union ioctl_publish_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOW('M', 5, union ioctl_take_msg_args)
-#define AGNOCAST_NEW_SHM_CMD _IOW('I', 1, union ioctl_new_shm_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW('G', 1, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW(0xA6, 1, union ioctl_subscriber_args)
+#define AGNOCAST_PUBLISHER_ADD_CMD _IOW(0xA6, 2, union ioctl_publisher_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOW(0xA6, 5, union ioctl_receive_msg_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
+#define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 9, union ioctl_get_subscriber_num_args)
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -153,15 +153,15 @@ union ioctl_get_subscriber_num_args {
   uint32_t ret_subscriber_num;
 };
 
-#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW(0xA6, 1, union ioctl_subscriber_args)
-#define AGNOCAST_PUBLISHER_ADD_CMD _IOW(0xA6, 2, union ioctl_publisher_args)
+#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOWR(0xA6, 1, union ioctl_subscriber_args)
+#define AGNOCAST_PUBLISHER_ADD_CMD _IOWR(0xA6, 2, union ioctl_publisher_args)
 #define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
 #define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOW(0xA6, 5, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOW(0xA6, 6, union ioctl_publish_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOW(0xA6, 7, union ioctl_take_msg_args)
-#define AGNOCAST_NEW_SHM_CMD _IOW(0xA6, 8, union ioctl_new_shm_args)
-#define AGNOCAST_GET_VERSION_CMD _IOW(0xA6, 9, struct ioctl_get_version_args)
-#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOW(0xA6, 10, union ioctl_get_subscriber_num_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 5, union ioctl_receive_msg_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 6, union ioctl_publish_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 7, union ioctl_take_msg_args)
+#define AGNOCAST_NEW_SHM_CMD _IOWR(0xA6, 8, union ioctl_new_shm_args)
+#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOWR(0xA6, 10, union ioctl_get_subscriber_num_args)
 
 }  // namespace agnocast


### PR DESCRIPTION
## Description
`#define AGNOCAST_SUBSCRIBER_ADD_CMD _IOW('S', 1, union ioctl_subscriber_args)`
デバドラのマジックナンバー(ioctlのコマンドの、例えば上における'S')はデバドラ内で基本的には統一されるようなので一応統一しました。また、なるべく既存のデバドラの利用している番号とはかぶらないように選ぶべきなようなので一応下のLinuxのDocumentationに挙げられているものは避けて、0xA6を選びました。(適当です。) 
https://elixir.bootlin.com/linux/v6.13/source/Documentation/userspace-api/ioctl/ioctl-number.rst

またコマンド番号(上の例における1)は一般的には1からインクリメンタルにつけていくようですが、ros2agnocast用のコマンドは20以降をつけています。これは今後の拡張性のための余裕をもたせる意図です。

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
