### PR TITLE
fix(ros2agnocast): show Agnocast label for topics that exist in both ROS2 and Agnocast

### DIFF
--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -303,8 +303,9 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 else:
                     print(f"    {sub.name}: {', '.join(sub.types)}")
 
+            ros2_sub_name_set = {sub.name for sub in subscribers}
             for agnocast_sub in agnocast_subscribers:
-                if agnocast_sub in [sub.name for sub in subscribers]:
+                if agnocast_sub in ros2_sub_name_set:
                     continue
                 matching_topics = [topic for topic in ros2_topic_dir if topic['name'] == agnocast_sub]
                 if matching_topics:
@@ -323,8 +324,9 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 else:
                     print(f"    {pub.name}: {', '.join(pub.types)}")
 
+            ros2_pub_name_set = {pub.name for pub in publishers}
             for agnocast_pub in agnocast_publishers:
-                if agnocast_pub in [pub.name for pub in publishers]:
+                if agnocast_pub in ros2_pub_name_set:
                     continue
                 matching_topics = [topic for topic in ros2_topic_dir if topic['name'] == agnocast_pub]
                 if matching_topics:


### PR DESCRIPTION
## Description
When a topic is registered as both a ROS2 and Agnocast publisher/subscriber on the same node, `ros2 node info_agnocast` was silently skipping the Agnocast entry, showing no label at all. Add Agnocast label (e.g. `(Agnocast enabled, bridged)`) to the ROS2 entry in this case.

## Related links
https://github.com/autowarefoundation/autoware_universe/pull/12304

## How was this PR tested?
Tested with `voxel_based_compare_map_filter` in Autoware with above PR.

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
