### PR TITLE
fix(bridge): persist callback_group in performance bridge to prevent premature destruction

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -34,8 +34,8 @@ private:
 
   std::atomic_bool shutdown_requested_ = false;
 
-  std::unordered_map<std::string, std::shared_ptr<void>> active_r2a_bridges_;
-  std::unordered_map<std::string, std::shared_ptr<void>> active_a2r_bridges_;
+  std::unordered_map<std::string, PerformanceBridgeResult> active_r2a_bridges_;
+  std::unordered_map<std::string, PerformanceBridgeResult> active_a2r_bridges_;
   std::unordered_map<std::string, RequestMap> request_cache_;
 
   void start_ros_execution();

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -303,13 +303,13 @@ void PerformanceBridgeManager::create_bridge_if_needed(
           RCLCPP_ERROR(
             logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
         }
-        active_r2a_bridges_[topic_name] = result.entity_handle;
+        active_r2a_bridges_[topic_name] = result;
       } else {
         if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
           RCLCPP_ERROR(
             logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
         }
-        active_a2r_bridges_[topic_name] = result.entity_handle;
+        active_a2r_bridges_[topic_name] = result;
       }
 
       if (result.callback_group) {


### PR DESCRIPTION
## Description

Store the full `PerformanceBridgeResult` (including `callback_group`) in `active_r2a_bridges_` / `active_a2r_bridges_` instead of only `entity_handle`.

### Problem

When a performance bridge is created, `create_bridge_if_needed()` receives a `PerformanceBridgeResult` containing both `entity_handle` and `callback_group`. However, only `entity_handle` was stored in the active bridges map:

```cpp
active_r2a_bridges_[topic_name] = result.entity_handle;
```

After `result` goes out of scope at the end of `create_bridge_if_needed()`, `result.callback_group` (a `SharedPtr`) is destroyed. Since no other component holds a strong reference to the callback group, it is prematurely deallocated:

- `rclcpp::Node` stores callback groups as `WeakPtr` (`node_base.hpp:142`)
- `rclcpp::Executor` stores callback groups as `WeakPtr` (`WeakCallbackGroupsToNodesMap`)
- `rclcpp::SubscriptionBase` does not hold any reference to its callback group

As a result, the executor cannot discover or spin the bridge's callback group, and bridge callbacks are never invoked.

Note that this issue specifically affects the **R2A (ROS → Agnocast) direction** of performance bridges. The A2R direction is unaffected because its callback group is kept alive by the global `CallbackInfo` registry (`agnocast_callback_info.hpp:44`). Standard bridges are also unaffected because their bridge classes hold the callback group as a member variable.

### Fix

Change the type of `active_r2a_bridges_` / `active_a2r_bridges_` from `std::shared_ptr<void>` to `PerformanceBridgeResult`, and store the full result object. This keeps the `callback_group` `SharedPtr` alive for the bridge's lifetime.

## Related links

- https://github.com/autowarefoundation/agnocast/pull/1170#discussion_r2910523442

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.