### PR TITLE
fix(script): remove shm stress

### DIFF
--- a/scripts/e2e_test_stress
+++ b/scripts/e2e_test_stress
@@ -39,19 +39,14 @@ run-stress-ng() {
         echo "Run stress-ng with VM ${PERCENTAGES[$index]}%" | sudo tee /dev/kmsg
         stress-ng --vm 1 --vm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
 
-    elif [ "$1" -lt "$((NUM_PERCENTAGES * 3))" ]; then
-        index=$(($1 - NUM_PERCENTAGES * 2))
-        echo "Run stress-ng with SHM ${PERCENTAGES[$index]}%" | sudo tee /dev/kmsg
-        stress-ng --shm 1 --shm-bytes ${PERCENTAGES[$index]}% --timeout $TIMEOUT &
-
     else
-        index=$(($1 - NUM_PERCENTAGES * 3))
+        index=$(($1 - NUM_PERCENTAGES * 2))
         echo "Run stress-ng with MQ ${MQ_PERCENT[$index]}" | sudo tee /dev/kmsg
         stress-ng --mq ${MQ_PERCENT[$index]} --timeout $TIMEOUT &
     fi
 }
 
-NUM_LOOP=$((NUM_PERCENTAGES * 4)) # cpu_load, vm, shm, mq
+NUM_LOOP=$((NUM_PERCENTAGES * 3)) # cpu_load, vm, mq
 for i in $(seq 1 $NUM_LOOP); do
     echo "============================================================================" | sudo tee /dev/kmsg
     echo "============================ Outer Loop $i / $NUM_LOOP ============================" | sudo tee /dev/kmsg


### PR DESCRIPTION
## Description

Removed shared memory stress test

## Related links

[TIER IV INTERNAL](https://star4.slack.com/archives/C07FL8616EM/p1744599171545759?thread_ts=1744172890.705859&cid=C07FL8616EM)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
