### PR TITLE
refactor(agnocastlib)[need-minor-update]: reduce lock scope of global mutex in kmod

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -2197,6 +2197,7 @@ static long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long a
           &topic_info_pub_args, (union ioctl_topic_info_args __user *)arg,
           sizeof(topic_info_pub_args)))
       return -EFAULT;
+    if (topic_info_pub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
     char * topic_name_buf = kmalloc(topic_info_pub_args.topic_name.len + 1, GFP_KERNEL);
     if (!topic_name_buf) return -ENOMEM;
     if (copy_from_user(


### PR DESCRIPTION
## Description
Reduce global_mutex lock scope in agnocast_ioctl. Move mutex lock/unlock to wrap only the critical section of each ioctl command, excluding copy_from_user, copy_to_user, and memory allocation from the locked region.

Effect when running run_talker/run_listener.
- publish_msg got 1.5 times faster
- receive_msg got 1.7 times faster

This performance improvement will be even larger if we have more participants.

TODO
- refactor agnocast_ioctl function since it got too large
- more improvement by separating the lock into topic struct level.

## Related links

## How was this PR tested?


Before this PR.
```
[12273.425661] agnocast: receive_msg timing stats (n=1000): avg=4181 ns, median=3911 ns
[12323.418363] agnocast: publish_msg timing stats (n=1000): avg=5814 ns, median=5844 ns
[12323.418745] agnocast: receive_msg timing stats (n=1000): avg=4631 ns, median=4216 ns
```

After this PR.
```
[12049.759088] agnocast: receive_msg timing stats (n=1000): avg=2287 ns, median=2322 ns
[12099.760600] agnocast: publish_msg timing stats (n=1000): avg=3669 ns, median=3689 ns
[12099.760982] agnocast: receive_msg timing stats (n=1000): avg=2167 ns, median=2259 ns
```

PS: Below is the example of the measurement for this PR code. 

```
// Timing measurement
#define TIMING_BUFFER_SIZE 1000
static u64 publish_msg_timing_buffer[TIMING_BUFFER_SIZE];
static u64 receive_msg_timing_buffer[TIMING_BUFFER_SIZE];
static int publish_msg_timing_count = 0;
static int receive_msg_timing_count = 0;
static DEFINE_SPINLOCK(timing_lock);

static int cmp_u64(const void * a, const void * b)
{
  u64 va = *(const u64 *)a;
  u64 vb = *(const u64 *)b;
  if (va < vb) return -1;
  if (va > vb) return 1;
  return 0;
}

static void output_timing_stats(u64 * buffer, int count, const char * cmd_name)
{
  u64 sum = 0;
  u64 median;
  int i;

  for (i = 0; i < count; i++) {
    sum += buffer[i];
  }

  sort(buffer, count, sizeof(u64), cmp_u64, NULL);
  if (count % 2 == 0) {
    median = (buffer[count / 2 - 1] + buffer[count / 2]) / 2;
  } else {
    median = buffer[count / 2];
  }

  pr_info("agnocast: %s timing stats (n=%d): avg=%llu ns, median=%llu ns\n",
          cmd_name, count, sum / count, median);
}

static void record_timing(u64 * buffer, int * count, u64 elapsed_ns, const char * cmd_name)
{
  unsigned long flags;

  spin_lock_irqsave(&timing_lock, flags);
  buffer[*count] = elapsed_ns;
  (*count)++;
  if (*count >= TIMING_BUFFER_SIZE) {
    output_timing_stats(buffer, *count, cmd_name);
    *count = 0;
  }
  spin_unlock_irqrestore(&timing_lock, flags);
}

```

Example of actual measurement in the code before this PR.
```
// When locking
{
  u64 start_time_ns = ktime_get_ns();
  mutex_lock(&global_mutex);

// When unlocking
  mutex_unlock(&global_mutex);
  if (cmd == AGNOCAST_PUBLISH_MSG_CMD) {
    record_timing(publish_msg_timing_buffer, &publish_msg_timing_count, ktime_get_ns() - start_time_ns, "publish_msg");
  } else if (cmd == AGNOCAST_RECEIVE_MSG_CMD) {
    record_timing(receive_msg_timing_buffer, &receive_msg_timing_count, ktime_get_ns() - start_time_ns, "receive_msg");
  }
```



- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
