### PR TITLE
fix(agnocastlib): context semantics to align with rclcpp

### DIFF
--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -53,22 +53,10 @@ public:
     const std::string & node_name, const std::string & namespace_,
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
-  std::string get_name() const
-  {
-    return node_base_->get_name();
-  }
-  rclcpp::Logger get_logger() const
-  {
-    return logger_;
-  }
-  std::string get_namespace() const
-  {
-    return node_base_->get_namespace();
-  }
-  std::string get_fully_qualified_name() const
-  {
-    return node_base_->get_fully_qualified_name();
-  }
+  std::string get_name() const { return node_base_->get_name(); }
+  rclcpp::Logger get_logger() const { return logger_; }
+  std::string get_namespace() const { return node_base_->get_namespace(); }
+  std::string get_fully_qualified_name() const { return node_base_->get_fully_qualified_name(); }
 
   rclcpp::CallbackGroup::SharedPtr create_callback_group(
     rclcpp::CallbackGroupType group_type, bool automatically_add_to_executor_with_node = true)
@@ -286,20 +274,11 @@ public:
     node_parameters_->remove_on_set_parameters_callback(handler);
   }
 
-  rclcpp::Clock::SharedPtr get_clock()
-  {
-    return node_clock_->get_clock();
-  }
+  rclcpp::Clock::SharedPtr get_clock() { return node_clock_->get_clock(); }
 
-  rclcpp::Clock::ConstSharedPtr get_clock() const
-  {
-    return node_clock_->get_clock();
-  }
+  rclcpp::Clock::ConstSharedPtr get_clock() const { return node_clock_->get_clock(); }
 
-  rclcpp::Time now() const
-  {
-    return node_clock_->get_clock()->now();
-  }
+  rclcpp::Time now() const { return node_clock_->get_clock()->now(); }
 
   template <typename MessageT>
   typename agnocast::Publisher<MessageT>::SharedPtr create_publisher(

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_base.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_base.hpp
@@ -64,14 +64,8 @@ public:
   std::string resolve_topic_or_service_name(
     const std::string & name, bool is_service, bool only_expand = false) const override;
 
-  const rcl_arguments_t * get_local_args() const
-  {
-    return local_args_;
-  }
-  const rcl_arguments_t * get_global_args() const
-  {
-    return global_args_;
-  }
+  const rcl_arguments_t * get_local_args() const { return local_args_; }
+  const rcl_arguments_t * get_global_args() const { return global_args_; }
 
 private:
   std::string node_name_;


### PR DESCRIPTION
## Description
Fix context semantics for standalone `agnocast::Node`.

For standalone agnocast nodes (without `rclcpp::init()`), the `context` is not `nullptr` but has `is_valid() == false`. Updated code and comments to check `context->is_valid()` instead of checking for `nullptr`, aligning with ROS2 semantics.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
