### PR TITLE
fix(cie_thread_configurator): ensure NonRosThreadInfo message delivery before shutdown

### DIFF
--- a/src/cie_thread_configurator/include/cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/cie_thread_configurator/include/cie_thread_configurator/cie_thread_configurator.hpp
@@ -85,7 +85,13 @@ std::thread spawn_non_ros2_thread(const char * thread_name, F && f, Args &&... a
       message->thread_id = tid;
       message->thread_name = thread_name;
       publisher->publish(*message);
-      publisher->wait_for_all_acked(std::chrono::milliseconds(500));
+      const bool all_acked = publisher->wait_for_all_acked(std::chrono::milliseconds(500));
+      if (!all_acked) {
+        RCLCPP_WARN(
+          node->get_logger(),
+          "Timed out waiting for NonRosThreadInfo acknowledgment (thread '%s').",
+          thread_name.c_str());
+      }
     } else {
       RCLCPP_WARN(
         node->get_logger(),


### PR DESCRIPTION
## Description

Fix flaky test failure `test_thread_configurator_receives_non_ros_thread_info` in GitHub Actions CI.

The `spawn_non_ros2_thread` function was publishing a `NonRosThreadInfo` message and immediately shutting down the context. Since `publish()` is asynchronous in ROS 2, the message might not be delivered before shutdown, especially in slower CI environments.

Changes:
- Change QoS from `keep_all()` to `reliable()` for the NonRosThreadInfo publisher
- Add `wait_for_all_acked(500ms)` after publishing to ensure the message is delivered before context shutdown

## Related links

N/A

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application
- [x] `colcon test --packages-select agnocastlib --ctest-args -R test_agnocast_component_container_cie_launch` - all tests pass

## Notes for reviewers

## Version Update Label (Required)
