### PR TITLE
test(heaphook): fix unit test for test_aligned_alloc function

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -622,26 +622,31 @@ mod tests {
     }
 
     #[test]
-    fn test_aligned_alloc() {
+    fn test_aligned_alloc_normal() {
         // Arrange
         let start = MEMPOOL_START.load(Ordering::SeqCst);
         let end = MEMPOOL_END.load(Ordering::SeqCst);
         let alignments = [8, 16, 32, 64, 128, 256, 512, 1024, 2048];
-        let sizes = [10, 32, 100, 512, 1000, 4096];
 
         for &alignment in &alignments {
+            let sizes = [
+                alignment,
+                alignment * 2,
+                alignment * 4,
+                alignment * 8,
+                alignment * 16,
+            ];
+
             for &size in &sizes {
                 // Act
                 let ptr = aligned_alloc(alignment, size);
 
                 // Assert
                 assert!(!ptr.is_null(), "aligned_alloc must not return NULL");
-
                 assert!(
                     ptr as usize >= start,
                     "aligned_alloc returned memory below the memory pool start address"
                 );
-
                 assert!(
                     ptr as usize + size <= end,
                     "aligned_alloc allocated memory exceeds the memory pool end address"


### PR DESCRIPTION
## Description
The test_aligned_alloc function to properly comply with the C standard specification for aligned_alloc(). In the previous implementation, the sizes used in the tests were not multiples of the alignment values.

> The function aligned_alloc() is the same as memalign(), except for the added restriction that size should be a multiple of alignment.


(https://linux.die.net/man/3/aligned_alloc)
## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
