### PR TITLE
Fix typo related to KUnit execution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ A custom kernel with the following CONFIG enabled is required to run KUnit Test 
 If booting with the custom kernel, the following script can be used to run unit tests on kernel modules and generate coverage reports.
 
 ```bash
-bash script/run_kunit
+bash scripts/run_kunit
 ```
 
 You can also use [pre-commit](#setup-pre-commit)


### PR DESCRIPTION
## Description
The path was previously shown as "script", but has been corrected to "scripts" to reflect the actual directory structure.
## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
