### PR TITLE
fix(heaphook): fix memory-related functions to match C semantics

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -422,7 +422,7 @@ pub extern "C" fn posix_memalign(memptr: &mut *mut c_void, alignment: usize, siz
     }
 
     // `alignment` must be a power of two and a multiple of `sizeof(void *)`.
-    if !alignment.is_power_of_two() || alignment % size_of::<*mut c_void>() != 0 {
+    if !alignment.is_power_of_two() || alignment & (size_of::<*mut c_void>() - 1) != 0 {
         return libc::EINVAL;
     }
 
@@ -449,7 +449,7 @@ pub extern "C" fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void {
     }
 
     // `alignment` should be a power of two and `size` should be a multiple of `alignment`.
-    if !alignment.is_power_of_two() || size % alignment != 0 {
+    if !alignment.is_power_of_two() || size & (alignment - 1) != 0 {
         return ptr::null_mut();
     }
 

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -473,10 +473,6 @@ pub extern "C" fn memalign(alignment: usize, size: usize) -> *mut c_void {
     }
 
     // `alignment` must be a power of two.
-    if !alignment.is_power_of_two() {
-        return ptr::null_mut();
-    }
-
     let layout = match Layout::from_size_align(size, alignment) {
         Ok(layout) => layout,
         Err(_) => return ptr::null_mut(),

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -448,8 +448,8 @@ pub extern "C" fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void {
         };
     }
 
-    // `size` should be a multiple of `alignment`.
-    if size % alignment != 0 {
+    // `alignment` should be a power of two and `size` should be a multiple of `alignment`.
+    if !alignment.is_power_of_two() || size % alignment != 0 {
         return ptr::null_mut();
     }
 
@@ -470,6 +470,11 @@ pub extern "C" fn memalign(alignment: usize, size: usize) -> *mut c_void {
         return unsafe {
             (*ORIGINAL_MEMALIGN.get_or_init(init_original_memalign))(alignment, size)
         };
+    }
+
+    // `alignment` must be a power of two.
+    if !alignment.is_power_of_two() {
+        return ptr::null_mut();
     }
 
     let layout = match Layout::from_size_align(size, alignment) {

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -374,7 +374,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
 
     match (is_shared, should_use_original) {
         (true, true) => {
-            // In the child processes, ignore the free operation to the shared memory
+            // In the child processes, ignore the free operation to the shared memory.
             (*ORIGINAL_MALLOC.get_or_init(init_original_malloc))(new_size)
         }
         (true, false) => {
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
 
             match NonNull::new(ptr.cast()) {
                 Some(non_null_ptr) => {
-                    // If size is equal to zero, and ptr is not NULL, then the call is equivalent to free(ptr).
+                    // If `new_size` is equal to zero, and `ptr` is not NULL, then the call is equivalent to `free(ptr)`.
                     if new_layout.size() == 0 {
                         tlsf_deallocate_wrapped(non_null_ptr);
                         return ptr::null_mut();
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
                     }
                 }
                 None => {
-                    // If ptr is NULL, then the call is equivalent to malloc(size).
+                    // If `ptr` is NULL, then the call is equivalent to `malloc(size)`.
                     match tlsf_allocate_wrapped(new_layout) {
                         Some(non_null_ptr) => non_null_ptr.as_ptr().cast(),
                         None => ptr::null_mut(),

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -460,12 +460,14 @@ pub extern "C" fn memalign(alignment: usize, size: usize) -> *mut c_void {
         };
     }
 
-    match Layout::from_size_align(size, alignment) {
-        Ok(layout) => match tlsf_allocate_wrapped(layout) {
-            Some(non_null_ptr) => non_null_ptr.as_ptr().cast(),
-            None => std::ptr::null_mut(),
-        },
-        Err(_) => ptr::null_mut(),
+    let layout = match Layout::from_size_align(size, alignment) {
+        Ok(layout) => layout,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    match tlsf_allocate_wrapped(layout) {
+        Some(non_null_ptr) => non_null_ptr.as_ptr().cast(),
+        None => std::ptr::null_mut(),
     }
 }
 

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -820,4 +820,45 @@ mod tests {
             unsafe { libc::free(realloc_ptr) };
         }
     }
+
+    #[test]
+    fn test_posix_memalign_should_fail() {
+        let mut ptr: *mut c_void = ptr::null_mut();
+
+        assert_eq!(
+            unsafe { libc::posix_memalign(&mut ptr, 0, 8) },
+            libc::EINVAL,
+            "posix_memalign should return EINVAL if the alignment is not a power of two"
+        );
+
+        assert_eq!(
+            unsafe {libc::posix_memalign(&mut ptr, size_of::<*mut c_void>() / 2, 8)},
+            libc::EINVAL,
+            "posix_memalign should return EINVAL if the alignment is not a multiple of `sizeof(void *)`"
+        );
+    }
+
+    #[test]
+    fn test_aligned_alloc_should_fail() {
+        assert_eq!(
+            unsafe { libc::aligned_alloc(0, 8) },
+            ptr::null_mut(),
+            "aligned_alloc should return NULL if the alignment is not a power of two"
+        );
+
+        assert_eq!(
+            unsafe { libc::aligned_alloc(2, 7) },
+            ptr::null_mut(),
+            "aligned_alloc should return NULL if the size is not a multiple of the alignment"
+        );
+    }
+
+    #[test]
+    fn test_memalign_should_fail() {
+        assert_eq!(
+            unsafe { libc::memalign(0, 8) },
+            ptr::null_mut(),
+            "memalign should return NULL if the alignment is not a power of two"
+        );
+    }
 }

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -189,11 +189,6 @@ fn init_tlsf() {
     }
 }
 
-fn tlsf_deallocate(ptr: NonNull<u8>) {
-    let mut tlsf = TLSF.get().unwrap().lock().unwrap();
-    unsafe { tlsf.deallocate(ptr, LAYOUT_ALIGN) }
-}
-
 fn tlsf_allocate_wrapped(layout: Layout) -> Option<NonNull<u8>> {
     // the alignment must be greater than POINTER_ALIGN to ensure that `aligned_ptr` is POINTER_ALIGN-byte aligned.
     let align = layout.align().max(POINTER_ALIGN);
@@ -260,7 +255,9 @@ fn tlsf_deallocate_wrapped(ptr: NonNull<u8>) {
     // get the original pointer
     // SAFETY: `ptr` must have been allocated by `tlsf_allocate_wrapped`.
     let original_ptr = unsafe { *ptr.as_ptr().byte_sub(POINTER_SIZE).cast() };
-    tlsf_deallocate(original_ptr);
+
+    let mut tlsf = TLSF.get().unwrap().lock().unwrap();
+    unsafe { tlsf.deallocate(original_ptr, LAYOUT_ALIGN) }
 }
 
 #[cfg(not(test))]

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -191,12 +191,12 @@ fn init_tlsf() {
 
 fn tlsf_allocate_wrapped(layout: Layout) -> Option<NonNull<u8>> {
     // the alignment must be greater than POINTER_ALIGN to ensure that `aligned_ptr` is POINTER_ALIGN-byte aligned.
-    let align = layout.align().max(POINTER_ALIGN);
-    debug_assert!(align.is_power_of_two() && align >= POINTER_ALIGN);
+    let alignment = layout.align().max(POINTER_ALIGN);
+    debug_assert!(alignment.is_power_of_two() && alignment >= POINTER_ALIGN);
 
     // the original pointer returned by the internal allocator
     let size = layout.size();
-    let layout = Layout::from_size_align(POINTER_SIZE + size + align, LAYOUT_ALIGN).ok()?;
+    let layout = Layout::from_size_align(POINTER_SIZE + size + alignment, LAYOUT_ALIGN).ok()?;
     let mut tlsf = TLSF.get().unwrap().lock().unwrap();
     let original_ptr = tlsf.allocate(layout)?;
     let original_addr = original_ptr.as_ptr() as usize;
@@ -207,10 +207,10 @@ fn tlsf_allocate_wrapped(layout: Layout) -> Option<NonNull<u8>> {
     // We avoid using `Layout::align` because doing so requires us to remember the alignment.
     // This is because `Tlsf::{reallocate, deallocate}` functions require the same alignment.
     // See: https://docs.rs/rlsf/latest/rlsf/struct.Tlsf.html
-    let aligned_addr = (original_addr + POINTER_SIZE + align - 1) & !(align - 1);
+    let aligned_addr = (original_addr + POINTER_SIZE + alignment - 1) & !(alignment - 1);
 
     // SAFETY: `aligned_addr` must be non-zero.
-    debug_assert!(aligned_addr % align == 0 && aligned_addr != 0);
+    debug_assert!(aligned_addr % alignment == 0 && aligned_addr != 0);
     let aligned_ptr = unsafe { NonNull::new_unchecked(aligned_addr as *mut u8) };
 
     // store the original pointer
@@ -221,8 +221,8 @@ fn tlsf_allocate_wrapped(layout: Layout) -> Option<NonNull<u8>> {
 
 fn tlsf_reallocate_wrapped(ptr: NonNull<u8>, new_layout: Layout) -> Option<NonNull<u8>> {
     // the alignment must be greater than POINTER_ALIGN to ensure that `aligned_ptr` is POINTER_ALIGN-byte aligned.
-    let align = new_layout.align().max(POINTER_ALIGN);
-    debug_assert!(align.is_power_of_two() && align >= POINTER_ALIGN);
+    let alignment = new_layout.align().max(POINTER_ALIGN);
+    debug_assert!(alignment.is_power_of_two() && alignment >= POINTER_ALIGN);
 
     // get the original pointer
     // SAFETY: `ptr` must have been allocated by `tlsf_allocate_wrapped`.
@@ -230,7 +230,7 @@ fn tlsf_reallocate_wrapped(ptr: NonNull<u8>, new_layout: Layout) -> Option<NonNu
 
     // the original pointer returned by the internal allocator
     let size = new_layout.size();
-    let new_layout = Layout::from_size_align(POINTER_SIZE + size + align, LAYOUT_ALIGN).ok()?;
+    let new_layout = Layout::from_size_align(POINTER_SIZE + size + alignment, LAYOUT_ALIGN).ok()?;
     let mut tlsf = TLSF.get().unwrap().lock().unwrap();
     let original_ptr = unsafe { tlsf.reallocate(original_ptr, new_layout) }?;
     let original_addr = original_ptr.as_ptr() as usize;
@@ -241,10 +241,10 @@ fn tlsf_reallocate_wrapped(ptr: NonNull<u8>, new_layout: Layout) -> Option<NonNu
     // We avoid using `Layout::align` because doing so requires us to remember the alignment.
     // This is because `Tlsf::{reallocate, deallocate}` functions require the same alignment.
     // See: https://docs.rs/rlsf/latest/rlsf/struct.Tlsf.html
-    let aligned_addr: usize = (original_addr + POINTER_SIZE + align - 1) & !(align - 1);
+    let aligned_addr: usize = (original_addr + POINTER_SIZE + alignment - 1) & !(alignment - 1);
 
     // SAFETY: `aligned_addr` must be non-zero.
-    debug_assert!(aligned_addr % align == 0 && aligned_addr != 0);
+    debug_assert!(aligned_addr % alignment == 0 && aligned_addr != 0);
     let aligned_ptr = unsafe { NonNull::new_unchecked(aligned_addr as *mut u8) };
 
     // store the original pointer


### PR DESCRIPTION
## Description
Fixed memory-related functions to match the semantics of C:

- Modified to use `Layout` to ensure the alignment is a power of two.
- Fixed `realloc(ptr, size)` so that when ptr is not `NULL` and size is zero, it behaves equivalently to `free(ptr)`.
- Fixed `aligned_alloc` so that the size is a multiple of the alignment.
- Fixed `posix_memalign` so that the alignment is a multiple of two and also a multiple of `sizeof(void *)`.

See:
https://linux.die.net/man/3/posix_memalign
https://linux.die.net/man/3/malloc

I will create the unit tests in a separate PR.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
