### PR TITLE
refator(agnocastlib): revert pub options

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -42,7 +42,10 @@ extern "C" uint32_t agnocast_get_borrowed_publisher_num();
 
 struct PublisherOptions
 {
-  // Currently empty, reserved for future use.
+  // NOTE: This option is deprecated. Any values set here will be ignored.
+  bool do_always_ros2_publish = false;
+  // NOTE: This option is deprecated. Any values set here will be ignored.
+  rclcpp::QosOverridingOptions qos_overriding_options;
 };
 
 template <typename MessageT, typename BridgeRequestPolicy>
@@ -66,8 +69,16 @@ public:
 
   BasicPublisher(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    const PublisherOptions & /*options*/)
+    const PublisherOptions & options)
   {
+    if (options.do_always_ros2_publish) {
+      RCLCPP_ERROR(logger, "The 'do_always_ros2_publish' option is deprecated.");
+    }
+
+    if (!options.qos_overriding_options.get_policy_kinds().empty()) {
+      RCLCPP_ERROR(logger, "The 'qos_overriding_options' option is deprecated.");
+    }
+
     constructor_impl(node, topic_name, qos);
 
     TRACEPOINT(


### PR DESCRIPTION
## Description
The following PR will revert the deleted Options and avoid major updates by explicitly stating that they are deprecated.
When the option is set, the compilation passes, but the error statement at runtime indicates that the option is invalid.

[#872](https://github.com/tier4/agnocast/pull/872/files#diff-927a06133c992c266267e7020aa2398613e81deeb7b88477873d154ba0411150L44-L48)

## Related links

## How was this PR tested?

```
  yutarokobayashi@npc2500109:~/agnocast$ bash scripts/run_talker 
[INFO] [launch]: All log files can be found below /home/yutarokobayashi/.ros/log/2026-01-07-19-46-50-570033-npc2500109-22761
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [talker-1]: process started with pid [22762]
[talker-1] [ERROR 1767782810.692172547] [Agnocast]: The 'do_always_ros2_publish' option is deprecated. (BasicPublisher() at /home/yutarokobayashi/agnocast/src/agnocastlib/include/agnocast/agnocast_publisher.hpp:75)
[talker-1] [ERROR 1767782810.692235549] [Agnocast]: The 'qos_overriding_options' option is deprecated. (BasicPublisher() at /home/yutarokobayashi/agnocast/src/agnocastlib/include/agnocast/agnocast_publisher.hpp:79)
```


- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
