### PR TITLE
fix: arguments of TRACEPOINT for CARET

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -150,6 +150,7 @@ public:
     }
 
     if (take_args.ret_addr == 0) {
+      TRACEPOINT(agnocast_take, static_cast<void *>(this), 0, 0);
       return agnocast::ipc_shared_ptr<const MessageT>();
     }
 

--- a/src/agnocastlib/include/agnocast/agnocast_tracepoint_call.h
+++ b/src/agnocastlib/include/agnocast/agnocast_tracepoint_call.h
@@ -63,12 +63,10 @@ TRACEPOINT_EVENT(
   agnocast_publish,
   TP_ARGS(
     const void *, publisher_handle_arg,
-    const void *, message_arg,
     const int64_t, entry_id_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, publisher_handle, publisher_handle_arg)
-    ctf_integer_hex(const void *, message, message_arg)
     ctf_integer(const int64_t, entry_id, entry_id_arg)
   )
 )
@@ -78,13 +76,11 @@ TRACEPOINT_EVENT(
   agnocast_create_callable,
   TP_ARGS(
     const void *, callable_arg,
-    const void *, message_arg,
     const int64_t, entry_id_arg,
     const uint64_t, pid_ciid_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, callable, callable_arg)
-    ctf_integer_hex(const void *, message, message_arg)
     ctf_integer(const int64_t, entry_id, entry_id_arg)
     ctf_integer(const uint64_t, pid_ciid, pid_ciid_arg)
   )

--- a/src/agnocastlib/include/agnocast/agnocast_tracepoint_wrapper.h
+++ b/src/agnocastlib/include/agnocast/agnocast_tracepoint_wrapper.h
@@ -28,13 +28,11 @@ DECLARE_TRACEPOINT(
 DECLARE_TRACEPOINT(
   agnocast_publish,
   const void * publisher_handle,
-  const void * message,
   const int64_t entry_id)
 
 DECLARE_TRACEPOINT(
   agnocast_create_callable,
   const void * callable,
-  const void * message,
   const int64_t entry_id,
   const uint64_t pid_ciid)
 

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -63,8 +63,7 @@ void AgnocastExecutor::receive_message(
       uint64_t pid_ciid = (static_cast<uint64_t>(my_pid_) << PID_SHIFT_BITS) | callback_info_id;
       TRACEPOINT(
         agnocast_create_callable, static_cast<const void *>(callable.get()),
-        reinterpret_cast<void *>(receive_args.ret_entry_addrs[i]), receive_args.ret_entry_ids[i],
-        pid_ciid);
+        receive_args.ret_entry_ids[i], pid_ciid);
     }
 
     {

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -73,9 +73,7 @@ union ioctl_publish_msg_args publish_core(
     exit(EXIT_FAILURE);
   }
 
-  TRACEPOINT(
-    agnocast_publish, publisher_handle, reinterpret_cast<const void *>(msg_virtual_address),
-    publish_msg_args.ret_entry_id);
+  TRACEPOINT(agnocast_publish, publisher_handle, publish_msg_args.ret_entry_id);
 
   for (uint32_t i = 0; i < publish_msg_args.ret_subscriber_num; i++) {
     const topic_local_id_t subscriber_id = publish_msg_args.ret_subscriber_ids[i];

--- a/src/agnocastlib/src/agnocast_tracepoint_wrapper.c
+++ b/src/agnocastlib/src/agnocast_tracepoint_wrapper.c
@@ -63,27 +63,23 @@ void TRACEPOINT(
 void TRACEPOINT(
   agnocast_publish,
   const void * publisher_handle,
-  const void * message,
   const int64_t entry_id)
 {
   CONDITIONAL_TP(
     agnocast_publish,
     publisher_handle,
-    message,
     entry_id);
 }
 
 void TRACEPOINT(
   agnocast_create_callable,
   const void * callable,
-  const void * message,
   const int64_t entry_id,
   const uint64_t pid_ciid)
 {
   CONDITIONAL_TP(
     agnocast_create_callable,
     callable,
-    message,
     entry_id,
     pid_ciid);
 }


### PR DESCRIPTION
## Description

This change is needed for CARET refactoring.

## Related links

## How was this PR tested?

- [ ] Autoware (required) -> skip
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
