### PR TITLE
fix(agnocastlib): extract receive_message as independent function

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -8,6 +8,8 @@
 namespace agnocast
 {
 
+class AgnocastExecutable;
+
 // Base class for a type-erased object
 class AnyObject
 {
@@ -102,5 +104,11 @@ uint32_t register_callback(
 
   return callback_info_id;
 }
+
+void receive_message(
+  [[maybe_unused]] const uint32_t callback_info_id,  // for CARET
+  [[maybe_unused]] const pid_t my_pid,               // for CARET
+  const CallbackInfo & callback_info, std::mutex & ready_agnocast_executables_mutex,
+  std::vector<AgnocastExecutable> & ready_agnocast_executables);
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -34,9 +34,6 @@ protected:
   pid_t my_pid_;
   std::mutex wait_mutex_;
 
-  void receive_message(
-    [[maybe_unused]] const uint32_t callback_info_id,  // for CARET
-    const CallbackInfo & callback_info);
   void prepare_epoll();
   bool get_next_agnocast_executable(AgnocastExecutable & agnocast_executable, const int timeout_ms);
   static void execute_agnocast_executable(AgnocastExecutable & agnocast_executable);

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -1,5 +1,7 @@
 #include "agnocast/agnocast_callback_info.hpp"
 
+#include "agnocast/agnocast.hpp"
+
 namespace agnocast
 {
 
@@ -8,5 +10,60 @@ const int callback_map_bkt_cnt = 100;  // arbitrary size to prevent rehash
 std::unordered_map<uint32_t, CallbackInfo> id2_callback_info(callback_map_bkt_cnt);
 std::atomic<uint32_t> next_callback_info_id;
 std::atomic<bool> need_epoll_updates{false};
+
+void receive_message(
+  [[maybe_unused]] const uint32_t callback_info_id,  // for CARET
+  [[maybe_unused]] const pid_t my_pid,               // for CARET
+  const CallbackInfo & callback_info, std::mutex & ready_agnocast_executables_mutex,
+  std::vector<AgnocastExecutable> & ready_agnocast_executables)
+{
+  union ioctl_receive_msg_args receive_args = {};
+  receive_args.topic_name = {callback_info.topic_name.c_str(), callback_info.topic_name.size()};
+  receive_args.subscriber_id = callback_info.subscriber_id;
+
+  {
+    std::lock_guard<std::mutex> lock(mmap_mtx);
+
+    if (ioctl(agnocast_fd, AGNOCAST_RECEIVE_MSG_CMD, &receive_args) < 0) {
+      RCLCPP_ERROR(logger, "AGNOCAST_RECEIVE_MSG_CMD failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    // Map the shared memory region with read permissions whenever a new publisher is discovered.
+    for (uint32_t i = 0; i < receive_args.ret_pub_shm_info.publisher_num; i++) {
+      const pid_t pid = receive_args.ret_pub_shm_info.publisher_pids[i];
+      const uint64_t addr = receive_args.ret_pub_shm_info.shm_addrs[i];
+      const uint64_t size = receive_args.ret_pub_shm_info.shm_sizes[i];
+      map_read_only_area(pid, addr, size);
+    }
+  }
+
+  // older messages first
+  for (int32_t i = static_cast<int32_t>(receive_args.ret_entry_num) - 1; i >= 0; i--) {
+    const std::shared_ptr<std::function<void()>> callable =
+      std::make_shared<std::function<void()>>([callback_info, receive_args, i]() {
+        auto typed_msg = callback_info.message_creator(
+          reinterpret_cast<void *>(receive_args.ret_entry_addrs[i]), callback_info.topic_name,
+          callback_info.subscriber_id, receive_args.ret_entry_ids[i]);
+        callback_info.callback(std::move(*typed_msg));
+      });
+
+    {
+      constexpr uint8_t PID_SHIFT_BITS = 32;
+      uint64_t pid_callback_info_id =
+        (static_cast<uint64_t>(my_pid) << PID_SHIFT_BITS) | callback_info_id;
+      TRACEPOINT(
+        agnocast_create_callable, static_cast<const void *>(callable.get()),
+        receive_args.ret_entry_ids[i], pid_callback_info_id);
+    }
+
+    {
+      std::lock_guard<std::mutex> ready_lock{ready_agnocast_executables_mutex};
+      ready_agnocast_executables.emplace_back(
+        AgnocastExecutable{callable, callback_info.callback_group});
+    }
+  }
+}
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -22,59 +22,6 @@ AgnocastExecutor::~AgnocastExecutor()
   close(epoll_fd_);
 }
 
-void AgnocastExecutor::receive_message(
-  [[maybe_unused]] const uint32_t callback_info_id,  // for CARET
-  const CallbackInfo & callback_info)
-{
-  union ioctl_receive_msg_args receive_args = {};
-  receive_args.topic_name = {callback_info.topic_name.c_str(), callback_info.topic_name.size()};
-  receive_args.subscriber_id = callback_info.subscriber_id;
-
-  {
-    std::lock_guard<std::mutex> lock(mmap_mtx);
-
-    if (ioctl(agnocast_fd, AGNOCAST_RECEIVE_MSG_CMD, &receive_args) < 0) {
-      RCLCPP_ERROR(logger, "AGNOCAST_RECEIVE_MSG_CMD failed: %s", strerror(errno));
-      close(agnocast_fd);
-      exit(EXIT_FAILURE);
-    }
-
-    // Map the shared memory region with read permissions whenever a new publisher is discovered.
-    for (uint32_t i = 0; i < receive_args.ret_pub_shm_info.publisher_num; i++) {
-      const pid_t pid = receive_args.ret_pub_shm_info.publisher_pids[i];
-      const uint64_t addr = receive_args.ret_pub_shm_info.shm_addrs[i];
-      const uint64_t size = receive_args.ret_pub_shm_info.shm_sizes[i];
-      map_read_only_area(pid, addr, size);
-    }
-  }
-
-  // older messages first
-  for (int32_t i = static_cast<int32_t>(receive_args.ret_entry_num) - 1; i >= 0; i--) {
-    const std::shared_ptr<std::function<void()>> callable =
-      std::make_shared<std::function<void()>>([callback_info, receive_args, i]() {
-        auto typed_msg = callback_info.message_creator(
-          reinterpret_cast<void *>(receive_args.ret_entry_addrs[i]), callback_info.topic_name,
-          callback_info.subscriber_id, receive_args.ret_entry_ids[i]);
-        callback_info.callback(std::move(*typed_msg));
-      });
-
-    {
-      constexpr uint8_t PID_SHIFT_BITS = 32;
-      uint64_t pid_callback_info_id =
-        (static_cast<uint64_t>(my_pid_) << PID_SHIFT_BITS) | callback_info_id;
-      TRACEPOINT(
-        agnocast_create_callable, static_cast<const void *>(callable.get()),
-        receive_args.ret_entry_ids[i], pid_callback_info_id);
-    }
-
-    {
-      std::lock_guard<std::mutex> ready_lock{ready_agnocast_executables_mutex_};
-      ready_agnocast_executables_.emplace_back(
-        AgnocastExecutable{callable, callback_info.callback_group});
-    }
-  }
-}
-
 void AgnocastExecutor::prepare_epoll()
 {
   std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
@@ -102,7 +49,9 @@ void AgnocastExecutor::prepare_epoll()
     }
 
     if (callback_info.is_transient_local) {
-      receive_message(callback_info_id, callback_info);
+      agnocast::receive_message(
+        callback_info_id, my_pid_, callback_info, ready_agnocast_executables_mutex_,
+        ready_agnocast_executables_);
     }
 
     callback_info.need_epoll_update = false;
@@ -183,7 +132,9 @@ void AgnocastExecutor::wait_and_handle_epoll_event(const int timeout_ms)
     return;
   }
 
-  receive_message(callback_info_id, callback_info);
+  agnocast::receive_message(
+    callback_info_id, my_pid_, callback_info, ready_agnocast_executables_mutex_,
+    ready_agnocast_executables_);
 }
 
 bool AgnocastExecutor::get_next_ready_agnocast_executable(AgnocastExecutable & agnocast_executable)


### PR DESCRIPTION
## Description

To support the new agnocast::Node functionality (https://github.com/tier4/agnocast/pull/728), a dedicated Executor is required. Accordingly, the logic shared with existing Executors will be factored out into reusable functions.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
