### PR TITLE
ci(workflow): collapse coverage report comment by default

### DIFF
--- a/src/agnocastlib/src/agnocast_smart_pointer.cpp
+++ b/src/agnocastlib/src/agnocast_smart_pointer.cpp
@@ -17,5 +17,4 @@ void release_subscriber_reference(
   }
 }
 
-// dummy for CI trigger
 }  // namespace agnocast


### PR DESCRIPTION
## Description

Wrap the coverage report PR comment in a `<details>/<summary>` tag so it is collapsed by default on GitHub, reducing visual noise in PR conversations.

## Related links

## How was this PR tested?

https://github.com/tier4/agnocast/pull/1027#issuecomment-3871600122

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.