### PR TITLE
fix(ci): use sequential build to fix package dependency resolution

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-heaphook.yaml
@@ -108,26 +108,8 @@ jobs:
         CCACHE_COMPRESSLEVEL: "6"
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-        # Workaround: colcon's parallel build may start configuring packages before
-        # dependencies are installed. Split into stages to ensure proper resolution.
-        # Stage 1: Build cie_config_msgs and cie_thread_configurator
-        colcon build --packages-up-to cie_thread_configurator --cmake-args \
-          -DCOVERAGE=ON \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        # Source workspace to make cie_config_msgs available
-        source install/setup.bash
-        # Stage 2: Build agnocastlib and its dependencies
-        colcon build --packages-up-to agnocastlib --cmake-args \
-          -DCOVERAGE=ON \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        # Source workspace to make agnocastlib available
-        source install/setup.bash
-        # Stage 3: Build remaining packages (agnocast_e2e_test, agnocast_sample_application)
-        colcon build --cmake-args \
+        # Use sequential build with merge-install to ensure proper dependency resolution
+        colcon build --parallel-workers 1 --merge-install --cmake-args \
           -DCOVERAGE=ON \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -151,7 +133,7 @@ jobs:
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
         source install/setup.bash
-        colcon test --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_unit_agnocastlib|test_integration_agnocastlib|test_integration_test_agnocast_component_container_cie_launch"
+        colcon test --merge-install --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_unit_agnocastlib|test_integration_agnocastlib|test_integration_test_agnocast_component_container_cie_launch"
 
     - name: Display coverage report in PR comment
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.cpp_changed == 'true'
@@ -223,4 +205,4 @@ jobs:
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
         source install/setup.bash
-        colcon test --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_integration_agnocast_heaphook"
+        colcon test --merge-install --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_integration_agnocast_heaphook"


### PR DESCRIPTION
## Description

Uses sequential build (`--parallel-workers 1`) with `--merge-install` to fix package dependency resolution issues in colcon's parallel build.

### Problem

In colcon's parallel build, package configuration can start before dependent packages are fully installed. This causes `find_package()` to fail, breaking the build of packages like `cie_config_msgs` and `agnocastlib`.

Specifically:
- agnocastlib executes `find_package(cie_config_msgs)` before cie_config_msgs is placed in the install directory
- CMAKE_PREFIX_PATH fails to resolve correctly, preventing package discovery

### Solution

By using `--parallel-workers 1`, packages are built sequentially, ensuring each dependency is fully installed before dependent packages are configured. Combined with `--merge-install`, this provides a simple and reliable solution.

## How was this PR tested?

https://github.com/tier4/agnocast/actions/runs/21086779410/job/60651430297?pr=931

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.