### PR TITLE
feat(agnocastlib): implement factory functions for bridge node instantiation

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
@@ -12,7 +12,8 @@ namespace agnocast
 static constexpr size_t DEFAULT_QOS_DEPTH = 10;
 
 template <typename MessageT>
-void send_bridge_request(const std::string & topic_name, topic_local_id_t id, BridgeDirection dir);
+void send_bridge_request(
+  const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
 
 // Policy for agnocast::Subscription.
 // Requests a bridge that forwards messages from ROS 2 to Agnocast (R2A).
@@ -156,7 +157,8 @@ std::shared_ptr<void> start_agno_to_ros_node(
 }
 
 template <typename MessageT>
-void send_bridge_request(const std::string & topic_name, topic_local_id_t id, BridgeDirection dir)
+void send_bridge_request(
+  const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
 {
   (void)topic_name;  // TODO(yutarokobayashi): Remove
   (void)id;          // TODO(yutarokobayashi): Remove
@@ -164,10 +166,12 @@ void send_bridge_request(const std::string & topic_name, topic_local_id_t id, Br
   // We capture 'fn_reverse' because bridge_manager is responsible for managing both directions
   // independently. Storing the reverse factory allows us to instantiate the return path on-demand
   // within the same process.
-  auto fn_current = (dir == BridgeDirection::ROS2_TO_AGNOCAST) ? &start_ros_to_agno_node<MessageT>
-                                                               : &start_agno_to_ros_node<MessageT>;
-  auto fn_reverse = (dir == BridgeDirection::ROS2_TO_AGNOCAST) ? &start_agno_to_ros_node<MessageT>
-                                                               : &start_ros_to_agno_node<MessageT>;
+  auto fn_current = (direction == BridgeDirection::ROS2_TO_AGNOCAST)
+                      ? &start_ros_to_agno_node<MessageT>
+                      : &start_agno_to_ros_node<MessageT>;
+  auto fn_reverse = (direction == BridgeDirection::ROS2_TO_AGNOCAST)
+                      ? &start_agno_to_ros_node<MessageT>
+                      : &start_ros_to_agno_node<MessageT>;
 
   (void)fn_current;  // TODO(yutarokobayashi): Remove
   (void)fn_reverse;  // TODO(yutarokobayashi): Remove


### PR DESCRIPTION
## Description
This PR implements the template functions `start_ros_to_agno_node` and `start_agno_to_ros_node` to instantiate bridge nodes dynamically based on the direction. 

Currently, a hardcoded default QoS is used. Implementation of specific QoS retrieval (subscriber/publisher configuration) is deferred to a future PR.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
