### PR TITLE
fix(bridge): skip publishing when there is no ros2 sub in a2r bridge

### DIFF
--- a/src/ros2agnocast/ros2agnocast/templates/bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/bridge_plugin.cpp.em
@@ -53,11 +53,6 @@ extern "C" PerformanceBridgeResult create_a2r_bridge(
   auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
 
   auto agno_callback = [ros_pub](const agnocast::ipc_shared_ptr<@(cpp_type)> msg) {
-    // The kernel module already skips notifying bridge subscribers when ros2_subscriber_num == 0,
-    // but this serves as a fallback since ros2_subscriber_num updates are periodic.
-    if (ros_pub->get_subscription_count() == 0) {
-      return;
-    }
     auto loaned_msg = ros_pub->borrow_loaned_message();
     if (loaned_msg.is_valid()) {
       loaned_msg.get() = *msg;


### PR DESCRIPTION
## Description
Skip publishing to A2R bridge subscribers when there are no ROS 2 subscribers on the topic, reducing unnecessary IPC and serialization overhead.

  - Kernel module: In agnocast_ioctl_publish_msg, skip notifying bridge subscribers when ros2_subscriber_num == 0.
  - Bridge plugin template: As a fallback, check get_subscription_count() before publishing, since ros2_subscriber_num is updated periodically and may be momentarily stale.


## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
