### PR TITLE
fix(agnocast_heaphook): fix data corruption in reallocate when aligned offset changes

### DIFF
--- a/agnocast_heaphook/src/lib.rs
+++ b/agnocast_heaphook/src/lib.rs
@@ -1105,5 +1105,4 @@ mod tests {
             "memalign should return NULL if the alignment is not a power of two"
         );
     }
-
 }

--- a/agnocast_heaphook/src/tlsf.rs
+++ b/agnocast_heaphook/src/tlsf.rs
@@ -64,8 +64,7 @@ unsafe impl SharedMemoryAllocator for TLSFAllocator {
         let size = new_layout.size();
         // get the original pointer and compute the old aligned offset
         // SAFETY: `ptr` must have been allocated by `allocate`.
-        let old_original_ptr: NonNull<u8> =
-            unsafe { *ptr.as_ptr().byte_sub(POINTER_SIZE).cast() };
+        let old_original_ptr: NonNull<u8> = unsafe { *ptr.as_ptr().byte_sub(POINTER_SIZE).cast() };
         let old_offset = ptr.as_ptr() as usize - old_original_ptr.as_ptr() as usize;
 
         // The new block must be large enough for both the final layout (metadata + user data +
@@ -146,9 +145,8 @@ mod tests {
         assert!(pool_ptr != libc::MAP_FAILED);
 
         // SAFETY: mmap'd memory lives until munmap; we intentionally leak it for 'static.
-        let pool: &'static mut [MaybeUninit<u8>] = unsafe {
-            std::slice::from_raw_parts_mut(pool_ptr as *mut MaybeUninit<u8>, pool_size)
-        };
+        let pool: &'static mut [MaybeUninit<u8>] =
+            unsafe { std::slice::from_raw_parts_mut(pool_ptr as *mut MaybeUninit<u8>, pool_size) };
         let mut tlsf: TlsfType = Tlsf::new();
         tlsf.insert_free_block(pool);
         TLSFAllocator {
@@ -157,8 +155,7 @@ mod tests {
     }
 
     fn get_offset(ptr: NonNull<u8>) -> usize {
-        let original_ptr: NonNull<u8> =
-            unsafe { *ptr.as_ptr().byte_sub(POINTER_SIZE).cast() };
+        let original_ptr: NonNull<u8> = unsafe { *ptr.as_ptr().byte_sub(POINTER_SIZE).cast() };
         ptr.as_ptr() as usize - original_ptr.as_ptr() as usize
     }
 


### PR DESCRIPTION
## Description

When rlsf's reallocate() relocated a block, it copied raw bytes from the old block to the new block. However, user data starts at an aligned offset within the block, and if the new block has a different base address alignment, the offset differs, causing the user to see shifted/corrupted data.

Fix by computing the old and new aligned offsets and performing a memmove within the new block when they differ. This preserves rlsf's in-place block expansion optimization and avoids per-allocation metadata overhead.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1` (required)
- [ ] `bash scripts/test/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

A new test failed if this PR fix is reverted.

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
