### PR TITLE
fix(kmod): bug when receive/take msgs after publisher exits

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -4,6 +4,7 @@
 #include "../agnocast_memory_allocator.h"
 
 #include <kunit/test.h>
+#include <linux/delay.h>
 
 static char * TOPIC_NAME = "/kunit_test_topic";
 static char * NODE_NAME = "/kunit_test_node";
@@ -662,6 +663,79 @@ void test_case_receive_msg_twice(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 0);
+}
+
+void test_case_receive_msg_with_exited_publisher(struct kunit * test)
+{
+  // Arrange
+  const uint32_t qos_depth = 1;
+  const bool is_transient_local = true;
+
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  const pid_t publisher_pid = 1000;
+  setup_one_publisher(test, publisher_pid, qos_depth, is_transient_local, &publisher_id, &ret_addr);
+
+  uint64_t msg_addr = 0x1000;
+  union ioctl_publish_args ioctl_publish_msg_ret;
+  int ret1 = publish_msg(TOPIC_NAME, publisher_id, msg_addr, &ioctl_publish_msg_ret);
+
+  topic_local_id_t subscriber_id1;
+  const pid_t subscriber_pid1 = 2000;
+  setup_one_subscriber(test, subscriber_pid1, qos_depth, is_transient_local, &subscriber_id1);
+
+  union ioctl_receive_msg_args ioctl_receive_msg_ret1;
+  int ret2 = receive_msg(TOPIC_NAME, subscriber_id1, &ioctl_receive_msg_ret1);
+
+  enqueue_exit_pid(publisher_pid);
+
+  // wait for exit_worker_thread to handle process exit
+  msleep(10);
+
+  topic_local_id_t subscriber_id2;
+  const pid_t subscriber_pid2 = 2001;
+  setup_one_subscriber(test, subscriber_pid2, qos_depth, is_transient_local, &subscriber_id2);
+
+  union ioctl_get_subscriber_num_args ioctl_get_subscriber_num_ret;
+  int ret3 = get_subscriber_num(TOPIC_NAME, &ioctl_get_subscriber_num_ret);
+
+  KUNIT_ASSERT_EQ(test, ret1, 0);
+  KUNIT_ASSERT_EQ(test, ret2, 0);
+  KUNIT_ASSERT_EQ(test, ret3, 0);
+  KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
+  KUNIT_ASSERT_FALSE(test, is_in_proc_info_htable(publisher_pid));
+  KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
+  KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
+  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_ASSERT_EQ(test, ioctl_get_subscriber_num_ret.ret_subscriber_num, 2);
+  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
+  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, publisher_id), 0);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id1), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id2), 0);
+  KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_entry_num, 1);
+  KUNIT_ASSERT_EQ(
+    test, ioctl_receive_msg_ret1.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
+  KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_entry_addrs[0], msg_addr);
+  KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_pub_shm_info.publisher_num, 1);
+  KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_pub_shm_info.publisher_pids[0], publisher_pid);
+  KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_pub_shm_info.shm_addrs[0], ret_addr);
+
+  // Act
+  union ioctl_receive_msg_args ioctl_receive_msg_ret2;
+  int ret4 = receive_msg(TOPIC_NAME, subscriber_id2, &ioctl_receive_msg_ret2);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret4, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret2.ret_entry_num, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret2.ret_pub_shm_info.publisher_num, 0);
 }
 
 void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -27,6 +27,7 @@
     KUNIT_CASE(test_case_receive_msg_2pub_in_same_process),                                         \
     KUNIT_CASE(test_case_receive_msg_2sub_in_same_process),                                         \
     KUNIT_CASE(test_case_receive_msg_twice),                                                        \
+    KUNIT_CASE(test_case_receive_msg_with_exited_publisher),                                        \
     KUNIT_CASE(test_case_receive_msg_too_many_mapping_processes)
 
 void test_case_receive_msg_no_topic_when_receive(struct kunit * test);
@@ -54,4 +55,5 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);
 void test_case_receive_msg_2pub_in_same_process(struct kunit * test);
 void test_case_receive_msg_2sub_in_same_process(struct kunit * test);
 void test_case_receive_msg_twice(struct kunit * test);
+void test_case_receive_msg_with_exited_publisher(struct kunit * test);
 void test_case_receive_msg_too_many_mapping_processes(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -4,6 +4,7 @@
 #include "../agnocast_memory_allocator.h"
 
 #include <kunit/test.h>
+#include <linux/delay.h>
 
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
@@ -764,6 +765,79 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret5, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 0);
+}
+
+void test_case_take_msg_with_exited_publisher(struct kunit * test)
+{
+  // Arrange
+  const uint32_t qos_depth = 1;
+  const bool is_transient_local = true;
+  const bool allow_same_message = true;
+
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  const pid_t publisher_pid = 1000;
+  setup_one_publisher(test, publisher_pid, qos_depth, is_transient_local, &publisher_id, &ret_addr);
+
+  uint64_t msg_addr = 0x1000;
+  union ioctl_publish_args ioctl_publish_msg_ret;
+  int ret1 = publish_msg(TOPIC_NAME, publisher_id, msg_addr, &ioctl_publish_msg_ret);
+
+  topic_local_id_t subscriber_id1;
+  const pid_t subscriber_pid1 = 2000;
+  setup_one_subscriber(test, subscriber_pid1, qos_depth, is_transient_local, &subscriber_id1);
+
+  union ioctl_take_msg_args ioctl_take_msg_ret1;
+  int ret2 = take_msg(TOPIC_NAME, subscriber_id1, allow_same_message, &ioctl_take_msg_ret1);
+
+  enqueue_exit_pid(publisher_pid);
+
+  // wait for exit_worker_thread to handle process exit
+  msleep(10);
+
+  topic_local_id_t subscriber_id2;
+  const pid_t subscriber_pid2 = 2001;
+  setup_one_subscriber(test, subscriber_pid2, qos_depth, is_transient_local, &subscriber_id2);
+
+  union ioctl_get_subscriber_num_args ioctl_get_subscriber_num_ret;
+  int ret3 = get_subscriber_num(TOPIC_NAME, &ioctl_get_subscriber_num_ret);
+
+  KUNIT_ASSERT_EQ(test, ret1, 0);
+  KUNIT_ASSERT_EQ(test, ret2, 0);
+  KUNIT_ASSERT_EQ(test, ret3, 0);
+  KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
+  KUNIT_ASSERT_FALSE(test, is_in_proc_info_htable(publisher_pid));
+  KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
+  KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
+  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_ASSERT_EQ(test, ioctl_get_subscriber_num_ret.ret_subscriber_num, 2);
+  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
+  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, publisher_id), 0);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id1), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id2), 0);
+  KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
+  KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_addr, msg_addr);
+  KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.publisher_num, 1);
+  KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.publisher_pids[0], publisher_pid);
+  KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.shm_addrs[0], ret_addr);
+
+  // Act
+  union ioctl_take_msg_args ioctl_take_msg_ret2;
+  int ret4 = take_msg(TOPIC_NAME, subscriber_id2, allow_same_message, &ioctl_take_msg_ret2);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret4, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret2.ret_entry_id, -1);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret2.ret_addr, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret2.ret_pub_shm_info.publisher_num, 0);
 }
 
 void test_case_take_msg_too_many_mapping_processes(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -28,6 +28,7 @@
     KUNIT_CASE(test_case_take_msg_pubsub_in_same_process),                                       \
     KUNIT_CASE(test_case_take_msg_2pub_in_same_process),                                         \
     KUNIT_CASE(test_case_take_msg_2sub_in_same_process),                                         \
+    KUNIT_CASE(test_case_take_msg_with_exited_publisher),                                        \
     KUNIT_CASE(test_case_take_msg_too_many_mapping_processes)
 
 void test_case_take_msg_no_topic(struct kunit * test);
@@ -57,4 +58,5 @@ void test_case_take_msg_one_new_pub(struct kunit * test);
 void test_case_take_msg_pubsub_in_same_process(struct kunit * test);
 void test_case_take_msg_2pub_in_same_process(struct kunit * test);
 void test_case_take_msg_2sub_in_same_process(struct kunit * test);
+void test_case_take_msg_with_exited_publisher(struct kunit * test);
 void test_case_take_msg_too_many_mapping_processes(struct kunit * test);


### PR DESCRIPTION
## Description

When `receive_msg`, it gets message entry but does not mmap shared memory for exited publisher.
This PR solved the problem and added kunit tests.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
