### PR TITLE
test(heaphook): add unit test for memalign function

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -655,4 +655,38 @@ mod tests {
             }
         }
     }
+    #[test]
+    fn test_memalign_normal() {
+        // Arrange
+        let start = MEMPOOL_START.load(Ordering::SeqCst);
+        let end = MEMPOOL_END.load(Ordering::SeqCst);
+        let alignments = [8, 16, 32, 64, 128, 256, 512, 1024, 2048];
+        let sizes = [10, 32, 100, 512, 1000, 4096];
+
+        for &alignment in &alignments {
+            for &size in &sizes {
+                // Act
+                let ptr = memalign(alignment, size);
+
+                // Assert
+                assert!(!ptr.is_null(), "memalign must not return NULL");
+
+                assert!(
+                    ptr as usize >= start,
+                    "memalign returned memory below the memory pool start address"
+                );
+
+                assert!(
+                    ptr as usize + size <= end,
+                    "memalign allocated memory exceeds the memory pool end address"
+                );
+                assert_eq!(
+                    ptr as usize % alignment,
+                    0,
+                    "memalign memory should be aligned to the specified boundary"
+                );
+                unsafe { free(ptr) };
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
implementation of the unit test of the memalign function included in agnocast_heaphook

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
