### PR TITLE
test(heaphook): add unit test for aligned_alloc function

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -620,4 +620,39 @@ mod tests {
 
         unsafe { free(ptr) };
     }
+
+    #[test]
+    fn test_aligned_alloc() {
+        // Arrange
+        let start = MEMPOOL_START.load(Ordering::SeqCst);
+        let end = MEMPOOL_END.load(Ordering::SeqCst);
+        let alignments = [8, 16, 32, 64, 128, 256, 512, 1024, 2048];
+        let sizes = [10, 32, 100, 512, 1000, 4096];
+
+        for &alignment in &alignments {
+            for &size in &sizes {
+                // Act
+                let ptr = aligned_alloc(alignment, size);
+
+                // Assert
+                assert!(!ptr.is_null(), "aligned_alloc must not return NULL");
+
+                assert!(
+                    ptr as usize >= start,
+                    "aligned_alloc returned memory below the memory pool start address"
+                );
+
+                assert!(
+                    ptr as usize + size <= end,
+                    "aligned_alloc allocated memory exceeds the memory pool end address"
+                );
+                assert_eq!(
+                    ptr as usize % alignment,
+                    0,
+                    "aligned_alloc memory should be aligned to the specified boundary"
+                );
+                unsafe { free(ptr) };
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
implementation of the unit test of the aligned_alloc function included in agnocast_heaphook
## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
