### PR TITLE
fix(agnocastlib): fix validate_ld_preload

### DIFF
--- a/src/agnocastlib/test/integration/src/initialize_shutdown_mock.cpp
+++ b/src/agnocastlib/test/integration/src/initialize_shutdown_mock.cpp
@@ -13,6 +13,8 @@ int shm_fd;
 namespace agnocast
 {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 extern "C" void * initialize_agnocast(
   const uint64_t shm_size, const unsigned char * heaphook_version_ptr,
   const size_t heaphook_version_str_len)
@@ -41,6 +43,7 @@ extern "C" void * initialize_agnocast(
 
   return ret;
 }
+#pragma GCC diagnostic pop
 
 void shutdown_agnocast()
 {


### PR DESCRIPTION
## Description
[TIER IV Internal slack](https://star4.slack.com/archives/C07FL8616EM/p1743138977450959)の議論に基づいて、validate_ld_preloadを

- LD_PRELOADに何も指定されていない or "libagnocast_heaphook.so"が見つからないなら落とす
- libagnocast_heaphook.soフルパス前後に':'がなければ警告

に変更しました。

## Related links

## How was this PR tested?
e2e_1to1テストにて、LD_PRELOADをlibagnocast_heaphook.so単体にしたときにwarningがでることを確認

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
