### PR TITLE
fix(agnocastlib): prevent bridge counting

### DIFF
--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -78,7 +78,14 @@ SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_na
     RCLCPP_ERROR(logger, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));
     return {-1, false};
   }
-  return {static_cast<int>(args.ret_other_process_subscriber_num), args.ret_a2r_bridge_exist};
+
+  int total_subs =
+    static_cast<int>(args.ret_other_process_subscriber_num + args.ret_same_process_subscriber_num);
+  if (args.ret_a2r_bridge_exist && total_subs > 0) {
+    total_subs--;
+  }
+
+  return {total_subs, args.ret_a2r_bridge_exist};
 }
 
 PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name)
@@ -89,7 +96,13 @@ PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name
     RCLCPP_ERROR(logger, "AGNOCAST_GET_PUBLISHER_NUM_CMD failed: %s", strerror(errno));
     return {-1, false};
   }
-  return {static_cast<int>(args.ret_publisher_num), args.ret_bridge_exist};
+
+  int total_pubs = static_cast<int>(args.ret_publisher_num);
+  if (args.ret_bridge_exist && total_pubs > 0) {
+    total_pubs--;
+  }
+
+  return {total_pubs, args.ret_bridge_exist};
 }
 
 bool has_external_ros2_publisher(const rclcpp::Node * node, const std::string & topic_name)


### PR DESCRIPTION
## Description
This PR improves the publisher/subscriber counting by ensuring the counting wrapper functions return only the count of external applications, excluding the bridge's own instances.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/e2e_test_1to1` (required)
- [x] `bash scripts/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
