### PR TITLE
feat(agnocastlib, test): add --disable-stdout-logs support with test

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -202,7 +202,7 @@ This provides the same argument parsing functionality as rcl.
 | `--log-level` | ✓ | **Full Support** | - | Set log level |
 | `--enable-rosout-logs` | ✗ | **Unsupported** | TBD | Enable logging to rosout |
 | `--disable-external-lib-logs` | ✓ | **Full Support** | - | Disable external library logs (file logging via rcl_logging_spdlog) |
-| `--disable-stdout-logs` | ✗ | **Unsupported** | TBD | Disable stdout logging |
+| `--disable-stdout-logs` | ✓ | **Full Support** | - | Disable stdout logging |
 | `-e` (enclave) | ✗ | **Unsupported** | TBD | Specify security enclave |
 
 ### 3.2 Parameter Override Resolution

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -141,7 +141,8 @@ if(BUILD_TESTING)
     test/unit/test_agnocast_epoll_manager.cpp
     test/unit/test_node_topics.cpp
     test/unit/test_node_base.cpp
-    test/unit/test_cie_client_utils.cpp)
+    test/unit/test_cie_client_utils.cpp
+    test/unit/test_agnocast_context.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs)

--- a/src/agnocastlib/src/node/agnocast_context.cpp
+++ b/src/agnocastlib/src/node/agnocast_context.cpp
@@ -3,8 +3,10 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast_signal_handler.hpp"
 
+#include <rcl/arguments.h>
 #include <rcl/error_handling.h>
 #include <rcl/logging.h>
+#include <rcutils/logging.h>
 #include <rcutils/logging_macros.h>
 
 namespace agnocast
@@ -32,6 +34,10 @@ void Context::init(int argc, char const * const * argv)
   // ~/.ros/log/ files via rcl_logging_spdlog, matching rclcpp::init() behavior.
   // This also applies --log-level from parsed_arguments_ via
   // rcl_arguments_get_log_levels() internally.
+  // rcl_logging_configure_with_output_handler reads --disable-stdout-logs and
+  // --disable-external-lib-logs from parsed_arguments_ and registers only the
+  // enabled sub-handlers inside rcl_logging_multiple_output_handler, so stdout
+  // can be suppressed while file logging via spdlog is preserved.
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_logging_configure_with_output_handler(
     parsed_arguments_.get(), &allocator, rcl_logging_multiple_output_handler);

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -1,0 +1,91 @@
+#include "agnocast/node/agnocast_context.hpp"
+
+#include <gtest/gtest.h>
+#include <rcl/logging.h>
+#include <rcutils/logging.h>
+#include <rcutils/logging_macros.h>
+
+// =========================================
+// agnocast::Context --disable-stdout-logs tests
+// =========================================
+
+class AgnocastContextStdoutLogsTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { original_handler_ = rcutils_logging_get_output_handler(); }
+
+  void TearDown() override
+  {
+    // Finalize rcl logging so the next test can call rcl_logging_configure again.
+    rcl_ret_t ret = rcl_logging_fini();
+    (void)ret;
+    // Restore the original handler so other tests are not affected.
+    rcutils_logging_set_output_handler(original_handler_);
+  }
+
+  rcutils_logging_output_handler_t original_handler_;
+};
+
+TEST_F(AgnocastContextStdoutLogsTest, disable_stdout_logs_suppresses_console_output)
+{
+  const char * argv[] = {"program", "--ros-args", "--disable-stdout-logs", "--log-level", "debug"};
+  int argc = 5;
+  agnocast::Context ctx;
+  ctx.init(argc, argv);
+
+  testing::internal::CaptureStderr();
+  RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
+  fflush(stdout);
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_TRUE(output.empty()) << "Expected no stdout output with --disable-stdout-logs, got: "
+                              << output;
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, no_flag_emits_console_output)
+{
+  const char * argv[] = {"program", "--ros-args", "--log-level", "debug"};
+  int argc = 4;
+  agnocast::Context ctx;
+  ctx.init(argc, argv);
+
+  testing::internal::CaptureStderr();
+  RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
+  fflush(stdout);
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(output.empty()) << "Expected stdout output without --disable-stdout-logs";
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, flag_outside_ros_args_is_ignored)
+{
+  // --disable-stdout-logs appears before --ros-args, so it is not a ROS argument
+  const char * argv[] = {"program", "--disable-stdout-logs", "--ros-args", "--log-level", "debug"};
+  int argc = 5;
+  agnocast::Context ctx;
+  ctx.init(argc, argv);
+
+  testing::internal::CaptureStderr();
+  RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
+  fflush(stdout);
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(output.empty()) << "Flag outside --ros-args must be ignored; expected stdout output";
+}
+
+TEST_F(AgnocastContextStdoutLogsTest, flag_after_double_dash_terminator_is_ignored)
+{
+  // --disable-stdout-logs appears after -- (end of ROS args), so it is not a ROS argument
+  const char * argv[] = {"program", "--ros-args", "--log-level",
+                         "debug",   "--",         "--disable-stdout-logs"};
+  int argc = 6;
+  agnocast::Context ctx;
+  ctx.init(argc, argv);
+
+  testing::internal::CaptureStderr();
+  RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
+  fflush(stdout);
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(output.empty()) << "Flag after -- must be ignored; expected stdout output";
+}

--- a/src/agnocastlib/test/unit/test_agnocast_context.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_context.cpp
@@ -8,6 +8,8 @@
 // =========================================
 // agnocast::Context --disable-stdout-logs tests
 // =========================================
+// Note: despite the flag name, rcutils/rcl's default console handler routes all output to stderr
+// when stdout is not a TTY (as is the case inside a test process). Tests therefore capture stderr.
 
 class AgnocastContextStdoutLogsTest : public ::testing::Test
 {
@@ -35,7 +37,7 @@ TEST_F(AgnocastContextStdoutLogsTest, disable_stdout_logs_suppresses_console_out
 
   testing::internal::CaptureStderr();
   RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
-  fflush(stdout);
+
   const std::string output = testing::internal::GetCapturedStderr();
 
   EXPECT_TRUE(output.empty()) << "Expected no stdout output with --disable-stdout-logs, got: "
@@ -51,7 +53,7 @@ TEST_F(AgnocastContextStdoutLogsTest, no_flag_emits_console_output)
 
   testing::internal::CaptureStderr();
   RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
-  fflush(stdout);
+
   const std::string output = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(output.empty()) << "Expected stdout output without --disable-stdout-logs";
@@ -67,7 +69,7 @@ TEST_F(AgnocastContextStdoutLogsTest, flag_outside_ros_args_is_ignored)
 
   testing::internal::CaptureStderr();
   RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
-  fflush(stdout);
+
   const std::string output = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(output.empty()) << "Flag outside --ros-args must be ignored; expected stdout output";
@@ -84,7 +86,7 @@ TEST_F(AgnocastContextStdoutLogsTest, flag_after_double_dash_terminator_is_ignor
 
   testing::internal::CaptureStderr();
   RCUTILS_LOG_INFO_NAMED("agnocast_test", "test message");
-  fflush(stdout);
+
   const std::string output = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(output.empty()) << "Flag after -- must be ignored; expected stdout output";


### PR DESCRIPTION
## Description
add `--disable-stdout-logs` support with test

When agnocast::init() is called, Context::init() in agnocast_context.cpp does two things:                   
                                                                                                              
  1. Always: calls `rcl_logging_configure_with_output_handler(…, rcl_logging_multiple_output_handler)` to route 
  logs to file via spdlog (the normal path inherited from main).                                              
  2. Conditionally: scans `argv` directly for `--disable-stdout-logs` within the `--ros-args … -- `scope. If found, 
  it immediately overrides the handler with a local `noop_log_output_handler` — a no-op function that silently  
  drops every log call.                                                                                       
                                                                                                              
  The argv scan is manual because `rcl_arguments_t` has no public API to query this flag, and using             
  `rcl_logging_configure()` in agnocast is avoided since it would try to set up a `rosout` publisher, which       
  requires an `rcl_node_t` that agnocast doesn't have. 

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
