### PR TITLE
test(agnocastlib): add integration test for message_filters Subscriber with agnocast::Node

### DIFF
--- a/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
+++ b/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <type_traits>
 
 namespace agnocast
 {
@@ -273,19 +272,9 @@ public:
       topic_ = topic;
       qos_ = qos;
       options_ = options;
-      if constexpr (std::is_same_v<NodeType, rclcpp::Node>) {
-        sub_ = agnocast::create_subscription<M>(
-          node, topic, detail::to_rclcpp_qos(qos),
-          [this](ipc_shared_ptr<M> msg) { this->cb(std::move(msg)); }, options);
-      } else if constexpr (std::is_same_v<NodeType, agnocast::Node>) {
-        sub_ = node->template create_subscription<M>(
-          topic, detail::to_rclcpp_qos(qos),
-          [this](ipc_shared_ptr<M> msg) { this->cb(std::move(msg)); }, options);
-      } else {
-        static_assert(
-          !std::is_same_v<NodeType, NodeType>,
-          "Unsupported NodeType: expected rclcpp::Node or agnocast::Node.");
-      }
+      sub_ = agnocast::create_subscription<M>(
+        node, topic, detail::to_rclcpp_qos(qos),
+        [this](ipc_shared_ptr<M> msg) { this->cb(std::move(msg)); }, options);
       node_raw_ = node;
     }
   }

--- a/src/agnocastlib/test/integration/message_filters/test_subscriber.cpp
+++ b/src/agnocastlib/test/integration/message_filters/test_subscriber.cpp
@@ -268,6 +268,8 @@ protected:
     }
     executor_.reset();
     node_.reset();
+    // TODO(Koichi98): Call agnocast::shutdown() once available.
+    // See https://github.com/tier4/agnocast/issues/1019
   }
 
   void waitFor(


### PR DESCRIPTION
## Description

Add integration test for `message_filters::Subscriber<Msg, agnocast::Node>` with `AgnocastOnlySingleThreadedExecutor`.

`agnocast::Node` support in `message_filters::Subscriber` works out of the box thanks to the templated `agnocast::create_subscription` from #1016, so no production code changes are needed.

## Related links

- #1016

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1_with_ros2sub` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application
- [x] unit tests

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.