### PR TITLE
fix(agnocastlib): unify the target name with the project name

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -17,18 +17,18 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(tracetools REQUIRED)
 
-add_library(agnocast SHARED
+add_library(${PROJECT_NAME} SHARED
   src/agnocast.cpp src/agnocast_utils.cpp src/agnocast_publisher.cpp src/agnocast_subscription.cpp
   src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_executor.cpp
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp)
 # ament_target_dependencies(agnocast rclcpp)
 
-target_link_libraries(agnocast
+target_link_libraries(${PROJECT_NAME}
   ${rclcpp_LIBRARIES}
   ${tracetools_LIBRARIES}
 )
 
-target_include_directories(agnocast PUBLIC
+target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   ${rclcpp_INCLUDE_DIRS}
@@ -38,7 +38,7 @@ target_include_directories(agnocast PUBLIC
 add_executable(agnocast_component_container src/agnocast_component_container.cpp)
 
 target_link_libraries(agnocast_component_container
-  agnocast
+  ${PROJECT_NAME}
 )
 
 ament_target_dependencies(agnocast_component_container rclcpp rclcpp_components)
@@ -46,7 +46,7 @@ ament_target_dependencies(agnocast_component_container rclcpp rclcpp_components)
 add_executable(agnocast_component_container_mt src/agnocast_component_container_mt.cpp)
 
 target_link_libraries(agnocast_component_container_mt
-  agnocast
+  ${PROJECT_NAME}
 )
 
 ament_target_dependencies(agnocast_component_container_mt rclcpp rclcpp_components)
@@ -56,7 +56,7 @@ install(
   DESTINATION lib/${PROJECT_NAME}
 )
 
-install(TARGETS agnocast
+install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -96,14 +96,14 @@ if(BUILD_TESTING)
   include_directories(${gmock-global_SOURCE_DIR}/include)
 
   find_package(ament_cmake_gmock REQUIRED)
-  
+
   # Unit tests
   ament_add_gmock(test_unit_${PROJECT_NAME}
     test/unit/test_agnocast_utils.cpp
     test/unit/test_agnocast_subscription.cpp
     test/unit/test_mocked_agnocast.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include)
-  target_link_libraries(test_unit_${PROJECT_NAME} gmock-global agnocast)
+  target_link_libraries(test_unit_${PROJECT_NAME} gmock-global ${PROJECT_NAME})
   set_tests_properties(test_unit_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )
@@ -115,7 +115,7 @@ if(BUILD_TESTING)
     test/integration/src/ioctl_mock.cpp
     test/integration/src/node_for_executor_test.cpp)
   target_include_directories(test_integration_${PROJECT_NAME} PRIVATE test/integration/include)
-  target_link_libraries(test_integration_${PROJECT_NAME} agnocast)
+  target_link_libraries(test_integration_${PROJECT_NAME} ${PROJECT_NAME})
   set_tests_properties(test_integration_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
     TIMEOUT 120
@@ -133,7 +133,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_integration_agnocast_heaphook
     test/integration/test_agnocast_heaphook.cpp)
-  target_link_libraries(test_integration_agnocast_heaphook agnocast)
+  target_link_libraries(test_integration_agnocast_heaphook ${PROJECT_NAME})
   set_tests_properties(test_integration_agnocast_heaphook PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libinitialize_shutdown_mock.so:${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:;AGNOCAST_MEMPOOL_SIZE=1000000")
 endif()


### PR DESCRIPTION
## Description
Autoware適用のときに、targetとprojectの名前が統一されていないと不都合が生じる場面があったので、統一する。

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] sample application

## Notes for reviewers
