### PR TITLE
fix(agnocastlib): prevent unsigned integer underflow in thread count computation

### DIFF
--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -4,6 +4,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/version.h"
 
+#include <algorithm>
+
 namespace agnocast
 {
 
@@ -13,10 +15,11 @@ MultiThreadedAgnocastExecutor::MultiThreadedAgnocastExecutor(
   std::chrono::nanoseconds ros2_next_exec_timeout, int agnocast_next_exec_timeout_ms)
 : agnocast::AgnocastExecutor(options),
   number_of_ros2_threads_(
-    number_of_ros2_threads != 0 ? number_of_ros2_threads : std::thread::hardware_concurrency() / 2),
+    number_of_ros2_threads != 0 ? number_of_ros2_threads
+                                : std::max<size_t>(1, std::thread::hardware_concurrency() / 2)),
   number_of_agnocast_threads_(
     number_of_agnocast_threads != 0 ? number_of_agnocast_threads
-                                    : std::thread::hardware_concurrency() / 2),
+                                    : std::max<size_t>(1, std::thread::hardware_concurrency() / 2)),
   yield_before_execute_(yield_before_execute),
   ros2_next_exec_timeout_(ros2_next_exec_timeout),
   agnocast_next_exec_timeout_ms_(agnocast_next_exec_timeout_ms)

--- a/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
@@ -2,13 +2,16 @@
 
 #include "agnocast/agnocast.hpp"
 
+#include <algorithm>
+
 namespace agnocast
 {
 
 AgnocastOnlyMultiThreadedExecutor::AgnocastOnlyMultiThreadedExecutor(
   size_t number_of_threads, bool yield_before_execute, int next_exec_timeout_ms)
 : number_of_threads_(
-    number_of_threads != 0 ? number_of_threads : std::thread::hardware_concurrency()),
+    number_of_threads != 0 ? number_of_threads
+                           : std::max<size_t>(1, std::thread::hardware_concurrency())),
   yield_before_execute_(yield_before_execute),
   next_exec_timeout_ms_(next_exec_timeout_ms)
 {


### PR DESCRIPTION
## Description

When hardware_concurrency() returns 0 or 1, the fallback thread count could be 0, causing `number_of_threads_ - 1` to wrap to SIZE_MAX and attempt to create billions of threads. Use std::max<size_t>(1, ...) to guarantee a minimum of 1 thread.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1` (required)
- [ ] `bash scripts/test/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
