### PR TITLE
style: add a trailing underscore to the data member of Subscriber

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -60,7 +60,7 @@ public:
 template <typename MessageT>
 class Subscription : public SubscriptionBase
 {
-  std::pair<mqd_t, std::string> mq_subscription;
+  std::pair<mqd_t, std::string> mq_subscription_;
 
 public:
   using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
@@ -76,7 +76,7 @@ public:
 
     id_ = add_subscriber_args.ret_id;
 
-    mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription);
+    mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
     auto node_base = node->get_node_base_interface();
     rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node_base, options);
 
@@ -94,7 +94,7 @@ public:
 #endif
   }
 
-  ~Subscription() { remove_mq(mq_subscription); }
+  ~Subscription() { remove_mq(mq_subscription_); }
 };
 
 template <typename MessageT>

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -53,7 +53,7 @@ mqd_t open_mq_for_subscription(
 
 void remove_mq(const std::pair<mqd_t, std::string> & mq_subscription)
 {
-  /* The message queue is destroyed when all the publisher processes it. */
+  /* The message queue is destroyed when all the publisher processes close it. */
   if (mq_close(mq_subscription.first) == -1) {
     RCLCPP_ERROR(logger, "mq_close failed: %s", strerror(errno));
   }

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -53,7 +53,7 @@ mqd_t open_mq_for_subscription(
 
 void remove_mq(const std::pair<mqd_t, std::string> & mq_subscription)
 {
-  /* The message queue is destroyed when all the publisher processes close it. */
+  /* The message queue is destroyed after all the publisher processes close it. */
   if (mq_close(mq_subscription.first) == -1) {
     RCLCPP_ERROR(logger, "mq_close failed: %s", strerror(errno));
   }

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -53,8 +53,7 @@ mqd_t open_mq_for_subscription(
 
 void remove_mq(const std::pair<mqd_t, std::string> & mq_subscription)
 {
-  /* It's best to notify the publisher and have it call mq_close, but currently
-    this is not being done. The message queue is destroyed when the publisher process exits. */
+  /* The message queue is destroyed when all the publisher processes it. */
   if (mq_close(mq_subscription.first) == -1) {
     RCLCPP_ERROR(logger, "mq_close failed: %s", strerror(errno));
   }


### PR DESCRIPTION
## Description
This PR renames `mq_subscription` to `mq_subscription_` to conform to the Google C++ Style Guide.  
It also updates an outdated comment in the `remove_mq` function.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers
