### PR TITLE
refactor(agnocastlib): separate bridge request policies by direction

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -44,7 +44,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
   PublisherOptions options;
-  return std::make_shared<BasicPublisher<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosRequestPolicy>>(
     node, topic_name, qos, options);
 }
 
@@ -53,7 +53,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   rclcpp::Node * node, const std::string & topic_name, const size_t qos_history_depth)
 {
   PublisherOptions options;
-  return std::make_shared<BasicPublisher<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosRequestPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 
@@ -62,7 +62,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
   const PublisherOptions & options)
 {
-  return std::make_shared<BasicPublisher<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosRequestPolicy>>(
     node, topic_name, qos, options);
 }
 
@@ -71,7 +71,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   rclcpp::Node * node, const std::string & topic_name, const size_t qos_history_depth,
   const PublisherOptions & options)
 {
-  return std::make_shared<BasicPublisher<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosRequestPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 
@@ -80,7 +80,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback)
 {
   const agnocast::SubscriptionOptions options;
-  return std::make_shared<BasicSubscription<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastRequestPolicy>>(
     node, topic_name, qos, std::forward<Func>(callback), options);
 }
 
@@ -90,7 +90,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   Func && callback)
 {
   const agnocast::SubscriptionOptions options;
-  return std::make_shared<BasicSubscription<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastRequestPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
     std::forward<Func>(callback), options);
 }
@@ -100,7 +100,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
   agnocast::SubscriptionOptions options)
 {
-  return std::make_shared<BasicSubscription<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastRequestPolicy>>(
     node, topic_name, qos, std::forward<Func>(callback), options);
 }
 
@@ -109,7 +109,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   rclcpp::Node * node, const std::string & topic_name, const size_t qos_history_depth,
   Func && callback, agnocast::SubscriptionOptions options)
 {
-  return std::make_shared<BasicSubscription<MessageT, DefaultBridgeRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastRequestPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
     std::forward<Func>(callback), options);
 }

--- a/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -9,22 +10,34 @@ namespace agnocast
 {
 
 template <typename MessageT>
-void send_bridge_request(const std::string & topic_name, const rclcpp::QoS & qos)
+void send_bridge_request(const std::string & topic_name, topic_local_id_t id, BridgeDirection dir)
 {
   (void)topic_name;  // TODO: Remove
-  (void)qos;         // TODO: Remove
+  (void)id;          // TODO: Remove
+  (void)dir;         // TODO: Remove
   // TODO: Implement the actual message queue communication to request a bridge.
   // Note: This implementation depends on AgnocastPublisher and AgnocastSubscription.
 }
 
-// Default policy for user-facing Publisher/Subscription.
-// Requests a bridge to be created for the topic.
-struct DefaultBridgeRequestPolicy
+// Policy for agnocast::Subscription.
+// Requests a bridge that forwards messages from ROS 2 to Agnocast (R2A).
+struct RosToAgnocastRequestPolicy
 {
   template <typename MessageT>
-  static void request_bridge(const std::string & topic_name, const rclcpp::QoS & qos)
+  static void request_bridge(const std::string & topic_name, topic_local_id_t id)
   {
-    send_bridge_request<MessageT>(topic_name, qos);
+    send_bridge_request<MessageT>(topic_name, id, BridgeDirection::ROS2_TO_AGNOCAST);
+  }
+};
+
+// Policy for agnocast::Publisher.
+// Requests a bridge that forwards messages from Agnocast to ROS 2 (A2R).
+struct AgnocastToRosRequestPolicy
+{
+  template <typename MessageT>
+  static void request_bridge(const std::string & topic_name, topic_local_id_t id)
+  {
+    send_bridge_request<MessageT>(topic_name, id, BridgeDirection::AGNOCAST_TO_ROS2);
   }
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -72,8 +72,6 @@ public:
     const PublisherOptions & options)
   : topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name))
   {
-    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, qos);
-
     rclcpp::PublisherOptions pub_options;
     pub_options.qos_overriding_options = options.qos_overriding_options;
     ros2_publisher_ = node->create_publisher<MessageT>(topic_name_, qos, pub_options);
@@ -92,6 +90,7 @@ public:
     }
 
     id_ = initialize_publisher(topic_name_, node->get_fully_qualified_name(), actual_qos);
+    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
 
     ros2_publish_mq_name_ = create_mq_name_for_ros2_publish(topic_name_, id_);
 
@@ -236,10 +235,10 @@ public:
   }
 };
 
-struct DefaultBridgeRequestPolicy;
+struct AgnocastToRosRequestPolicy;
 
 template <typename MessageT>
-using Publisher = agnocast::BasicPublisher<MessageT, agnocast::DefaultBridgeRequestPolicy>;
+using Publisher = agnocast::BasicPublisher<MessageT, agnocast::AgnocastToRosRequestPolicy>;
 
 // The Publisher that does not instantiate a ros2 publisher
 template <typename MessageT>

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -91,12 +91,12 @@ class BasicSubscription : public SubscriptionBase
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     rclcpp::CallbackGroup::SharedPtr callback_group, agnocast::SubscriptionOptions options)
   {
-    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, qos);
-
     union ioctl_add_subscriber_args add_subscriber_args =
       initialize(qos, false, node->get_fully_qualified_name());
 
     id_ = add_subscriber_args.ret_id;
+    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
     const bool is_transient_local = qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
@@ -148,10 +148,10 @@ public:
   ~BasicSubscription() { remove_mq(mq_subscription_); }
 };
 
-struct DefaultBridgeRequestPolicy;
+struct RosToAgnocastRequestPolicy;
 
 template <typename MessageT>
-using Subscription = agnocast::BasicSubscription<MessageT, agnocast::DefaultBridgeRequestPolicy>;
+using Subscription = agnocast::BasicSubscription<MessageT, agnocast::RosToAgnocastRequestPolicy>;
 
 template <typename MessageT>
 class TakeSubscription : public SubscriptionBase


### PR DESCRIPTION
## Description
The fundamental reason for this separation is the asymmetric QoS requirements between the two data flow directions, which necessitates distinct bridge creation logic:

R2A (agnocast::Subscription): Future updates will require the bridge to inherit QoS settings (Reliability) directly from the user's subscription configuration. This is critical to ensure compatibility with external ROS 2 Publishers.

A2R (agnocast::Publisher): This direction follows a different QoS strategy (typically fixed to Reliable) and does not necessarily need to mirror the user's publisher settings.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
