### PR TITLE
fix(kunit): get_topic_num wasn't updated in kunit test

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_decrement_rc.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_decrement_rc.c
@@ -30,14 +30,14 @@ static void setup_one_publisher(
 
 void test_case_decrement_rc_no_topic(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(
     test, decrement_message_entry_rc(TOPIC_NAME, current->nsproxy->ipc_ns, 0, 0), -EINVAL);
 }
 
 void test_case_decrement_rc_no_message(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   // Arrange
   topic_local_id_t ret_publisher_id;
@@ -53,7 +53,7 @@ void test_case_decrement_rc_no_message(struct kunit * test)
 
 void test_case_decrement_rc_no_pubsub_id(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   // Arrange
   topic_local_id_t ret_publisher_id;
@@ -78,7 +78,7 @@ void test_case_decrement_rc_no_pubsub_id(struct kunit * test)
 
 void test_case_decrement_rc_last_reference(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   // Arrange
   topic_local_id_t ret_publisher_id;
@@ -104,7 +104,7 @@ void test_case_decrement_rc_last_reference(struct kunit * test)
 
 void test_case_decrement_rc_multi_reference(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 0);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   // Arrange
   topic_local_id_t ret_publisher_id;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -131,7 +131,7 @@ void test_case_do_exit_with_publisher(struct kunit * test)
   setup_one_publisher(test, publisher_pid);
 
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
 
   // Act
@@ -142,7 +142,7 @@ void test_case_do_exit_with_publisher(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 }
 
 void test_case_do_exit_with_subscriber(struct kunit * test)
@@ -156,7 +156,7 @@ void test_case_do_exit_with_subscriber(struct kunit * test)
   int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
 
   // Act
@@ -167,7 +167,7 @@ void test_case_do_exit_with_subscriber(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 }
 
 // Test case for process exit where there are two publishers and subscribers in one process
@@ -185,7 +185,7 @@ void test_case_do_exit_with_many_pubsub_in_one_process(struct kunit * test)
   int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
@@ -197,7 +197,7 @@ void test_case_do_exit_with_many_pubsub_in_one_process(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 }
 
 // Test case for process exit where there are two publishers and subscribers in different processes
@@ -222,7 +222,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
@@ -240,7 +240,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_publisher_exi
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(publisher_pid2));
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
@@ -276,7 +276,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
@@ -294,7 +294,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_subscriber_ex
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(publisher_pid2));
   KUNIT_EXPECT_FALSE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
@@ -330,7 +330,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_ex
   int ret = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 4);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 2);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 2);
 
@@ -347,7 +347,7 @@ void test_case_do_exit_with_many_pubsub_in_different_processes_and_all_pubsub_ex
   int ret1 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
 }
@@ -360,7 +360,7 @@ void test_case_do_exit_with_entry(struct kunit * test)
   const topic_local_id_t publisher_id = setup_one_publisher(test, publisher_pid);
   const uint64_t entry_id = setup_one_entry(test, publisher_id, msg_virtual_address);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(
@@ -374,7 +374,7 @@ void test_case_do_exit_with_entry(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
 }
@@ -403,7 +403,7 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
@@ -422,7 +422,7 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
   int ret4 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
@@ -452,7 +452,7 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
@@ -471,7 +471,7 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   int ret2 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(
     test, is_in_publisher_htable(TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id));
@@ -495,7 +495,7 @@ void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit *
   int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
   KUNIT_EXPECT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
@@ -521,7 +521,7 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, get_proc_info_htable_size(), 2);
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 1);
   KUNIT_ASSERT_EQ(test, get_topic_entries_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
@@ -541,7 +541,7 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   KUNIT_EXPECT_EQ(test, ret2, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 1);
   KUNIT_EXPECT_TRUE(test, is_in_proc_info_htable(publisher_pid));
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(
@@ -564,7 +564,7 @@ void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit 
   int ret3 = get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, &get_subscriber_num_args);
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, get_proc_info_htable_size(), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 0);
   KUNIT_EXPECT_EQ(test, get_subscriber_num_args.ret_subscriber_num, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publisher_add.c
@@ -13,7 +13,7 @@ static const bool qos_is_transient_local = false;
 void test_case_publisher_add_normal(struct kunit * test)
 {
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   union ioctl_publisher_args publisher_args;
   int ret = publisher_add(
@@ -25,14 +25,14 @@ void test_case_publisher_add_normal(struct kunit * test)
   KUNIT_EXPECT_EQ(test, publisher_args.ret_id, 0);
   KUNIT_EXPECT_TRUE(
     test, is_in_publisher_htable(topic_name, current->nsproxy->ipc_ns, publisher_args.ret_id));
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }
 
 void test_case_publisher_add_many(struct kunit * test)
 {
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   const int publisher_num = MAX_PUBLISHER_NUM;
   int ret;
@@ -46,14 +46,14 @@ void test_case_publisher_add_many(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, publisher_args.ret_id, publisher_num - 1);
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), publisher_num);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }
 
 void test_case_publisher_add_too_many(struct kunit * test)
 {
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), 0);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 0);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 0);
 
   const int publisher_num = MAX_PUBLISHER_NUM + 1;
   int ret = 0;
@@ -66,6 +66,6 @@ void test_case_publisher_add_too_many(struct kunit * test)
 
   KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
   KUNIT_EXPECT_EQ(test, get_publisher_num(topic_name, current->nsproxy->ipc_ns), MAX_PUBLISHER_NUM);
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -746,7 +746,7 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
   KUNIT_ASSERT_FALSE(test, is_in_proc_info_htable(publisher_pid));
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_TRUE(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_subscriber_add.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_subscriber_add.c
@@ -40,7 +40,7 @@ void test_case_subscriber_add_normal(struct kunit * test)
   KUNIT_EXPECT_EQ(test, subscriber_args.ret_id, 0);
   KUNIT_EXPECT_TRUE(
     test, is_in_subscriber_htable(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_args.ret_id));
-  KUNIT_EXPECT_EQ(test, get_topic_num(), 1);
+  KUNIT_EXPECT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -867,7 +867,7 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   KUNIT_ASSERT_FALSE(test, is_in_proc_info_htable(publisher_pid));
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid1));
   KUNIT_ASSERT_TRUE(test, is_in_proc_info_htable(subscriber_pid2));
-  KUNIT_ASSERT_EQ(test, get_topic_num(), 1);
+  KUNIT_ASSERT_EQ(test, get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_TRUE(test, is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
   KUNIT_ASSERT_EQ(test, get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns), 1);
   KUNIT_ASSERT_TRUE(


### PR DESCRIPTION
## Description
PR #603 でget_topic_numはstruct ipc_namespace*を引数に取るように変更されていたが、それがkunitテストには反映されていなかったので修正。

## Related links
PR #603 

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
