### PR TITLE
refactor(kmod): removed excessive dmesg 

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1633,22 +1633,27 @@ int add_bridge(
       ioctl_ret->ret_pid = existing->pid;
       ioctl_ret->ret_has_r2a = existing->has_r2a;
       ioctl_ret->ret_has_a2r = existing->has_a2r;
-      dev_info(
-        agnocast_device, "Bridge (topic=%s) already exists with different pid.\n", topic_name);
       return -EEXIST;
     }
 
     // pid matches
     if (is_r2a) {
-      existing->has_r2a = true;
+      if (!existing->has_r2a) {
+        existing->has_r2a = true;
+        dev_info(
+          agnocast_device, "Bridge (topic=%s) r2a direction added for pid=%d.\n", topic_name, pid);
+      }
     } else {
-      existing->has_a2r = true;
+      if (!existing->has_a2r) {
+        existing->has_a2r = true;
+        dev_info(
+          agnocast_device, "Bridge (topic=%s) a2r direction added for pid=%d.\n", topic_name, pid);
+      }
     }
 
     ioctl_ret->ret_pid = existing->pid;
     ioctl_ret->ret_has_r2a = existing->has_r2a;
     ioctl_ret->ret_has_a2r = existing->has_a2r;
-    dev_info(agnocast_device, "Bridge (topic=%s) updated flags for pid %d.\n", topic_name, pid);
     return 0;
   }
 
@@ -1688,6 +1693,10 @@ int add_bridge(
   uint32_t hash_val = full_name_hash(NULL, topic_name, strlen(topic_name));
 
   hash_add(bridge_htable, &br_info->node, hash_val);
+
+  dev_info(
+    agnocast_device, "Bridge (topic=%s) added. pid=%d, r2a=%d, a2r=%d.\n", topic_name, pid,
+    br_info->has_r2a, br_info->has_a2r);
 
   return 0;
 }


### PR DESCRIPTION
## Description
Removed dmesg from the update determination when it is working properly.

Change to put out only the following four timings.
- Create new bridge 
- Add new bridge direction 
- Delete bridge direction 
- Delete bridge

```
[30957.586927] agnocast_class agnocast: Bridge (topic=/my_topic) added. pid=21922, r2a=1, a2r=0.
[30965.891392] agnocast_class agnocast: Bridge (topic=/my_topic) a2r direction added for pid=21922.
[30966.892822] agnocast_class agnocast: Bridge (topic=/my_topic) direction removed. Remaining: r2a=1, a2r=0.
[30968.895107] agnocast_class agnocast: Bridge (topic=/my_topic) removed completely.
[30968.910831] agnocast_class agnocast: Process (pid=21922) has exited. (process_exit_cleanup)
```


## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
