### PR TITLE
fix(kmod)[need-minor-update]: increase `MEMPOOL_NUM`

### DIFF
--- a/agnocast_kmod/agnocast_memory_allocator.h
+++ b/agnocast_kmod/agnocast_memory_allocator.h
@@ -5,7 +5,7 @@
 // Maximum number of processes that can be mapped to a memory pool
 #define MAX_PROCESS_NUM_PER_MEMPOOL 32
 
-#define MEMPOOL_NUM 1000
+#define MEMPOOL_NUM 1024
 
 // Default is 8GB, can be overridden by insmod parameter mempool_size_gb
 extern int mempool_size_gb;


### PR DESCRIPTION
## Description
To increase `MAX_PUBLISHER_NUM` to 1024, this PR `MEMPOOL_NUM` beforehand.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/e2e_test_1to1` (required)
- [ ] `bash scripts/e2e_test_2to2` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
