### PR TITLE
refactor(agnocastlib): rename BUILD_BRIDGE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ export AGNOCAST_BRIDGE_MODE=off
 Performance mode requires pre-compiled bridge plugins. Build with:
 
 ```bash
-BUILD_GENERIC_BRIDGE=ON colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+AGNOCAST_BUILD_BRIDGE_PLUGINS=ON colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 For detailed information, see [Bridge Documentation](./docs/agnocast_ros2_bridge.md).

--- a/docs/agnocast_ros2_bridge.md
+++ b/docs/agnocast_ros2_bridge.md
@@ -142,10 +142,10 @@ def generate_launch_description():
 Performance mode requires pre-compiled bridge plugins. Build with:
 
 ```bash
-BUILD_GENERIC_BRIDGE=ON colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+AGNOCAST_BUILD_BRIDGE_PLUGINS=ON colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
-When `BUILD_GENERIC_BRIDGE=ON` is set, the build system automatically:
+When `AGNOCAST_BUILD_BRIDGE_PLUGINS=ON` is set, the build system automatically:
 
 1. Retrieves all available message types via `ros2 interface list -m`
 2. Generates R2A and A2R bridge plugins for each message type

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -59,16 +59,16 @@ target_include_directories(agnocast PUBLIC
   ${LTTNGUST_INCLUDE_DIRS}
 )
 
-# Start of generic bridge plugin
+# Start of bridge plugin build
 
-if("$ENV{BUILD_GENERIC_BRIDGE}" STREQUAL "ON")
-  set(BUILD_GENERIC_BRIDGE ON)
+if("$ENV{AGNOCAST_BUILD_BRIDGE_PLUGINS}" STREQUAL "ON")
+  set(AGNOCAST_BUILD_BRIDGE_PLUGINS ON)
 else()
-  set(BUILD_GENERIC_BRIDGE OFF)
+  set(AGNOCAST_BUILD_BRIDGE_PLUGINS OFF)
 endif()
 
-if(BUILD_GENERIC_BRIDGE)
-  message(STATUS "BUILD_GENERIC_BRIDGE is ON. Generating bridge plugins...")
+if(AGNOCAST_BUILD_BRIDGE_PLUGINS)
+  message(STATUS "AGNOCAST_BUILD_BRIDGE_PLUGINS is ON. Generating bridge plugins...")
   set(MESSAGE_TYPES_FILE "${CMAKE_CURRENT_BINARY_DIR}/ros2_interfaces.txt")
   execute_process(
     COMMAND ros2 interface list -m


### PR DESCRIPTION
## Description
Rename `BUILD_GENERIC_BRIDGE` to `AGNOCAST_BUILD_BRIDGE_PLUGINS`.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
