### PR TITLE
docs: add agnocast_components_register_node macro usage to CIE doc

### DIFF
--- a/docs/callback_isolated_executor_for_agnocast.md
+++ b/docs/callback_isolated_executor_for_agnocast.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-#### Using `agnocast_components_register_node` Macro
+#### `agnocast_components_register_node` Macro
 
 Instead of manually configuring component containers and launch files, you can use the `agnocast_components_register_node()` CMake macro (provided by the [`agnocast_components`](../src/agnocast_components) package) as a drop-in replacement for `rclcpp_components_register_node()`. This macro generates a standalone executable that uses the specified Agnocast executor.
 


### PR DESCRIPTION
## Description

Add documentation for the `agnocast_components_register_node()` CMake macro to the CIE doc, showing how it can be used as a drop-in replacement for `rclcpp_components_register_node()`.

## Related links

- https://github.com/tier4/agnocast/pull/1025

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

Documentation-only change.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.