### PR TITLE
refactor(kmod): reorder ioctl command

### DIFF
--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -8,14 +8,14 @@ else
   ifeq ($(CONFIG_KUNIT)$(CONFIG_GCOV_KERNEL),yy)
     obj-m := agnocast_kunit.o
 	agnocast_kunit-objs := agnocast_kunit_main.o agnocast_main.o agnocast_memory_allocator.o\
+	  agnocast_kunit/agnocast_kunit_add_process.o \
 	  agnocast_kunit/agnocast_kunit_add_subscriber.o \
 	  agnocast_kunit/agnocast_kunit_add_publisher.o \
 	  agnocast_kunit/agnocast_kunit_increment_rc.o \
 	  agnocast_kunit/agnocast_kunit_decrement_rc.o \
-	  agnocast_kunit/agnocast_kunit_receive_msg.o \
 	  agnocast_kunit/agnocast_kunit_publish_msg.o \
+	  agnocast_kunit/agnocast_kunit_receive_msg.o \
 	  agnocast_kunit/agnocast_kunit_take_msg.o \
-	  agnocast_kunit/agnocast_kunit_add_process.o \
 	  agnocast_kunit/agnocast_kunit_get_subscriber_num.o \
 	  agnocast_kunit/agnocast_kunit_do_exit.o
 	ccflags-y += -DKUNIT_BUILD -fprofile-arcs -ftest-coverage

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -24,6 +24,20 @@ struct name_info
   uint64_t len;
 };
 
+struct ioctl_get_version_args
+{
+  char ret_version[VERSION_BUFFER_LEN];
+};
+
+union ioctl_add_process_args {
+  uint64_t shm_size;
+  struct
+  {
+    uint64_t ret_addr;
+    bool ret_unlink_daemon_exist;
+  };
+};
+
 union ioctl_add_subscriber_args {
   struct
   {
@@ -107,20 +121,6 @@ union ioctl_take_msg_args {
   };
 };
 
-union ioctl_add_process_args {
-  uint64_t shm_size;
-  struct
-  {
-    uint64_t ret_addr;
-    bool ret_unlink_daemon_exist;
-  };
-};
-
-struct ioctl_get_version_args
-{
-  char ret_version[VERSION_BUFFER_LEN];
-};
-
 union ioctl_get_subscriber_num_args {
   struct name_info topic_name;
   uint32_t ret_subscriber_num;
@@ -132,15 +132,15 @@ struct ioctl_get_exit_process_args
   pid_t ret_pid;
 };
 
-#define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 1, union ioctl_add_subscriber_args)
-#define AGNOCAST_ADD_PUBLISHER_CMD _IOWR(0xA6, 2, union ioctl_add_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 5, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 6, union ioctl_publish_msg_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 7, union ioctl_take_msg_args)
-#define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 8, union ioctl_add_process_args)
-#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
+#define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
+#define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
+#define AGNOCAST_ADD_PUBLISHER_CMD _IOWR(0xA6, 4, union ioctl_add_publisher_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 5, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 6, struct ioctl_update_entry_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 7, union ioctl_publish_msg_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 8, union ioctl_receive_msg_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 9, union ioctl_take_msg_args)
 #define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOWR(0xA6, 10, union ioctl_get_subscriber_num_args)
 #define AGNOCAST_GET_EXIT_PROCESS_CMD _IOR(0xA6, 11, struct ioctl_get_exit_process_args)
 

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -28,6 +28,23 @@ struct name_info
   uint64_t len;
 };
 
+struct ioctl_get_version_args
+{
+  char ret_version[VERSION_BUFFER_LEN];
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+union ioctl_add_process_args {
+  uint64_t shm_size;
+  struct
+  {
+    uint64_t ret_addr;
+    bool ret_unlink_daemon_exist;
+  };
+};
+#pragma GCC diagnostic pop
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 union ioctl_add_subscriber_args {
@@ -129,23 +146,6 @@ union ioctl_take_msg_args {
 };
 #pragma GCC diagnostic pop
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-union ioctl_add_process_args {
-  uint64_t shm_size;
-  struct
-  {
-    uint64_t ret_addr;
-    bool ret_unlink_daemon_exist;
-  };
-};
-#pragma GCC diagnostic pop
-
-struct ioctl_get_version_args
-{
-  char ret_version[VERSION_BUFFER_LEN];
-};
-
 union ioctl_get_subscriber_num_args {
   struct name_info topic_name;
   uint32_t ret_subscriber_num;
@@ -157,15 +157,15 @@ struct ioctl_get_exit_process_args
   pid_t ret_pid;
 };
 
-#define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 1, union ioctl_add_subscriber_args)
-#define AGNOCAST_ADD_PUBLISHER_CMD _IOWR(0xA6, 2, union ioctl_add_publisher_args)
-#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 3, struct ioctl_update_entry_args)
-#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 4, struct ioctl_update_entry_args)
-#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 5, union ioctl_receive_msg_args)
-#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 6, union ioctl_publish_msg_args)
-#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 7, union ioctl_take_msg_args)
-#define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 8, union ioctl_add_process_args)
-#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 9, struct ioctl_get_version_args)
+#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
+#define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
+#define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
+#define AGNOCAST_ADD_PUBLISHER_CMD _IOWR(0xA6, 4, union ioctl_add_publisher_args)
+#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 5, struct ioctl_update_entry_args)
+#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 6, struct ioctl_update_entry_args)
+#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 7, union ioctl_publish_msg_args)
+#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 8, union ioctl_receive_msg_args)
+#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 9, union ioctl_take_msg_args)
 #define AGNOCAST_GET_SUBSCRIBER_NUM_CMD _IOWR(0xA6, 10, union ioctl_get_subscriber_num_args)
 #define AGNOCAST_GET_EXIT_PROCESS_CMD _IOR(0xA6, 11, struct ioctl_get_exit_process_args)
 


### PR DESCRIPTION
## Description
ioctlのコマンドの数値的な順番を以下のように変更。

```
#define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
#define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
#define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
#define AGNOCAST_ADD_PUBLISHER_CMD _IOWR(0xA6, 4, union ioctl_add_publisher_args)
#define AGNOCAST_INCREMENT_RC_CMD _IOW(0xA6, 5, struct ioctl_update_entry_args)
#define AGNOCAST_DECREMENT_RC_CMD _IOW(0xA6, 6, struct ioctl_update_entry_args)
#define AGNOCAST_PUBLISH_MSG_CMD _IOWR(0xA6, 7, union ioctl_publish_msg_args)
#define AGNOCAST_RECEIVE_MSG_CMD _IOWR(0xA6, 8, union ioctl_receive_msg_args)
#define AGNOCAST_TAKE_MSG_CMD _IOWR(0xA6, 9, union ioctl_take_msg_args)
```

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
