### PR TITLE
fix(README.md): shell command typo error in For User part

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Since ROS packages under `src/` such as `agnocastlib` are not yet distributed fr
 Therefore, to perform the source build, first check out the specific version as follows:
 
 ```bash
-git clone --branch v2.1.2 https://github.com/tier4/agnocast.git
+git clone --branch 2.1.2 https://github.com/tier4/agnocast.git
 cd agnocast
 ```
 


### PR DESCRIPTION
## Description
The For Users section in README.md contains a typo in the clone command:
```shell
git clone --branch v2.1.2 https://github.com/tier4/agnocast.git
```

This fails because the repository does not have a v2.1.2 ref:
```shell
git clone --branch v2.1.2 https://github.com/tier4/agnocast.git
Cloning into 'agnocast'...
fatal: Remote branch v2.1.2 not found in upstream origin
```

The correct tag name is 2.1.2 (without the v prefix). This PR updates the command accordingly.
## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
