### PR TITLE
fix: lock for atomically obtain shmem info via ioctl and do mmap

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -6,6 +6,8 @@
 namespace agnocast
 {
 
+extern std::mutex mmap_mtx;
+
 void map_read_only_area(const pid_t pid, const uint64_t shm_addr, const uint64_t shm_size);
 
 struct AgnocastExecutable

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -16,8 +16,25 @@ namespace agnocast
 int agnocast_fd = -1;
 std::vector<int> shm_fds;
 std::mutex shm_fds_mtx;
-// To obtain shm info of the publisher process via ioctl(RECEIVE_MSG) and perform mmap atomically.
 std::mutex mmap_mtx;
+// mmap_mtx: Prevents a race condition and segfault between two threads
+// in a multithreaded executor using the same mqueue_fd.
+//
+// Race Scenario:
+// 1. Thread 1 (T1):
+//    - Calls epoll_wait(), mq_receive(), then ioctl(RECEIVE_CMD), initially obtaining
+//      publisher info (PID, shared memory address `shm_addr`).
+//    - Critical: OS context switch occurs *after* ioctl() but *before* T1 fully
+//      processes/maps `shm_addr`.
+// 2. Thread 2 (T2):
+//    - Calls epoll_wait(), mq_receive(), then ioctl(RECEIVE_CMD) on the same mqueue_fd,
+//      but does *not* receive publisher info (assuming it's already set up).
+//    - Proceeds to a callback which attempts to use `shm_addr`, leading to a SEGFAULT.
+//
+// Root Cause: T2's callback uses `shm_addr` that T1 fetched but hadn't initialized/mapped yet.
+// This mutex ensures atomicity for T1's critical section: from ioctl fetching publisher
+// info through to completing shared memory setup.
+
 void poll_for_unlink()
 {
   if (setsid() == -1) {

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -16,7 +16,8 @@ namespace agnocast
 int agnocast_fd = -1;
 std::vector<int> shm_fds;
 std::mutex shm_fds_mtx;
-
+// To obtain shm info for the publisher process via ioctl(RECEIVE_MSG) and perform mmap atomically.
+std::mutex mmap_mtx;
 void poll_for_unlink()
 {
   if (setsid() == -1) {

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -16,7 +16,7 @@ namespace agnocast
 int agnocast_fd = -1;
 std::vector<int> shm_fds;
 std::mutex shm_fds_mtx;
-// To obtain shm info for the publisher process via ioctl(RECEIVE_MSG) and perform mmap atomically.
+// To obtain shm info of the publisher process via ioctl(RECEIVE_MSG) and perform mmap atomically.
 std::mutex mmap_mtx;
 void poll_for_unlink()
 {

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -29,18 +29,23 @@ void AgnocastExecutor::receive_message(
   union ioctl_receive_msg_args receive_args = {};
   receive_args.topic_name = {callback_info.topic_name.c_str(), callback_info.topic_name.size()};
   receive_args.subscriber_id = callback_info.subscriber_id;
-  if (ioctl(agnocast_fd, AGNOCAST_RECEIVE_MSG_CMD, &receive_args) < 0) {
-    RCLCPP_ERROR(logger, "AGNOCAST_RECEIVE_MSG_CMD failed: %s", strerror(errno));
-    close(agnocast_fd);
-    exit(EXIT_FAILURE);
-  }
 
-  // Map the shared memory region with read permissions whenever a new publisher is discovered.
-  for (uint32_t i = 0; i < receive_args.ret_pub_shm_info.publisher_num; i++) {
-    const pid_t pid = receive_args.ret_pub_shm_info.publisher_pids[i];
-    const uint64_t addr = receive_args.ret_pub_shm_info.shm_addrs[i];
-    const uint64_t size = receive_args.ret_pub_shm_info.shm_sizes[i];
-    map_read_only_area(pid, addr, size);
+  {
+    std::lock_guard<std::mutex> lock(mmap_mtx);
+
+    if (ioctl(agnocast_fd, AGNOCAST_RECEIVE_MSG_CMD, &receive_args) < 0) {
+      RCLCPP_ERROR(logger, "AGNOCAST_RECEIVE_MSG_CMD failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    // Map the shared memory region with read permissions whenever a new publisher is discovered.
+    for (uint32_t i = 0; i < receive_args.ret_pub_shm_info.publisher_num; i++) {
+      const pid_t pid = receive_args.ret_pub_shm_info.publisher_pids[i];
+      const uint64_t addr = receive_args.ret_pub_shm_info.shm_addrs[i];
+      const uint64_t size = receive_args.ret_pub_shm_info.shm_sizes[i];
+      map_read_only_area(pid, addr, size);
+    }
   }
 
   // older messages first


### PR DESCRIPTION
## Description

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
