### PR TITLE
fix(agnocastlib): remove rclcpp::ok() dependency from AgnocastOnlyCallbackIsolatedExecutor

### DIFF
--- a/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
@@ -117,15 +117,15 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
   }  // guard child_resources_mutex_
 
   // Monitoring loop: wait for notification when new callback groups are created
-  while (spinning_.load() && rclcpp::ok()) {
+  while (spinning_.load()) {
     {
       std::unique_lock<std::mutex> lock(callback_group_created_cv_mutex_);
       callback_group_created_cv_.wait(
-        lock, [this] { return callback_group_created_ || !spinning_.load() || !rclcpp::ok(); });
+        lock, [this] { return callback_group_created_ || !spinning_.load(); });
       callback_group_created_ = false;
     }
 
-    if (!spinning_.load() || !rclcpp::ok()) {
+    if (!spinning_.load()) {
       break;
     }
 
@@ -157,7 +157,7 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
     }
 
     std::lock_guard<std::mutex> guard{child_resources_mutex_};
-    if (!spinning_.load() || !rclcpp::ok()) {
+    if (!spinning_.load()) {
       break;
     }
     for (auto & [group, node] : new_groups) {


### PR DESCRIPTION
## Description

The "AgnocastOnly" executors are designed to work with `agnocast::init()` alone, but the CIE's monitoring loop checked `rclcpp::ok()` in 4 places, causing it to exit immediately without `rclcpp::init()`.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1` (required)
- [ ] `bash scripts/test/e2e_test_2to2` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
