### PR TITLE
style: rename ciid

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -85,12 +85,12 @@ public:
       std::forward<Func>(callback), topic_name_, id_, is_transient_local, mq, callback_group);
 
     {
-      uint64_t pid_ciid = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id;
+      uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id;
       TRACEPOINT(
         agnocast_subscription_init, static_cast<const void *>(this),
         static_cast<const void *>(node_base->get_shared_rcl_node_handle().get()),
         static_cast<const void *>(&callback), static_cast<const void *>(callback_group.get()),
-        tracetools::get_symbol(callback), topic_name_.c_str(), qos.depth(), pid_ciid);
+        tracetools::get_symbol(callback), topic_name_.c_str(), qos.depth(), pid_callback_info_id);
     }
   }
 

--- a/src/agnocastlib/include/agnocast/agnocast_tracepoint_call.h
+++ b/src/agnocastlib/include/agnocast/agnocast_tracepoint_call.h
@@ -44,7 +44,7 @@ TRACEPOINT_EVENT(
     const char *, symbol_arg,
     const char *, topic_name_arg,
     const size_t, queue_depth_arg,
-    const uint64_t, pid_ciid_arg
+    const uint64_t, pid_callback_info_id_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, subscription_handle, subscription_handle_arg)
@@ -54,7 +54,7 @@ TRACEPOINT_EVENT(
     ctf_string(symbol, symbol_arg)
     ctf_string(topic_name, topic_name_arg)
     ctf_integer(const size_t, queue_depth, queue_depth_arg)
-    ctf_integer(const uint64_t, pid_ciid, pid_ciid_arg)
+    ctf_integer(const uint64_t, pid_callback_info_id, pid_callback_info_id_arg)
   )
 )
 
@@ -77,12 +77,12 @@ TRACEPOINT_EVENT(
   TP_ARGS(
     const void *, callable_arg,
     const int64_t, entry_id_arg,
-    const uint64_t, pid_ciid_arg
+    const uint64_t, pid_callback_info_id_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, callable, callable_arg)
     ctf_integer(const int64_t, entry_id, entry_id_arg)
-    ctf_integer(const uint64_t, pid_ciid, pid_ciid_arg)
+    ctf_integer(const uint64_t, pid_callback_info_id, pid_callback_info_id_arg)
   )
 )
 

--- a/src/agnocastlib/include/agnocast/agnocast_tracepoint_wrapper.h
+++ b/src/agnocastlib/include/agnocast/agnocast_tracepoint_wrapper.h
@@ -23,7 +23,7 @@ DECLARE_TRACEPOINT(
   const char * function_symbol,
   const char * topic_name,
   const size_t queue_depth,
-  const uint64_t pid_ciid)
+  const uint64_t pid_callback_info_id)
 
 DECLARE_TRACEPOINT(
   agnocast_publish,
@@ -34,7 +34,7 @@ DECLARE_TRACEPOINT(
   agnocast_create_callable,
   const void * callable,
   const int64_t entry_id,
-  const uint64_t pid_ciid)
+  const uint64_t pid_callback_info_id)
 
 DECLARE_TRACEPOINT(
   agnocast_callable_start,

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -60,10 +60,11 @@ void AgnocastExecutor::receive_message(
 
     {
       constexpr uint8_t PID_SHIFT_BITS = 32;
-      uint64_t pid_ciid = (static_cast<uint64_t>(my_pid_) << PID_SHIFT_BITS) | callback_info_id;
+      uint64_t pid_callback_info_id =
+        (static_cast<uint64_t>(my_pid_) << PID_SHIFT_BITS) | callback_info_id;
       TRACEPOINT(
         agnocast_create_callable, static_cast<const void *>(callable.get()),
-        receive_args.ret_entry_ids[i], pid_ciid);
+        receive_args.ret_entry_ids[i], pid_callback_info_id);
     }
 
     {

--- a/src/agnocastlib/src/agnocast_tracepoint_wrapper.c
+++ b/src/agnocastlib/src/agnocast_tracepoint_wrapper.c
@@ -46,7 +46,7 @@ void TRACEPOINT(
   const char * function_symbol,
   const char * topic_name,
   const size_t queue_depth,
-  const uint64_t pid_ciid)
+  const uint64_t pid_callback_info_id)
 {
   CONDITIONAL_TP(
     agnocast_subscription_init,
@@ -57,7 +57,7 @@ void TRACEPOINT(
     function_symbol,
     topic_name,
     queue_depth,
-    pid_ciid);
+    pid_callback_info_id);
 }
 
 void TRACEPOINT(
@@ -75,13 +75,13 @@ void TRACEPOINT(
   agnocast_create_callable,
   const void * callable,
   const int64_t entry_id,
-  const uint64_t pid_ciid)
+  const uint64_t pid_callback_info_id)
 {
   CONDITIONAL_TP(
     agnocast_create_callable,
     callable,
     entry_id,
-    pid_ciid);
+    pid_callback_info_id);
 }
 
 void TRACEPOINT(


### PR DESCRIPTION
## Description

This renames `ciid` to `callback_info_id`.

## Related links

https://github.com/tier4/cspell-dicts/pull/122#pullrequestreview-3470949715

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers
