### PR TITLE
fix(CI): split cache-building and test/validation steps by event type

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
@@ -53,7 +53,7 @@ jobs:
         fi
 
     - name: Setup ROS 2 environment
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common curl gcovr ccache
@@ -64,7 +64,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends ros-${{ env.ROS_DISTRO }}-desktop python3-colcon-common-extensions ros-${{ env.ROS_DISTRO }}-ament-cmake python3-colcon-mixin
 
     - name: Cache rosdep
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       uses: actions/cache@v4
       with:
         path: |
@@ -74,7 +74,7 @@ jobs:
           ${{ runner.os }}-rosdep-${{ env.ROS_DISTRO }}-
 
     - name: Install dependencies
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
         sudo apt-get install -y --no-install-recommends python3-rosdep
@@ -83,7 +83,7 @@ jobs:
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
     - name: Cache ccache
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       uses: actions/cache@v4
       with:
         path: ~/.ccache
@@ -94,7 +94,7 @@ jobs:
           ${{ runner.os }}-ccache-
 
     - name: Configure ccache
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         mkdir -p ~/.ccache
         ccache --version
@@ -102,7 +102,7 @@ jobs:
         ccache --zero-stats
 
     - name: Build src
-      if: github.event_name == 'push' || steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.cpp_changed == 'true' || steps.check_diff.outputs.heaphook_changed == 'true')
       env:
         CCACHE_COMPRESS: "true"
         CCACHE_COMPRESSLEVEL: "6"
@@ -145,7 +145,7 @@ jobs:
     # ===== agnocast_heaphook =====
 
     - name: Cache Rust (cargo + target + rustup)
-      if: github.event_name == 'push' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.heaphook_changed == 'true')
       uses: actions/cache@v4
       with:
         path: |
@@ -158,7 +158,7 @@ jobs:
           ${{ runner.os }}-rust-${{ env.RUST_TOOLCHAIN }}-
 
     - name: Setup Rust environment
-      if: github.event_name == 'push' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         rustup set profile minimal
         rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --no-self-update
@@ -166,7 +166,7 @@ jobs:
         rustup component add clippy rustfmt --toolchain ${{ env.RUST_TOOLCHAIN }}
 
     - name: Generate vendor directory
-      if: github.event_name == 'push' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         cd agnocast_heaphook
         mkdir -p .cargo
@@ -185,7 +185,7 @@ jobs:
         cargo clippy -- --deny warnings
 
     - name: Build agnocast_heaphook
-      if: github.event_name == 'push' || steps.check_diff.outputs.heaphook_changed == 'true'
+      if: github.event_name == 'push' || (steps.check_diff.outputs.heaphook_changed == 'true')
       run: |
         cd agnocast_heaphook
         cargo build --release


### PR DESCRIPTION
## Description

This PR optimizes the build-and-test-agnocastlib-heaphook workflow by splitting cache-building and test/validation steps based on event type (main push vs PR).

## Related links

[Issue](https://github.com/tier4/agnocast/actions/runs/20255738311) (workflow is skipped in main branch)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes 

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.