### PR TITLE
feat(agnocastlib): add timer init tracepoint

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -195,7 +195,7 @@ TimerBase::SharedPtr create_timer(
     node_handle = static_cast<const void *>(
       node->get_node_base_interface()->get_shared_rcl_node_handle().get());
   } else {
-    node_handle = get_node_base_address(node);
+    node_handle = static_cast<const void *>(node->get_node_base_interface().get());
   }
 
   TRACEPOINT(


### PR DESCRIPTION
## Description
The agnocast::create_timer() free function in agnocast.hpp creates an agnocast::GenericTimer directly without going through Node::create_timer_impl(). Since the agnocast_timer_init tracepoint was only placed inside Node::create_wall_timer() and Node::create_timer_impl(), timers created via the free function were not traced.

**Changes**
Added agnocast_timer_init tracepoint to agnocast::create_timer() in agnocast.hpp, just before return timer;.

**Verification**
Ran no_rclcpp_publisher + no_rclcpp_subscriber with LTTng tracing enabled. Confirmed agnocast_timer_init now appears in babeltrace output with correct timer_handle, node_handle, symbol, and period values.
Furthermore, I confirmed that the implementation works correctly for rclcpp nodes using minimal_publisher and minimal_listener modified to use gnocast::create_timer().

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
