### PR TITLE
fix(Publisher): workaround for only calling borrow_loaned_message()

### DIFF
--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -14,6 +14,16 @@ extern "C" uint32_t agnocast_get_borrowed_publisher_num()
 
 void increment_borrowed_publisher_num()
 {
+  if (borrowed_publisher_num == 1) {
+    return;
+
+    // NOTE:
+    //   This is a workaround for the case where borrow_loaned_message() is called but publish() is
+    //   not. This implementation assumes only one loan/publish within a single callback and will
+    //   need to be modified in the future. For this future modification, the type of
+    //   borrowed_publisher_num is left as uint32_t.
+  }
+
   borrowed_publisher_num++;
 }
 

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -75,6 +75,7 @@ TEST_F(AgnocastPublisherTest, test_publish_normal)
 
   // Assert
   EXPECT_EQ(publish_core_mock_called_count, 1);
+  EXPECT_EQ(agnocast_get_borrowed_publisher_num(), 0);
 }
 
 TEST_F(AgnocastPublisherTest, test_publish_null_message)
@@ -114,6 +115,21 @@ TEST_F(AgnocastPublisherTest, test_publish_different_message)
   EXPECT_EXIT(
     dummy_publisher->publish(std::move(diff_message)), ::testing::ExitedWithCode(EXIT_FAILURE),
     "Invalid message to publish.");
+}
+
+TEST_F(AgnocastPublisherTest, test_publish_loan_num_and_pub_num_mismatch)
+{
+  // Arrange
+  agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
+  message.reset();  // This simulates the early return.
+  agnocast::ipc_shared_ptr<std_msgs::msg::Int32> next_message =
+    dummy_publisher->borrow_loaned_message();
+
+  // Act
+  dummy_publisher->publish(std::move(next_message));
+
+  // Assert
+  EXPECT_EQ(agnocast_get_borrowed_publisher_num(), 0);
 }
 
 // =========================================


### PR DESCRIPTION
## Description

See https://tier4.atlassian.net/wiki/spaces/CRL/pages/3630565680/20250408+Agnocast+Sync and https://star4.slack.com/archives/C07FL8616EM/p1744164837355909.

## Related links

## How was this PR tested?

- [ ] Autoware (required) -> Since this PR does not affect the behavior, I'm going to skip this.
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
