### PR TITLE
feat(agnocastlib): add close_parent_mq

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_ipc_event_loop.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_ipc_event_loop.hpp
@@ -25,6 +25,8 @@ public:
 
   void set_parent_mq_handler(EventCallback cb);
 
+  void close_parent_mq();
+
 private:
   rclcpp::Logger logger_;
 

--- a/src/agnocastlib/src/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_manager.cpp
@@ -139,7 +139,7 @@ void BridgeManager::check_parent_alive()
   }
   if (kill(target_pid_, 0) != 0) {
     is_parent_alive_ = false;
-    // TODO(yutarokobayashi): close parent mq
+    event_loop_.close_parent_mq();
   }
 }
 


### PR DESCRIPTION
## Description
This PR implements close_parent_mq.

1. Added close_parent_mq() to close and unlink parent message queue
2. Resources are cleaned up both in destructor and when parent process dies
3. Handles ENOENT errors gracefully during mq_unlink

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
