### PR TITLE
feat: add agnocast_construct_executor tracepoints

### DIFF
--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -20,6 +20,11 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
   ros2_next_exec_timeout_(ros2_next_exec_timeout),
   agnocast_next_exec_timeout_ms_(agnocast_next_exec_timeout_ms)
 {
+#ifdef TRACETOOLS_LTTNG_ENABLED
+  TRACEPOINT(
+    agnocast_construct_executor, static_cast<const void *>(this),
+    "agnocast_multi_threaded_executor");
+#endif
 }
 
 void MultiThreadedAgnocastExecutor::validate_callback_group(

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -11,6 +11,12 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
   const rclcpp::ExecutorOptions & options, int next_exec_timeout_ms)
 : agnocast::AgnocastExecutor(options), next_exec_timeout_ms_(next_exec_timeout_ms)
 {
+#ifdef TRACETOOLS_LTTNG_ENABLED
+  TRACEPOINT(
+    agnocast_construct_executor, static_cast<const void *>(this),
+    "agnocast_single_threaded_executor");
+#endif
+
   const int next_exec_timeout_ms_threshold = 500;  // Rough value
   if (next_exec_timeout_ms_ > next_exec_timeout_ms_threshold) {
     RCLCPP_WARN(


### PR DESCRIPTION
## Description

This adds the `agnocast_construct_executor` traceponits for CARET.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [x] sample application can be measured correctly by CARET.

## Notes for reviewers
