### PR TITLE
refactor(agnocastlib): use local logger

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_manager.hpp
@@ -50,8 +50,8 @@ private:
   void check_active_bridges();
   void check_should_exit();
 
-  static int get_agnocast_subscriber_count(const std::string & topic_name);
-  static int get_agnocast_publisher_count(const std::string & topic_name);
+  int get_agnocast_subscriber_count(const std::string & topic_name);
+  int get_agnocast_publisher_count(const std::string & topic_name);
   void remove_active_bridge(const std::string & topic_name_with_direction);
 };
 

--- a/src/agnocastlib/src/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_manager.cpp
@@ -244,7 +244,7 @@ int BridgeManager::get_agnocast_subscriber_count(const std::string & topic_name)
   union ioctl_get_subscriber_num_args args = {};
   args.topic_name = {topic_name.c_str(), topic_name.size()};
   if (ioctl(agnocast_fd, AGNOCAST_GET_SUBSCRIBER_NUM_CMD, &args) < 0) {
-    RCLCPP_ERROR(logger, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));
+    RCLCPP_ERROR(logger_, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));
     return -1;
   }
   return static_cast<int>(args.ret_subscriber_num);
@@ -255,7 +255,7 @@ int BridgeManager::get_agnocast_publisher_count(const std::string & topic_name)
   union ioctl_get_publisher_num_args args = {};
   args.topic_name = {topic_name.c_str(), topic_name.size()};
   if (ioctl(agnocast_fd, AGNOCAST_GET_PUBLISHER_NUM_CMD, &args) < 0) {
-    RCLCPP_ERROR(logger, "AGNOCAST_GET_PUBLISHER_NUM_CMD failed: %s", strerror(errno));
+    RCLCPP_ERROR(logger_, "AGNOCAST_GET_PUBLISHER_NUM_CMD failed: %s", strerror(errno));
     return -1;
   }
   return static_cast<int>(args.ret_publisher_num);
@@ -286,7 +286,7 @@ void BridgeManager::remove_active_bridge(const std::string & topic_name_with_dir
 
     if (ioctl(agnocast_fd, AGNOCAST_REMOVE_BRIDGE_CMD, &remove_bridge_args) != 0) {
       RCLCPP_ERROR(
-        logger, "AGNOCAST_REMOVE_BRIDGE_CMD failed for topic '%s': %s",
+        logger_, "AGNOCAST_REMOVE_BRIDGE_CMD failed for topic '%s': %s",
         std::string(topic_name_view).c_str(), strerror(errno));
     }
   }


### PR DESCRIPTION
## Description
Fixed because a global logger was being used instead of a local one.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
