### PR TITLE
fix(agnocastlib): extract prepare_epoll as independent function

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "agnocast/agnocast_smart_pointer.hpp"
+#include "sys/epoll.h"
 
 #include <mutex>
 #include <type_traits>
@@ -110,5 +111,53 @@ void receive_message(
   [[maybe_unused]] const pid_t my_pid,               // for CARET
   const CallbackInfo & callback_info, std::mutex & ready_agnocast_executables_mutex,
   std::vector<AgnocastExecutable> & ready_agnocast_executables);
+
+template <class ValidateFn>
+void prepare_epoll_impl(
+  const int epoll_fd, const pid_t my_pid, std::mutex & ready_agnocast_executables_mutex,
+  std::vector<AgnocastExecutable> & ready_agnocast_executables,
+  ValidateFn && validate_callback_group)
+{
+  std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+
+  for (auto & it : id2_callback_info) {
+    const uint32_t callback_info_id = it.first;
+    CallbackInfo & callback_info = it.second;
+
+    if (!callback_info.need_epoll_update) {
+      continue;
+    }
+
+    if (!validate_callback_group(callback_info.callback_group)) {
+      continue;
+    }
+
+    struct epoll_event ev = {};
+    ev.events = EPOLLIN;
+    ev.data.u32 = callback_info_id;
+
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, callback_info.mqdes, &ev) == -1) {
+      RCLCPP_ERROR(logger, "epoll_ctl failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    if (callback_info.is_transient_local) {
+      agnocast::receive_message(
+        callback_info_id, my_pid, callback_info, ready_agnocast_executables_mutex,
+        ready_agnocast_executables);
+    }
+
+    callback_info.need_epoll_update = false;
+  }
+
+  const bool all_updated = std::none_of(
+    id2_callback_info.begin(), id2_callback_info.end(),
+    [](const auto & it) { return it.second.need_epoll_update; });
+
+  if (all_updated) {
+    need_epoll_updates.store(false);
+  }
+}
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -24,46 +24,11 @@ AgnocastExecutor::~AgnocastExecutor()
 
 void AgnocastExecutor::prepare_epoll()
 {
-  std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-
-  // Check if each callback's callback_group is included in this executor
-  for (auto & it : id2_callback_info) {
-    const uint32_t callback_info_id = it.first;
-    CallbackInfo & callback_info = it.second;
-    if (!callback_info.need_epoll_update) {
-      continue;
-    }
-
-    if (!validate_callback_group(callback_info.callback_group)) {
-      continue;
-    }
-
-    struct epoll_event ev = {};
-    ev.events = EPOLLIN;
-    ev.data.u32 = callback_info_id;
-
-    if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, callback_info.mqdes, &ev) == -1) {
-      RCLCPP_ERROR(logger, "epoll_ctl failed: %s", strerror(errno));
-      close(agnocast_fd);
-      exit(EXIT_FAILURE);
-    }
-
-    if (callback_info.is_transient_local) {
-      agnocast::receive_message(
-        callback_info_id, my_pid_, callback_info, ready_agnocast_executables_mutex_,
-        ready_agnocast_executables_);
-    }
-
-    callback_info.need_epoll_update = false;
-  }
-
-  const bool all_updated = std::none_of(
-    id2_callback_info.begin(), id2_callback_info.end(),
-    [](const auto & it) { return it.second.need_epoll_update; });
-
-  if (all_updated) {
-    need_epoll_updates.store(false);
-  }
+  agnocast::prepare_epoll_impl(
+    epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,
+    [this](const rclcpp::CallbackGroup::SharedPtr & group) {
+      return validate_callback_group(group);
+    });
 }
 
 bool AgnocastExecutor::get_next_agnocast_executable(


### PR DESCRIPTION
## Description

To support the new agnocast::Node functionality (https://github.com/tier4/agnocast/pull/728), a dedicated Executor is required. Accordingly, the logic shared with existing Executors will be factored out into reusable functions.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
