### PR TITLE
fix: prevent signed integer overflow in ms-to-ns conversion

### DIFF
--- a/src/agnocast_components/src/agnocast_component_container_mt.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_mt.cpp
@@ -29,8 +29,9 @@ int main(int argc, char * argv[])
     const bool yield_before_execute = node->get_parameter_or("yield_before_execute", false);
     const int ros2_next_exec_timeout_ms = node->get_parameter_or("ros2_next_exec_timeout_ms", -1);
     const nanoseconds ros2_next_exec_timeout_ns =
-      ros2_next_exec_timeout_ms == -1 ? nanoseconds(-1)
-                                      : nanoseconds(ros2_next_exec_timeout_ms * 1000 * 1000);
+      ros2_next_exec_timeout_ms == -1
+        ? nanoseconds(-1)
+        : nanoseconds(static_cast<int64_t>(ros2_next_exec_timeout_ms) * 1000 * 1000);
     const int agnocast_next_exec_timeout_ms =
       node->get_parameter_or("agnocast_next_exec_timeout_ms", 50);
 

--- a/src/agnocastlib/src/agnocast_component_container_mt.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_mt.cpp
@@ -34,8 +34,9 @@ int main(int argc, char * argv[])
     const bool yield_before_execute = node->get_parameter_or("yield_before_execute", false);
     const int ros2_next_exec_timeout_ms = node->get_parameter_or("ros2_next_exec_timeout_ms", -1);
     const nanoseconds ros2_next_exec_timeout_ns =
-      ros2_next_exec_timeout_ms == -1 ? nanoseconds(-1)
-                                      : nanoseconds(ros2_next_exec_timeout_ms * 1000 * 1000);
+      ros2_next_exec_timeout_ms == -1
+        ? nanoseconds(-1)
+        : nanoseconds(static_cast<int64_t>(ros2_next_exec_timeout_ms) * 1000 * 1000);
     const int agnocast_next_exec_timeout_ms =
       node->get_parameter_or("agnocast_next_exec_timeout_ms", 50);
 

--- a/src/agnocastlib/test/integration/test_agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_multi_threaded_executor.cpp
@@ -14,7 +14,8 @@ protected:
     int next_exec_timeout_ms = std::get<1>(GetParam());
     cbg_type_ = std::get<2>(GetParam());
     int agnocast_next_exec_timeout_ms = next_exec_timeout_ms;
-    std::chrono::nanoseconds ros2_next_exec_timeout(next_exec_timeout_ms * 1000 * 1000);
+    std::chrono::nanoseconds ros2_next_exec_timeout(
+      static_cast<int64_t>(next_exec_timeout_ms) * 1000 * 1000);
 
     // Set the execution time of each callback
     uint64_t num_cbs = NUM_AGNOCAST_SUB_CBS + NUM_AGNOCAST_CBS_TO_BE_ADDED + NUM_ROS2_SUB_CBS;


### PR DESCRIPTION
## Description

Cast ros2_next_exec_timeout_ms to int64_t before multiplying by `1000*1000` to avoid undefined behavior when the timeout exceeds 2147 ms.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1` (required)
- [ ] `bash scripts/test/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
