### PR TITLE
fix(test): suppress warning for unused variable

### DIFF
--- a/src/agnocastlib/test/integration/src/initialize_shutdown_mock.cpp
+++ b/src/agnocastlib/test/integration/src/initialize_shutdown_mock.cpp
@@ -13,6 +13,8 @@ int shm_fd;
 namespace agnocast
 {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 extern "C" void * initialize_agnocast(
   const uint64_t shm_size, const unsigned char * heaphook_version_ptr,
   const size_t heaphook_version_str_len)
@@ -41,6 +43,7 @@ extern "C" void * initialize_agnocast(
 
   return ret;
 }
+#pragma GCC diagnostic pop
 
 void shutdown_agnocast()
 {


### PR DESCRIPTION
## Description
#557 においてテストでのみ利用されるinitialize_agnocastのmock用関数においてビルド時にwarningが出力されていたのでそのsuppressをしました。

## Related links
#557 

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
