### PR TITLE
fix(heaphook): Handle unexpected `realloc` by returning null

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -451,8 +451,8 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
 
     match (is_shared, should_use_original) {
         (true, true) => {
-            // In the child processes, ignore the free operation to the shared memory.
-            (*ORIGINAL_MALLOC.get_or_init(init_original_malloc))(new_size)
+            // Ignore unexpected calls to `realloc`.
+            ptr::null_mut()
         }
         (true, false) => {
             // The default global allocator assumes `realloc` returns 16-byte aligned address (on x64 platforms).

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -342,7 +342,8 @@ fn should_use_original_func() -> bool {
 
 #[cfg(test)]
 fn should_use_original_func() -> bool {
-    false
+    // In tests, we use glibc functions only when the allocator is uninitialized.
+    AGNOCAST_SHARED_MEMORY_ALLOCATOR.get().is_none()
 }
 
 /// # Safety

--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -314,9 +314,9 @@ unsafe trait SharedMemoryAllocator {
 /// Returns true when glibc functions must be used.
 /// It is intended to be called from memory allocation functions such as `malloc` or `realloc`.
 ///
-/// We must use glibc functions when any of the following condtions hold:
+/// We must use glibc functions when any of the following conditions hold:
 /// * When the shared memory allocator is not initialized.
-/// * When in a forked process (since we do not expect forked process to operate on shared memory).
+/// * When in a forked process (since we do not expect forked processes to operate on shared memory).
 /// * When `agnocast_get_borrowed_publisher_num` returns 0, i.e., when the publisher is not using shared memory.
 #[cfg(not(test))]
 fn should_use_original_func() -> bool {


### PR DESCRIPTION
## Description
In the current implementation, when `realloc` is called on shared memory, and `should_use_original_func` returns true, glibc’s `malloc` will be invoked. 
```rust
#[cfg(not(test))]
fn should_use_original_func() -> bool {
    extern "C" {
        fn agnocast_get_borrowed_publisher_num() -> u32;
    }

    if IS_FORKED_CHILD.load(Ordering::Relaxed) {
        return true;
    }

    unsafe {
        if agnocast_get_borrowed_publisher_num() == 0 {
            return true;
        }
    }

    false
}
```
```rust
match (is_shared, should_use_original) {
        (true, true) => {
            // In the child processes, ignore the free operation to the shared memory.
            (*ORIGINAL_MALLOC.get_or_init(init_original_malloc))(new_size)
        }
```

This happens in the following cases:
| is_shared  | IS_FORKED_CHILD | agnocast_get_borrowed_publisher_num() == 0 |
| :---: | :---: | :---: |
| 1 | 1 | 0 |
| 1 | 1 | 1 |
|1 | 0 | 1 |

The first two cases correspond to when a forked process performs `realloc` on shared memory, but we do not expect forked processes to operate on shared memory. The last case corresponds to when `realloc` is performed after the publisher has published a message. Therefore, these should be considered errors. 

For this reason, I modified the code to return a null pointer in such cases.

In addition, I added a doc comment to `should_use_original_func` to clarify when glibc functions should be used.
## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
