### PR TITLE
fix(kmod): add node name log for  insert_publisher/subscriber_info

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -278,9 +278,9 @@ static int insert_subscriber_info(
 
   dev_info(
     agnocast_device,
-    "Subscriber (topic_local_id=%d, pid=%d) is added to the topic (topic_name=%s). "
+    "Subscriber (topic_local_id=%d, pid=%d, node_name=%s) is added to the topic (topic_name=%s). "
     "(insert_subscriber_info)\n",
-    new_id, subscriber_pid, wrapper->key);
+    new_id, subscriber_pid, node_name, wrapper->key);
 
   // Check if the topic has any volatile publishers.
   if (qos_is_transient_local) {
@@ -372,9 +372,9 @@ static int insert_publisher_info(
 
   dev_info(
     agnocast_device,
-    "Publisher (topic_local_id=%d, pid=%d) is added to the topic (topic_name=%s). "
+    "Publisher (topic_local_id=%d, pid=%d, node_name=%s) is added to the topic (topic_name=%s). "
     "(insert_publisher_info)\n",
-    new_id, publisher_pid, wrapper->key);
+    new_id, publisher_pid, node_name, wrapper->key);
 
   // Check if the topic has any transient local subscribers.
   if (!qos_is_transient_local) {


### PR DESCRIPTION
## Description
As in title.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
