### PR TITLE
feat(agnocastlib): implement service

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -4,6 +4,7 @@
 #include "agnocast/agnocast_callback_isolated_executor.hpp"
 #include "agnocast/agnocast_multi_threaded_executor.hpp"
 #include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_service.hpp"
 #include "agnocast/agnocast_single_threaded_executor.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -113,6 +114,15 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
   return std::make_shared<PollingSubscriber<MessageT>>(node, topic_name, qos);
+}
+
+template <typename ServiceT, typename Func>
+typename Service<ServiceT>::SharedPtr create_service(
+  rclcpp::Node * node, const std::string & service_name, Func && callback,
+  const rclcpp::QoS & qos = rclcpp::ServicesQoS(), rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  return std::make_shared<Service<ServiceT>>(
+    node, service_name, std::forward<Func>(callback), qos, group);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -227,4 +227,57 @@ public:
   }
 };
 
+// The Publisher that does not instantiate a ros2 publisher
+template <typename MessageT>
+class AgnocastOnlyPublisher
+{
+  const std::string topic_name_;
+  const topic_local_id_t id_;
+  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> opened_mqs_;
+
+public:
+  using SharedPtr = std::shared_ptr<AgnocastOnlyPublisher<MessageT>>;
+
+  AgnocastOnlyPublisher(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  : topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name)),
+    id_(initialize_publisher(topic_name_, node->get_fully_qualified_name(), qos))
+  {
+  }
+
+  ipc_shared_ptr<MessageT> borrow_loaned_message()
+  {
+    increment_borrowed_publisher_num();
+    MessageT * ptr = new MessageT();
+    return ipc_shared_ptr<MessageT>(ptr, topic_name_.c_str(), id_);
+  }
+
+  int64_t publish(ipc_shared_ptr<MessageT> && message)
+  {
+    if (!message || topic_name_ != message.get_topic_name()) {
+      RCLCPP_ERROR(logger, "Invalid message to publish.");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    decrement_borrowed_publisher_num();
+
+    const union ioctl_publish_msg_args publish_msg_args =
+      publish_core(this, topic_name_, id_, reinterpret_cast<uint64_t>(message.get()), opened_mqs_);
+
+    message.set_entry_id(publish_msg_args.ret_entry_id);
+
+    for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
+      MessageT * release_ptr = reinterpret_cast<MessageT *>(publish_msg_args.ret_released_addrs[i]);
+      delete release_ptr;
+    }
+
+    message.reset();
+
+    return publish_msg_args.ret_entry_id;
+  }
+
+  uint32_t get_subscription_count() const { return get_subscription_count_core(topic_name_); }
+};
+
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_smart_pointer.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/agnocast_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace agnocast
+{
+
+template <typename ServiceT>
+class Service
+{
+public:
+  // To avoid name conflicts, members of RequestT and ResponseT are given an underscore prefix.
+  struct RequestT : public ServiceT::Request
+  {
+    std::string _node_name;
+  };
+  struct ResponseT : public ServiceT::Response
+  {
+    int64_t _request_entry_id;
+  };
+
+private:
+  rclcpp::Node * node_;
+  const std::string service_name_;
+  const rclcpp::QoS qos_;
+  std::mutex publishers_mtx_;
+  // AgnocastOnlyPublisher is used since ResponseT is not a compatible ROS message type.
+  std::unordered_map<std::string, typename AgnocastOnlyPublisher<ResponseT>::SharedPtr> publishers_;
+  typename Subscription<RequestT>::SharedPtr subscriber_;
+
+public:
+  using SharedPtr = std::shared_ptr<Service<ServiceT>>;
+
+  template <typename Func>
+  Service(
+    rclcpp::Node * node, const std::string & service_name, Func && callback,
+    const rclcpp::QoS & qos, rclcpp::CallbackGroup::SharedPtr group)
+  : node_(node),
+    service_name_(node_->get_node_services_interface()->resolve_service_name(service_name)),
+    qos_(qos)
+  {
+    static_assert(
+      std::is_invocable_v<
+        std::decay_t<Func>, const ipc_shared_ptr<RequestT> &, ipc_shared_ptr<ResponseT> &>,
+      "Callback must be callable with "
+      "(const ipc_shared_ptr<RequestT> &, ipc_shared_ptr<ResponseT> &)");
+
+    auto subscriber_callback =
+      [this, callback = std::forward<Func>(callback)](const ipc_shared_ptr<RequestT> & request) {
+        typename AgnocastOnlyPublisher<ResponseT>::SharedPtr publisher;
+
+        {
+          std::lock_guard<std::mutex> lock(publishers_mtx_);
+          auto it = publishers_.find(request->_node_name);
+          if (it == publishers_.end()) {
+            std::string topic_name =
+              create_service_response_topic_name(service_name_, request->_node_name);
+            publisher = std::make_shared<AgnocastOnlyPublisher<ResponseT>>(node_, topic_name, qos_);
+            publishers_[request->_node_name] = publisher;
+          } else {
+            publisher = it->second;
+          }
+        }
+
+        ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
+        response->_request_entry_id = request.get_entry_id();
+
+        callback(request, response);
+
+        publisher->publish(std::move(response));
+      };
+
+    SubscriptionOptions options{group};
+    std::string topic_name = create_service_request_topic_name(service_name_);
+    subscriber_ = std::make_shared<Subscription<RequestT>>(
+      node, topic_name, qos, std::move(subscriber_callback), options);
+  }
+};
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -16,6 +16,9 @@ std::string create_mq_name_for_agnocast_publish(
 std::string create_mq_name_for_ros2_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_shm_name(const pid_t pid);
+std::string create_service_request_topic_name(const std::string & service_name);
+std::string create_service_response_topic_name(
+  const std::string & service_name, const std::string & client_node_name);
 uint64_t agnocast_get_timestamp();
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -78,6 +78,17 @@ std::string create_shm_name(const pid_t pid)
   return "/agnocast@" + std::to_string(pid);
 }
 
+std::string create_service_request_topic_name(const std::string & service_name)
+{
+  return service_name + "_request";
+}
+
+std::string create_service_response_topic_name(
+  const std::string & service_name, const std::string & client_node_name)
+{
+  return service_name + "_response" + client_node_name;
+}
+
 uint64_t agnocast_get_timestamp()
 {
   auto now = std::chrono::system_clock::now();


### PR DESCRIPTION
## Description
This is the first PR in a series of PRs for service/client communication.
In this PR, we introduce the implementation of `Service`, which corresponds to `rclcpp::Service`. `Service` sets up a subscription callback to receive requests and publish responses. For more details, please refer to the design document.

## Related links
Design doc: [TierIV Internal](https://tier4.atlassian.net/wiki/x/bgCO8w)

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
