### PR TITLE
fix: remove unnecessary TRACETOOLS_LTTNG_ENABLED

### DIFF
--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -20,11 +20,9 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
   ros2_next_exec_timeout_(ros2_next_exec_timeout),
   agnocast_next_exec_timeout_ms_(agnocast_next_exec_timeout_ms)
 {
-#ifdef TRACETOOLS_LTTNG_ENABLED
   TRACEPOINT(
     agnocast_construct_executor, static_cast<const void *>(this),
     "agnocast_multi_threaded_executor");
-#endif
 }
 
 bool MultiThreadedAgnocastExecutor::validate_callback_group(

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -73,11 +73,9 @@ union ioctl_publish_msg_args publish_core(
     exit(EXIT_FAILURE);
   }
 
-#ifdef TRACETOOLS_LTTNG_ENABLED
   TRACEPOINT(
     agnocast_publish, publisher_handle, reinterpret_cast<const void *>(msg_virtual_address),
     publish_msg_args.ret_entry_id);
-#endif
 
   for (uint32_t i = 0; i < publish_msg_args.ret_subscriber_num; i++) {
     const topic_local_id_t subscriber_id = publish_msg_args.ret_subscriber_ids[i];

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -11,11 +11,9 @@ SingleThreadedAgnocastExecutor::SingleThreadedAgnocastExecutor(
   const rclcpp::ExecutorOptions & options, int next_exec_timeout_ms)
 : agnocast::AgnocastExecutor(options), next_exec_timeout_ms_(next_exec_timeout_ms)
 {
-#ifdef TRACETOOLS_LTTNG_ENABLED
   TRACEPOINT(
     agnocast_construct_executor, static_cast<const void *>(this),
     "agnocast_single_threaded_executor");
-#endif
 
   const int next_exec_timeout_ms_threshold = 500;  // Rough value
   if (next_exec_timeout_ms_ > next_exec_timeout_ms_threshold) {


### PR DESCRIPTION
## Description

`#ifdef TRACETOOLS_LTTNG_ENABLED` is unnecessary because `CONDITIONAL_TP` is used.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers
