### PR TITLE
fix(agnocastlib): no exit when in standard bridge

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -154,7 +154,8 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge(BridgeMode brid
   }
 
   if (
-    bridge_mode == BridgeMode::Performance && add_process_args.ret_performance_bridge_daemon_exist) {
+    bridge_mode == BridgeMode::Performance &&
+    add_process_args.ret_performance_bridge_daemon_exist) {
     close(agnocast_fd);
     exit(EXIT_SUCCESS);
   }


### PR DESCRIPTION
## Description
In `acquire_agnocast_resources_for_bridge()`, the early exit when another bridge manager already exists was applied unconditionally to both Standard and Performance bridge modes. In Standard mode, each process needs its own bridge manager, so the second process's bridge manager was incorrectly exiting, causing e2e test failures.

  This fix passes BridgeMode to `acquire_agnocast_resources_for_bridge()` and only exits early for `BridgeMode::Performance`.


Fix for bug within the following PR.
https://github.com/autowarefoundation/agnocast/pull/1140

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
