### PR TITLE
fix(test): filter bridge node messages in agnocast-only CIE test

### DIFF
--- a/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
@@ -49,12 +49,12 @@ public:
   }
 
   std::vector<agnocast_cie_config_msgs::msg::CallbackGroupInfo> get_received_messages_for_node(
-    const std::string & node_name)
+    const std::string & node_name) const
   {
     std::lock_guard<std::mutex> lock(mutex_);
     std::vector<agnocast_cie_config_msgs::msg::CallbackGroupInfo> filtered;
     for (const auto & msg : received_messages_) {
-      if (msg.callback_group_id.find(node_name) == 0) {
+      if (msg.callback_group_id.rfind(node_name, 0) == 0) {
         filtered.push_back(msg);
       }
     }
@@ -63,7 +63,7 @@ public:
 
 private:
   rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr subscription_;
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::vector<agnocast_cie_config_msgs::msg::CallbackGroupInfo> received_messages_;
 };
 
@@ -99,7 +99,7 @@ TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, test_spin_publishes_callback_gr
   std::thread callback_isolated_thread(
     [&callback_isolated_executor]() { callback_isolated_executor->spin(); });
 
-  const std::string test_node_name = "/agnocast_only_dummy_node";
+  const std::string test_node_name = test_node->get_fully_qualified_name();
   auto start_time = std::chrono::steady_clock::now();
   constexpr auto timeout = std::chrono::seconds(10);
   while (receiver_node->get_received_messages_for_node(test_node_name).size() < 3u) {


### PR DESCRIPTION
## Description

The agnocast-only CIE integration test (`test_spin_publishes_callback_group_info`) was failing because the bridge node — started by `request_bridge` when the CIE's agnocast client publisher is created — also publishes `CallbackGroupInfo` messages on the same topic. This caused the receiver to see 5 messages (3 from the test node + 2 from the bridge node) instead of the expected 3.

This PR adds a `get_received_messages_for_node()` helper that filters messages by `callback_group_id` prefix, and uses it in both the wait loop and the assertion so only the test node's callback groups are counted.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] sample application
- [x] Ran `test_integration_agnocast_only_callback_isolated_executor_agnocastlib` locally — 2/2 tests passed

## Notes for reviewers

The root cause is that `create_agnocast_client_publisher()` triggers `AgnocastToRosRequestPolicy::request_bridge`, which causes the bridge manager to start an `agnocast_bridge_node`. This bridge node runs in its own CIE and publishes its own `CallbackGroupInfo` messages (default callback group + bridge subscription callback group) on the same `/agnocast_cie_thread_configurator/callback_group_info` topic. The test's rclcpp subscriber receives all messages from all sources on that topic.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.