### PR TITLE
feat(agnocastlib): single threaded executor for cie

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -26,6 +26,10 @@ class AgnocastExecutor : public rclcpp::Executor
 
   void wait_and_handle_epoll_event(const int timeout_ms);
   bool get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable);
+
+  // Return false iff this Executor is SingleThreadedAgnocastExecutor
+  // and used for internal implementation of CallbackIsolatedAgnocastExecutor
+  // and `group` is "not" the callback group dedicated by this Executor.
   virtual bool validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const = 0;
 
 protected:

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -26,7 +26,7 @@ class AgnocastExecutor : public rclcpp::Executor
 
   void wait_and_handle_epoll_event(const int timeout_ms);
   bool get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable);
-  virtual void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const = 0;
+  virtual bool validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const = 0;
 
 protected:
   int epoll_fd_;

--- a/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_multi_threaded_executor.hpp
@@ -21,7 +21,7 @@ class MultiThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
 
   void ros2_spin();
   void agnocast_spin();
-  void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
+  bool validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
 
 public:
   RCLCPP_PUBLIC

--- a/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
@@ -12,7 +12,12 @@ class SingleThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   RCLCPP_DISABLE_COPY(SingleThreadedAgnocastExecutor)
 
   const int next_exec_timeout_ms_;
-  void validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
+  bool validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const override;
+
+  // Activate when this Executor is used for the implementation of a
+  // CallbackIsolatedAgnocastExecutor.
+  bool is_dedicated_to_one_callback_group_ = false;
+  rclcpp::CallbackGroup::SharedPtr dedicated_callback_group_ = nullptr;
 
 public:
   RCLCPP_PUBLIC
@@ -22,6 +27,11 @@ public:
 
   RCLCPP_PUBLIC
   void spin() override;
+
+  // Not used for public API, but required to be exposed for the internal implementation
+  void dedicate_to_callback_group(
+    const rclcpp::CallbackGroup::SharedPtr & group,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -87,7 +87,7 @@ void AgnocastExecutor::prepare_epoll()
       continue;
     }
 
-    validate_callback_group(callback_info.callback_group);
+    if (!validate_callback_group(callback_info.callback_group)) continue;
 
     struct epoll_event ev = {};
     ev.events = EPOLLIN;

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -87,7 +87,9 @@ void AgnocastExecutor::prepare_epoll()
       continue;
     }
 
-    if (!validate_callback_group(callback_info.callback_group)) continue;
+    if (!validate_callback_group(callback_info.callback_group)) {
+      continue;
+    }
 
     struct epoll_event ev = {};
     ev.events = EPOLLIN;

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -27,7 +27,7 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
 #endif
 }
 
-void MultiThreadedAgnocastExecutor::validate_callback_group(
+bool MultiThreadedAgnocastExecutor::validate_callback_group(
   const rclcpp::CallbackGroup::SharedPtr & group) const
 {
   if (!group) {
@@ -37,7 +37,7 @@ void MultiThreadedAgnocastExecutor::validate_callback_group(
   }
 
   if (group->type() == rclcpp::CallbackGroupType::Reentrant) {
-    return;
+    return true;
   }
 
   bool is_shared_with_ros2 = false;
@@ -74,6 +74,8 @@ void MultiThreadedAgnocastExecutor::validate_callback_group(
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+
+  return true;
 }
 
 void MultiThreadedAgnocastExecutor::spin()

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -35,7 +35,10 @@ bool SingleThreadedAgnocastExecutor::validate_callback_group(
     exit(EXIT_FAILURE);
   }
 
-  if (is_dedicated_to_one_callback_group_ && group != dedicated_callback_group_) return false;
+  if (is_dedicated_to_one_callback_group_) {
+    return group == dedicated_callback_group_;
+  }
+
   return true;
 }
 

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -26,7 +26,7 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
   }
 }
 
-void SingleThreadedAgnocastExecutor::validate_callback_group(
+bool SingleThreadedAgnocastExecutor::validate_callback_group(
   const rclcpp::CallbackGroup::SharedPtr & group) const
 {
   if (!group) {
@@ -34,6 +34,9 @@ void SingleThreadedAgnocastExecutor::validate_callback_group(
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+
+  if (is_dedicated_to_one_callback_group_ && group != dedicated_callback_group_) return false;
+  return true;
 }
 
 void SingleThreadedAgnocastExecutor::spin()
@@ -62,6 +65,22 @@ void SingleThreadedAgnocastExecutor::spin()
       execute_any_executable(any_executable);
     }
   }
+}
+
+void SingleThreadedAgnocastExecutor::dedicate_to_callback_group(
+  const rclcpp::CallbackGroup::SharedPtr & group,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node)
+{
+  if (!group) {
+    RCLCPP_ERROR(logger, "The passed callback group is nullptr.");
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+
+  is_dedicated_to_one_callback_group_ = true;
+  dedicated_callback_group_ = group;
+
+  add_callback_group(group, node);
 }
 
 }  // namespace agnocast


### PR DESCRIPTION
## Description
This is the first pull request to begin integrating the [CallbackIsolatedExecutor](https://github.com/tier4/callback_isolated_executor) into Agnocast.  
The `CallbackIsolatedAgnocastExecutor` is designed as "a set of `SingleThreadedAgnocastExecutor` instances, each dedicated to a single callback group."

The challenge in implementing this model lies in the current Agnocast design, which assumes only one executor per process. This assumption makes it impossible to poll only Agnocast callbacks belonging to a specific callback group.

This pull request enables a `SingleThreadedAgnocastExecutor` to be dedicated to a specific callback group.


## Related links

[TIER IV Internal](https://tier4.atlassian.net/wiki/spaces/CRL/pages/3815211404/CallbackIsolatedAgnocastExecutor)

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers
