### PR TITLE
fix(agnocastlib): unlink bridge manager mq on cleanup to prevent RLIMIT_MSGQUEUE exhaustion

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -266,7 +266,9 @@ inline void IpcEventLoopBase::cleanup_resources()
   }
 
   if (!mq_name_.empty()) {
-    mq_unlink(mq_name_.c_str());
+    if (mq_unlink(mq_name_.c_str()) == -1 && errno != ENOENT) {
+      RCLCPP_WARN(logger_, "Failed to unlink mq_name='%s': %s", mq_name_.c_str(), strerror(errno));
+    }
   }
   mq_name_.clear();
 }


### PR DESCRIPTION
## Description

Bridge manager daemon processes create a POSIX message queue (`/agnocast_bridge_manager@<pid>`) via `IpcEventLoopBase`, but `cleanup_resources()` only calls `mq_close` without `mq_unlink`. Although the bridge manager daemon is registered with the kernel module (via `acquire_agnocast_resources_for_bridge()`) and `poll_for_unlink` is designed to clean up mqs for exited processes, there is a race condition where `poll_for_unlink` exits before processing the bridge manager daemon's exit:

1. Container process exits
2. `poll_for_unlink` daemon processes the container's exit (`mq_unlink` for the container PID is a no-op since the container doesn't own a bridge manager mq)
3. Bridge manager daemon detects parent death and begins shutdown (event loop timeout up to 1s + `rclcpp::shutdown()` + thread join)
4. Meanwhile, `poll_for_unlink` polls again — no exited processes yet (bridge manager is still shutting down), and `get_process_num > 0` so `ret_daemon_should_exit = false`
5. Before the next poll cycle, a new test iteration starts and new containers register with the kernel module
6. Bridge manager daemon finally exits — the kernel module marks it as exited
7. `poll_for_unlink` processes the bridge manager's exit and calls `mq_unlink` for it
8. However, since new containers are now registered, `ret_daemon_should_exit = false`, and the unlink daemon continues serving — **this path works correctly**

The problematic path occurs when the bridge manager daemon takes longer to shut down and the unlink daemon happens to see `get_process_num == 0` (all old processes exited, new ones not yet registered) between test iterations. In this window, `ret_daemon_should_exit` becomes `true` and the unlink daemon exits — leaving the bridge manager's mq orphaned if the bridge manager exits after the unlink daemon.

Over repeated e2e test iterations, these orphaned mqs accumulate and exhaust the per-user `RLIMIT_MSGQUEUE` limit (default 800KB), causing `mq_open` to fail with `errno 24 (EMFILE)`.

This fix adds `mq_unlink` in `IpcEventLoopBase::cleanup_resources()` so the bridge manager daemon unlinks its own mq on normal shutdown. This is safe because `mq_unlink` is idempotent — if the `poll_for_unlink` daemon already unlinked it, the call simply returns `ENOENT`. The `poll_for_unlink` daemon continues to serve as a backup for abnormal exits (e.g., SIGKILL).

### Reproduction

This issue can be reproduced on the `fix/integration-test-heaphook-preload` branch by running:

```bash
bash scripts/e2e_test_2to2
```

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.