### PR TITLE
feat(agnocastlib): add send_bridge_request

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_node.hpp
@@ -257,6 +257,7 @@ void send_bridge_request(
     RCLCPP_ERROR(
       logger, "mq_open failed for name '%s': %s (errno: %d)", mq_name.c_str(), strerror(errno),
       errno);
+    return;
   }
 
   if (mq_send(mq, reinterpret_cast<const char *>(&msg), sizeof(msg), 0) < 0) {
@@ -265,6 +266,7 @@ void send_bridge_request(
       errno);
 
     mq_close(mq);
+    return;
   }
 
   mq_close(mq);


### PR DESCRIPTION
## Description
It Implement the `send_bridge_request` function, which packages the factory function's location (library path and memory offset) and sends it to the bridge manager via a POSIX message queue.

- Uses dladdr to retrieve the shared library path and calculate the offset of the factory functions.
- Sends a MqMsgBridge structure containing the target topic, ID, and factory details to the IPC queue (mq_send).
- Supports bidirectional factory registration (current and reverse direction) to allow on-demand instantiation of the return path.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
