### PR TITLE
refactor(kmod): get ipc_ns in agnocast_ioctl

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -192,12 +192,12 @@ void agnocast_exit_kprobe(void);
 void agnocast_exit_device(void);
 
 int subscriber_add(
-  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   const bool is_take_sub, union ioctl_subscriber_args * ioctl_ret);
 
 int publisher_add(
-  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   union ioctl_publisher_args * ioctl_ret);
 
@@ -243,7 +243,8 @@ int get_proc_info_htable_size(void);
 bool is_in_proc_info_htable(const pid_t pid);
 int get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns);
 int64_t get_latest_received_entry_id(
-  const char * topic_name, struct ipc_namespace * ipc_ns, const topic_local_id_t subscriber_id);
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id);
 bool is_in_topic_entries(
   const char * topic_name, const struct ipc_namespace * ipc_ns, int64_t entry_id);
 int get_entry_rc(

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -257,6 +257,6 @@ int get_publisher_num(const char * topic_name, const struct ipc_namespace * ipc_
 bool is_in_publisher_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t publisher_id);
-int get_topic_num(void);
+int get_topic_num(const struct ipc_namespace * ipc_ns);
 bool is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 #endif

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <linux/ipc_namespace.h>
 #include <linux/types.h>
 
 #define MAX_PUBLISHER_NUM 4        // Maximum number of publishers per topic
@@ -191,38 +192,44 @@ void agnocast_exit_kprobe(void);
 void agnocast_exit_device(void);
 
 int subscriber_add(
-  const char * topic_name, const char * node_name, const pid_t subscriber_pid,
-  const uint32_t qos_depth, const bool qos_is_transient_local, const bool is_take_sub,
-  union ioctl_subscriber_args * ioctl_ret);
+  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
+  const bool is_take_sub, union ioctl_subscriber_args * ioctl_ret);
 
 int publisher_add(
-  const char * topic_name, const char * node_name, const pid_t publisher_pid,
-  const uint32_t qos_depth, const bool qos_is_transient_local,
+  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   union ioctl_publisher_args * ioctl_ret);
 
 int increment_message_entry_rc(
-  const char * topic_name, const topic_local_id_t pubsub_id, const int64_t entry_id);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
+  const int64_t entry_id);
 
 int decrement_message_entry_rc(
-  const char * topic_name, const topic_local_id_t pubsub_id, const int64_t entry_id);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
+  const int64_t entry_id);
 
 int receive_msg(
-  const char * topic_name, const topic_local_id_t subscriber_id,
-  union ioctl_receive_msg_args * ioctl_ret);
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id, union ioctl_receive_msg_args * ioctl_ret);
 
 int publish_msg(
-  const char * topic_name, const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  union ioctl_publish_args * ioctl_ret);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id,
+  const uint64_t msg_virtual_address, union ioctl_publish_args * ioctl_ret);
 
 int take_msg(
-  const char * topic_name, const topic_local_id_t subscriber_id, bool allow_same_message,
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id, bool allow_same_message,
   union ioctl_take_msg_args * ioctl_ret);
 
 int new_shm_addr(const pid_t pid, uint64_t shm_size, union ioctl_new_shm_args * ioctl_ret);
 
-int get_subscriber_num(const char * topic_name, union ioctl_get_subscriber_num_args * ioctl_ret);
+int get_subscriber_num(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  union ioctl_get_subscriber_num_args * ioctl_ret);
 
-int get_topic_list(union ioctl_topic_list_args * topic_list_args);
+int get_topic_list(
+  const struct ipc_namespace * ipc_ns, union ioctl_topic_list_args * topic_list_args);
 
 void process_exit_cleanup(const pid_t pid);
 
@@ -234,13 +241,21 @@ void enqueue_exit_pid(const pid_t pid);
 #ifdef KUNIT_BUILD
 int get_proc_info_htable_size(void);
 bool is_in_proc_info_htable(const pid_t pid);
-int get_topic_entries_num(const char * topic_name);
-int64_t get_latest_received_entry_id(const char * topic_name, const topic_local_id_t subscriber_id);
-bool is_in_topic_entries(const char * topic_name, int64_t entry_id);
-int get_entry_rc(const char * topic_name, const int64_t entry_id, const topic_local_id_t pubsub_id);
-bool is_in_subscriber_htable(const char * topic_name, const topic_local_id_t subscriber_id);
-int get_publisher_num(const char * topic_name);
-bool is_in_publisher_htable(const char * topic_name, const topic_local_id_t publisher_id);
+int get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns);
+int64_t get_latest_received_entry_id(
+  const char * topic_name, struct ipc_namespace * ipc_ns, const topic_local_id_t subscriber_id);
+bool is_in_topic_entries(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, int64_t entry_id);
+int get_entry_rc(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const int64_t entry_id,
+  const topic_local_id_t pubsub_id);
+bool is_in_subscriber_htable(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id);
+int get_publisher_num(const char * topic_name, const struct ipc_namespace * ipc_ns);
+bool is_in_publisher_htable(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t publisher_id);
 int get_topic_num(void);
-bool is_in_topic_htable(const char * topic_name);
+bool is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 #endif

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -41,11 +41,11 @@ static topic_local_id_t setup_one_publisher(struct kunit * test, const pid_t pub
 {
   union ioctl_publisher_args publisher_args;
   int ret = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
-  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_args.ret_id));
+  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_args.ret_id));
 
   return publisher_args.ret_id;
 }
@@ -54,12 +54,12 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
 {
   union ioctl_subscriber_args subscriber_args;
   int ret = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
     &subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
-  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_args.ret_id));
+  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id));
 
   return subscriber_args.ret_id;
 }
@@ -68,10 +68,10 @@ static uint64_t setup_one_entry(
   struct kunit * test, const topic_local_id_t publisher_id, const uint64_t msg_virtual_address)
 {
   union ioctl_publish_args publish_args;
-  int ret = publish_msg(TOPIC_NAME, publisher_id, msg_virtual_address, &publish_args);
+  int ret = publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
-  KUNIT_ASSERT_TRUE(test, is_in_topic_entries(TOPIC_NAME, publish_args.ret_entry_id));
+  KUNIT_ASSERT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, publish_args.ret_entry_id));
 
   return publish_args.ret_entry_id;
 }
@@ -127,7 +127,7 @@ void test_case_do_exit_with_publisher(struct kunit * test)
 
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -148,7 +148,7 @@ void test_case_do_exit_with_subscriber(struct kunit * test)
   setup_one_subscriber(test, subscriber_pid);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
@@ -177,11 +177,11 @@ void test_case_do_exit_with_many_pubsub_in_one_process(struct kunit * test)
   setup_one_subscriber(test, pid);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 2);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
   // Act
@@ -214,11 +214,11 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   const topic_local_id_t subscriber_id1 = setup_one_subscriber(test, subscriber_pid1);
   const topic_local_id_t subscriber_id2 = setup_one_subscriber(test, subscriber_pid2);
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 2);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
   // Act
@@ -228,7 +228,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   msleep(10);
 
   // Assert
-  int ret1 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 3);
   KUNIT_EXPECT_FALSE(test, is_in_proc_info_htable(publisher_pid1));
@@ -236,13 +236,13 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
-  KUNIT_EXPECT_FALSE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id2));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_EXPECT_FALSE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
+  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
+  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
+  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
 }
 
 // Test case for process exit where there are two publishers and subscribers in different processes
@@ -264,11 +264,11 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   const topic_local_id_t subscriber_id1 = setup_one_subscriber(test, subscriber_pid1);
   const topic_local_id_t subscriber_id2 = setup_one_subscriber(test, subscriber_pid2);
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 2);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
   // Act
@@ -278,7 +278,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   msleep(10);
 
   // Assert
-  int ret1 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 3);
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(publisher_pid1));
@@ -286,13 +286,13 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   KUNIT_EXPECT_FALSE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 2);
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id2));
-  KUNIT_EXPECT_FALSE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
+  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
+  KUNIT_EXPECT_FALSE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
+  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
 }
 
 // Test case for process exit where there are two publishers and subscribers in different processes
@@ -314,11 +314,11 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_ex
   setup_one_subscriber(test, subscriber_pid1);
   setup_one_subscriber(test, subscriber_pid2);
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 2);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
   // Act
@@ -331,11 +331,11 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_ex
   msleep(10);
 
   // Assert
-  int ret1 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
 }
 
@@ -348,9 +348,9 @@ void test_case_do_exit_with_entry(struct kunit * test)
   const uint64_t entry_id = setup_one_entry(test, publisher_id, msg_virtual_address);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -361,8 +361,8 @@ void test_case_do_exit_with_entry(struct kunit * test)
   // Assert
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
 }
 
 // Test case for process exit where there is a message entry with a subscriber reference,
@@ -374,25 +374,25 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   const uint64_t msg_virtual_address = setup_one_process(test, publisher_pid);
   const topic_local_id_t publisher_id = setup_one_publisher(test, publisher_pid);
   const uint64_t entry_id = setup_one_entry(test, publisher_id, msg_virtual_address);
-  int ret1 = decrement_message_entry_rc(TOPIC_NAME, publisher_id, entry_id);
+  int ret1 = decrement_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, entry_id);
 
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret2 = increment_message_entry_rc(TOPIC_NAME, subscriber_id, entry_id);
+  int ret2 = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret3 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 0);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -401,15 +401,15 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   msleep(10);
 
   // Assert
-  int ret4 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret4 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 0);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
 }
 
 // Test case for process exit order: publisher exits first, then subscriber exits
@@ -424,19 +424,19 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret = increment_message_entry_rc(TOPIC_NAME, subscriber_id, entry_id);
+  int ret = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret1 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -445,18 +445,18 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   msleep(10);
 
   // Assert
-  int ret2 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret2 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id));
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, entry_id));
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 0);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id));
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id));
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -465,13 +465,13 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   msleep(10);
 
   // Assert
-  int ret3 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
 }
 
 // Test case for process exit order: subscriber exits first, then publisher exits
@@ -486,19 +486,19 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret = increment_message_entry_rc(TOPIC_NAME, subscriber_id, entry_id);
+  int ret = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  int ret1 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -507,19 +507,19 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   msleep(10);
 
   // Assert
-  int ret2 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret2 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(publisher_pid));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, entry_id));
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, publisher_id), 1);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, entry_id, subscriber_id), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id));
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -528,10 +528,10 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   msleep(10);
 
   // Assert
-  int ret3 = get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -41,11 +41,13 @@ static topic_local_id_t setup_one_publisher(struct kunit * test, const pid_t pub
 {
   union ioctl_publisher_args publisher_args;
   int ret = publisher_add(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH,
+    QOS_IS_TRANSIENT_LOCAL, &publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
-  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_args.ret_id));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_args.ret_id));
 
   return publisher_args.ret_id;
 }
@@ -54,12 +56,13 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
 {
   union ioctl_subscriber_args subscriber_args;
   int ret = subscriber_add(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id));
 
   return subscriber_args.ret_id;
 }
@@ -68,10 +71,12 @@ static uint64_t setup_one_entry(
   struct kunit * test, const topic_local_id_t publisher_id, const uint64_t msg_virtual_address)
 {
   union ioctl_publish_args publish_args;
-  int ret = publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_args);
+  int ret = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
-  KUNIT_ASSERT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, publish_args.ret_entry_id));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, publish_args.ret_entry_id));
 
   return publish_args.ret_entry_id;
 }
@@ -239,10 +244,14 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
-  KUNIT_EXPECT_FALSE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
+  KUNIT_EXPECT_FALSE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
 }
 
 // Test case for process exit where there are two publishers and subscribers in different processes
@@ -289,10 +298,14 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
-  KUNIT_EXPECT_FALSE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id1));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id2));
+  KUNIT_EXPECT_FALSE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
 }
 
 // Test case for process exit where there are two publishers and subscribers in different processes
@@ -350,7 +363,8 @@ void test_case_do_exit_with_entry(struct kunit * test)
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -374,12 +388,14 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   const uint64_t msg_virtual_address = setup_one_process(test, publisher_pid);
   const topic_local_id_t publisher_id = setup_one_publisher(test, publisher_pid);
   const uint64_t entry_id = setup_one_entry(test, publisher_id, msg_virtual_address);
-  int ret1 = decrement_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, entry_id);
+  int ret1 =
+    decrement_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, entry_id);
 
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret2 = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
+  int ret2 =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
   int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
@@ -391,8 +407,10 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -408,8 +426,10 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
 }
 
 // Test case for process exit order: publisher exits first, then subscriber exits
@@ -424,7 +444,8 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
+  int ret =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
   int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
@@ -435,8 +456,10 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(publisher_pid);
@@ -450,13 +473,17 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id));
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id));
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 0);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -486,7 +513,8 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   const pid_t subscriber_pid = PID_BASE + 1;
   setup_one_process(test, subscriber_pid);
   const topic_local_id_t subscriber_id = setup_one_subscriber(test, subscriber_pid);
-  int ret = increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
+  int ret =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
   int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
@@ -497,8 +525,10 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
-  KUNIT_ASSERT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_ASSERT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 1);
 
   // Act
   enqueue_exit_pid(subscriber_pid);
@@ -514,12 +544,15 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_entries(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id));
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
-  KUNIT_EXPECT_EQ(test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, publisher_id), 1);
+  KUNIT_EXPECT_EQ(
+    test, get_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, entry_id, subscriber_id), 0);
 
   // Act
   enqueue_exit_pid(publisher_pid);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -18,8 +18,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_subscriber_args subscriber_args;
   int ret2 = subscriber_add(
-    topic_name, node_name, subscriber_pid, qos_depth, qos_is_transient_local, is_take_sub,
-    &subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    qos_is_transient_local, is_take_sub, &subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -34,7 +34,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_publisher_args publisher_args;
   int ret2 = publisher_add(
-    topic_name, node_name, publisher_pid, qos_depth, qos_is_transient_local, &publisher_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    qos_is_transient_local, &publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -46,7 +47,7 @@ void test_case_get_subscriber_num_normal(struct kunit * test)
   setup_one_subscriber(test, topic_name);
 
   union ioctl_get_subscriber_num_args subscriber_num_args;
-  int ret = get_subscriber_num(topic_name, &subscriber_num_args);
+  int ret = get_subscriber_num(topic_name, current->nsproxy->ipc_ns, &subscriber_num_args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_subscriber_num, 1);
@@ -60,7 +61,7 @@ void test_case_get_subscriber_num_many(struct kunit * test)
   }
 
   union ioctl_get_subscriber_num_args subscriber_num_args;
-  int ret = get_subscriber_num(topic_name, &subscriber_num_args);
+  int ret = get_subscriber_num(topic_name, current->nsproxy->ipc_ns, &subscriber_num_args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_subscriber_num, MAX_SUBSCRIBER_NUM);
@@ -75,8 +76,8 @@ void test_case_get_subscriber_num_different_topic(struct kunit * test)
 
   union ioctl_get_subscriber_num_args subscriber_num_args1;
   union ioctl_get_subscriber_num_args subscriber_num_args2;
-  int ret1 = get_subscriber_num(topic_name1, &subscriber_num_args1);
-  int ret2 = get_subscriber_num(topic_name2, &subscriber_num_args2);
+  int ret1 = get_subscriber_num(topic_name1, current->nsproxy->ipc_ns, &subscriber_num_args1);
+  int ret2 = get_subscriber_num(topic_name2, current->nsproxy->ipc_ns, &subscriber_num_args2);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -91,7 +92,7 @@ void test_case_get_subscriber_num_with_exit(struct kunit * test)
 
   union ioctl_get_subscriber_num_args subscriber_num_args;
   process_exit_cleanup(subscriber_pid);
-  int ret = get_subscriber_num(topic_name, &subscriber_num_args);
+  int ret = get_subscriber_num(topic_name, current->nsproxy->ipc_ns, &subscriber_num_args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_subscriber_num, 0);
@@ -103,7 +104,7 @@ void test_case_get_subscriber_num_no_subscriber(struct kunit * test)
   setup_one_publisher(test, topic_name);
 
   union ioctl_get_subscriber_num_args subscriber_num_args;
-  int ret = get_subscriber_num(topic_name, &subscriber_num_args);
+  int ret = get_subscriber_num(topic_name, current->nsproxy->ipc_ns, &subscriber_num_args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_subscriber_num, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.c
@@ -23,7 +23,8 @@ static void setup_one_publisher(
 
   union ioctl_publisher_args publisher_args;
   int ret2 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH,
+    QOS_IS_TRANSIENT_LOCAL, &publisher_args);
   *publisher_id = publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -39,8 +40,8 @@ static void setup_one_subscriber(struct kunit * test, topic_local_id_t * subscri
 
   union ioctl_subscriber_args subscriber_args;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, QOS_DEPTH, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
   *subscriber_id = subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -54,7 +55,8 @@ static void setup_one_entry(
   setup_one_publisher(test, publisher_id, &ret_addr);
 
   union ioctl_publish_args publish_args;
-  int ret = publish_msg(TOPIC_NAME, *publisher_id, ret_addr, &publish_args);
+  int ret =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, *publisher_id, ret_addr, &publish_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
 
@@ -71,7 +73,8 @@ void test_case_increment_rc(struct kunit * test)
   setup_one_subscriber(test, &subscriber_id);
 
   // Act
-  int ret_inc = increment_message_entry_rc(TOPIC_NAME, subscriber_id, entry_id);
+  int ret_inc =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, entry_id);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret_inc, 0);
@@ -83,7 +86,7 @@ void test_case_increment_rc_without_topic(struct kunit * test)
   const char * invalid_topic_name = "/kunit_test_topic_dummy";
 
   // Act
-  int ret = increment_message_entry_rc(invalid_topic_name, 0, 0);
+  int ret = increment_message_entry_rc(invalid_topic_name, current->nxproxy->ipc_ns 0, 0);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -97,7 +100,8 @@ void test_case_increment_rc_without_entry(struct kunit * test)
   const int64_t invalid_entry_id = -1;
 
   // Act
-  int ret = increment_message_entry_rc(TOPIC_NAME, subscriber_id, invalid_entry_id);
+  int ret = increment_message_entry_rc(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, invalid_entry_id);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -111,7 +115,8 @@ void test_case_increment_rc_by_publisher(struct kunit * test)
   setup_one_entry(test, &publisher_id, &entry_id);
 
   // Act
-  int ret = increment_message_entry_rc(TOPIC_NAME, publisher_id, entry_id);
+  int ret =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, entry_id);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -126,7 +131,8 @@ void test_case_increment_rc_by_invalid_pubsub_id(struct kunit * test)
   topic_local_id_t invalid_pubsub_id = -1;
 
   // Act
-  int ret = increment_message_entry_rc(TOPIC_NAME, invalid_pubsub_id, entry_id);
+  int ret =
+    increment_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, invalid_pubsub_id, entry_id);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_increment_rc.c
@@ -86,7 +86,7 @@ void test_case_increment_rc_without_topic(struct kunit * test)
   const char * invalid_topic_name = "/kunit_test_topic_dummy";
 
   // Act
-  int ret = increment_message_entry_rc(invalid_topic_name, current->nxproxy->ipc_ns 0, 0);
+  int ret = increment_message_entry_rc(invalid_topic_name, current->nsproxy->ipc_ns, 0, 0);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -248,7 +248,7 @@ void test_case_publish_msg_excessive_release_count(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, MAX_RELEASE_NUM);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 2);
 }
 
 void test_case_publish_msg_ret_one_subscriber(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -21,8 +21,8 @@ static void setup_one_subscriber(struct kunit * test, topic_local_id_t * subscri
 
   union ioctl_subscriber_args subscriber_args;
   int ret2 = subscriber_add(
-    topic_name, node_name, subscriber_pid, qos_depth, qos_is_transient_local, is_take_sub,
-    &subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    qos_is_transient_local, is_take_sub, &subscriber_args);
   *subscriber_id = subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -40,7 +40,8 @@ static void setup_one_publisher(
 
   union ioctl_publisher_args publisher_args;
   int ret2 = publisher_add(
-    topic_name, node_name, publisher_pid, qos_depth, qos_is_transient_local, &publisher_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    qos_is_transient_local, &publisher_args);
   *publisher_id = publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -56,7 +57,8 @@ void test_case_publish_msg_no_topic(struct kunit * test)
   union ioctl_publish_args ioctl_publish_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, msg_virtual_address, &ioctl_publish_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &ioctl_publish_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -74,7 +76,9 @@ void test_case_publish_msg_no_publisher(struct kunit * test)
   union ioctl_publish_args ioctl_publish_msg_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, msg_virtual_address, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address,
+    &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_ASSERT_EQ(test, ret, -EINVAL);
@@ -90,14 +94,18 @@ void test_case_publish_msg_simple_publish_without_any_release(struct kunit * tes
   union ioctl_publish_args ioctl_publish_msg_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 1);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
 }
 
 void test_case_publish_msg_different_publisher_no_release(struct kunit * test)
@@ -109,24 +117,32 @@ void test_case_publish_msg_different_publisher_no_release(struct kunit * test)
   setup_one_publisher(test, &publisher_id2, &ret_addr2);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(topic_name, publisher_id1, ret_addr1, &ioctl_publish_msg_ret1);
-  int ret2 =
-    decrement_message_entry_rc(topic_name, publisher_id1, ioctl_publish_msg_ret1.ret_entry_id);
+  int ret1 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id1, ret_addr1, &ioctl_publish_msg_ret1);
+  int ret2 = decrement_message_entry_rc(
+    topic_name, current->nsproxy->ipc_ns, publisher_id1, ioctl_publish_msg_ret1.ret_entry_id);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
 
   // Act
-  int ret3 = publish_msg(topic_name, publisher_id2, ret_addr2, &ioctl_publish_msg_ret2);
+  int ret3 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id2, ret_addr2, &ioctl_publish_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret1.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret2.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret1.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret2.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 2);
 }
 
 void test_case_publish_msg_referenced_node_not_released(struct kunit * test)
@@ -137,21 +153,29 @@ void test_case_publish_msg_referenced_node_not_released(struct kunit * test)
   setup_one_publisher(test, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
 
   // Act
-  int ret2 = publish_msg(topic_name, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_subscriber_num, 0);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret1.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret2.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 2);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret1.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret2.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 2);
 }
 
 void test_case_publish_msg_single_release_return(struct kunit * test)
@@ -162,16 +186,18 @@ void test_case_publish_msg_single_release_return(struct kunit * test)
   setup_one_publisher(test, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
-  int ret2 =
-    decrement_message_entry_rc(topic_name, publisher_id, ioctl_publish_msg_ret1.ret_entry_id);
+  int ret1 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret2 = decrement_message_entry_rc(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ioctl_publish_msg_ret1.ret_entry_id);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
 
   // Act
-  int ret3 = publish_msg(topic_name, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret3 = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
@@ -179,9 +205,14 @@ void test_case_publish_msg_single_release_return(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_released_addrs[0], ret_addr);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret2.ret_subscriber_num, 0);
   KUNIT_EXPECT_EQ(
-    test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret1.ret_entry_id), false);
-  KUNIT_EXPECT_EQ(test, is_in_topic_entries(topic_name, ioctl_publish_msg_ret2.ret_entry_id), true);
-  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name), 1);
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret1.ret_entry_id),
+    false);
+  KUNIT_EXPECT_EQ(
+    test,
+    is_in_topic_entries(topic_name, current->nsproxy->ipc_ns, ioctl_publish_msg_ret2.ret_entry_id),
+    true);
+  KUNIT_EXPECT_EQ(test, get_topic_entries_num(topic_name, current->nsproxy->ipc_ns), 1);
 }
 
 void test_case_publish_msg_excessive_release_count(struct kunit * test)
@@ -194,21 +225,24 @@ void test_case_publish_msg_excessive_release_count(struct kunit * test)
   int64_t entry_ids[MAX_RELEASE_NUM + 1];
   for (int i = 0; i < MAX_RELEASE_NUM + 1; i++) {
     union ioctl_publish_args ioctl_publish_msg_ret;
-    int ret = publish_msg(topic_name, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
+    int ret = publish_msg(
+      topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     entry_ids[i] = ioctl_publish_msg_ret.ret_entry_id;
 
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
 
   for (int i = 0; i < MAX_RELEASE_NUM + 1; i++) {
-    int ret = decrement_message_entry_rc(topic_name, publisher_id, entry_ids[i]);
+    int ret =
+      decrement_message_entry_rc(topic_name, current->nsproxy->ipc_ns, publisher_id, entry_ids[i]);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
 
   union ioctl_publish_args ioctl_publish_msg_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -228,7 +262,8 @@ void test_case_publish_msg_ret_one_subscriber(struct kunit * test)
   union ioctl_publish_args ioctl_publish_msg_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -252,7 +287,8 @@ void test_case_publish_msg_ret_many_subscribers(struct kunit * test)
   union ioctl_publish_args ioctl_publish_msg_ret;
 
   // Act
-  int ret = publish_msg(topic_name, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
@@ -26,7 +26,7 @@ void test_case_publisher_add_normal(struct kunit * test)
   KUNIT_EXPECT_TRUE(
     test, is_in_publisher_htable(topic_name, current->nsproxy->ipc_ns, publisher_args.ret_id));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }
 
 void test_case_publisher_add_many(struct kunit * test)
@@ -47,7 +47,7 @@ void test_case_publisher_add_many(struct kunit * test)
   KUNIT_EXPECT_EQ(test, publisher_args.ret_id, publisher_num - 1);
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), publisher_num);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }
 
 void test_case_publisher_add_too_many(struct kunit * test)
@@ -67,5 +67,5 @@ void test_case_publisher_add_too_many(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), MAX_PUBLISHER_NUM);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
@@ -12,24 +12,26 @@ static const bool qos_is_transient_local = false;
 
 void test_case_publisher_add_normal(struct kunit * test)
 {
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
 
   union ioctl_publisher_args publisher_args;
   int ret = publisher_add(
-    topic_name, node_name, publisher_pid, qos_depth, qos_is_transient_local, &publisher_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    qos_is_transient_local, &publisher_args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), 1);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, publisher_args.ret_id, 0);
-  KUNIT_EXPECT_TRUE(test, is_in_publisher_htable(topic_name, publisher_args.ret_id));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_publisher_htable(topic_name, current->nsproxy->ipc_ns, publisher_args.ret_id));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
 }
 
 void test_case_publisher_add_many(struct kunit * test)
 {
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
 
   const int publisher_num = MAX_PUBLISHER_NUM;
@@ -37,19 +39,20 @@ void test_case_publisher_add_many(struct kunit * test)
   union ioctl_publisher_args publisher_args;
   for (int i = 0; i < publisher_num; i++) {
     ret = publisher_add(
-      topic_name, node_name, publisher_pid, qos_depth, qos_is_transient_local, &publisher_args);
+      topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+      qos_is_transient_local, &publisher_args);
   }
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, publisher_args.ret_id, publisher_num - 1);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), publisher_num);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), publisher_num);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
 }
 
 void test_case_publisher_add_too_many(struct kunit * test)
 {
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), 0);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
 
   const int publisher_num = MAX_PUBLISHER_NUM + 1;
@@ -57,11 +60,12 @@ void test_case_publisher_add_too_many(struct kunit * test)
   for (int i = 0; i < publisher_num; i++) {
     union ioctl_publisher_args publisher_args;
     ret = publisher_add(
-      topic_name, node_name, publisher_pid, qos_depth, qos_is_transient_local, &publisher_args);
+      topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+      qos_is_transient_local, &publisher_args);
   }
 
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
-  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name), MAX_PUBLISHER_NUM);
+  KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), MAX_PUBLISHER_NUM);
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name));
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -756,7 +756,7 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
     test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
   KUNIT_ASSERT_TRUE(
     test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
-  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(
     test,
     get_entry_rc(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -19,8 +19,8 @@ static void setup_one_subscriber(
 
   union ioctl_subscriber_args subscriber_args;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, qos_depth, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
+    IS_TAKE_SUB, &subscriber_args);
   *subscriber_id = subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -37,7 +37,8 @@ static void setup_one_publisher(
 
   union ioctl_publisher_args publisher_args;
   int ret2 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, qos_depth, is_transient_local, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
+    &publisher_args);
   *publisher_id = publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -51,7 +52,8 @@ void test_case_receive_msg_no_topic_when_receive(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -72,7 +74,8 @@ void test_case_receive_msg_no_subscriber_when_receive(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -91,7 +94,8 @@ void test_case_receive_msg_no_publish_nothing_to_receive(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -114,20 +118,22 @@ void test_case_receive_msg_receive_one(struct kunit * test)
   setup_one_subscriber(test, subscriber_pid, qos_depth, is_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -153,16 +159,19 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_p
     test, subscriber_pid, subscriber_qos_depth, is_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret3 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret3 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
@@ -170,7 +179,7 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_p
   KUNIT_EXPECT_EQ(
     test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -196,20 +205,22 @@ void test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_p
     test, subscriber_pid, subscriber_qos_depth, is_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -236,25 +247,28 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than
 
   for (int i = 0; i < MAX_QOS_DEPTH; i++) {
     union ioctl_publish_args ioctl_publish_msg_ret;
-    int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
+    int ret = publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, publisher_id, ret_addr + MAX_QOS_DEPTH + 1, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + MAX_QOS_DEPTH + 1,
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -281,23 +295,26 @@ void test_case_receive_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_a
 
   for (int i = 0; i < MAX_QOS_DEPTH - 1; i++) {
     union ioctl_publish_args ioctl_publish_msg_ret;
-    int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+    int ret = publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret3 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret3 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 10);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -318,7 +335,8 @@ void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_a
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   topic_local_id_t subscriber_id;
@@ -330,14 +348,15 @@ void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_a
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -358,15 +377,18 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret3;
-  int ret3 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret3);
+  int ret3 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret3);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   topic_local_id_t subscriber_id;
@@ -378,7 +400,8 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret4 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -386,7 +409,7 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_
   KUNIT_EXPECT_EQ(
     test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret3.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -407,11 +430,13 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smal
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -423,7 +448,8 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smal
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret4 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -431,7 +457,7 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smal
   KUNIT_EXPECT_EQ(
     test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_receive_msg_ret.ret_entry_ids[0]);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -452,11 +478,13 @@ void test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smal
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -468,13 +496,14 @@ void test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smal
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret4 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 2);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
     ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -504,7 +533,8 @@ void test_case_receive_msg_one_new_pub(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -525,12 +555,13 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_subscriber_args subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, pid, subscriber_qos_depth, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, subscriber_qos_depth, is_transient_local,
+    IS_TAKE_SUB, &subscriber_args);
   union ioctl_publisher_args publisher_args;
   const uint32_t publisher_qos_depth = 10;
   int ret3 = publisher_add(
-    TOPIC_NAME, NODE_NAME, pid, publisher_qos_depth, is_transient_local, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, publisher_qos_depth, is_transient_local,
+    &publisher_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -538,7 +569,8 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_args.ret_id, &ioctl_receive_msg_ret);
+  int ret4 = receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -563,12 +595,12 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_publisher_args publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, publisher_qos_depth, is_transient_local,
-    &publisher_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth,
+    is_transient_local, &publisher_args1);
   union ioctl_publisher_args publisher_args2;
   int ret3 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, publisher_qos_depth, is_transient_local,
-    &publisher_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth,
+    is_transient_local, &publisher_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -576,7 +608,8 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
 
   // Act
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret4 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -597,13 +630,13 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_subscriber_args subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, subscriber_qos_depth1, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth1,
+    is_transient_local, IS_TAKE_SUB, &subscriber_args1);
   union ioctl_subscriber_args subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, subscriber_qos_depth2, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth2,
+    is_transient_local, IS_TAKE_SUB, &subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -616,13 +649,15 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_args1.ret_id, &ioctl_receive_msg_ret);
+  int ret4 = receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args1.ret_id, &ioctl_receive_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
 
   // Act
-  int ret5 = receive_msg(TOPIC_NAME, subscriber_args2.ret_id, &ioctl_receive_msg_ret);
+  int ret5 = receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args2.ret_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret5, 0);
@@ -649,7 +684,8 @@ void test_case_receive_msg_twice(struct kunit * test)
     test, publisher_pid, publisher_qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
-  int ret1 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret1 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.publisher_num, 1);
@@ -657,7 +693,8 @@ void test_case_receive_msg_twice(struct kunit * test)
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
 
   // Act
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id, &ioctl_receive_msg_ret);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, &ioctl_receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -678,14 +715,16 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
 
   uint64_t msg_addr = 0x1000;
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, msg_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);
 
   topic_local_id_t subscriber_id1;
   const pid_t subscriber_pid1 = 2000;
   setup_one_subscriber(test, subscriber_pid1, qos_depth, is_transient_local, &subscriber_id1);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret1;
-  int ret2 = receive_msg(TOPIC_NAME, subscriber_id1, &ioctl_receive_msg_ret1);
+  int ret2 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1, &ioctl_receive_msg_ret1);
 
   enqueue_exit_pid(publisher_pid);
 
@@ -697,7 +736,8 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
   setup_one_subscriber(test, subscriber_pid2, qos_depth, is_transient_local, &subscriber_id2);
 
   union ioctl_get_subscriber_num_args ioctl_get_subscriber_num_ret;
-  int ret3 = get_subscriber_num(TOPIC_NAME, &ioctl_get_subscriber_num_ret);
+  int ret3 =
+    get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &ioctl_get_subscriber_num_ret);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -707,19 +747,31 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
-  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
-  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+  KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
+  KUNIT_ASSERT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_ASSERT_EQ(test, ioctl_get_subscriber_num_ret.ret_subscriber_num, 2);
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2));
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, publisher_id), 0);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_ns, ioctl_publish_msg_ret.ret_entry_id, publisher_id),
+    0);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id1), 1);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_ns, ioctl_publish_msg_ret.ret_entry_id, subscriber_id1),
+    1);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id2), 0);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_ns, ioctl_publish_msg_ret.ret_entry_id, subscriber_id2),
+    0);
   KUNIT_ASSERT_EQ(test, ioctl_receive_msg_ret1.ret_entry_num, 1);
   KUNIT_ASSERT_EQ(
     test, ioctl_receive_msg_ret1.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
@@ -730,7 +782,8 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
 
   // Act
   union ioctl_receive_msg_args ioctl_receive_msg_ret2;
-  int ret4 = receive_msg(TOPIC_NAME, subscriber_id2, &ioctl_receive_msg_ret2);
+  int ret4 =
+    receive_msg(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id2, &ioctl_receive_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -758,7 +811,8 @@ void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
     char topic_name[50];
     snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
     ret = publisher_add(
-      topic_name, NODE_NAME, publisher_pid, qos_depth, is_transient_local, &publisher_args);
+      topic_name, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
+      &publisher_args);
     KUNIT_ASSERT_EQ(test, ret, 0);
     for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
       if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {
@@ -768,31 +822,33 @@ void test_case_receive_msg_too_many_mapping_processes(struct kunit * test)
       KUNIT_ASSERT_EQ(test, ret, 0);
 
       ret = subscriber_add(
-        topic_name, NODE_NAME, subscriber_pid++, qos_depth, is_transient_local, IS_TAKE_SUB,
-        &subscriber_args);
+        topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid++, qos_depth,
+        is_transient_local, IS_TAKE_SUB, &subscriber_args);
       KUNIT_ASSERT_EQ(test, ret, 0);
       union ioctl_receive_msg_args receive_msg_ret;
-      ret = receive_msg(topic_name, subscriber_args.ret_id, &receive_msg_ret);
+      ret =
+        receive_msg(topic_name, current->nsproxy->ipc_ns, subscriber_args.ret_id, &receive_msg_ret);
       KUNIT_ASSERT_EQ(test, ret, 0);
       mmap_process_num++;
     }
   }
   const char * topic_name = "/kunit_test_topic_1000";
   ret = publisher_add(
-    topic_name, NODE_NAME, publisher_pid, qos_depth, is_transient_local, &publisher_args);
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
+    &publisher_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), MAX_PROCESS_NUM_PER_MEMPOOL);
 
   ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   ret = subscriber_add(
-    topic_name, NODE_NAME, subscriber_pid, qos_depth, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
+    IS_TAKE_SUB, &subscriber_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // Act
   union ioctl_receive_msg_args receive_msg_ret;
-  ret = receive_msg(topic_name, subscriber_args.ret_id, &receive_msg_ret);
+  ret = receive_msg(topic_name, current->nsproxy->ipc_ns, subscriber_args.ret_id, &receive_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_subscriber_add.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_subscriber_add.c
@@ -29,18 +29,19 @@ void test_case_subscriber_add_normal(struct kunit * test)
 
   // Act
   int ret = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+    QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   union ioctl_get_subscriber_num_args get_subscriber_num_args;
-  get_subscriber_num(TOPIC_NAME, &get_subscriber_num_args);
+  get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_EXPECT_EQ(test, subscriber_args.ret_id, 0);
-  KUNIT_EXPECT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_args.ret_id));
+  KUNIT_EXPECT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id));
   KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
-  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
+  KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
 }
 
 void test_case_subscriber_add_invalid_qos(struct kunit * test)
@@ -53,8 +54,8 @@ void test_case_subscriber_add_invalid_qos(struct kunit * test)
 
   // Act
   int ret = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, invalid_qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, invalid_qos_depth,
+    QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -70,14 +71,14 @@ void test_case_subscriber_add_too_many_subscribers(struct kunit * test)
   for (uint32_t i = 0; i < MAX_SUBSCRIBER_NUM; i++) {
     union ioctl_subscriber_args subscriber_args;
     subscriber_add(
-      TOPIC_NAME, NODE_NAME, subscriber_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-      &subscriber_args);
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
   }
 
   // Act
   int ret = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+    QOS_IS_TRANSIENT_LOCAL, IS_TAKE_SUB, &subscriber_args);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -125,8 +125,8 @@ void test_case_take_msg_take_one(struct kunit * test)
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
@@ -209,8 +209,8 @@ void test_case_take_msg_take_one_again_with_allow_same_message(struct kunit * te
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
@@ -258,8 +258,8 @@ void test_case_take_msg_take_one_again_not_allow_same_message(struct kunit * tes
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
@@ -348,8 +348,8 @@ void test_case_take_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
@@ -437,8 +437,8 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   for (int i = 0; i < MAX_QOS_DEPTH - 1; i++) {
@@ -479,8 +479,8 @@ void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_
     test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   topic_local_id_t subscriber_id;
@@ -836,8 +836,8 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
 
   uint64_t msg_addr = 0x1000;
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);
 
   topic_local_id_t subscriber_id1;
   const pid_t subscriber_pid1 = 2000;
@@ -858,7 +858,7 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
 
   union ioctl_get_subscriber_num_args ioctl_get_subscriber_num_ret;
   int ret3 =
-    get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns,  & ioctl_get_subscriber_num_ret);
+    get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &ioctl_get_subscriber_num_ret);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -870,7 +870,8 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
-  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
   KUNIT_ASSERT_EQ(test, ioctl_get_subscriber_num_ret.ret_subscriber_num, 2);
   KUNIT_ASSERT_TRUE(
     test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id1));

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -19,8 +19,8 @@ static void setup_one_subscriber(
 
   union ioctl_subscriber_args subscriber_args;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, qos_depth, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, subscriber_pid, qos_depth, is_transient_local,
+    IS_TAKE_SUB, &subscriber_args);
   *subscriber_id = subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -37,7 +37,8 @@ static void setup_one_publisher(
 
   union ioctl_publisher_args publisher_args;
   int ret2 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, qos_depth, is_transient_local, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, publisher_pid, qos_depth, is_transient_local,
+    &publisher_args);
   *publisher_id = publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -53,7 +54,8 @@ void test_case_take_msg_no_topic(struct kunit * test)
   bool is_transient_local = false;
 
   // Act
-  int ret = take_msg(TOPIC_NAME, subscriber_id, is_transient_local, &ioctl_take_msg_ret);
+  int ret = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, is_transient_local, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -75,7 +77,8 @@ void test_case_take_msg_no_subscriber(struct kunit * test)
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -95,7 +98,8 @@ void test_case_take_msg_no_publish_nothing_to_take(struct kunit * test)
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -121,20 +125,23 @@ void test_case_take_msg_take_one(struct kunit * test)
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -158,23 +165,27 @@ void test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two(struct kuni
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool allow_same_message = true;
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret3 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret3 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret1.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -198,28 +209,31 @@ void test_case_take_msg_take_one_again_with_allow_same_message(struct kunit * te
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
   const bool allow_same_message = true;
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret1);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_ASSERT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
     ioctl_take_msg_ret1.ret_entry_id);
 
   union ioctl_take_msg_args ioctl_take_msg_ret2;
 
   // Act
-  int ret3 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret2);
+  int ret3 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret2.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
     ioctl_take_msg_ret1.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -244,22 +258,25 @@ void test_case_take_msg_take_one_again_not_allow_same_message(struct kunit * tes
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
   const bool allow_same_message = false;
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret1);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_ASSERT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
     ioctl_take_msg_ret1.ret_entry_id);
 
   union ioctl_take_msg_args ioctl_take_msg_ret2;
 
   // Act
-  int ret3 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret2);
+  int ret3 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
@@ -286,23 +303,27 @@ void test_case_take_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool allow_same_message = true;
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret3 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret3 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -327,20 +348,23 @@ void test_case_take_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -366,25 +390,29 @@ void test_case_take_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_pu
 
   for (int i = 0; i < MAX_QOS_DEPTH; i++) {
     union ioctl_publish_args ioctl_publish_msg_ret;
-    int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
+    int ret = publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 =
-    publish_msg(TOPIC_NAME, publisher_id, ret_addr + MAX_QOS_DEPTH + 1, &ioctl_publish_msg_ret);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + MAX_QOS_DEPTH + 1,
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -409,12 +437,14 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
     test, subscriber_pid, subscriber_qos_depth, subscriber_transient_local, &subscriber_id);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   for (int i = 0; i < MAX_QOS_DEPTH - 1; i++) {
     union ioctl_publish_args ioctl_publish_msg_ret;
-    int ret = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+    int ret = publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
 
@@ -422,13 +452,14 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret3 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret3 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id),
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
     ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
@@ -448,7 +479,8 @@ void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_
     test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   topic_local_id_t subscriber_id;
@@ -462,7 +494,8 @@ void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -485,15 +518,18 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_tha
     test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret3;
-  int ret3 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret3);
+  int ret3 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret3);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   topic_local_id_t subscriber_id;
@@ -507,13 +543,15 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_tha
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret4 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret3.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -533,11 +571,13 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_publish_num_smaller
     test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -551,13 +591,15 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_publish_num_smaller
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret4 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -576,11 +618,13 @@ void test_case_take_msg_transient_local_publish_num_smaller_than_sub_qos_smaller
     test, publisher_pid, publisher_qos_depth, publisher_transient_local, &publisher_id, &ret_addr);
 
   union ioctl_publish_args ioctl_publish_msg_ret1;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
+  int ret1 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_args ioctl_publish_msg_ret2;
-  int ret2 = publish_msg(TOPIC_NAME, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
+  int ret2 = publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -594,13 +638,15 @@ void test_case_take_msg_transient_local_publish_num_smaller_than_sub_qos_smaller
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret4 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret1.ret_entry_id);
   KUNIT_EXPECT_EQ(
-    test, get_latest_received_entry_id(TOPIC_NAME, subscriber_id), ioctl_take_msg_ret.ret_entry_id);
+    test, get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id),
+    ioctl_take_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_pids[0], publisher_pid);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
@@ -630,7 +676,8 @@ void test_case_take_msg_one_new_pub(struct kunit * test)
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -651,13 +698,14 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_subscriber_args subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, pid, subscriber_qos_depth, publisher_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, pid, subscriber_qos_depth,
+    publisher_transient_local, IS_TAKE_SUB, &subscriber_args);
 
   union ioctl_publisher_args publisher_args;
   const uint32_t publisher_qos_depth = 10;
   int ret3 = publisher_add(
-    TOPIC_NAME, NODE_NAME, pid, publisher_qos_depth, publisher_transient_local, &publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, pid, publisher_qos_depth,
+    publisher_transient_local, &publisher_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -666,7 +714,9 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret4 = take_msg(TOPIC_NAME, subscriber_args.ret_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_args.ret_id, allow_same_message,
+    &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -692,15 +742,15 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
   const uint32_t publisher_qos_depth1 = 10;
   const bool publisher_transient_local1 = true;
   int ret2 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, publisher_qos_depth1, publisher_transient_local1,
-    &publisher_args1);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, publisher_pid, publisher_qos_depth1,
+    publisher_transient_local1, &publisher_args1);
 
   union ioctl_publisher_args publisher_args2;
   const uint32_t publisher_qos_depth2 = 1;
   const bool publisher_transient_local2 = true;
   int ret3 = publisher_add(
-    TOPIC_NAME, NODE_NAME, publisher_pid, publisher_qos_depth2, publisher_transient_local2,
-    &publisher_args2);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, publisher_pid, publisher_qos_depth2,
+    publisher_transient_local2, &publisher_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -709,7 +759,8 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_take_msg_args ioctl_take_msg_ret;
 
   // Act
-  int ret4 = take_msg(TOPIC_NAME, subscriber_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id, allow_same_message, &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -730,14 +781,14 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_subscriber_args subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, subscriber_qos_depth1, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args1);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, subscriber_pid, subscriber_qos_depth1,
+    is_transient_local, IS_TAKE_SUB, &subscriber_args1);
 
   union ioctl_subscriber_args subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = subscriber_add(
-    TOPIC_NAME, NODE_NAME, subscriber_pid, subscriber_qos_depth2, is_transient_local, IS_TAKE_SUB,
-    &subscriber_args2);
+    TOPIC_NAME, current->nsproxy->ipc_nsNODE_NAME, subscriber_pid, subscriber_qos_depth2,
+    is_transient_local, IS_TAKE_SUB, &subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -751,7 +802,9 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
 
   union ioctl_take_msg_args ioctl_take_msg_ret;
   const bool allow_same_message = true;
-  int ret4 = take_msg(TOPIC_NAME, subscriber_args1.ret_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_args1.ret_id, allow_same_message,
+    &ioctl_take_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.publisher_num, 1);
@@ -759,7 +812,9 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_info.shm_addrs[0], ret_addr);
 
   // Act
-  int ret5 = take_msg(TOPIC_NAME, subscriber_args2.ret_id, allow_same_message, &ioctl_take_msg_ret);
+  int ret5 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_args2.ret_id, allow_same_message,
+    &ioctl_take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret5, 0);
@@ -781,14 +836,16 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
 
   uint64_t msg_addr = 0x1000;
   union ioctl_publish_args ioctl_publish_msg_ret;
-  int ret1 = publish_msg(TOPIC_NAME, publisher_id, msg_addr, &ioctl_publish_msg_ret);
+  int ret1 =
+    publish_msg(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id, msg_addr, &ioctl_publish_msg_ret);
 
   topic_local_id_t subscriber_id1;
   const pid_t subscriber_pid1 = 2000;
   setup_one_subscriber(test, subscriber_pid1, qos_depth, is_transient_local, &subscriber_id1);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
-  int ret2 = take_msg(TOPIC_NAME, subscriber_id1, allow_same_message, &ioctl_take_msg_ret1);
+  int ret2 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id1, allow_same_message, &ioctl_take_msg_ret1);
 
   enqueue_exit_pid(publisher_pid);
 
@@ -800,7 +857,8 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   setup_one_subscriber(test, subscriber_pid2, qos_depth, is_transient_local, &subscriber_id2);
 
   union ioctl_get_subscriber_num_args ioctl_get_subscriber_num_ret;
-  int ret3 = get_subscriber_num(TOPIC_NAME, &ioctl_get_subscriber_num_ret);
+  int ret3 =
+    get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns & ioctl_get_subscriber_num_ret);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -812,17 +870,28 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME));
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME), 1);
-  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, publisher_id));
+  KUNIT_ASSERT_TRUE(test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_nspublisher_id));
   KUNIT_ASSERT_EQ(test, ioctl_get_subscriber_num_ret.ret_subscriber_num, 2);
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id1));
-  KUNIT_ASSERT_TRUE(test, is_in_subscriber_htable(TOPIC_NAME, subscriber_id2));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id1));
+  KUNIT_ASSERT_TRUE(
+    test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id2));
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME), 1);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, publisher_id), 0);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_nsioctl_publish_msg_ret.ret_entry_id, publisher_id),
+    0);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id1), 1);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_nsioctl_publish_msg_ret.ret_entry_id, subscriber_id1),
+    1);
   KUNIT_ASSERT_EQ(
-    test, get_entry_rc(TOPIC_NAME, ioctl_publish_msg_ret.ret_entry_id, subscriber_id2), 0);
+    test,
+    get_entry_rc(
+      TOPIC_NAME, current->nsproxy->ipc_nsioctl_publish_msg_ret.ret_entry_id, subscriber_id2),
+    0);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_addr, msg_addr);
   KUNIT_ASSERT_EQ(test, ioctl_take_msg_ret1.ret_pub_shm_info.publisher_num, 1);
@@ -831,7 +900,8 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
 
   // Act
   union ioctl_take_msg_args ioctl_take_msg_ret2;
-  int ret4 = take_msg(TOPIC_NAME, subscriber_id2, allow_same_message, &ioctl_take_msg_ret2);
+  int ret4 = take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_nssubscriber_id2, allow_same_message, &ioctl_take_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret4, 0);
@@ -861,7 +931,8 @@ void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
     char topic_name[50];
     snprintf(topic_name, sizeof(topic_name), "/kunit_test_topic%d", i);
     ret = publisher_add(
-      topic_name, NODE_NAME, publisher_pid, qos_depth, qos_transient_local, &publisher_args);
+      topic_name, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth,
+      qos_transient_local, &publisher_args);
     KUNIT_ASSERT_EQ(test, ret, 0);
     for (int j = 0; j < MAX_SUBSCRIBER_NUM; j++) {
       if (mmap_process_num >= MAX_PROCESS_NUM_PER_MEMPOOL) {
@@ -871,31 +942,36 @@ void test_case_take_msg_too_many_mapping_processes(struct kunit * test)
       KUNIT_ASSERT_EQ(test, ret, 0);
 
       ret = subscriber_add(
-        topic_name, NODE_NAME, subscriber_pid++, qos_depth, qos_transient_local, IS_TAKE_SUB,
-        &subscriber_args);
+        topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid++, qos_depth,
+        qos_transient_local, IS_TAKE_SUB, &subscriber_args);
       KUNIT_ASSERT_EQ(test, ret, 0);
       union ioctl_take_msg_args take_msg_ret;
-      ret = take_msg(topic_name, subscriber_args.ret_id, allow_same_message, &take_msg_ret);
+      ret = take_msg(
+        topic_name, current->nsproxy->ipc_ns, subscriber_args.ret_id, allow_same_message,
+        &take_msg_ret);
       KUNIT_ASSERT_EQ(test, ret, 0);
       mmap_process_num++;
     }
   }
   const char * topic_name = "/kunit_test_topic_1000";
   ret = publisher_add(
-    topic_name, NODE_NAME, publisher_pid, qos_depth, qos_transient_local, &publisher_args);
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, qos_transient_local,
+    &publisher_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), MAX_PROCESS_NUM_PER_MEMPOOL);
 
   ret = new_shm_addr(subscriber_pid, PAGE_SIZE, &new_shm_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   ret = subscriber_add(
-    topic_name, NODE_NAME, subscriber_pid, qos_depth, qos_transient_local, IS_TAKE_SUB,
-    &subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, qos_transient_local,
+    IS_TAKE_SUB, &subscriber_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // Act
   union ioctl_take_msg_args take_msg_ret;
-  ret = take_msg(topic_name, subscriber_args.ret_id, allow_same_message, &take_msg_ret);
+  ret = take_msg(
+    topic_name, current->nsproxy->ipc_ns, subscriber_args.ret_id, allow_same_message,
+    &take_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -93,9 +93,8 @@ struct topic_struct
 
 struct topic_wrapper
 {
-#ifndef KUNIT_BUILD
-  struct ipc_namespace * ipc_ns;  // For use in separating topic namespaces when using containers.
-#endif
+  const struct ipc_namespace *
+    ipc_ns;  // For use in separating topic namespaces when using containers.
   char * key;
   struct topic_struct topic;
   struct hlist_node node;
@@ -135,12 +134,12 @@ static pid_t convert_pid_to_local(pid_t global_pid)
 
   return local_pid;
 }
+#endif
 
 static int ipc_eq(const struct ipc_namespace * ipc_ns1, const struct ipc_namespace * ipc_ns2)
 {
   return ipc_ns1 == ipc_ns2;
 }
-#endif
 
 static unsigned long get_topic_hash(const char * str)
 {
@@ -156,18 +155,14 @@ static struct topic_wrapper * find_topic(
 
   hash_for_each_possible(topic_hashtable, entry, node, hash_val)
   {
-#ifdef KUNIT_BUILD
-    if (strcmp(entry->key, topic_name) == 0) return entry;
-#else
     if (ipc_eq(entry->ipc_ns, ipc_ns) && strcmp(entry->key, topic_name) == 0) return entry;
-#endif
   }
 
   return NULL;
 }
 
 static int add_topic(
-  const char * topic_name, struct ipc_namespace * ipc_ns, struct topic_wrapper ** wrapper)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, struct topic_wrapper ** wrapper)
 {
   *wrapper = find_topic(topic_name, ipc_ns);
   if (*wrapper) {
@@ -696,7 +691,7 @@ static int set_publisher_shm_info(
 }
 
 int subscriber_add(
-  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   const bool is_take_sub, union ioctl_subscriber_args * ioctl_ret)
 {
@@ -721,7 +716,7 @@ int subscriber_add(
 }
 
 int publisher_add(
-  const char * topic_name, struct ipc_namespace * ipc_ns, const char * node_name,
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   union ioctl_publisher_args * ioctl_ret)
 {

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1725,14 +1725,16 @@ bool is_in_publisher_htable(
   return true;
 }
 
-int get_topic_num(void)
+int get_topic_num(const struct ipc_namespace * ipc_ns)
 {
   int count = 0;
   struct topic_wrapper * wrapper;
   int bkt_wrapper;
   hash_for_each(topic_hashtable, bkt_wrapper, wrapper, node)
   {
-    count++;
+    if (ipc_eq(wrapper->ipc_ns, ipc_ns)) {
+      count++;
+    }
   }
   return count;
 }

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -96,7 +96,6 @@ struct topic_wrapper
 {
   const struct ipc_namespace *
     ipc_ns;  // For use in separating topic namespaces when using containers.
-  struct ipc_namespace * ipc_ns;  // For use in separating topic namespaces when using containers.
   char * key;
   struct topic_struct topic;
   struct hlist_node node;
@@ -136,14 +135,9 @@ static pid_t convert_pid_to_local(pid_t global_pid)
 
   return local_pid;
 }
-
-static bool ipc_eq(const struct ipc_namespace * ipc_ns1, const struct ipc_namespace * ipc_ns2)
-{
-  return ipc_ns1 == ipc_ns2;
-}
 #endif
 
-static int ipc_eq(const struct ipc_namespace * ipc_ns1, const struct ipc_namespace * ipc_ns2)
+static bool ipc_eq(const struct ipc_namespace * ipc_ns1, const struct ipc_namespace * ipc_ns2)
 {
   return ipc_ns1 == ipc_ns2;
 }

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1341,7 +1341,7 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
   mutex_lock(&global_mutex);
   int ret = 0;
   const pid_t pid = current->tgid;
-  struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
   if (cmd == AGNOCAST_SUBSCRIBER_ADD_CMD) {
     union ioctl_subscriber_args sub_args;


### PR DESCRIPTION
## Description
ipc_nsに関するrefactoring PR。

- ipc_nsに関連する処理をifndef KUNIT_BUILDから外し、kunit build時にも利用するよう変更。
- ipc_nsをcurrent->nsproxy->ipc_nsのように毎回取得するのではなく、pid同様agnocast_ioctl冒頭で取得してそれを各関数に引数で渡すように変更
- 上にともなって各テストの関数にipc_nsを渡すように変更
    - current->...は静的に決まらないのでグローバル変数は利用できない
    - 各関数冒頭で取得してそれを利用することも考えたが、変更範囲が多く作業が大変だったため文字列を一括で変換できるcurrent->nsproxy->ipc_nsを毎回取得する記法で一旦対応。(必要あれば今後のkunitテストのリファクタリングで対応。)

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
