### PR TITLE
fix(agnocastlib): seal shmem to prevent truncate shrink

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -200,6 +200,12 @@ void * map_area(
       close(agnocast_fd);
       return nullptr;
     }
+
+    if (fchmod(shm_fd, 0444) == -1) {
+      RCLCPP_ERROR(logger, "fchmod failed: %s", strerror(errno));
+      close(agnocast_fd);
+      return nullptr;
+    }
   }
 
   int prot = writable ? PROT_READ | PROT_WRITE : PROT_READ;


### PR DESCRIPTION
## Description
[TIER IV Internal Link](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3653304535/KASAN+Segfault)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
