### PR TITLE
fix: run test_integration_agnocast_heaphook when test code updates

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
@@ -38,7 +38,7 @@ jobs:
       run: |
         set -e
         if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
-            | grep -q '^agnocast_heaphook/'; then
+            | grep -qE '^agnocast_heaphook/|^test_agnocast_heaphook\.cpp$'; then
           echo "heaphook_changed=true" >> $GITHUB_OUTPUT
         else
           echo "heaphook_changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
