### PR TITLE
feat(agnocastlib): add safe_strncpy

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef>
+
+namespace agnocast
+{
+
+void safe_strncpy(char * dest, const char * src, size_t dest_size);
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_utils.cpp
@@ -1,0 +1,19 @@
+#include "agnocast/agnocast_bridge_utils.hpp"
+
+#include <cstring>
+
+namespace agnocast
+{
+
+void safe_strncpy(char * dest, const char * src, size_t dest_size)
+{
+  if (dest_size == 0) return;
+  if (src == nullptr) {
+    dest[0] = '\0';
+    return;
+  }
+  std::strncpy(dest, src, dest_size - 1);
+  dest[dest_size - 1] = '\0';
+}
+
+}  // namespace agnocast


### PR DESCRIPTION
## Description
Introduced `safe_strncpy`, a wrapper around `std::strncpy` that guarantees null-termination.
`agnocast_bridge_utils.cpp/hpp` will implement common functions to be used in the bridge.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
