### PR TITLE
fix(kmod): fix check_daemon_necessity defining location

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -690,6 +690,21 @@ static int get_version(struct ioctl_get_version_args * ioctl_ret)
   return 0;
 }
 
+static bool check_daemon_necessity(const struct ipc_namespace * ipc_ns)
+{
+  struct process_info * proc_info;
+  int bkt;
+  hash_for_each(proc_info_htable, bkt, proc_info, node)
+  {
+    if (ipc_eq(ipc_ns, proc_info->ipc_ns)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 int add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, uint64_t shm_size,
   union ioctl_add_process_args * ioctl_ret)
@@ -1085,20 +1100,6 @@ int take_msg(
   sub_info->need_mmap_update = false;
 
   return 0;
-}
-
-static bool check_daemon_necessity(const struct ipc_namespace * ipc_ns)
-{
-  struct process_info * proc_info;
-  int bkt;
-  hash_for_each(proc_info_htable, bkt, proc_info, node)
-  {
-    if (ipc_eq(ipc_ns, proc_info->ipc_ns)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 int get_subscriber_num(

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -704,7 +704,6 @@ static bool check_daemon_necessity(const struct ipc_namespace * ipc_ns)
   return false;
 }
 
-
 int add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, uint64_t shm_size,
   union ioctl_add_process_args * ioctl_ret)


### PR DESCRIPTION
## Description

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
