### PR TITLE
refactor(test): not to use gmock-global

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -85,16 +85,6 @@ configure_file(
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 if(BUILD_TESTING)
-  # For gmock-global
-  include(FetchContent)
-  FetchContent_Declare(
-    gmock-global
-    GIT_REPOSITORY https://github.com/apriorit/gmock-global.git
-    GIT_TAG        master
-  )
-  FetchContent_MakeAvailable(gmock-global)
-  include_directories(${gmock-global_SOURCE_DIR}/include)
-
   find_package(ament_cmake_gmock REQUIRED)
   
   # Unit tests
@@ -103,7 +93,7 @@ if(BUILD_TESTING)
     test/unit/test_agnocast_subscription.cpp
     test/unit/test_mocked_agnocast.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include)
-  target_link_libraries(test_unit_${PROJECT_NAME} gmock-global agnocast)
+  target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   set_tests_properties(test_unit_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -6,46 +6,34 @@
 
 #include "std_msgs/msg/int32.hpp"
 
-#include <gmock-global/gmock-global.h>
-#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace agnocast;
-using testing::_;
 
-MOCK_GLOBAL_FUNC3(
-  decrement_rc_mock, void(const std::string &, const topic_local_id_t, const int64_t));
-MOCK_GLOBAL_FUNC3(
-  increment_rc_mock, void(const std::string &, const topic_local_id_t, const int64_t));
-MOCK_GLOBAL_FUNC2(
-  initialize_publisher_mock, topic_local_id_t(const std::string &, const rclcpp::QoS &));
-MOCK_GLOBAL_FUNC5(
-  publish_core_mock, union ioctl_publish_args(
-                       const void *, const std::string &, const topic_local_id_t, const uint64_t,
-                       std::unordered_map<std::string, std::tuple<mqd_t, bool>> &));
+int decrement_rc_mock_called_count = 0;
+int increment_rc_mock_called_count = 0;
+int publish_core_mock_called_count = 0;
 
 namespace agnocast
 {
-void decrement_rc(const std::string & tn, const topic_local_id_t sub_id, const int64_t entry_id)
+void decrement_rc(const std::string &, const topic_local_id_t, const int64_t)
 {
-  decrement_rc_mock(tn, sub_id, entry_id);
+  decrement_rc_mock_called_count++;
 }
-void increment_rc(const std::string & tn, const topic_local_id_t sub_id, const int64_t entry_id)
+void increment_rc(const std::string &, const topic_local_id_t, const int64_t)
 {
-  increment_rc_mock(tn, sub_id, entry_id);
+  increment_rc_mock_called_count++;
 }
-topic_local_id_t initialize_publisher(
-  const std::string & topic_name, [[maybe_unused]] const std::string & node_name,
-  const rclcpp::QoS & qos)
+topic_local_id_t initialize_publisher(const std::string &, const std::string &, const rclcpp::QoS &)
 {
-  return initialize_publisher_mock(topic_name, qos);
+  return 0;  // Dummy value
 }
 union ioctl_publish_args publish_core(
-  const void * publisher_handle, const std::string & topic_name,
-  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<std::string, std::tuple<mqd_t, bool>> & opened_mqs)
+  const void *, const std::string &, const topic_local_id_t, const uint64_t,
+  std::unordered_map<std::string, std::tuple<mqd_t, bool>> &)
 {
-  return publish_core_mock(
-    publisher_handle, topic_name, publisher_id, msg_virtual_address, opened_mqs);
+  publish_core_mock_called_count++;
+  return ioctl_publish_args{};  // Dummy value
 }
 }  // namespace agnocast
 
@@ -62,9 +50,10 @@ protected:
     dummy_tn = "/dummy";
     pid = getpid();
     node = std::make_shared<rclcpp::Node>("dummy_node");
-    EXPECT_GLOBAL_CALL(initialize_publisher_mock, initialize_publisher_mock(dummy_tn, _)).Times(1);
     dummy_publisher =
       agnocast::create_publisher<std_msgs::msg::Int32>(node.get(), dummy_tn, dummy_qos);
+
+    publish_core_mock_called_count = 0;
   }
 
   void TearDown() override { rclcpp::shutdown(); }
@@ -78,16 +67,22 @@ protected:
 
 TEST_F(AgnocastPublisherTest, test_publish_normal)
 {
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(dummy_tn, _, _)).Times(1);
-  EXPECT_GLOBAL_CALL(publish_core_mock, publish_core_mock(_, dummy_tn, _, _, _)).Times(1);
+  // Arrange
   agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
+
+  // Act
   dummy_publisher->publish(std::move(message));
+
+  // Assert
+  EXPECT_EQ(publish_core_mock_called_count, 1);
 }
 
 TEST_F(AgnocastPublisherTest, test_publish_null_message)
 {
+  // Arrange
   agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message;
 
+  // Act & Assert
   EXPECT_EXIT(
     dummy_publisher->publish(std::move(message)), ::testing::ExitedWithCode(EXIT_FAILURE),
     "Invalid message to publish.");
@@ -95,13 +90,11 @@ TEST_F(AgnocastPublisherTest, test_publish_null_message)
 
 TEST_F(AgnocastPublisherTest, test_publish_already_published_message)
 {
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(dummy_tn, _, _)).Times(1);
-  EXPECT_GLOBAL_CALL(publish_core_mock, publish_core_mock(_, dummy_tn, _, _, _)).Times(1);
-
+  // Arrange
   agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
-
   dummy_publisher->publish(std::move(message));
 
+  // Act & Assert
   EXPECT_EXIT(
     dummy_publisher->publish(std::move(message)), ::testing::ExitedWithCode(EXIT_FAILURE),
     "Invalid message to publish.");
@@ -109,19 +102,15 @@ TEST_F(AgnocastPublisherTest, test_publish_already_published_message)
 
 TEST_F(AgnocastPublisherTest, test_publish_different_message)
 {
+  // Arrange
   std::string diff_dummy_tn = "/dummy2";
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(dummy_tn, _, _)).Times(1);
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(diff_dummy_tn, _, _)).Times(1);
-  EXPECT_GLOBAL_CALL(initialize_publisher_mock, initialize_publisher_mock(diff_dummy_tn, _))
-    .Times(1);
-  EXPECT_GLOBAL_CALL(publish_core_mock, publish_core_mock(_, dummy_tn, _, _, _)).Times(0);
-
   agnocast::Publisher<std_msgs::msg::Int32>::SharedPtr diff_publisher =
     agnocast::create_publisher<std_msgs::msg::Int32>(node.get(), diff_dummy_tn, dummy_qos);
   agnocast::ipc_shared_ptr<std_msgs::msg::Int32> diff_message =
     diff_publisher->borrow_loaned_message();
   agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
 
+  // Act & Assert
   EXPECT_EXIT(
     dummy_publisher->publish(std::move(diff_message)), ::testing::ExitedWithCode(EXIT_FAILURE),
     "Invalid message to publish.");
@@ -139,6 +128,9 @@ protected:
     dummy_tn = "dummy";
     dummy_pubsub_id = 1;
     dummy_entry_id = 2;
+
+    decrement_rc_mock_called_count = 0;
+    increment_rc_mock_called_count = 0;
   }
 
   std::string dummy_tn;
@@ -148,35 +140,40 @@ protected:
 
 TEST_F(AgnocastSmartPointerTest, reset_normal)
 {
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   sut.reset();
 
+  // Assert
+  EXPECT_EQ(decrement_rc_mock_called_count, 1);
   EXPECT_EQ(nullptr, sut.get());
 }
 
 TEST_F(AgnocastSmartPointerTest, reset_nullptr)
 {
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(_, _, _)).Times(0);
+  // Arrange
   std::shared_ptr<agnocast::ipc_shared_ptr<int>> sut;
+
+  // Act
   sut.reset();
+
+  // Assert
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
 }
 
 TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)
 {
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(2);
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   agnocast::ipc_shared_ptr<int> sut2 = sut;
 
+  // Assert
+  EXPECT_EQ(increment_rc_mock_called_count, 1);
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
   EXPECT_EQ(sut.get(), sut2.get());
   EXPECT_EQ(sut.get_topic_name(), sut2.get_topic_name());
   EXPECT_EQ(sut.get_entry_id(), sut2.get_entry_id());
@@ -184,39 +181,33 @@ TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)
 
 TEST_F(AgnocastSmartPointerTest, copy_constructor_empty)
 {
-  EXPECT_GLOBAL_CALL(increment_rc_mock, increment_rc_mock(_, _, _)).Times(0);
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(_, _, _)).Times(0);
-
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut;
+
+  // Act & Assert
   EXPECT_NO_THROW(agnocast::ipc_shared_ptr<int> sut2{sut});
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
 }
 
 TEST_F(AgnocastSmartPointerTest, copy_assignment_normal)
 {
+  // Arrange
   int * ptr = new int(0);
   int * ptr2 = new int(1);
   std::string dummy_tn2 = "dummy2";
   topic_local_id_t dummy_pubsub_id2 = 2;
   int64_t dummy_entry_id2 = 3;
 
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(2);
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn2, dummy_pubsub_id2, dummy_entry_id2))
-    .Times(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn2, dummy_pubsub_id2, dummy_entry_id2))
-    .Times(1);
-
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
   agnocast::ipc_shared_ptr<int> sut2{ptr2, dummy_tn2, dummy_pubsub_id2, dummy_entry_id2};
 
+  // Act
   sut2 = sut;
 
+  // Assert
+  EXPECT_EQ(decrement_rc_mock_called_count, 1);
+  EXPECT_EQ(increment_rc_mock_called_count, 1);
   EXPECT_EQ(ptr, sut2.get());
   EXPECT_EQ(dummy_tn, sut2.get_topic_name());
   EXPECT_EQ(dummy_pubsub_id, sut2.get_pubsub_id());
@@ -225,19 +216,16 @@ TEST_F(AgnocastSmartPointerTest, copy_assignment_normal)
 
 TEST_F(AgnocastSmartPointerTest, copy_assignment_self)
 {
+  // Arrange
   int * ptr = new int(0);
-
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
-
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   sut = sut;
 
+  // Assert
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
   EXPECT_EQ(ptr, sut.get());
   EXPECT_EQ(dummy_tn, sut.get_topic_name());
   EXPECT_EQ(dummy_pubsub_id, sut.get_pubsub_id());
@@ -246,27 +234,29 @@ TEST_F(AgnocastSmartPointerTest, copy_assignment_self)
 
 TEST_F(AgnocastSmartPointerTest, copy_assignment_empty)
 {
-  EXPECT_GLOBAL_CALL(increment_rc_mock, increment_rc_mock(_, _, _)).Times(0);
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(_, _, _)).Times(0);
-
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut;
+
+  // Act
   sut = agnocast::ipc_shared_ptr<int>();
-  EXPECT_NO_THROW();
+
+  // Assert
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
 }
 
 TEST_F(AgnocastSmartPointerTest, move_constructor_normal)
 {
+  // Arrange
   int * ptr = new int(0);
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   agnocast::ipc_shared_ptr<int> sut2 = std::move(sut);
 
+  // Assert
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
   EXPECT_EQ(nullptr, sut.get());
   EXPECT_EQ(ptr, sut2.get());
   EXPECT_EQ(dummy_tn, sut2.get_topic_name());
@@ -275,18 +265,17 @@ TEST_F(AgnocastSmartPointerTest, move_constructor_normal)
 
 TEST_F(AgnocastSmartPointerTest, move_assignment_normal)
 {
+  // Arrange
   int * ptr = new int(0);
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
-
   agnocast::ipc_shared_ptr<int> sut2;
+
+  // Act
   sut2 = std::move(sut);
 
+  // Assert
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
   EXPECT_EQ(nullptr, sut.get());
   EXPECT_EQ(ptr, sut2.get());
   EXPECT_EQ(dummy_tn, sut2.get_topic_name());
@@ -295,17 +284,16 @@ TEST_F(AgnocastSmartPointerTest, move_assignment_normal)
 
 TEST_F(AgnocastSmartPointerTest, move_assignment_self)
 {
+  // Arrange
   int * ptr = new int(0);
-  EXPECT_GLOBAL_CALL(
-    increment_rc_mock, increment_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   sut = std::move(sut);
 
+  // Assert
+  EXPECT_EQ(increment_rc_mock_called_count, 0);
+  EXPECT_EQ(decrement_rc_mock_called_count, 0);
   EXPECT_EQ(ptr, sut.get());
   EXPECT_EQ(dummy_tn, sut.get_topic_name());
   EXPECT_EQ(dummy_entry_id, sut.get_entry_id());
@@ -313,48 +301,51 @@ TEST_F(AgnocastSmartPointerTest, move_assignment_self)
 
 TEST_F(AgnocastSmartPointerTest, dereference_operator)
 {
+  // Arrange
   int * ptr = new int(0);
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
   agnocast::ipc_shared_ptr<int> sut{ptr, dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   int & result = *sut;
 
+  // Assert
   EXPECT_EQ(ptr, &result);
 }
 
 TEST_F(AgnocastSmartPointerTest, arrow_operator)
 {
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
+  // Arrange
   agnocast::ipc_shared_ptr<std::vector<int>> sut{
     new std::vector<int>{0}, dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   size_t result = sut->size();
 
+  // Assert
   EXPECT_EQ(1, result);
 }
 
 TEST_F(AgnocastSmartPointerTest, bool_operator_true)
 {
-  EXPECT_GLOBAL_CALL(
-    decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, dummy_entry_id))
-    .Times(1);
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut{new int(0), dummy_tn, dummy_pubsub_id, dummy_entry_id};
 
+  // Act
   bool result = static_cast<bool>(sut);
 
+  // Assert
   EXPECT_TRUE(result);
 }
 
 TEST_F(AgnocastSmartPointerTest, bool_operator_false)
 {
+  // Arrange
   agnocast::ipc_shared_ptr<int> sut;
 
+  // Act
   bool result = static_cast<bool>(sut);
 
+  // Assert
   EXPECT_FALSE(result);
 }
 
@@ -384,7 +375,7 @@ TEST_F(AgnocastCallbackInfoTest, callback_first_arg)
 
 TEST_F(AgnocastCallbackInfoTest, get_erased_callback_normal)
 {
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, _)).Times(1);
+  // Arrange
   bool callback_called = false;
   int data = 0;
   agnocast::TypedMessagePtr<int> int_arg{
@@ -393,23 +384,25 @@ TEST_F(AgnocastCallbackInfoTest, get_erased_callback_normal)
     callback_called = true;
   };
 
+  // Act
   agnocast::TypeErasedCallback erased_callback = agnocast::get_erased_callback<int>(int_callback);
   erased_callback(int_arg);
 
+  // Assert
   EXPECT_TRUE(callback_called);
 }
 
 TEST_F(AgnocastCallbackInfoTest, get_erased_callback_invalid_type)
 {
-  EXPECT_GLOBAL_CALL(decrement_rc_mock, decrement_rc_mock(dummy_tn, dummy_pubsub_id, _)).Times(1);
+  // Arrange
   int data = 0;
   agnocast::TypedMessagePtr<int> int_arg{
     agnocast::ipc_shared_ptr<int>(&data, dummy_tn, dummy_pubsub_id)};
   auto float_callback = [&](agnocast::ipc_shared_ptr<float> /*unused_arg*/) {};
 
+  // Act & Assert
   agnocast::TypeErasedCallback erased_callback =
     agnocast::get_erased_callback<float>(float_callback);
-
   EXPECT_EXIT(
     erased_callback(int_arg), ::testing::ExitedWithCode(EXIT_FAILURE),
     "Agnocast internal implementation error: bad allocation when callback is called");


### PR DESCRIPTION
## Description

To solve this [issue](https://star4.slack.com/archives/C07FL8616EM/p1743460649530579), this refactors the unit tests not to use gmock-global.

## Related links

## How was this PR tested?

- [x] unit tests

## Notes for reviewers
