### PR TITLE
fix(kunit): update the max process number

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -5,7 +5,7 @@
 #include <kunit/test.h>
 
 static pid_t pid = 1000;
-static const int max_process_num = 1000 + 100 + 10;
+static const int max_process_num = 3000 + 300 + 30;
 
 void test_case_add_process_normal(struct kunit * test)
 {


### PR DESCRIPTION
## Description
This PR updates the kunit constant to reflect the new maximum process numbers set in commit d05c230.

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] sample application