### PR TITLE
fix(sample_app): add missing agnocast_components dependency to package.xml

### DIFF
--- a/src/agnocast_sample_application/package.xml
+++ b/src/agnocast_sample_application/package.xml
@@ -28,6 +28,7 @@
   <depend>rclcpp_components</depend>
 
   <depend>agnocastlib</depend>
+  <depend>agnocast_components</depend>
   <depend>agnocast_sample_interfaces</depend>
 
   <export>


### PR DESCRIPTION
## Description

The `CMakeLists.txt` of `agnocast_sample_application` uses `find_package(agnocast_components REQUIRED)`, but `package.xml` was missing the `agnocast_components` dependency declaration. This meant `colcon build` could not guarantee the correct build order, causing a CMake error when `agnocast_sample_application` was built before `agnocast_components`.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

Only adds `<depend>agnocast_components</depend>` to `package.xml`.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.