### PR TITLE
docs(kmod): clarify exit PID ring buffer cannot overflow in production

### DIFF
--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -3343,7 +3343,9 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper, const pid
   }
 }
 
-// Ring buffer to hold exited pids
+// Ring buffer to hold exited pids.
+// EXIT_QUEUE_SIZE (65536) far exceeds mempool_num (default 4096), and only Agnocast PIDs are
+// enqueued (via is_agnocast_pid()), each exiting at most once, so the ring buffer cannot overflow.
 static DEFINE_SPINLOCK(pid_queue_lock);
 static pid_t exit_pid_queue[EXIT_QUEUE_SIZE];
 static uint32_t queue_head;


### PR DESCRIPTION
## Description

follow up https://github.com/autowarefoundation/agnocast/pull/1159

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
