### PR TITLE
build: set C++ standard explicitly to support Clang builds

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(agnocastlib)
 
+# Clang requires explicit C++ standard setting to find standard library headers
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 option(COVERAGE "Enable coverage reporting for gcov" OFF)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
## Description

This PR adds support for building with Clang.

When building `agnocastlib` with Clang (`clang-15` in my case), the following compiler errors occur (excerpt):

```
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:550:10: error: no member named 'optional' in namespace 'std'
    std::optional<CallbackInfoVariant>
...
/opt/ros/humble/include/rclcpp/rclcpp/client.hpp:788:36: /opt/ros/humble/include/rclcpp/rclcpp/client.hpp:550:19: error: no template named 'variant' in namespace 'std'
error:   using CallbackInfoVariant = std::variant<
...
```

This is a result of Clang not finding standard library headers because no C++ standard has been set.
This PR sets the C++ standard to 17 if not set already, and now `agnocastlib` builds fine with Clang.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

Steps to reproduce:
```bash
# Install Clang 15
sudo apt update
sudo apt install clang-15 libstdc++-12-dev

# Set build environment
source /opt/ros/humble/setup.bash
export CC=$(which clang-15)
export CXX=$(which clang++-15)

# Add this PR's fork as a remote
git remote add mojomex https://github.com/mojomex/agnocast
git fetch mojomex

# Build Agnocast (assuming the workdir is the root of this git repo)
git checkout main
rm -rf build install
colcon build  # This will fail
git checkout mojomex/build/support-clang
rm -rf build install
colcon build  # This will succeed
```