### PR TITLE
feat(agnocastlib): add get_parameters overload

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -236,7 +236,7 @@ The following tables compare methods that are **directly defined** in each class
 | `has_parameter()` | ✓ | ✓ | |
 | `get_parameter()` | ✓ | ✓ | |
 | `get_parameter_or()` | ✓ | ✗ | |
-| `get_parameters()` | ✓ | ✓ | agnocast does not support prefix specification |
+| `get_parameters()` | ✓ | ✓ | |
 | `set_parameter()` | ✓ | ✓ | |
 | `set_parameters()` | ✓ | ✓ | |
 | `set_parameters_atomically()` | ✓ | ✓ | |

--- a/src/agnocast_sample_application/src/no_rclcpp_subscriber.cpp
+++ b/src/agnocast_sample_application/src/no_rclcpp_subscriber.cpp
@@ -51,7 +51,7 @@ public:
     get_parameter("topic_name", topic_name_);
 
     std::map<std::string, rclcpp::Parameter> qos_parameters;
-    get_node_parameters_interface()->get_parameters_by_prefix("qos", qos_parameters);
+    get_parameters("qos", qos_parameters);
     queue_size_ = qos_parameters["queue_size"].as_int();
     transient_local_ = qos_parameters["transient_local"].as_bool();
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -124,6 +124,20 @@ public:
     return node_parameters_->get_parameters(names);
   }
 
+  template <typename ParameterT>
+  bool get_parameters(const std::string & prefix, std::map<std::string, ParameterT> & values) const
+  {
+    std::map<std::string, rclcpp::Parameter> params;
+    bool result = node_parameters_->get_parameters_by_prefix(prefix, params);
+    if (result) {
+      for (const auto & param : params) {
+        values[param.first] = static_cast<ParameterT>(param.second.get_value<ParameterT>());
+      }
+    }
+
+    return result;
+  }
+
   rcl_interfaces::msg::SetParametersResult set_parameter(const rclcpp::Parameter & parameter)
   {
     return set_parameters_atomically({parameter});


### PR DESCRIPTION
## Description
This PR adds the overload of `Node::get_parameters` that internally uses `NodeParameters::get_parameters_by_prefix`. The sample application `no_rclcpp_listener` has been updated to use `Node::get_parameters` instead of `NodeParameters::get_parameters_by_prefix`.

## Related links
`rclcpp::Node::get_parameters`
https://github.com/ros2/rclcpp/blob/41182a972055bdcfd9c19888c2f302ef8882b0ca/rclcpp/include/rclcpp/node_impl.hpp#L332

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers