### PR TITLE
fix: error when upgrading heaphook

### DIFF
--- a/agnocast_heaphook/debian/changelog
+++ b/agnocast_heaphook/debian/changelog
@@ -1,4 +1,4 @@
-agnocast-heaphook-v2.1.2 (2.1.2-1) jammy; urgency=medium
+agnocast-heaphook-v2.1.2 (2.1.2-2) jammy; urgency=medium
 
   * fix(heaphook): fix memory-related functions to match C semantics (#657 <https://github.com/tier4/agnocast/issues/657>)
   * refactor(heaphook): modify tlsf_{allocate, reallocate}_wrapped to return Option<NonNull<u8>> (#653 <https://github.com/tier4/agnocast/issues/653>)

--- a/agnocast_heaphook/debian/control
+++ b/agnocast_heaphook/debian/control
@@ -9,5 +9,8 @@ Homepage: https://github.com/tier4/agnocast
 Package: agnocast-heaphook-v2.1.2
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Provides: agnocast-heaphook
+Conflicts: agnocast-heaphook, agnocast-heaphook-v2.1.0, agnocast-heaphook-v2.1.1
+Replaces: agnocast-heaphook-v2.1.0, agnocast-heaphook-v2.1.1
 Description: A heap runtime replacement for Agnocast.
  To achieve true zero-copy communication with Agnocast, message objects must be placed in shared memory. Therefore, all heap allocation and deallocation operations are intercepted and customized using LD_PRELOAD hooks.


### PR DESCRIPTION
## Description
Before this PR, we cannot locally upgrade agnocast-heaphook by the error below.

```
dpkg: error processing archive /var/cache/apt/archives/agnocast-heaphook-v2.1.2_2.1.2-1_all.deb (--unpack):
trying to overwrite '/opt/ros/humble/lib/libagnocast_heaphook.so', which is also in package agnocast-heaphook-v2.1.1 2.1.1-1
dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
Errors were encountered while processing:
 /var/cache/apt/archives/agnocast-heaphook-v2.1.2_2.1.2-1_all.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

## Related links
[TIER IV Internal Link](https://tier4.atlassian.net/wiki/spaces/CRL/pages/4040917027/agnocast-heaphook+upgrade)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
