### PR TITLE
feat(agnocastlib): add --enable-rosout-logs full support with test

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -198,7 +198,7 @@ This provides the same argument parsing functionality as rcl.
 | `--` (end marker) | ✓ | **Full Support** | - | ROS arguments end marker |
 | `-r node:old:=new` | ✓ | **Full Support** | - | Node-specific remapping |
 | `--log-level` | ✓ | **Full Support** | - | Set log level |
-| `--enable-rosout-logs` | ✗ | **Unsupported** | TBD | Enable logging to rosout |
+| `--enable-rosout-logs` | ✓ | **Full Support** | - | Enable logging to rosout |
 | `--disable-external-lib-logs` | ✓ | **Full Support** | - | Disable external library logs (file logging via rcl_logging_spdlog) |
 | `--disable-stdout-logs` | ✓ | **Full Support** | - | Disable stdout logging |
 | `-e` (enclave) | ✗ | **Unsupported** | TBD | Specify security enclave |

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
@@ -45,7 +46,7 @@ add_library(agnocast SHARED
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp
   src/agnocast_callback_isolated_executor.cpp
   src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp
-  src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_signal_handler.cpp
+  src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_rosout.cpp src/node/agnocast_signal_handler.cpp
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
   src/cie_client_utils.cpp
@@ -56,7 +57,7 @@ add_library(agnocast SHARED
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
   src/node/diagnostic_updater/diagnostic_updater.cpp)
 
-ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_introspection_cpp)
+ament_target_dependencies(agnocast rcl_interfaces rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_introspection_cpp)
 
 target_link_libraries(agnocast
   ${rcl_yaml_param_parser_LIBRARIES}

--- a/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_context.hpp
@@ -28,8 +28,11 @@ public:
     return parsed_arguments_.is_valid() ? parsed_arguments_.get() : nullptr;
   }
 
+  bool is_rosout_enabled() const { return enable_rosout_logs_; }
+
 private:
   bool initialized_ = false;
+  bool enable_rosout_logs_ = false;
   ParsedArguments parsed_arguments_;
 };
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -65,6 +65,9 @@ public:
     const std::string & node_name, const std::string & namespace_,
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
+  AGNOCAST_PUBLIC
+  ~Node();
+
   /// Return the name of the node.
   /// @return Node name.
   AGNOCAST_PUBLIC
@@ -573,8 +576,8 @@ public:
   template <typename DurationRepT, typename DurationT, typename CallbackT>
   [[deprecated(
     "Use the 3-argument Node::create_timer(period, callback, group) or "
-    "agnocast::create_timer() free function instead.")]]
-  typename GenericTimer<CallbackT>::SharedPtr create_timer(
+    "agnocast::create_timer() free function instead.")]] typename GenericTimer<CallbackT>::SharedPtr
+  create_timer(
     std::chrono::duration<DurationRepT, DurationT> period, CallbackT && callback,
     rclcpp::CallbackGroup::SharedPtr group, rclcpp::Clock::SharedPtr clock)
   {

--- a/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace agnocast
+{
+class Node;
+
+// Sets up a global /rosout publisher and installs a custom rcutils output handler
+// that chains the existing handler and publishes log messages to /rosout.
+// Only the first call creates the publisher; subsequent calls are no-ops.
+void setup_rosout_handler(Node * node);
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_rosout.hpp
@@ -1,12 +1,24 @@
 #pragma once
 
+#include "rclcpp/qos.hpp"
+
 namespace agnocast
 {
 class Node;
 
-// Sets up a global /rosout publisher and installs a custom rcutils output handler
-// that chains the existing handler and publishes log messages to /rosout.
-// Only the first call creates the publisher; subsequent calls are no-ops.
-void setup_rosout_handler(Node * node);
+// Creates a per-node /rosout publisher with the given QoS, registers it keyed by the node's
+// logger name, and installs the custom rcutils output handler (only on the first call).
+void setup_rosout_handler(Node * node, const rclcpp::QoS & qos);
+
+// Removes the /rosout publisher registered for this node's logger name.
+void teardown_rosout_handler(Node * node);
+
+// Clears all registered publishers, restores the original rcutils handler, and resets the
+// installed flag so that a subsequent init/setup cycle works correctly.
+// Must be called during agnocast::shutdown().
+void shutdown_rosout_handler();
+
+// Returns the number of currently registered per-node rosout publishers (for testing).
+size_t get_rosout_publisher_count();
 
 }  // namespace agnocast

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -24,6 +24,7 @@
   <depend>libgoogle-glog-dev</depend>
   <depend>liblttng-ust-dev</depend>
   <depend>message_filters</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rcl_yaml_param_parser</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -47,6 +47,21 @@ void Context::init(int argc, char const * const * argv)
     rcl_reset_error();
   }
 
+  // Detect --enable-rosout-logs within --ros-args scope.
+  // There is no public rcl API to extract this flag from rcl_arguments_t, so we scan argv
+  // directly. rcl_logging_configure() cannot be used as it would initialize spdlog and attempt to
+  // set up a rosout publisher (which requires rcl_node_t), neither of which exist in agnocast.
+  bool in_ros_args = false;
+  for (const auto & arg : args) {
+    if (arg == "--ros-args") {
+      in_ros_args = true;
+    } else if (arg == "--") {
+      in_ros_args = false;
+    } else if (in_ros_args && arg == "--enable-rosout-logs") {
+      enable_rosout_logs_ = true;
+    }
+  }
+
   initialized_ = true;
   TRACEPOINT(agnocast_init, static_cast<const void *>(this));
 }

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 
 #include "agnocast/agnocast_tracepoint_wrapper.h"
+#include "agnocast/node/agnocast_rosout.hpp"
 #include "agnocast_signal_handler.hpp"
 
 #include <rcl/arguments.h>
@@ -92,6 +93,7 @@ void shutdown()
 
   SignalHandler::notify_all_executors();
   SignalHandler::uninstall();
+  shutdown_rosout_handler();
 
   rcl_ret_t ret = rcl_logging_fini();
   if (ret != RCL_RET_OK) {

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -3,6 +3,7 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/node/agnocast_arguments.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_rosout.hpp"
 
 #include <rcl/time.h>
 
@@ -34,6 +35,13 @@ Node::Node(
 {
   if (options.start_parameter_services()) {
     node_parameters_->start_parameter_services(this);
+  }
+
+  // Set up rosout publisher and handler if --enable-rosout-logs was specified.
+  // Must be after node_base_, node_topics_, and node_parameters_ are initialized
+  // (required by the publisher constructor). Only the first Node triggers setup.
+  if (g_context.is_rosout_enabled()) {
+    setup_rosout_handler(this);
   }
 
   TRACEPOINT(

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -37,16 +37,23 @@ Node::Node(
     node_parameters_->start_parameter_services(this);
   }
 
-  // Set up rosout publisher and handler if --enable-rosout-logs was specified.
+  // Set up per-node /rosout publisher if --enable-rosout-logs was specified.
   // Must be after node_base_, node_topics_, and node_parameters_ are initialized
-  // (required by the publisher constructor). Only the first Node triggers setup.
+  // (required by the publisher constructor).
   if (g_context.is_rosout_enabled()) {
-    setup_rosout_handler(this);
+    setup_rosout_handler(this, options.rosout_qos());
   }
 
   TRACEPOINT(
     agnocast_node_init, static_cast<const void *>(node_base_.get()), this->get_name().c_str(),
     this->get_namespace().c_str());
+}
+
+Node::~Node()
+{
+  if (g_context.is_rosout_enabled()) {
+    teardown_rosout_handler(this);
+  }
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_rosout.cpp
+++ b/src/agnocastlib/src/node/agnocast_rosout.cpp
@@ -1,0 +1,131 @@
+#include "agnocast/node/agnocast_rosout.hpp"
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+
+#include <rcl_interfaces/msg/log.hpp>
+
+#include <rcutils/logging.h>
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdio>
+#include <mutex>
+
+namespace agnocast
+{
+
+static Publisher<rcl_interfaces::msg::Log>::SharedPtr g_rosout_pub;
+static std::mutex g_rosout_mtx;
+static std::atomic<bool> g_in_handler{false};
+static std::atomic<bool> g_rosout_initialized{false};
+static rcutils_logging_output_handler_t g_original_handler = nullptr;
+
+static uint8_t severity_to_log_level(int severity)
+{
+  switch (severity) {
+    case RCUTILS_LOG_SEVERITY_DEBUG:
+      return rcl_interfaces::msg::Log::DEBUG;
+    case RCUTILS_LOG_SEVERITY_INFO:
+      return rcl_interfaces::msg::Log::INFO;
+    case RCUTILS_LOG_SEVERITY_WARN:
+      return rcl_interfaces::msg::Log::WARN;
+    case RCUTILS_LOG_SEVERITY_ERROR:
+      return rcl_interfaces::msg::Log::ERROR;
+    case RCUTILS_LOG_SEVERITY_FATAL:
+      return rcl_interfaces::msg::Log::FATAL;
+    default:
+      return rcl_interfaces::msg::Log::INFO;
+  }
+}
+
+static void rosout_output_handler(
+  const rcutils_log_location_t * location, int severity, const char * name,
+  rcutils_time_point_value_t timestamp, const char * format, va_list * args) noexcept
+{
+  // Chain the original handler (console or noop, depending on --disable-stdout-logs).
+  // Pass a copy because the handler may consume the va_list via vsnprintf.
+  if (g_original_handler) {
+    va_list args_for_original;
+    va_copy(args_for_original, *args);
+    g_original_handler(location, severity, name, timestamp, format, &args_for_original);
+    va_end(args_for_original);
+  }
+
+  // Recursion guard: publishing may trigger log calls internally
+  bool expected = false;
+  if (!g_in_handler.compare_exchange_strong(expected, true)) {
+    return;
+  }
+  // RAII guard: ensures g_in_handler is cleared even if an exception is thrown internally
+  struct InHandlerGuard
+  {
+    ~InHandlerGuard() { g_in_handler.store(false); }
+  } guard;
+
+  try {
+    std::lock_guard<std::mutex> lock(g_rosout_mtx);
+    if (g_rosout_pub) {
+      auto loaned_msg = g_rosout_pub->borrow_loaned_message();
+
+      loaned_msg->stamp.sec = static_cast<int32_t>(timestamp / 1000000000LL);
+      loaned_msg->stamp.nanosec = static_cast<uint32_t>(timestamp % 1000000000LL);
+      loaned_msg->level = severity_to_log_level(severity);
+      loaned_msg->name = (name != nullptr) ? name : "";
+
+      // Format the message string from va_list
+      va_list args_copy;
+      va_copy(args_copy, *args);
+      int len = vsnprintf(nullptr, 0, format, args_copy);
+      va_end(args_copy);
+      if (len >= 0) {
+        const size_t msg_len = static_cast<size_t>(len);
+        std::string msg_str;
+        msg_str.resize(msg_len + 1);
+        va_copy(args_copy, *args);
+        vsnprintf(&msg_str[0], msg_len + 1, format, args_copy);
+        va_end(args_copy);
+        msg_str.resize(msg_len);
+        loaned_msg->msg = std::move(msg_str);
+      }
+
+      if (location != nullptr) {
+        loaned_msg->file = (location->file_name != nullptr) ? location->file_name : "";
+        loaned_msg->function = (location->function_name != nullptr) ? location->function_name : "";
+        loaned_msg->line = location->line_number;
+      }
+
+      g_rosout_pub->publish(std::move(loaned_msg));
+    }
+  } catch (...) {
+    // Swallow exceptions: throwing across this C callback boundary is UB
+  }
+}
+
+void setup_rosout_handler(Node * node)
+{
+  // Only set up once per process, even with multiple nodes
+  bool expected = false;
+  if (!g_rosout_initialized.compare_exchange_strong(expected, true)) {
+    return;
+  }
+
+  try {
+    auto pub = node->create_publisher<rcl_interfaces::msg::Log>(
+      "/rosout", rclcpp::QoS(100).reliable().transient_local());
+
+    {
+      std::lock_guard<std::mutex> lock(g_rosout_mtx);
+      g_rosout_pub = pub;
+    }
+
+    // Capture the current handler (console or noop) before replacing
+    g_original_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(rosout_output_handler);
+  } catch (...) {
+    g_rosout_initialized.store(false);
+    throw;
+  }
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_rosout.cpp
+++ b/src/agnocastlib/src/node/agnocast_rosout.cpp
@@ -11,14 +11,17 @@
 #include <cstdarg>
 #include <cstdio>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 
 namespace agnocast
 {
 
-static Publisher<rcl_interfaces::msg::Log>::SharedPtr g_rosout_pub;
+static std::unordered_map<std::string, Publisher<rcl_interfaces::msg::Log>::SharedPtr>
+  g_rosout_pubs;
 static std::mutex g_rosout_mtx;
 static std::atomic<bool> g_in_handler{false};
-static std::atomic<bool> g_rosout_initialized{false};
+static std::atomic<bool> g_handler_installed{false};
 static rcutils_logging_output_handler_t g_original_handler = nullptr;
 
 static uint8_t severity_to_log_level(int severity)
@@ -64,68 +67,91 @@ static void rosout_output_handler(
   } guard;
 
   try {
+    const std::string logger_name = (name != nullptr) ? name : "";
     std::lock_guard<std::mutex> lock(g_rosout_mtx);
-    if (g_rosout_pub) {
-      auto loaned_msg = g_rosout_pub->borrow_loaned_message();
-
-      loaned_msg->stamp.sec = static_cast<int32_t>(timestamp / 1000000000LL);
-      loaned_msg->stamp.nanosec = static_cast<uint32_t>(timestamp % 1000000000LL);
-      loaned_msg->level = severity_to_log_level(severity);
-      loaned_msg->name = (name != nullptr) ? name : "";
-
-      // Format the message string from va_list
-      va_list args_copy;
-      va_copy(args_copy, *args);
-      int len = vsnprintf(nullptr, 0, format, args_copy);
-      va_end(args_copy);
-      if (len >= 0) {
-        const size_t msg_len = static_cast<size_t>(len);
-        std::string msg_str;
-        msg_str.resize(msg_len + 1);
-        va_copy(args_copy, *args);
-        vsnprintf(&msg_str[0], msg_len + 1, format, args_copy);
-        va_end(args_copy);
-        msg_str.resize(msg_len);
-        loaned_msg->msg = std::move(msg_str);
-      }
-
-      if (location != nullptr) {
-        loaned_msg->file = (location->file_name != nullptr) ? location->file_name : "";
-        loaned_msg->function = (location->function_name != nullptr) ? location->function_name : "";
-        loaned_msg->line = location->line_number;
-      }
-
-      g_rosout_pub->publish(std::move(loaned_msg));
+    auto it = g_rosout_pubs.find(logger_name);
+    if (it == g_rosout_pubs.end()) {
+      return;
     }
+    auto & pub = it->second;
+
+    auto loaned_msg = pub->borrow_loaned_message();
+
+    loaned_msg->stamp.sec = static_cast<int32_t>(timestamp / 1000000000LL);
+    loaned_msg->stamp.nanosec = static_cast<uint32_t>(timestamp % 1000000000LL);
+    loaned_msg->level = severity_to_log_level(severity);
+    loaned_msg->name = logger_name;
+
+    // Format the message string from va_list
+    va_list args_copy;
+    va_copy(args_copy, *args);
+    int len = vsnprintf(nullptr, 0, format, args_copy);
+    va_end(args_copy);
+    if (len >= 0) {
+      const size_t msg_len = static_cast<size_t>(len);
+      std::string msg_str;
+      msg_str.resize(msg_len + 1);
+      va_copy(args_copy, *args);
+      vsnprintf(&msg_str[0], msg_len + 1, format, args_copy);
+      va_end(args_copy);
+      msg_str.resize(msg_len);
+      loaned_msg->msg = std::move(msg_str);
+    }
+
+    if (location != nullptr) {
+      loaned_msg->file = (location->file_name != nullptr) ? location->file_name : "";
+      loaned_msg->function = (location->function_name != nullptr) ? location->function_name : "";
+      loaned_msg->line = location->line_number;
+    }
+
+    pub->publish(std::move(loaned_msg));
   } catch (...) {
     // Swallow exceptions: throwing across this C callback boundary is UB
   }
 }
 
-void setup_rosout_handler(Node * node)
+void setup_rosout_handler(Node * node, const rclcpp::QoS & qos)
 {
-  // Only set up once per process, even with multiple nodes
-  bool expected = false;
-  if (!g_rosout_initialized.compare_exchange_strong(expected, true)) {
-    return;
+  auto pub = node->create_publisher<rcl_interfaces::msg::Log>("/rosout", qos);
+
+  {
+    std::lock_guard<std::mutex> lock(g_rosout_mtx);
+    g_rosout_pubs[node->get_logger().get_name()] = std::move(pub);
   }
 
-  try {
-    auto pub = node->create_publisher<rcl_interfaces::msg::Log>(
-      "/rosout", rclcpp::QoS(100).reliable().transient_local());
-
-    {
-      std::lock_guard<std::mutex> lock(g_rosout_mtx);
-      g_rosout_pub = pub;
-    }
-
-    // Capture the current handler (console or noop) before replacing
+  // Install handler only once per init/shutdown cycle
+  bool expected = false;
+  if (g_handler_installed.compare_exchange_strong(expected, true)) {
     g_original_handler = rcutils_logging_get_output_handler();
     rcutils_logging_set_output_handler(rosout_output_handler);
-  } catch (...) {
-    g_rosout_initialized.store(false);
-    throw;
   }
+}
+
+void teardown_rosout_handler(Node * node)
+{
+  std::lock_guard<std::mutex> lock(g_rosout_mtx);
+  g_rosout_pubs.erase(node->get_logger().get_name());
+}
+
+void shutdown_rosout_handler()
+{
+  {
+    std::lock_guard<std::mutex> lock(g_rosout_mtx);
+    g_rosout_pubs.clear();
+  }
+
+  if (g_handler_installed.exchange(false)) {
+    if (g_original_handler) {
+      rcutils_logging_set_output_handler(g_original_handler);
+      g_original_handler = nullptr;
+    }
+  }
+}
+
+size_t get_rosout_publisher_count()
+{
+  std::lock_guard<std::mutex> lock(g_rosout_mtx);
+  return g_rosout_pubs.size();
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/test/integration/test_agnocast_node.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_node.cpp
@@ -1,5 +1,6 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/agnocast_rosout.hpp"
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/parameter.hpp"
@@ -157,4 +158,54 @@ TEST_F(AgnocastNodeConstructionTest, clock_thread_enabled_creates_clock_callback
 
   // The default callback group plus the dedicated clock callback group.
   EXPECT_EQ(count_callback_groups(node), 2u);
+}
+
+// =========================================
+// Per-node rosout publisher tests
+// =========================================
+
+class AgnocastNodeRosoutTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    const char * argv[] = {"test", "--ros-args", "--enable-rosout-logs"};
+    int argc = 3;
+    agnocast::init(argc, const_cast<char **>(argv));
+  }
+
+  void TearDown() override { agnocast::shutdown(); }
+};
+
+TEST_F(AgnocastNodeRosoutTest, each_node_registers_its_own_publisher)
+{
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 0u);
+
+  auto node_a = std::make_shared<agnocast::Node>("rosout_node_a");
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 1u);
+
+  auto node_b = std::make_shared<agnocast::Node>("rosout_node_b");
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 2u);
+}
+
+TEST_F(AgnocastNodeRosoutTest, destroying_node_removes_its_publisher)
+{
+  auto node_a = std::make_shared<agnocast::Node>("rosout_destroy_a");
+  auto node_b = std::make_shared<agnocast::Node>("rosout_destroy_b");
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 2u);
+
+  node_a.reset();
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 1u);
+
+  node_b.reset();
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 0u);
+}
+
+TEST_F(AgnocastNodeRosoutTest, no_rosout_flag_registers_no_publisher)
+{
+  agnocast::shutdown();
+  agnocast::init(0, nullptr);
+
+  auto node = std::make_shared<agnocast::Node>("rosout_no_flag_node");
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 0u);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -91,3 +91,61 @@ TEST_F(AgnocastContextStdoutLogsTest, flag_after_double_dash_terminator_is_ignor
 
   EXPECT_FALSE(output.empty()) << "Flag after -- must be ignored; expected stdout output";
 }
+
+// =========================================
+// agnocast::Context --enable-rosout-logs tests
+// =========================================
+
+class AgnocastContextRosoutTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { original_handler_ = rcutils_logging_get_output_handler(); }
+
+  void TearDown() override { rcutils_logging_set_output_handler(original_handler_); }
+
+  rcutils_logging_output_handler_t original_handler_;
+};
+
+TEST_F(AgnocastContextRosoutTest, enable_rosout_logs_sets_flag)
+{
+  const char * argv[] = {"program", "--ros-args", "--enable-rosout-logs"};
+  int argc = 3;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_TRUE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, no_flag_rosout_disabled)
+{
+  const char * argv[] = {"program", "--ros-args", "--log-level", "info"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, flag_outside_ros_args_is_ignored)
+{
+  const char * argv[] = {"program", "--enable-rosout-logs", "--ros-args", "--log-level", "info"};
+  int argc = 5;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+TEST_F(AgnocastContextRosoutTest, flag_after_double_dash_is_ignored)
+{
+  const char * argv[] = {"program", "--ros-args", "--", "--enable-rosout-logs"};
+  int argc = 4;
+  agnocast::Context ctx;
+
+  ctx.init(argc, argv);
+
+  EXPECT_FALSE(ctx.is_rosout_enabled());
+}

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -1,4 +1,5 @@
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_rosout.hpp"
 
 #include <gtest/gtest.h>
 #include <rcl/logging.h>
@@ -148,4 +149,46 @@ TEST_F(AgnocastContextRosoutTest, flag_after_double_dash_is_ignored)
   ctx.init(argc, argv);
 
   EXPECT_FALSE(ctx.is_rosout_enabled());
+}
+
+// =========================================
+// shutdown_rosout_handler tests
+// =========================================
+
+class ShutdownRosoutHandlerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    original_handler_ = rcutils_logging_get_output_handler();
+    // Ensure a clean slate before each test
+    agnocast::shutdown_rosout_handler();
+  }
+
+  void TearDown() override
+  {
+    agnocast::shutdown_rosout_handler();
+    rcutils_logging_set_output_handler(original_handler_);
+  }
+
+  rcutils_logging_output_handler_t original_handler_;
+};
+
+TEST_F(ShutdownRosoutHandlerTest, shutdown_with_no_prior_setup_is_safe)
+{
+  // Should not crash or assert when called with an empty map and no handler installed
+  EXPECT_NO_THROW(agnocast::shutdown_rosout_handler());
+}
+
+TEST_F(ShutdownRosoutHandlerTest, shutdown_resets_publisher_count_to_zero)
+{
+  // publisher count starts at zero after a clean shutdown
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 0u);
+}
+
+TEST_F(ShutdownRosoutHandlerTest, repeated_shutdown_calls_are_idempotent)
+{
+  agnocast::shutdown_rosout_handler();
+  EXPECT_NO_THROW(agnocast::shutdown_rosout_handler());
+  EXPECT_EQ(agnocast::get_rosout_publisher_count(), 0u);
 }


### PR DESCRIPTION
## Description
add `--enable-rosout-logs` full support.

Since agnocast cannot use `rcl_logging_configure()` (it requires `rcl_node_t` and spdlog), the flag is detected by manually scanning `argv` within the `--ros-args` scope during `Context::init()`.
                                                                                                              
  When enabled, the first constructed Node calls `setup_rosout_handler()`, which creates a `/rosout` publisher    
  (reliable, transient_local, depth 100) and installs a custom rcutils log output handler. The handler chains
  the original console handler, then formats and publishes each log message as `rcl_interfaces/msg/Log` via     
  loaned messages, with a recursion guard to prevent infinite loops during publishing.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
