### PR TITLE
chore: add sample service/client application

### DIFF
--- a/scripts/run_client
+++ b/scripts/run_client
@@ -1,0 +1,2 @@
+source install/setup.bash
+ros2 launch agnocast_sample_application client.launch.xml

--- a/scripts/run_server
+++ b/scripts/run_server
@@ -1,0 +1,2 @@
+source install/setup.bash
+ros2 launch agnocast_sample_application server.launch.xml

--- a/src/agnocast_sample_application/CMakeLists.txt
+++ b/src/agnocast_sample_application/CMakeLists.txt
@@ -32,6 +32,18 @@ target_include_directories(cie_listener PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 
+add_executable(client src/minimal_client.cpp)
+ament_target_dependencies(client rclcpp agnocastlib agnocast_sample_interfaces)
+target_include_directories(client PRIVATE
+  ${agnocastlib_INCLUDE_DIRS}
+)
+
+add_executable(server src/minimal_server.cpp)
+ament_target_dependencies(server rclcpp agnocastlib agnocast_sample_interfaces)
+target_include_directories(server PRIVATE
+  ${agnocastlib_INCLUDE_DIRS}
+)
+
 add_library(listener_component SHARED src/minimal_subscriber.cpp)
 ament_target_dependencies(listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
 target_include_directories(listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
@@ -57,6 +69,12 @@ install(TARGETS cie_talker
   DESTINATION lib/${PROJECT_NAME})
 
 install(TARGETS cie_listener
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS client
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS server
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY launch

--- a/src/agnocast_sample_application/launch/client.launch.xml
+++ b/src/agnocast_sample_application/launch/client.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+    <node pkg="agnocast_sample_application" exec="client" name="client_node" output="screen">
+        <remap from="/sum_int_array" to="/srv/sum_int_array" />
+
+        <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
+        <env name="AGNOCAST_MEMPOOL_SIZE" value="16777216" /> <!-- 16MB-->
+    </node>
+</launch>

--- a/src/agnocast_sample_application/launch/server.launch.xml
+++ b/src/agnocast_sample_application/launch/server.launch.xml
@@ -1,0 +1,8 @@
+<launch>
+    <node pkg="agnocast_sample_application" exec="server" name="server_node" output="screen">
+        <remap from="/sum_int_array" to="/srv/sum_int_array" />
+
+        <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
+        <env name="AGNOCAST_MEMPOOL_SIZE" value="16777216" /> <!-- 16MB-->
+    </node>
+</launch>

--- a/src/agnocast_sample_application/src/minimal_client.cpp
+++ b/src/agnocast_sample_application/src/minimal_client.cpp
@@ -1,0 +1,54 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/srv/sum_int_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+constexpr size_t ARRAY_SIZE = 100;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("minimal_client");
+  std::thread spin_thread([node]() mutable {
+    agnocast::CallbackIsolatedAgnocastExecutor executor;
+    executor.add_node(node);
+    executor.spin();
+  });
+
+  auto client = agnocast::create_client<agnocast_sample_interfaces::srv::SumIntArray>(
+    node.get(), "sum_int_array");
+
+  while (!client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
+      return 0;
+    }
+    RCLCPP_INFO(node->get_logger(), "Service not available, waiting again...");
+  }
+
+  auto request1 = client->borrow_loaned_request();
+  for (size_t i = 1; i <= ARRAY_SIZE; ++i) {
+    request1->data.push_back(i);
+  }
+  client->async_send_request(
+    std::move(request1),
+    [node = node.get()](
+      agnocast::Client<agnocast_sample_interfaces::srv::SumIntArray>::SharedFuture future) {
+      RCLCPP_INFO(node->get_logger(), "Result1: %ld", future.get()->sum);
+    });
+
+  auto request2 = client->borrow_loaned_request();
+  for (size_t i = 0; i < ARRAY_SIZE; ++i) {
+    request2->data.push_back(i);
+  }
+  auto future = client->async_send_request(std::move(request2));
+  RCLCPP_INFO(node->get_logger(), "Result2: %ld", future.get()->sum);
+
+  spin_thread.join();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/agnocast_sample_application/src/minimal_server.cpp
+++ b/src/agnocast_sample_application/src/minimal_server.cpp
@@ -1,0 +1,40 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/srv/sum_int_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class MinimalService : public rclcpp::Node
+{
+  using RequestT = agnocast::Service<agnocast_sample_interfaces::srv::SumIntArray>::RequestT;
+  using ResponseT = agnocast::Service<agnocast_sample_interfaces::srv::SumIntArray>::ResponseT;
+
+  typename agnocast::Service<agnocast_sample_interfaces::srv::SumIntArray>::SharedPtr service_;
+
+public:
+  explicit MinimalService() : Node("minimal_server")
+  {
+    service_ = agnocast::create_service<agnocast_sample_interfaces::srv::SumIntArray>(
+      this, "sum_int_array",
+      [this](
+        const agnocast::ipc_shared_ptr<RequestT> & request,
+        agnocast::ipc_shared_ptr<ResponseT> & response) {
+        response->sum = 0;
+        for (int64_t value : request->data) {
+          response->sum += value;
+        }
+        RCLCPP_INFO(this->get_logger(), "Sending back response: [%ld]", response->sum);
+      });
+  }
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  agnocast::CallbackIsolatedAgnocastExecutor executor;
+  auto node = std::make_shared<MinimalService>();
+  executor.add_node(node);
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/agnocast_sample_interfaces/CMakeLists.txt
+++ b/src/agnocast_sample_interfaces/CMakeLists.txt
@@ -9,6 +9,10 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} "msg/DynamicSizeArray.msg" "msg/StaticSizeArray.msg")
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/DynamicSizeArray.msg"
+  "msg/StaticSizeArray.msg"
+  "srv/SumIntArray.srv"
+)
 
 ament_package()

--- a/src/agnocast_sample_interfaces/srv/SumIntArray.srv
+++ b/src/agnocast_sample_interfaces/srv/SumIntArray.srv
@@ -1,0 +1,3 @@
+int64[] data
+---
+int64 sum


### PR DESCRIPTION
## Description
This is the third PR in a series of PRs for service/client, following #707.

In this PR, we add a pair of sample applications that perform service/client communication. The sample server receives an array of integers and sends back its sum.

To start the sample server, run:
```
bash scripts/run_server
```
To start the sample client, run:
```
bash scripts/run_client
```

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

We confirmed that the sample applications ran as expected based on the output:
```
[server-1] [INFO] [1761285350.634608597] [server_node]: Sending back response: [5050]
[server-1] [INFO] [1761285350.634748397] [server_node]: Sending back response: [4950]
```
```
[client-1] [INFO] [1761285350.534196922] [client_node]: Service not available, waiting again...
[client-1] [INFO] [1761285350.634872745] [client_node]: Result1: 5050
[client-1] [INFO] [1761285350.635046155] [client_node]: Result2: 4950
```

## Notes for reviewers
