### PR TITLE
refactor(agnocastlib): restore nodename/namespace remapping

### DIFF
--- a/src/agnocastlib/src/node_interfaces/node_base.cpp
+++ b/src/agnocastlib/src/node_interfaces/node_base.cpp
@@ -46,7 +46,7 @@ NodeBase::NodeBase(
     rcl_ret_t ret = rcl_remap_node_name(
       local_args_, global_args_, node_name_.c_str(), allocator, &remapped_node_name);
 
-    if (RCL_RET_OK != ret) {
+    if (ret != RCL_RET_OK) {
       std::string error_msg =
         std::string("Failed to remap node name: ") + rcl_get_error_string().str;
       rcl_reset_error();
@@ -64,7 +64,7 @@ NodeBase::NodeBase(
     rcl_ret_t ret = rcl_remap_node_namespace(
       local_args_, global_args_, node_name_.c_str(), allocator, &remapped_namespace);
 
-    if (RCL_RET_OK != ret) {
+    if (ret != RCL_RET_OK) {
       std::string error_msg =
         std::string("Failed to remap namespace: ") + rcl_get_error_string().str;
       rcl_reset_error();


### PR DESCRIPTION
## Description
Restore node name and namespace remapping.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
