### PR TITLE
refactor(agnocastlib): remove comment

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_bridge_loader.hpp
@@ -22,7 +22,6 @@ public:
   BridgeLoader(const BridgeLoader &) = delete;
   BridgeLoader & operator=(const BridgeLoader &) = delete;
 
-  // NOLINT(readability-convert-member-functions-to-static)
   std::shared_ptr<void> create(
     const MqMsgBridge & req, const std::string & topic_name_with_direction,
     const rclcpp::Node::SharedPtr & node);

--- a/src/agnocastlib/src/agnocast_bridge_loader.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_loader.cpp
@@ -6,7 +6,7 @@
 #include <elf.h>
 #include <link.h>
 
-#include <cstdint>  // uintptr_t
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <utility>

--- a/src/agnocastlib/src/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/agnocast_bridge_manager.cpp
@@ -297,9 +297,6 @@ void BridgeManager::check_managed_bridges()
   }
 }
 
-// TODO(yutarokobayashi): Reconsider the exit logic.
-// This implementation should be revisited and finalized after fully understanding the overall
-// shutdown sequence.
 void BridgeManager::check_should_exit()
 {
   if (!is_parent_alive_ && active_bridges_.empty()) {


### PR DESCRIPTION
## Description
Remove the suppression comments on clang-tidy and the comments on the other TODOs that were left behind.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
