### PR TITLE
Remove broken source.crates-io config

### DIFF
--- a/agnocast_heaphook/.cargo/config.toml
+++ b/agnocast_heaphook/.cargo/config.toml
@@ -1,5 +1,0 @@
-[source.crates-io]
-replace-with = "vendored-sources"
-
-[source.vendored-sources]
-directory = "vendor"


### PR DESCRIPTION
## Description

The `agnocast_heaphook/.cargo/config.toml` configuration file instructs the Cargo to search for packages in the `vendor` directory. However, the directory is not available for public users. The patch removes this file to fix the issue.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers
