### PR TITLE
feat(agnocastlib): define structure and dependencies for BridgeLoader

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_loader.hpp
@@ -22,10 +22,20 @@ public:
   BridgeLoader(const BridgeLoader &) = delete;
   BridgeLoader & operator=(const BridgeLoader &) = delete;
 
+  std::shared_ptr<void> load_and_create(
+    const MqMsgBridge & req, const std::string & unique_key, rclcpp::Node::SharedPtr node);
+
 private:
   rclcpp::Logger logger_;
 
   std::map<std::string, std::pair<BridgeFn, std::shared_ptr<void>>> cached_factories_;
+
+  std::pair<void *, uintptr_t> load_library_base(const char * lib_path, const char * symbol_name);
+  std::pair<BridgeFn, std::shared_ptr<void>> resolve_factory_function(
+    const MqMsgBridge & req, const std::string & unique_key);
+  std::shared_ptr<void> create_bridge_instance(
+    BridgeFn entry_func, std::shared_ptr<void> lib_handle, rclcpp::Node::SharedPtr node,
+    const BridgeTargetInfo & target);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_bridge_loader.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_loader.cpp
@@ -1,4 +1,13 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 #include "agnocast/agnocast_bridge_loader.hpp"
+
+#include <dlfcn.h>
+#include <link.h>
+
+#include <cstring>
+#include <stdexcept>
 
 namespace agnocast
 {
@@ -12,4 +21,52 @@ BridgeLoader::~BridgeLoader()
   cached_factories_.clear();
 }
 
+std::shared_ptr<void> BridgeLoader::load_and_create(
+  const MqMsgBridge & req, const std::string & unique_key, rclcpp::Node::SharedPtr node)
+{
+  auto [entry_func, lib_handle] = resolve_factory_function(req, unique_key);
+
+  if (!entry_func) {
+    // TODO: Output error log and return
+    return nullptr;
+  }
+
+  return create_bridge_instance(entry_func, lib_handle, node, req.target);
+}
+
+std::pair<void *, uintptr_t> BridgeLoader::load_library_base(
+  const char * lib_path, const char * symbol_name)
+{
+  // TODO: Logic for loading the library via dlopen/dlinfo and retrieving the base address.
+  return {nullptr, 0};
+}
+
+std::pair<BridgeFn, std::shared_ptr<void>> BridgeLoader::resolve_factory_function(
+  const MqMsgBridge & req, const std::string & unique_key)
+{
+  // TODO: Cache check logic
+
+  // TODO: Call load_library_base to get the raw handle and base address
+  auto [raw_handle, base_addr] =
+    load_library_base(req.factory.shared_lib_path, req.factory.symbol_name);
+
+  (void)raw_handle;
+  (void)base_addr;
+
+  // TODO: Logic to calculate the function pointer from base address and offset, and cache it.
+
+  return {nullptr, nullptr};
+}
+
+std::shared_ptr<void> BridgeLoader::create_bridge_instance(
+  BridgeFn entry_func, std::shared_ptr<void> lib_handle, rclcpp::Node::SharedPtr node,
+  const BridgeTargetInfo & target)
+{
+  // TODO: Logic to call the factory function (entry_func) and create the bridge.
+  // TODO: Logic to manage the ownership of the created bridge instance and the library handle.
+  return nullptr;
+}
+
 }  // namespace agnocast
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
## Description
This PR defines the essential structure and the call dependencies between member functions for the `agnocast::BridgeLoader` class. To guide future implementation work by clearly indicating the role of each function and how they collaborate to load and create a bridge.

After merging this structure, subsequent, separate PRs will implement the logic within the // TODO sections (e.g., shared library loading, caching mechanism, and instance creation logic).

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
