### PR TITLE
fix(cie_thread_configurator): remove unnecessary sleep after publishing callback group info

### DIFF
--- a/src/cie_thread_configurator/src/util.cpp
+++ b/src/cie_thread_configurator/src/util.cpp
@@ -105,7 +105,6 @@ void publish_callback_group_info(
   message->thread_id = tid;
   message->callback_group_id = callback_group_id;
   publisher->publish(*message);
-  rclcpp::sleep_for(std::chrono::milliseconds(500));
 }
 
 std::map<std::string, std::string> get_hardware_info()


### PR DESCRIPTION
## Description

Remove unnecessary 500ms sleep after publishing callback group info message in `publish_callback_group_info` function.

## Related links

https://star4.slack.com/archives/C07FL8616EM/p1769566560849069

## How was this PR tested?

- [x] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

This removes a hardcoded 500ms sleep that was likely added for debugging or synchronization purposes but is not necessary for the publish operation.

## Version Update Label (Required)
