### PR TITLE
fix(ci): add --return-code-on-test-failure to colcon test commands

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
@@ -131,7 +131,7 @@ jobs:
       id: test
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-        colcon test --event-handlers console_direct+ --ctest-args -R "test_unit_agnocastlib|test_integration_agnocastlib"
+        colcon test --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_unit_agnocastlib|test_integration_agnocastlib"
 
     - name: Display coverage report in PR comment
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.cpp_changed == 'true'
@@ -202,4 +202,4 @@ jobs:
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.heaphook_changed == 'true'
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-        colcon test --event-handlers console_direct+ --ctest-args -R "test_integration_agnocast_heaphook"
+        colcon test --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_integration_agnocast_heaphook"


### PR DESCRIPTION
## Description

Added `--return-code-on-test-failure` flag to colcon test commands in the GitHub Actions workflow to ensure test failures properly cause the CI to fail.

Currently, colcon test returns exit code 0 even when tests fail, which allows the workflow to continue successfully despite test failures (ref: https://github.com/tier4/agnocast/actions/runs/19725532654/job/56516201732).

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: \`fix(foo)[needs major version update]: bar\` or \`feat(baz)[needs minor version update]: qux\`
- After receiving approval from reviewers, add the \`run-build-test\` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.