### PR TITLE
fix(sample_application): remove unnecessary test

### DIFF
--- a/src/agnocast_sample_application/launch/no_rclcpp_listener.launch.xml
+++ b/src/agnocast_sample_application/launch/no_rclcpp_listener.launch.xml
@@ -1,13 +1,5 @@
 <launch>
-    <arg name="use_remap" default="false" />
-
-    <node pkg="agnocast_sample_application" exec="no_rclcpp_listener" name="no_rclcpp_listener_node" output="screen" unless="$(var use_remap)">
+    <node pkg="agnocast_sample_application" exec="no_rclcpp_listener" name="no_rclcpp_listener_node" output="screen">
         <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-    </node>
-
-    <!-- check node_name remap -->
-    <node pkg="agnocast_sample_application" exec="no_rclcpp_listener" name="no_rclcpp_listener_node" output="screen" if="$(var use_remap)">
-        <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
-        <remap from="__node" to="no_rclcpp_listener_remapped" />
     </node>
 </launch>


### PR DESCRIPTION
## Description
Remove node name remapping test case from launch file.

The previous implementation incorrectly used `<remap from="__node" to="..."/>` in the launch file to test node name remapping. This happened to work during local testing because the implementation was temporarily using last-wins behavior. However, the merged version correctly uses first-wins behavior (matching rcl/rclcpp), where the `name` attribute in the `<node>` tag takes precedence over subsequent `<remap>` rules for `__node`, since both are passed as `-r __node:=...` arguments and the first one wins.

The previous cmd executed.
```
'/home/koichiimai/Agnocast/agnocast_latest/install/agnocast_sample_application/lib/agnocast_sample_application/no_rclcpp_listener --ros-args -r __node:=no_rclcpp_listener_node -r __node:=no_rclcpp_listener_remapped']
```


To set a node name, use the `name` attribute directly instead of `<remap from="__node" .../>`.



## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
