### PR TITLE
fix: use AGNOCAST prefix for MEMPOOL_SIZE

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -143,12 +143,12 @@ fn init_tlsf() -> Mutex<TlsfType> {
         )
     }
 
-    let mempool_size_env: String = std::env::var("MEMPOOL_SIZE").unwrap_or_else(|error| {
-        panic!("[ERROR] [Agnocast] {}: MEMPOOL_SIZE", error);
+    let mempool_size_env: String = std::env::var("AGNOCAST_MEMPOOL_SIZE").unwrap_or_else(|error| {
+        panic!("[ERROR] [Agnocast] {}: AGNOCAST_MEMPOOL_SIZE", error);
     });
 
     let mempool_size: usize = mempool_size_env.parse::<usize>().unwrap_or_else(|error| {
-        panic!("[ERROR] [Agnocast] {}: MEMPOOL_SIZE", error);
+        panic!("[ERROR] [Agnocast] {}: AGNOCAST_MEMPOOL_SIZE", error);
     });
 
     let page_size: usize = unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize };
@@ -185,7 +185,7 @@ fn tlsf_allocate(size: usize) -> *mut c_void {
     let mut tlsf = TLSF.get_or_init(init_tlsf).lock().unwrap();
 
     let ptr: std::ptr::NonNull<u8> = tlsf.allocate(layout).unwrap_or_else(|| {
-        panic!("[ERROR] [Agnocast] memory allocation failed: use larger MEMPOOL_SIZE");
+        panic!("[ERROR] [Agnocast] memory allocation failed: use larger AGNOCAST_MEMPOOL_SIZE");
     });
 
     ptr.as_ptr() as *mut c_void
@@ -203,7 +203,7 @@ fn tlsf_reallocate(ptr: std::ptr::NonNull<u8>, size: usize) -> *mut c_void {
 
     let new_ptr: std::ptr::NonNull<u8> = unsafe {
         tlsf.reallocate(ptr, layout).unwrap_or_else(|| {
-            panic!("[ERROR] [Agnocast] memory allocation failed: use larger MEMPOOL_SIZE");
+            panic!("[ERROR] [Agnocast] memory allocation failed: use larger AGNOCAST_MEMPOOL_SIZE");
         })
     };
 

--- a/docs/autoware_integration.md
+++ b/docs/autoware_integration.md
@@ -17,11 +17,11 @@ target_include_directories(target_library PRIVATE
 )
 ```
 
-For launch.xml ( `MEMPOOL_SIZE` can be configured based on how much the process will consume heap memory, see [shared memory](./docs/shared_memory.md) for more detail.):
+For launch.xml ( `AGNOCAST_MEMPOOL_SIZE` can be configured based on how much the process will consume heap memory, see [shared memory](./docs/shared_memory.md) for more detail.):
 
 ```xml
 <env name="LD_PRELOAD" value="libagnocast_heaphook.so"/>
-<env name="MEMPOOL_SIZE" value="134217728"/>  <!-- 128MB -->
+<env name="AGNOCAST_MEMPOOL_SIZE" value="134217728"/>  <!-- 128MB -->
 ```
 
 For packages.xml:

--- a/docs/how_to_set_environment_variables.md
+++ b/docs/how_to_set_environment_variables.md
@@ -12,7 +12,7 @@ Agnocast uses the `LD_PRELOAD` to replace the following memory allocation/deallo
 - `aligned_alloc`
 - `memalign`
 
-The hook library is generated as `libagnocast_heaphook.so`, so Agnocast requires to set `LD_PRELOAD` to `libagnocast_heaphook.so`. In addition, you have to specify appropriate `MEMPOOL_SIZE` as an environment variable because of [this](./shared_memory.md#how-virtual-addresses-are-decided).
+The hook library is generated as `libagnocast_heaphook.so`, so Agnocast requires to set `LD_PRELOAD` to `libagnocast_heaphook.so`. In addition, you have to specify appropriate `AGNOCAST_MEMPOOL_SIZE` as an environment variable because of [this](./shared_memory.md#how-virtual-addresses-are-decided).
 
 ## Integrate with ROS 2 launch
 
@@ -21,14 +21,14 @@ You can set environment variables through ROS 2 launch file systems as follows. 
 ```xml
 <node pkg="..." exec="..." name="...">
   <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-  <env name="MEMPOOL_SIZE" value="..." />
+  <env name="AGNOCAST_MEMPOOL_SIZE" value="..." />
 </node>
 ```
 
 ```xml
 <node_container pkg="agnocastlib" exec="agnocast_component_container" name="...">
   <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-  <env name="MEMPOOL_SIZE" value="..." />
+  <env name="AGNOCAST_MEMPOOL_SIZE" value="..." />
 </node_container>
 ```
 
@@ -39,7 +39,7 @@ container = ComposableNodeContainer(
     ...,
     additional_env={
         'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
-        "MEMPOOL_SIZE": "...",
+        "AGNOCAST_MEMPOOL_SIZE": "...",
     },
 )
 ```

--- a/docs/shared_memory.md
+++ b/docs/shared_memory.md
@@ -51,7 +51,7 @@ The restriction for the name is the same as the shared memory.
 
 ## How virtual addresses are decided?
 
-Any process which joins Agnocast has to set `MEMPOOL_SIZE` as an environment variable.
+Any process which joins Agnocast has to set `AGNOCAST_MEMPOOL_SIZE` as an environment variable.
 The passed value is aligned to 100kB.
 
 ## Known issues

--- a/scripts/e2e_test_many_exit
+++ b/scripts/e2e_test_many_exit
@@ -6,7 +6,7 @@ WAIT_TIME=5
 
 source install/setup.bash
 export LD_PRELOAD="libagnocast_heaphook.so:$LD_PRELOAD"
-export MEMPOOL_SIZE=67108864
+export AGNOCAST_MEMPOOL_SIZE=67108864
 for i in $(seq 1 $AGNOCAST_PROCESS_NUM); do
     ros2 run agnocast_sample_application talker --ros-args --remap __node:=talker_node$i --remap /my_topic:=/topic$i &
 done

--- a/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
+++ b/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
@@ -83,7 +83,7 @@ def generate_test_description():
                 output='screen',
                 additional_env={
                     'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
-                    'MEMPOOL_SIZE': '134217728',
+                    'AGNOCAST_MEMPOOL_SIZE': '134217728',
                 }
             )
         ]
@@ -138,7 +138,7 @@ def generate_test_description():
                 output='screen',
                 additional_env={
                     'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
-                    'MEMPOOL_SIZE': '134217728',
+                    'AGNOCAST_MEMPOOL_SIZE': '134217728',
                 }
             )
         )

--- a/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
+++ b/src/agnocast_e2e_test/test/test_1to1_with_ros2sub.py
@@ -167,7 +167,7 @@ def generate_test_description():
                 output='screen',
                 additional_env={
                     'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
-                    'MEMPOOL_SIZE': '134217728',
+                    'AGNOCAST_MEMPOOL_SIZE': '134217728',
                 }
             )
         )

--- a/src/agnocast_e2e_test/test/test_2to2.py
+++ b/src/agnocast_e2e_test/test/test_2to2.py
@@ -76,7 +76,7 @@ def generate_test_description():
             parameters=[{'number_of_ros2_threads': 8, 'number_of_agnocast_threads': 8}],
             additional_env={
                 'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
-                'MEMPOOL_SIZE': '134217728',
+                'AGNOCAST_MEMPOOL_SIZE': '134217728',
             }
         )
         containers.append(container)

--- a/src/agnocast_sample_application/launch/listener.launch.xml
+++ b/src/agnocast_sample_application/launch/listener.launch.xml
@@ -1,7 +1,7 @@
 <launch>
     <node_container pkg="agnocastlib" exec="agnocast_component_container" name="listener_container" namespace="" output="screen">
       <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-      <env name="MEMPOOL_SIZE" value="16777216" /> <!-- 16MB-->
+      <env name="AGNOCAST_MEMPOOL_SIZE" value="16777216" /> <!-- 16MB-->
 
       <composable_node pkg="agnocast_sample_application" plugin="MinimalSubscriber" name="listener_node" namespace="">
       </composable_node>

--- a/src/agnocast_sample_application/launch/talker.launch.xml
+++ b/src/agnocast_sample_application/launch/talker.launch.xml
@@ -1,6 +1,6 @@
 <launch>
     <node pkg="agnocast_sample_application" exec="talker" name="talker_node" output="screen">
         <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-        <env name="MEMPOOL_SIZE" value="67108864" />  <!-- 64MB-->
+        <env name="AGNOCAST_MEMPOOL_SIZE" value="67108864" />  <!-- 64MB-->
     </node>
 </launch>

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -135,7 +135,7 @@ if(BUILD_TESTING)
     test/integration/test_agnocast_heaphook.cpp)
   target_link_libraries(test_integration_agnocast_heaphook agnocast)
   set_tests_properties(test_integration_agnocast_heaphook PROPERTIES
-    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libinitialize_shutdown_mock.so:${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:;MEMPOOL_SIZE=1000000")
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libinitialize_shutdown_mock.so:${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:;AGNOCAST_MEMPOOL_SIZE=1000000")
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -63,7 +63,7 @@ TEST(AgnocastUtilsTest, validate_ld_preload_prefix)
 TEST(AgnocastUtilsTest, validate_ld_preload_only_libagnocast_heaphook)
 {
   setenv("LD_PRELOAD", "libagnocast_heaphook.so", 1);
-  setenv("MEMPOOL_SIZE", "10000000", 1);
+  setenv("AGNOCAST_MEMPOOL_SIZE", "10000000", 1);
   EXPECT_EXIT(agnocast::validate_ld_preload(), ::testing::ExitedWithCode(EXIT_FAILURE), "");
   unsetenv("LD_PRELOAD");
 }


### PR DESCRIPTION
## Description

Preplace `MEMPOOL_SIZE` for `AGNOCAST_MEMPOOL_SIZE`

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] sample application

## Notes for reviewers
