### PR TITLE
fix(agnocastlib): wait for NonRosThreadInfo in CIE container integration test

### DIFF
--- a/src/agnocastlib/test/integration/test_agnocast_component_container_cie_launch.py
+++ b/src/agnocastlib/test/integration/test_agnocast_component_container_cie_launch.py
@@ -88,6 +88,14 @@ class TestComponentContainerCIE(unittest.TestCase):
             )
 
     def test_thread_configurator_receives_non_ros_thread_info(self, proc_output, thread_configurator):
+        # spawn_non_ros2_thread creates a fresh rclcpp context with its own DDS participant,
+        # so DDS discovery can be slow on loaded CI machines. Wait for the message to appear.
+        proc_output.assertWaitFor(
+            'Received NonRosThreadInfo:',
+            timeout=10.0,
+            process=thread_configurator
+        )
+
         with launch_testing.asserts.assertSequentialStdout(proc_output, process=thread_configurator) as cm:
             output_text = "".join(cm._output)
             non_ros_thread_info_count = output_text.count('Received NonRosThreadInfo:')


### PR DESCRIPTION
## Description

Fix flaky `test_thread_configurator_receives_non_ros_thread_info` test in the CIE container integration test.

`spawn_non_ros2_thread` creates a fresh rclcpp context with its own DDS participant. DDS discovery for this new participant to find the PrerunNode's subscription can be slow on loaded CI machines (>3 seconds). The test was reading the output snapshot immediately without waiting, so if the `NonRosThreadInfo` message hadn't arrived yet, it failed with `0 != 1`.

Added `proc_output.assertWaitFor('Received NonRosThreadInfo:', timeout=10.0)` before checking the output count, consistent with how other tests in the same file wait for expected output.

## Related links

https://github.com/tier4/agnocast/actions/runs/21904379857/job/63240662647?pr=1038

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.