### PR TITLE
fix(agnocastlib): prevent circular include dependency

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -40,12 +40,6 @@ extern "C" struct initialize_agnocast_result initialize_agnocast(
   const unsigned char * heaphook_version_ptr, const size_t heaphook_version_str_len);
 
 template <typename MessageT>
-using Publisher = agnocast::BasicPublisher<MessageT, agnocast::DefaultBridgeRequestPolicy>;
-
-template <typename MessageT>
-using Subscription = agnocast::BasicSubscription<MessageT, agnocast::DefaultBridgeRequestPolicy>;
-
-template <typename MessageT>
 typename Publisher<MessageT>::SharedPtr create_publisher(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
 {

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -236,6 +236,11 @@ public:
   }
 };
 
+struct DefaultBridgeRequestPolicy;
+
+template <typename MessageT>
+using Publisher = agnocast::BasicPublisher<MessageT, agnocast::DefaultBridgeRequestPolicy>;
+
 // The Publisher that does not instantiate a ros2 publisher
 template <typename MessageT>
 class AgnocastOnlyPublisher

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -132,6 +132,11 @@ public:
   ~BasicSubscription() { remove_mq(mq_subscription_); }
 };
 
+struct DefaultBridgeRequestPolicy;
+
+template <typename MessageT>
+using Subscription = agnocast::BasicSubscription<MessageT, agnocast::DefaultBridgeRequestPolicy>;
+
 template <typename MessageT>
 class TakeSubscription : public SubscriptionBase
 {


### PR DESCRIPTION
## Description

An umbrella header generally includes all public header files in a library.
Therefore, if we place definitions that are intended to be used from other headers in the umbrella header, it can introduce circular dependencies: the umbrella header includes all headers, and those headers may in turn depend on definitions in the umbrella header.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
