### PR TITLE
fix(agnocastlib): close agnocast fd when exit

### DIFF
--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -33,6 +33,7 @@ void decrement_borrowed_publisher_num()
     RCLCPP_ERROR(
       logger,
       "The number of publish() called exceeds the number of borrow_loaned_message() called.");
+    close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
   borrowed_publisher_num--;


### PR DESCRIPTION
## Description
minor fix

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
