### PR TITLE
fix(kmod): add a boundary check for msg_virtual_address

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -714,7 +714,7 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
   const pid_t publisher_pid = 1000;
   setup_one_publisher(test, publisher_pid, qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
-  uint64_t msg_addr = 0x1000;
+  uint64_t msg_addr = ret_addr;
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -835,7 +835,7 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   const pid_t publisher_pid = 1000;
   setup_one_publisher(test, publisher_pid, qos_depth, is_transient_local, &publisher_id, &ret_addr);
 
-  uint64_t msg_addr = 0x1000;
+  uint64_t msg_addr = ret_addr;
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -914,6 +914,19 @@ int publish_msg(
     return -EINVAL;
   }
 
+  struct process_info * proc_info = find_process_info(pub_info->pid);
+  if (!proc_info) {
+    dev_warn(agnocast_device, "Process (pid=%d) does not exist. (publish_msg)\n", pub_info->pid);
+    return -EINVAL;
+  }
+
+  uint64_t mempool_start = proc_info->mempool_entry->addr;
+  uint64_t mempool_end = mempool_start + proc_info->shm_size;
+  if (msg_virtual_address < mempool_start || msg_virtual_address >= mempool_end) {
+    dev_warn(agnocast_device, "msg_virtual_address is out of bounds. (publish_msg)\n");
+    return -EINVAL;
+  }
+
   int ret = insert_message_entry(wrapper, pub_info, msg_virtual_address, ioctl_ret);
   if (ret < 0) {
     return ret;


### PR DESCRIPTION
## Description
This PR adds a boundary check for the `msg_virtual_address` argument in `publish_msg`.

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers
kunit test のソースコードを修正しましたが、テストの意図に反する変更ではないか確認していただきたいです。