### PR TITLE
feat(agnocast commandline): research and add supportable commandline args

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -199,7 +199,7 @@ This provides the same argument parsing functionality as rcl.
 | `--params-file file.yaml` | ✓ | **Full Support** | - | Load parameters from YAML file |
 | `--` (end marker) | ✓ | **Full Support** | - | ROS arguments end marker |
 | `-r node:old:=new` | ✓ | **Full Support** | - | Node-specific remapping |
-| `--log-level` | ✗ | **Unsupported** | TBD | Set log level |
+| `--log-level` | ✓ | **Full Support** | - | Set log level |
 | `--enable-rosout-logs` | ✗ | **Unsupported** | TBD | Enable logging to rosout |
 | `--disable-external-lib-logs` | ✗ | **Unsupported** | TBD | Disable external library logs |
 | `--disable-stdout-logs` | ✗ | **Unsupported** | TBD | Disable stdout logging |

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -200,9 +200,9 @@ This provides the same argument parsing functionality as rcl.
 | `--` (end marker) | ✓ | **Full Support** | - | ROS arguments end marker |
 | `-r node:old:=new` | ✓ | **Full Support** | - | Node-specific remapping |
 | `--log-level` | ✓ | **Full Support** | - | Set log level |
-| `--enable-rosout-logs` | ✗ | **Unsupported** | TBD | Enable logging to rosout |
-| `--disable-external-lib-logs` | ✗ | **Unsupported** | TBD | Disable external library logs |
-| `--disable-stdout-logs` | ✗ | **Unsupported** | TBD | Disable stdout logging |
+| `--enable-rosout-logs` | - | **Supportable** | TBD | Enable logging to rosout |
+| `--disable-external-lib-logs` | - | **Default** | - | Disable external library logs |
+| `--disable-stdout-logs` | ✓ | **Full Support** | - | Disable stdout logging |
 | `-e` (enclave) | ✗ | **Unsupported** | TBD | Specify security enclave |
 
 ### 3.2 Parameter Override Resolution

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -203,7 +203,7 @@ This provides the same argument parsing functionality as rcl.
 | `--enable-rosout-logs` | - | **Supportable** | TBD | Enable logging to rosout |
 | `--disable-external-lib-logs` | - | **Default** | - | Disable external library logs |
 | `--disable-stdout-logs` | ✓ | **Full Support** | - | Disable stdout logging |
-| `-e` (enclave) | ✗ | **Unsupported** | TBD | Specify security enclave |
+| `-e` (enclave) | ✗ | **Unsupported** | - | Specify security enclave |
 
 ### 3.2 Parameter Override Resolution
 

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -200,8 +200,8 @@ This provides the same argument parsing functionality as rcl.
 | `--` (end marker) | ✓ | **Full Support** | - | ROS arguments end marker |
 | `-r node:old:=new` | ✓ | **Full Support** | - | Node-specific remapping |
 | `--log-level` | ✓ | **Full Support** | - | Set log level |
-| `--enable-rosout-logs` | - | **Supportable** | TBD | Enable logging to rosout |
-| `--disable-external-lib-logs` | - | **Default** | - | Disable external library logs |
+| `--enable-rosout-logs` | ✓ | **Full Support** | - | Enable logging to rosout |
+| `--disable-external-lib-logs` | ✓ | **Full Support** | - | Disable external library logs |
 | `--disable-stdout-logs` | ✓ | **Full Support** | - | Disable stdout logging |
 | `-e` (enclave) | ✗ | **Unsupported** | - | Specify security enclave |
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -131,7 +131,8 @@ if(BUILD_TESTING)
     test/unit/test_mocked_agnocast.cpp
     test/unit/test_agnocast_executors.cpp
     test/unit/test_node_topics.cpp
-    test/unit/test_cie_client_utils.cpp)
+    test/unit/test_cie_client_utils.cpp
+    test/unit/test_agnocast_context.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs)

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(rosgraph_msgs REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(glog REQUIRED)
+find_package(spdlog REQUIRED)
 
 add_library(agnocast SHARED
   src/agnocast.cpp src/agnocast_utils.cpp src/agnocast_publisher.cpp src/agnocast_subscription.cpp
@@ -51,6 +52,7 @@ target_link_libraries(agnocast
   ${rcl_yaml_param_parser_LIBRARIES}
   ${tracetools_LIBRARIES}
   ${LTTNGUST_LIBRARIES}
+  spdlog::spdlog
 )
 
 target_include_directories(agnocast PUBLIC

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
@@ -36,7 +37,7 @@ add_library(agnocast SHARED
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp
   src/agnocast_callback_isolated_executor.cpp
   src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp
-  src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_signal_handler.cpp
+  src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_rosout.cpp src/node/agnocast_signal_handler.cpp
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
   src/node/agnocast_only_callback_isolated_executor.cpp
   src/cie_client_utils.cpp
@@ -44,7 +45,7 @@ add_library(agnocast SHARED
   src/bridge/standard/agnocast_standard_bridge_ipc_event_loop.cpp src/bridge/standard/agnocast_standard_bridge_loader.cpp src/bridge/standard/agnocast_standard_bridge_manager.cpp src/bridge/agnocast_bridge_utils.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp)
 
-ament_target_dependencies(agnocast rclcpp agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters)
+ament_target_dependencies(agnocast rcl_interfaces rclcpp agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters)
 
 target_link_libraries(agnocast
   ${rcl_yaml_param_parser_LIBRARIES}

--- a/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
@@ -27,8 +27,11 @@ public:
     return parsed_arguments_.is_valid() ? parsed_arguments_.get() : nullptr;
   }
 
+  bool is_rosout_enabled() const { return enable_rosout_logs_; }
+
 private:
   bool initialized_ = false;
+  bool enable_rosout_logs_ = false;
   ParsedArguments parsed_arguments_;
 };
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace agnocast
+{
+class Node;
+
+// Sets up a global /rosout publisher and installs a custom rcutils output handler
+// that chains the existing handler and publishes log messages to /rosout.
+// Only the first call creates the publisher; subsequent calls are no-ops.
+void setup_rosout_handler(Node * node);
+
+}  // namespace agnocast

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -21,11 +21,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+<<<<<<< HEAD
   <depend>ament_index_cpp</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>liblttng-ust-dev</depend>
   <depend>message_filters</depend>
   <depend>rcl_yaml_param_parser</depend>
+=======
+  <depend>rcl_interfaces</depend>
+>>>>>>> 71a28b4 (feat(test): add unit test for --enable-rosout-logs)
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rosgraph_msgs</depend>

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -48,19 +48,22 @@ void Context::init(int argc, char const * const * argv)
     rcl_reset_error();
   }
 
-  // Apply --disable-stdout-logs if present within --ros-args scope.
-  // There is no public rcl API to extract this flag from rcl_arguments_t, so we scan argv directly.
-  // rcl_logging_configure() cannot be used as it would initialize spdlog and attempt to set up a
-  // rosout publisher (which requires rcl_node_t), neither of which exist in agnocast.
+  // Apply --disable-stdout-logs and detect --enable-rosout-logs within --ros-args scope.
+  // There is no public rcl API to extract these flags from rcl_arguments_t, so we scan argv
+  // directly. rcl_logging_configure() cannot be used as it would initialize spdlog and attempt to
+  // set up a rosout publisher (which requires rcl_node_t), neither of which exist in agnocast.
   bool in_ros_args = false;
   for (const auto & arg : args) {
     if (arg == "--ros-args") {
       in_ros_args = true;
     } else if (arg == "--") {
       in_ros_args = false;
-    } else if (in_ros_args && arg == "--disable-stdout-logs") {
-      rcutils_logging_set_output_handler(noop_log_output_handler);
-      break;
+    } else if (in_ros_args) {
+      if (arg == "--disable-stdout-logs") {
+        rcutils_logging_set_output_handler(noop_log_output_handler);
+      } else if (arg == "--enable-rosout-logs") {
+        enable_rosout_logs_ = true;
+      }
     }
   }
 

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -1,4 +1,5 @@
 #include "agnocast/node/agnocast_context.hpp"
+#include <rcl/arguments.h>
 #include <rcl/log_level.h>
 #include <rcutils/logging.h>
 
@@ -9,6 +10,12 @@ namespace agnocast
 
 Context g_context;
 std::mutex g_context_mtx;
+
+static void noop_log_output_handler(
+  const rcutils_log_location_t *, int, const char *, rcutils_time_point_value_t, const char *,
+  va_list *)
+{
+}
 
 void Context::init(int argc, char const * const * argv)
 {
@@ -39,6 +46,22 @@ void Context::init(int argc, char const * const * argv)
     rcl_log_levels_fini(&log_levels);
   } else {
     rcl_reset_error();
+  }
+
+  // Apply --disable-stdout-logs if present within --ros-args scope.
+  // There is no public rcl API to extract this flag from rcl_arguments_t, so we scan argv directly.
+  // rcl_logging_configure() cannot be used as it would initialize spdlog and attempt to set up a
+  // rosout publisher (which requires rcl_node_t), neither of which exist in agnocast.
+  bool in_ros_args = false;
+  for (const auto & arg : args) {
+    if (arg == "--ros-args") {
+      in_ros_args = true;
+    } else if (arg == "--") {
+      in_ros_args = false;
+    } else if (in_ros_args && arg == "--disable-stdout-logs") {
+      rcutils_logging_set_output_handler(noop_log_output_handler);
+      break;
+    }
   }
 
   initialized_ = true;

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -3,6 +3,17 @@
 #include <rcl/log_level.h>
 #include <rcutils/logging.h>
 
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/spdlog.h>
+
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 
 namespace agnocast
@@ -10,6 +21,48 @@ namespace agnocast
 
 Context g_context;
 std::mutex g_context_mtx;
+
+/// Generate a ROS2-style log directory path: ~/.ros/log/<timestamp-hostname-pid>/
+static std::string generate_log_directory()
+{
+  std::string base_dir;
+  const char * ros_log_dir = std::getenv("ROS_LOG_DIR");
+  const char * ros_home = std::getenv("ROS_HOME");
+  if (ros_log_dir && ros_log_dir[0] != '\0') {
+    base_dir = ros_log_dir;
+  } else if (ros_home && ros_home[0] != '\0') {
+    base_dir = std::string(ros_home) + "/log";
+  } else {
+    const char * home = std::getenv("HOME");
+    base_dir = std::string(home ? home : "/tmp") + "/.ros/log";
+  }
+
+  auto now = std::chrono::system_clock::now();
+  auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  auto us =
+    std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count() % 1000000;
+  std::tm tm_buf{};
+  localtime_r(&time_t_now, &tm_buf);
+
+  char hostname[256] = {};
+  gethostname(hostname, sizeof(hostname));
+
+  std::ostringstream oss;
+  oss << base_dir << "/" << std::put_time(&tm_buf, "%Y-%m-%d-%H-%M-%S") << "-"
+      << std::setfill('0') << std::setw(6) << us << "-" << hostname << "-" << getpid();
+  return oss.str();
+}
+
+static void initialize_spdlog(const std::string & log_dir)
+{
+  std::filesystem::create_directories(log_dir);
+  std::string log_file = log_dir + "/agnocast.log";
+  spdlog::drop("agnocast");
+  auto logger = spdlog::basic_logger_mt("agnocast", log_file);
+  logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
+  logger->flush_on(spdlog::level::warn);
+  spdlog::set_default_logger(logger);
+}
 
 static void noop_log_output_handler(
   const rcutils_log_location_t *, int, const char *, rcutils_time_point_value_t, const char *,
@@ -48,11 +101,11 @@ void Context::init(int argc, char const * const * argv)
     rcl_reset_error();
   }
 
-  // Apply --disable-stdout-logs and detect --enable-rosout-logs within --ros-args scope.
-  // There is no public rcl API to extract these flags from rcl_arguments_t, so we scan argv
-  // directly. rcl_logging_configure() cannot be used as it would initialize spdlog and attempt to
-  // set up a rosout publisher (which requires rcl_node_t), neither of which exist in agnocast.
+  // Scan argv for flags that have no public rcl getter API.
+  // rcl_logging_configure() is not used because it would replace the rcutils output handler
+  // and couple agnocast to rcl's logging lifecycle.
   bool in_ros_args = false;
+  bool disable_external_lib_logs = false;
   for (const auto & arg : args) {
     if (arg == "--ros-args") {
       in_ros_args = true;
@@ -63,8 +116,15 @@ void Context::init(int argc, char const * const * argv)
         rcutils_logging_set_output_handler(noop_log_output_handler);
       } else if (arg == "--enable-rosout-logs") {
         enable_rosout_logs_ = true;
+      } else if (arg == "--disable-external-lib-logs") {
+        disable_external_lib_logs = true;
       }
     }
+  }
+
+  // Initialize spdlog file logging unless explicitly disabled.
+  if (!disable_external_lib_logs) {
+    initialize_spdlog(generate_log_directory());
   }
 
   initialized_ = true;

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -1,4 +1,6 @@
 #include "agnocast/node/agnocast_context.hpp"
+#include <rcl/log_level.h>
+#include <rcutils/logging.h>
 
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 
@@ -22,6 +24,23 @@ void Context::init(int argc, char const * const * argv)
   }
 
   parsed_arguments_ = parse_arguments(args);
+
+  // Apply --log-level settings from parsed arguments
+  rcl_log_levels_t log_levels = rcl_get_zero_initialized_log_levels();
+  rcl_ret_t ret = rcl_arguments_get_log_levels(parsed_arguments_.get(), &log_levels);
+  if (RCL_RET_OK == ret) {
+    if (log_levels.default_logger_level != RCUTILS_LOG_SEVERITY_UNSET) {
+      rcutils_logging_set_default_logger_level(static_cast<int>(log_levels.default_logger_level));
+    }
+    for (size_t i = 0; i < log_levels.num_logger_settings; ++i) {
+      rcutils_logging_set_logger_level(
+        log_levels.logger_settings[i].name, static_cast<int>(log_levels.logger_settings[i].level));
+    }
+    rcl_log_levels_fini(&log_levels);
+  } else {
+    rcl_reset_error();
+  }
+
   initialized_ = true;
 
   TRACEPOINT(agnocast_init, static_cast<const void *>(this));

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -3,6 +3,7 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/node/agnocast_arguments.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_rosout.hpp"
 
 #include <rcl/time.h>
 
@@ -41,6 +42,13 @@ Node::Node(
   node_time_source_ = std::make_shared<node_interfaces::NodeTimeSource>(node_clock_, this);
 
   node_services_ = std::make_shared<node_interfaces::NodeServices>(node_base_);
+
+  // Set up rosout publisher and handler if --enable-rosout-logs was specified.
+  // Must be after node_base_, node_topics_, and node_parameters_ are initialized
+  // (required by the publisher constructor). Only the first Node triggers setup.
+  if (g_context.is_rosout_enabled()) {
+    setup_rosout_handler(this);
+  }
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_rosout.cpp
+++ b/src/agnocastlib/src/node/agnocast_rosout.cpp
@@ -1,0 +1,117 @@
+#include "agnocast/node/agnocast_rosout.hpp"
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+
+#include <rcl_interfaces/msg/log.hpp>
+#include <rcutils/logging.h>
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdio>
+#include <mutex>
+
+namespace agnocast
+{
+
+static Publisher<rcl_interfaces::msg::Log>::SharedPtr g_rosout_pub;
+static std::mutex g_rosout_mtx;
+static std::atomic<bool> g_in_handler{false};
+static std::atomic<bool> g_rosout_initialized{false};
+static rcutils_logging_output_handler_t g_original_handler = nullptr;
+
+static uint8_t severity_to_log_level(int severity)
+{
+  switch (severity) {
+    case RCUTILS_LOG_SEVERITY_DEBUG:
+      return rcl_interfaces::msg::Log::DEBUG;
+    case RCUTILS_LOG_SEVERITY_INFO:
+      return rcl_interfaces::msg::Log::INFO;
+    case RCUTILS_LOG_SEVERITY_WARN:
+      return rcl_interfaces::msg::Log::WARN;
+    case RCUTILS_LOG_SEVERITY_ERROR:
+      return rcl_interfaces::msg::Log::ERROR;
+    case RCUTILS_LOG_SEVERITY_FATAL:
+      return rcl_interfaces::msg::Log::FATAL;
+    default:
+      return rcl_interfaces::msg::Log::INFO;
+  }
+}
+
+static void rosout_output_handler(
+  const rcutils_log_location_t * location, int severity, const char * name,
+  rcutils_time_point_value_t timestamp, const char * format, va_list * args)
+{
+  // Chain the original handler (console or noop, depending on --disable-stdout-logs).
+  // Pass a copy because the handler may consume the va_list via vsnprintf.
+  if (g_original_handler) {
+    va_list args_for_original;
+    va_copy(args_for_original, *args);
+    g_original_handler(location, severity, name, timestamp, format, &args_for_original);
+    va_end(args_for_original);
+  }
+
+  // Recursion guard: publishing may trigger log calls internally
+  bool expected = false;
+  if (!g_in_handler.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(g_rosout_mtx);
+    if (g_rosout_pub) {
+      auto loaned_msg = g_rosout_pub->borrow_loaned_message();
+
+      loaned_msg->stamp.sec = static_cast<int32_t>(timestamp / 1000000000LL);
+      loaned_msg->stamp.nanosec = static_cast<uint32_t>(timestamp % 1000000000LL);
+      loaned_msg->level = severity_to_log_level(severity);
+      loaned_msg->name = (name != nullptr) ? name : "";
+
+      // Format the message string from va_list
+      va_list args_copy;
+      va_copy(args_copy, *args);
+      int len = vsnprintf(nullptr, 0, format, args_copy);
+      va_end(args_copy);
+      if (len >= 0) {
+        std::string msg_str(static_cast<size_t>(len), '\0');
+        va_copy(args_copy, *args);
+        vsnprintf(&msg_str[0], static_cast<size_t>(len) + 1, format, args_copy);
+        va_end(args_copy);
+        loaned_msg->msg = std::move(msg_str);
+      }
+
+      if (location != nullptr) {
+        loaned_msg->file = (location->file_name != nullptr) ? location->file_name : "";
+        loaned_msg->function = (location->function_name != nullptr) ? location->function_name : "";
+        loaned_msg->line = location->line_number;
+      }
+
+      g_rosout_pub->publish(std::move(loaned_msg));
+    }
+  }
+
+  g_in_handler.store(false);
+}
+
+void setup_rosout_handler(Node * node)
+{
+  // Only set up once per process, even with multiple nodes
+  bool expected = false;
+  if (!g_rosout_initialized.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  auto pub = node->create_publisher<rcl_interfaces::msg::Log>(
+    "/rosout", rclcpp::QoS(100).reliable().transient_local());
+
+  {
+    std::lock_guard<std::mutex> lock(g_rosout_mtx);
+    g_rosout_pub = pub;
+  }
+
+  // Capture the current handler (console or noop) before replacing
+  g_original_handler = rcutils_logging_get_output_handler();
+  rcutils_logging_set_output_handler(rosout_output_handler);
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -1,0 +1,79 @@
+#include "agnocast/node/agnocast_context.hpp"
+
+#include <rcutils/logging.h>
+
+#include <gtest/gtest.h>
+
+// =========================================
+// agnocast::Context --disable-stdout-logs tests
+// =========================================
+
+class AgnocastContextStdoutLogsTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { original_handler_ = rcutils_logging_get_output_handler(); }
+
+  void TearDown() override
+  {
+    // Restore the original handler so other tests are not affected.
+    rcutils_logging_set_output_handler(original_handler_);
+  }
+
+  rcutils_logging_output_handler_t original_handler_;
+};
+
+TEST_F(AgnocastContextStdoutLogsTest, disable_stdout_logs_changes_handler)
+{
+  // Arrange
+  const char * argv[] = {"program", "--ros-args", "--disable-stdout-logs"};
+  int argc = 3;
+  agnocast::Context ctx;
+
+  // Act
+  ctx.init(argc, argv);
+
+  // Assert: output handler must have been replaced with a no-op
+  EXPECT_NE(rcutils_logging_get_output_handler(), original_handler_);
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, no_flag_keeps_handler_unchanged)
+{
+  // Arrange
+  const char * argv[] = {"program", "--ros-args", "--log-level", "info"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  // Act
+  ctx.init(argc, argv);
+
+  // Assert: output handler must not have changed
+  EXPECT_EQ(rcutils_logging_get_output_handler(), original_handler_);
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, flag_outside_ros_args_is_ignored)
+{
+  // Arrange: --disable-stdout-logs appears before --ros-args, so it is not a ROS argument
+  const char * argv[] = {"program", "--disable-stdout-logs", "--ros-args", "--log-level", "info"};
+  int argc = 5;
+  agnocast::Context ctx;
+
+  // Act
+  ctx.init(argc, argv);
+
+  // Assert: flag outside --ros-args scope must be ignored
+  EXPECT_EQ(rcutils_logging_get_output_handler(), original_handler_);
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, flag_after_double_dash_terminator_is_ignored)
+{
+  // Arrange: --disable-stdout-logs appears after -- (end of ROS args), so it is not a ROS argument
+  const char * argv[] = {"program", "--ros-args", "--", "--disable-stdout-logs"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  // Act
+  ctx.init(argc, argv);
+
+  // Assert: flag after -- must be ignored
+  EXPECT_EQ(rcutils_logging_get_output_handler(), original_handler_);
+}

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -5,6 +5,79 @@
 #include <gtest/gtest.h>
 
 // =========================================
+// agnocast::Context --enable-rosout-logs tests
+// =========================================
+
+class AgnocastContextRosoutTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { original_handler_ = rcutils_logging_get_output_handler(); }
+
+  void TearDown() override { rcutils_logging_set_output_handler(original_handler_); }
+
+  rcutils_logging_output_handler_t original_handler_;
+};
+
+TEST_F(AgnocastContextRosoutTest, enable_rosout_logs_sets_flag)
+{
+  const char * argv[] = {"program", "--ros-args", "--enable-rosout-logs"};
+  int argc = 3;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_TRUE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, no_flag_rosout_disabled)
+{
+  const char * argv[] = {"program", "--ros-args", "--log-level", "info"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, flag_outside_ros_args_is_ignored)
+{
+  const char * argv[] = {"program", "--enable-rosout-logs", "--ros-args", "--log-level", "info"};
+  int argc = 5;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, flag_after_double_dash_is_ignored)
+{
+  const char * argv[] = {"program", "--ros-args", "--", "--enable-rosout-logs"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, both_disable_stdout_and_enable_rosout)
+{
+  const char * argv[] = {
+    "program", "--ros-args", "--disable-stdout-logs", "--enable-rosout-logs"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  // --enable-rosout-logs flag should be set
+  EXPECT_TRUE(ctx.is_rosout_enabled());
+  // --disable-stdout-logs should have replaced the handler
+  EXPECT_NE(rcutils_logging_get_output_handler(), original_handler_);
+}
+
+// =========================================
 // agnocast::Context --disable-stdout-logs tests
 // =========================================
 


### PR DESCRIPTION
## Description

research and add supportable commandline args for agnocast nodeinterface
- `--log-level` : Full Support  #1174 
- `--enable-rosout-logs` : Full Support  #1172 
- `--disable-external-lib-logs` : Full Support #1204 
- `--disable-stdout-logs`  : Full Support #1173 
- `-e`: Unsupported

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1` (required)
- [ ] `bash scripts/test/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
