### PR TITLE
fix(agnocastlib): use transient_local QoS for CIE callback group info

### DIFF
--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -7,11 +7,9 @@
 #include "cie_config_msgs/msg/callback_group_info.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <thread>
 
 namespace agnocast
 {
@@ -90,7 +88,7 @@ create_rclcpp_client_publisher()
     "client_node" + std::to_string(idx++), "/cie_thread_configurator");
   auto publisher = node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
     "/cie_thread_configurator/callback_group_info",
-    rclcpp::QoS(CIE_QOS_DEPTH).keep_all().reliable());
+    rclcpp::QoS(CIE_QOS_DEPTH).keep_all().reliable().transient_local());
   return publisher;
 }
 
@@ -104,7 +102,8 @@ create_agnocast_client_publisher()
   auto publisher = node->create_publisher<cie_config_msgs::msg::CallbackGroupInfo>(
     // Note: agnocast Publisher does not support keep_all(), so KeepLast is used here
     // (unlike the rclcpp variant which uses keep_all()).
-    "/cie_thread_configurator/callback_group_info", rclcpp::QoS(rclcpp::KeepLast(CIE_QOS_DEPTH)));
+    "/cie_thread_configurator/callback_group_info",
+    rclcpp::QoS(rclcpp::KeepLast(CIE_QOS_DEPTH)).transient_local());
   return publisher;
 }
 
@@ -112,23 +111,6 @@ void publish_callback_group_info(
   const rclcpp::Publisher<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr & publisher,
   int64_t tid, const std::string & callback_group_id)
 {
-  // Wait for subscriber to connect before publishing (timeout: 5 seconds)
-  constexpr int subscriber_wait_interval_ms = 10;
-  constexpr int max_subscriber_wait_iterations = 500;  // 500 * 10ms = 5 seconds
-  int wait_count = 0;
-  while (publisher->get_subscription_count() == 0 && wait_count < max_subscriber_wait_iterations) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(subscriber_wait_interval_ms));
-    ++wait_count;
-  }
-
-  if (publisher->get_subscription_count() == 0) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("cie_thread_configurator"),
-      "No subscriber for CallbackGroupInfo. "
-      "Please run thread_configurator_node if you want to configure thread scheduling.");
-    return;
-  }
-
   auto message = std::make_shared<cie_config_msgs::msg::CallbackGroupInfo>();
   message->thread_id = tid;
   message->callback_group_id = callback_group_id;
@@ -139,24 +121,6 @@ void publish_callback_group_info(
   const agnocast::Publisher<cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr & publisher,
   int64_t tid, const std::string & callback_group_id)
 {
-  // Wait for bridge to be established before publishing (timeout: 5 seconds)
-  // The agnocast-to-ROS2 bridge setup is asynchronous and may take time.
-  constexpr int subscriber_wait_interval_ms = 10;
-  constexpr int max_subscriber_wait_iterations = 500;  // 500 * 10ms = 5 seconds
-  int wait_count = 0;
-  while (publisher->get_subscription_count() == 0 && wait_count < max_subscriber_wait_iterations) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(subscriber_wait_interval_ms));
-    ++wait_count;
-  }
-
-  if (publisher->get_subscription_count() == 0) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("cie_thread_configurator"),
-      "No subscriber for CallbackGroupInfo. "
-      "Please run thread_configurator_node if you want to configure thread scheduling.");
-    return;
-  }
-
   auto message = publisher->borrow_loaned_message();
   message->thread_id = tid;
   message->callback_group_id = callback_group_id;

--- a/src/cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/cie_thread_configurator/src/thread_configurator_node.cpp
@@ -103,8 +103,9 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node & yaml)
     id_to_non_ros_thread_config_[config.thread_str] = &config;
   }
 
-  auto qos =
-    rclcpp::QoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000)).reliable();
+  auto qos = rclcpp::QoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 5000))
+               .reliable()
+               .transient_local();
 
   // Create subscription for non-ROS thread info
   non_ros_thread_sub_ = this->create_subscription<cie_config_msgs::msg::NonRosThreadInfo>(


### PR DESCRIPTION
## Description

Replace the blocking subscriber wait loop (up to 5s timeout) in `publish_callback_group_info` with `transient_local` durability QoS. This eliminates startup delays when `thread_configurator_node` is not running, while ensuring messages are still delivered to late-joining subscribers via DDS.

Changes:
- Add `transient_local()` to both rclcpp and agnocast CIE client publishers
- Add `transient_local()` to `thread_configurator_node` subscriber QoS
- Remove the 5-second polling wait loops from both `publish_callback_group_info` overloads
- Remove unused `<chrono>` and `<thread>` includes

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

The A2R bridge's internal ROS2 publisher already uses `transient_local`, so the full message delivery chain (agnocast publisher → bridge → thread_configurator_node) is compatible without additional bridge changes.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.