### PR TITLE
feat(agnocastlib): add resolve_parameter_overrides implementation

### DIFF
--- a/src/agnocastlib/src/agnocast_arguments.cpp
+++ b/src/agnocastlib/src/agnocast_arguments.cpp
@@ -239,7 +239,7 @@ std::map<std::string, ParameterValue> resolve_parameter_overrides(
     &global_args.parameter_overrides, &local_args.parameter_overrides};
 
   for (const ParameterOverrides * source : arguments_sources) {
-    if (!source || !source->get()) {
+    if (source == nullptr || source->get() == nullptr) {
       continue;
     }
 


### PR DESCRIPTION
## Description
Add implementation of resolve_parameter_overrides by using rclcpp functions.

## Related links
resolve_parameter_overrides
https://github.com/ros2/rclcpp/blob/c42bb23a524059208304ada51055c0c88b838b46/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.cpp#L27

## How was this PR tested?
The functionality of this PR is already tested in the following PR.
https://github.com/tier4/agnocast/pull/853

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
