### PR TITLE
Change to use topic_local_id_t as the key for opened_mqs

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -31,7 +31,7 @@ topic_local_id_t initialize_publisher(
 union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle, /* for CARET */ const std::string & topic_name,
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<std::string, std::tuple<mqd_t, bool>> & opened_mqs);
+  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> & opened_mqs);
 uint32_t get_subscription_count_core(const std::string & topic_name);
 void increment_borrowed_publisher_num();
 void decrement_borrowed_publisher_num();
@@ -53,7 +53,7 @@ class Publisher
 {
   topic_local_id_t id_ = -1;
   std::string topic_name_;
-  std::unordered_map<std::string, std::tuple<mqd_t, bool>> opened_mqs_;
+  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> opened_mqs_;
   PublisherOptions options_;
 
   // ROS2 publish related variables

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -30,7 +30,7 @@ topic_local_id_t initialize_publisher(const std::string &, const std::string &, 
 }
 union ioctl_publish_msg_args publish_core(
   const void *, const std::string &, const topic_local_id_t, const uint64_t,
-  std::unordered_map<std::string, std::tuple<mqd_t, bool>> &)
+  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> &)
 {
   publish_core_mock_called_count++;
   return ioctl_publish_msg_args{};  // Dummy value


### PR DESCRIPTION
## Description
To avoid unnecessary string creation, changed to use `topic_local_id_t` as the key for `opened_mqs`.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application
- [x] `bash scripts/test_and_create_report` 

## Notes for reviewers
