### PR TITLE
fix(agnocastlib): unlink message queue in IpcEventLoopBase cleanup

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -263,16 +263,12 @@ inline void IpcEventLoopBase::cleanup_resources()
         logger_, "Failed to close mq_fd for mq_name='" << mq_name_ << "': " << strerror(errno));
     }
     mq_fd_ = -1;
-  }
 
-  if (!mq_name_.empty()) {
     if (mq_unlink(mq_name_.c_str()) == -1 && errno != ENOENT) {
       RCLCPP_WARN_STREAM(
         logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
     }
   }
-
-  mq_name_.clear();
 }
 
 }  // namespace agnocast


### PR DESCRIPTION
## Description
See https://github.com/autowarefoundation/agnocast/pull/1150#issuecomment-4004503169

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
