### PR TITLE
fix(smart_pointer): not calling decrement_rc when entry_id is -1

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -117,7 +117,9 @@ public:
   {
     if (ptr_ == nullptr) return;
 
-    decrement_rc(topic_name_, pubsub_id_, entry_id_);
+    if (entry_id_ > 0) {
+        decrement_rc(topic_name_, pubsub_id_, entry_id_);
+    }
 
     ptr_ = nullptr;
   }


### PR DESCRIPTION
## Description
Fix reset() for not calling decrement_rc() when entry_id is -1 since there is no corresponding entry_node in kmod.
This happens when return is called after borrow_loaned_message() without calling publish().

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
