### PR TITLE
fix(agnocastlib): use wait_for in CIE spin loop for signal handling

### DIFF
--- a/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
@@ -120,8 +120,9 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
   while (spinning_.load()) {
     {
       std::unique_lock<std::mutex> lock(callback_group_created_cv_mutex_);
-      callback_group_created_cv_.wait(
-        lock, [this] { return callback_group_created_ || !spinning_.load(); });
+      callback_group_created_cv_.wait_for(lock, std::chrono::milliseconds(100), [this] {
+        return callback_group_created_ || !spinning_.load();
+      });
       callback_group_created_ = false;
     }
 


### PR DESCRIPTION
## Description

The `AgnocastOnlyCallbackIsolatedExecutor` uses a condition variable to wait for new callback groups, but the signal handler (SIGINT/SIGTERM) only writes to `shutdown_event_fd_`, which wakes epoll-based executors.
The CIE's CV-based loop could miss the shutdown signal entirely, causing the process to hang on termination.
Replace cv.wait() with cv.wait_for() using a 100ms timeout so the loop periodically re-checks spinning_ and exits promptly after a signal is received.

## Related links

## How was this PR tested?

Tested on the scalability benchmark test.

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
