### PR TITLE
refactor(thread_configurator): split into separate executables and use ROS parameters

### DIFF
--- a/docs/callback_isolated_executor_for_agnocast.md
+++ b/docs/callback_isolated_executor_for_agnocast.md
@@ -34,9 +34,13 @@ agnocast_components_register_node(
 
 #### Multiple ROS domain support
 
-`agnocast_cie_thread_configurator` can handle callback groups from multiple ROS domains. Use launch arguments to specify domain IDs:
+`agnocast_cie_thread_configurator` can handle callback groups from multiple ROS domains. Use ROS parameters to specify domain IDs:
 
 ```bash
+# Option 1: Run prerun_node directly with ROS parameters
+ros2 run agnocast_cie_thread_configurator prerun_node --ros-args -p domains:=[0,1]
+
+# Option 2: Use the launch file
 ros2 launch agnocast_cie_thread_configurator thread_configurator.launch.xml prerun:=true domains:=[0,1]
 ```
 

--- a/docs/callback_isolated_executor_for_agnocast.md
+++ b/docs/callback_isolated_executor_for_agnocast.md
@@ -6,11 +6,11 @@
 
 ### Package, Class, and Executable Names
 
-| | Original | Agnocast Version |
-|--|----------|------------------|
-| Package | `callback_isolated_executor` | `agnocast_components` (recommended) or `agnocastlib` (deprecated) |
-| Executor Class | `CallbackIsolatedExecutor` | `agnocast::CallbackIsolatedAgnocastExecutor` |
-| Container Executable | `component_container_callback_isolated` | `agnocast_component_container_cie` |
+|                      | Original                                | Agnocast Version                                                  |
+| -------------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| Package              | `callback_isolated_executor`            | `agnocast_components` (recommended) or `agnocastlib` (deprecated) |
+| Executor Class       | `CallbackIsolatedExecutor`              | `agnocast::CallbackIsolatedAgnocastExecutor`                      |
+| Container Executable | `component_container_callback_isolated` | `agnocast_component_container_cie`                                |
 
 ### Features
 
@@ -34,10 +34,10 @@ agnocast_components_register_node(
 
 #### Multiple ROS domain support
 
-`agnocast_cie_thread_configurator` can handle callback groups from multiple ROS domains. Use the `--domains` option to specify domain IDs you use:
+`agnocast_cie_thread_configurator` can handle callback groups from multiple ROS domains. Use launch arguments to specify domain IDs:
 
 ```bash
-ros2 run agnocast_cie_thread_configurator thread_configurator_node --prerun --domains 0,1
+ros2 launch agnocast_cie_thread_configurator thread_configurator.launch.xml prerun:=true domains:=[0,1]
 ```
 
 #### RT Throttling

--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -14,11 +14,28 @@ find_package(yaml-cpp REQUIRED)
 add_library(thread_configurator SHARED src/util.cpp)
 ament_target_dependencies(thread_configurator rclcpp agnocast_cie_config_msgs)
 
-add_executable(thread_configurator_node src/main.cpp src/thread_configurator_node.cpp src/prerun_node.cpp)
+add_executable(
+  thread_configurator_node
+  src/main.cpp
+  src/thread_configurator_node.cpp
+  src/prerun_node.cpp
+)
 ament_target_dependencies(thread_configurator_node rclcpp agnocast_cie_config_msgs)
 target_link_libraries(thread_configurator_node yaml-cpp thread_configurator)
 
 target_include_directories(thread_configurator_node PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_executable(
+  prerun_node
+  src/prerun_node_main.cpp
+  src/prerun_node.cpp
+)
+ament_target_dependencies(prerun_node rclcpp agnocast_cie_config_msgs)
+target_link_libraries(prerun_node yaml-cpp thread_configurator)
+
+target_include_directories(prerun_node PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
@@ -40,7 +57,12 @@ install(
   DESTINATION include
 )
 
-install(TARGETS thread_configurator_node DESTINATION lib/${PROJECT_NAME})
+install(TARGETS thread_configurator_node prerun_node DESTINATION lib/${PROJECT_NAME})
+
+install(
+  DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+)
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/prerun_node.hpp
@@ -13,7 +13,7 @@
 class PrerunNode : public rclcpp::Node
 {
 public:
-  explicit PrerunNode(const std::set<size_t> & domain_ids);
+  explicit PrerunNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   void dump_yaml_config(std::filesystem::path path);
 
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -29,7 +29,7 @@ class ThreadConfiguratorNode : public rclcpp::Node
   };
 
 public:
-  explicit ThreadConfiguratorNode(const YAML::Node & yaml);
+  explicit ThreadConfiguratorNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   ~ThreadConfiguratorNode();
   void print_all_unapplied();
   bool has_configured_once() const;
@@ -37,6 +37,7 @@ public:
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;
 
 private:
+  void validate_hardware_info(const YAML::Node & yaml);
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
   bool issue_syscalls(const ThreadConfig & config);

--- a/src/agnocast_cie_thread_configurator/launch/thread_configurator.launch.xml
+++ b/src/agnocast_cie_thread_configurator/launch/thread_configurator.launch.xml
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="prerun" default="false" description="Launch prerun_node when true, otherwise launch thread_configurator_node"/>
+  <arg name="domains" default="[]" description="ROS domain IDs (e.g. [0,1])"/>
+  <arg name="config_file" default="" description="Path to thread configurator YAML config file"/>
+
+  <node
+    pkg="agnocast_cie_thread_configurator"
+    exec="prerun_node"
+    name="prerun_node"
+    output="screen"
+    if="$(var prerun)"
+  >
+    <param name="domains" value="$(var domains)"/>
+  </node>
+
+  <node
+    pkg="agnocast_cie_thread_configurator"
+    exec="thread_configurator_node"
+    name="thread_configurator_node"
+    output="screen"
+    unless="$(var prerun)"
+  >
+    <param name="config_file" value="$(var config_file)"/>
+  </node>
+</launch>

--- a/src/agnocast_cie_thread_configurator/launch/thread_configurator.launch.xml
+++ b/src/agnocast_cie_thread_configurator/launch/thread_configurator.launch.xml
@@ -1,4 +1,6 @@
 <launch>
+  <!-- prerun:=true launches prerun_node (uses 'domains', ignores 'config_file').
+       prerun:=false (default) launches thread_configurator_node (uses 'config_file', ignores 'domains'). -->
   <arg name="prerun" default="false" description="Launch prerun_node when true, otherwise launch thread_configurator_node"/>
   <arg name="domains" default="[]" description="ROS domain IDs (e.g. [0,1])"/>
   <arg name="config_file" default="" description="Path to thread configurator YAML config file"/>

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -48,10 +48,11 @@ int main(int argc, char * argv[])
 
   if (prerun_mode || !domain_ids.empty() || !config_filename.empty()) {
     std::cerr << "[DEPRECATED] CLI arguments (--prerun, --domains, --config-file) are deprecated. "
-              << "Use the launch file (thread_configurator.launch.xml) with ROS parameters instead."
-              << std::endl;
+              << "Run prerun_node directly with ROS parameters or use the launch file "
+              << "(thread_configurator.launch.xml) instead." << std::endl;
   }
 
+  // Backward-compatible CLI path: translates deprecated CLI args into ROS parameter overrides.
   try {
     if (prerun_mode) {
       std::cout << "prerun mode" << std::endl;

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -3,7 +3,9 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <filesystem>
+#include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 static std::vector<int64_t> parse_domain_ids(const std::string & domains_str)
@@ -14,7 +16,7 @@ static std::vector<int64_t> parse_domain_ids(const std::string & domains_str)
   while (std::getline(ss, token, ',')) {
     if (!token.empty()) {
       try {
-        domain_ids.push_back(static_cast<int64_t>(std::stoul(token)));
+        domain_ids.push_back(static_cast<int64_t>(std::stol(token)));
       } catch (const std::exception & e) {
         std::cerr << "[WARN] Invalid domain ID value: " << token << ". Skipping." << std::endl;
       }

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -52,44 +52,50 @@ int main(int argc, char * argv[])
               << std::endl;
   }
 
-  if (prerun_mode) {
-    std::cout << "prerun mode" << std::endl;
+  try {
+    if (prerun_mode) {
+      std::cout << "prerun mode" << std::endl;
 
-    rclcpp::NodeOptions options;
-    if (!domain_ids.empty()) {
-      options.append_parameter_override("domains", domain_ids);
+      rclcpp::NodeOptions options;
+      if (!domain_ids.empty()) {
+        options.append_parameter_override("domains", domain_ids);
+      }
+
+      auto node = std::make_shared<PrerunNode>(options);
+      auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+      executor->add_node(node);
+      for (const auto & sub_node : node->get_domain_nodes()) {
+        executor->add_node(sub_node);
+      }
+
+      executor->spin();
+
+      node->dump_yaml_config(std::filesystem::current_path());
+    } else {
+      rclcpp::NodeOptions options;
+      if (!config_filename.empty()) {
+        options.append_parameter_override("config_file", config_filename);
+      }
+
+      auto node = std::make_shared<ThreadConfiguratorNode>(options);
+      auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+      executor->add_node(node);
+      for (const auto & domain_node : node->get_domain_nodes()) {
+        executor->add_node(domain_node);
+      }
+
+      executor->spin();
+
+      if (!node->has_configured_once()) {
+        node->print_all_unapplied();
+      }
     }
-
-    auto node = std::make_shared<PrerunNode>(options);
-    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-    executor->add_node(node);
-    for (const auto & sub_node : node->get_domain_nodes()) {
-      executor->add_node(sub_node);
-    }
-
-    executor->spin();
-
-    node->dump_yaml_config(std::filesystem::current_path());
-  } else {
-    rclcpp::NodeOptions options;
-    if (!config_filename.empty()) {
-      options.append_parameter_override("config_file", config_filename);
-    }
-
-    auto node = std::make_shared<ThreadConfiguratorNode>(options);
-    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-    executor->add_node(node);
-    for (const auto & domain_node : node->get_domain_nodes()) {
-      executor->add_node(domain_node);
-    }
-
-    executor->spin();
-
-    if (!node->has_configured_once()) {
-      node->print_all_unapplied();
-    }
+  } catch (const std::exception & e) {
+    std::cerr << "[ERROR] " << e.what() << std::endl;
+    rclcpp::shutdown();
+    return 1;
   }
 
   rclcpp::shutdown();

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -1,132 +1,20 @@
-#include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/prerun_node.hpp"
 #include "agnocast_cie_thread_configurator/thread_configurator_node.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "yaml-cpp/yaml.h"
 
 #include <filesystem>
 #include <memory>
 #include <string>
 
-static bool validate_hardware_info(const YAML::Node & yaml)
+static std::vector<int64_t> parse_domain_ids(const std::string & domains_str)
 {
-  YAML::Node yaml_hw_info = yaml["hardware_info"];
-  auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
-
-  bool all_match = true;
-  std::vector<std::string> mismatches;
-
-  for (const auto & [key, current_value] : current_hw_info) {
-    if (!yaml_hw_info[key]) {
-      continue;
-    }
-
-    std::string yaml_value = yaml_hw_info[key].as<std::string>();
-    if (yaml_value != current_value) {
-      all_match = false;
-      mismatches.push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
-    }
-  }
-
-  // Report results
-  if (!all_match) {
-    std::cerr << "[ERROR] Hardware validation failed with the following "
-                 "mismatches:"
-              << std::endl;
-    for (const auto & mismatch : mismatches) {
-      std::cerr << "  - " << mismatch << std::endl;
-    }
-  } else {
-    std::cout << "[INFO] Hardware validation successful. Configuration matches "
-                 "this system."
-              << std::endl;
-  }
-
-  return all_match;
-}
-
-static void spin_thread_configurator_node(const std::string & config_filename)
-{
-  YAML::Node config;
-
-  try {
-    config = YAML::LoadFile(config_filename);
-  } catch (const std::exception & e) {
-    std::cerr << "Error reading the YAML file: " << e.what() << std::endl;
-    return;
-  }
-
-  // Validate hardware information if present in YAML
-  if (config["hardware_info"]) {
-    if (!validate_hardware_info(config)) {
-      std::cerr << "[ERROR] Hardware information validation failed. The "
-                   "configuration may not match this system."
-                << std::endl;
-      return;
-    }
-  } else {
-    std::cout << "[WARN] No hardware_info section found in configuration file. "
-                 "Skipping hardware validation."
-              << std::endl;
-  }
-
-  std::cout << "rt_throttling:" << std::endl;
-  std::cout << config["rt_throttling"] << std::endl;
-  std::cout << "callback_groups:" << std::endl;
-  std::cout << config["callback_groups"] << std::endl;
-  std::cout << "non_ros_threads:" << std::endl;
-  std::cout << config["non_ros_threads"] << std::endl;
-
-  auto node = std::make_shared<ThreadConfiguratorNode>(config);
-  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-  executor->add_node(node);
-  for (const auto & domain_node : node->get_domain_nodes()) {
-    executor->add_node(domain_node);
-  }
-
-  executor->spin();
-
-  if (!node->has_configured_once()) {
-    node->print_all_unapplied();
-  }
-}
-
-static void spin_prerun_node(const std::set<size_t> & domain_ids)
-{
-  std::cout << "prerun mode" << std::endl;
-
-  auto node = std::make_shared<PrerunNode>(domain_ids);
-  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-  executor->add_node(node);
-  for (const auto & sub_node : node->get_domain_nodes()) {
-    executor->add_node(sub_node);
-  }
-
-  executor->spin();
-
-  node->dump_yaml_config(std::filesystem::current_path());
-}
-
-static std::set<size_t> parse_domain_ids(const std::string & domains_str)
-{
-  // https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Domain-ID.html#choosing-a-domain-id-short-version
-  constexpr size_t max_domain_id = 101;
-
-  std::set<size_t> domain_ids;
+  std::vector<int64_t> domain_ids;
   std::stringstream ss(domains_str);
   std::string token;
   while (std::getline(ss, token, ',')) {
     if (!token.empty()) {
       try {
-        size_t domain_id = std::stoul(token);
-        if (domain_id > max_domain_id) {
-          std::cerr << "[WARN] Domain ID " << domain_id << " exceeds maximum valid value ("
-                    << max_domain_id << "). Skipping." << std::endl;
-          continue;
-        }
-        domain_ids.insert(domain_id);
+        domain_ids.push_back(static_cast<int64_t>(std::stoul(token)));
       } catch (const std::exception & e) {
         std::cerr << "[WARN] Invalid domain ID value: " << token << ". Skipping." << std::endl;
       }
@@ -141,7 +29,7 @@ int main(int argc, char * argv[])
   std::vector<std::string> args = rclcpp::remove_ros_arguments(argc, argv);
 
   bool prerun_mode = false;
-  std::set<size_t> domain_ids;
+  std::vector<int64_t> domain_ids;
   std::string config_filename;
 
   for (size_t i = 0; i < args.size(); ++i) {
@@ -156,16 +44,50 @@ int main(int argc, char * argv[])
     }
   }
 
+  if (prerun_mode || !domain_ids.empty() || !config_filename.empty()) {
+    std::cerr << "[DEPRECATED] CLI arguments (--prerun, --domains, --config-file) are deprecated. "
+              << "Use the launch file (thread_configurator.launch.xml) with ROS parameters instead."
+              << std::endl;
+  }
+
   if (prerun_mode) {
-    spin_prerun_node(domain_ids);
-  } else {
-    if (config_filename.empty()) {
-      std::cerr << "[ERROR] --config-file must be provided when not running in --prerun mode."
-                << std::endl;
-      rclcpp::shutdown();
-      return 1;
+    std::cout << "prerun mode" << std::endl;
+
+    rclcpp::NodeOptions options;
+    if (!domain_ids.empty()) {
+      options.append_parameter_override("domains", domain_ids);
     }
-    spin_thread_configurator_node(config_filename);
+
+    auto node = std::make_shared<PrerunNode>(options);
+    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+    executor->add_node(node);
+    for (const auto & sub_node : node->get_domain_nodes()) {
+      executor->add_node(sub_node);
+    }
+
+    executor->spin();
+
+    node->dump_yaml_config(std::filesystem::current_path());
+  } else {
+    rclcpp::NodeOptions options;
+    if (!config_filename.empty()) {
+      options.append_parameter_override("config_file", config_filename);
+    }
+
+    auto node = std::make_shared<ThreadConfiguratorNode>(options);
+    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+    executor->add_node(node);
+    for (const auto & domain_node : node->get_domain_nodes()) {
+      executor->add_node(domain_node);
+    }
+
+    executor->spin();
+
+    if (!node->has_configured_once()) {
+      node->print_all_unapplied();
+    }
   }
 
   rclcpp::shutdown();

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -23,7 +23,8 @@ PrerunNode::PrerunNode(const rclcpp::NodeOptions & options) : Node("prerun_node"
   for (const auto raw_domain_id : domains) {
     if (raw_domain_id < 0) {
       RCLCPP_WARN(
-        this->get_logger(), "Negative domain ID %ld is invalid. Skipping.", raw_domain_id);
+        this->get_logger(), "Negative domain ID %lld is invalid. Skipping.",
+        static_cast<long long>(raw_domain_id));
       continue;
     }
 

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -9,10 +9,35 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <string>
 
-PrerunNode::PrerunNode(const std::set<size_t> & domain_ids) : Node("prerun_node")
+PrerunNode::PrerunNode(const rclcpp::NodeOptions & options) : Node("prerun_node", options)
 {
+  // https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Domain-ID.html#choosing-a-domain-id-short-version
+  constexpr size_t max_domain_id = 101;
+
+  const auto domains =
+    this->declare_parameter<std::vector<int64_t>>("domains", std::vector<int64_t>{});
+  std::set<size_t> domain_ids;
+  for (const auto raw_domain_id : domains) {
+    if (raw_domain_id < 0) {
+      RCLCPP_WARN(
+        this->get_logger(), "Negative domain ID %ld is invalid. Skipping.", raw_domain_id);
+      continue;
+    }
+
+    const size_t domain_id = static_cast<size_t>(raw_domain_id);
+    if (domain_id > max_domain_id) {
+      RCLCPP_WARN(
+        this->get_logger(), "Domain ID %zu exceeds maximum valid value (%zu). Skipping.", domain_id,
+        max_domain_id);
+      continue;
+    }
+
+    domain_ids.insert(domain_id);
+  }
+
   size_t default_domain_id = agnocast_cie_thread_configurator::get_default_domain_id();
 
   auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();

--- a/src/agnocast_cie_thread_configurator/src/prerun_node_main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node_main.cpp
@@ -1,0 +1,25 @@
+#include "agnocast_cie_thread_configurator/prerun_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <filesystem>
+#include <memory>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<PrerunNode>();
+  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  executor->add_node(node);
+  for (const auto & sub_node : node->get_domain_nodes()) {
+    executor->add_node(sub_node);
+  }
+
+  executor->spin();
+
+  node->dump_yaml_config(std::filesystem::current_path());
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/agnocast_cie_thread_configurator/src/prerun_node_main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node_main.cpp
@@ -2,23 +2,30 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <filesystem>
+#include <iostream>
 #include <memory>
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  auto node = std::make_shared<PrerunNode>();
-  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  try {
+    auto node = std::make_shared<PrerunNode>();
+    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-  executor->add_node(node);
-  for (const auto & sub_node : node->get_domain_nodes()) {
-    executor->add_node(sub_node);
+    executor->add_node(node);
+    for (const auto & sub_node : node->get_domain_nodes()) {
+      executor->add_node(sub_node);
+    }
+
+    executor->spin();
+
+    node->dump_yaml_config(std::filesystem::current_path());
+  } catch (const std::exception & e) {
+    std::cerr << "[ERROR] " << e.what() << std::endl;
+    rclcpp::shutdown();
+    return 1;
   }
-
-  executor->spin();
-
-  node->dump_yaml_config(std::filesystem::current_path());
 
   rclcpp::shutdown();
   return 0;

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -18,10 +18,27 @@
 #include <string>
 #include <unordered_map>
 
-ThreadConfiguratorNode::ThreadConfiguratorNode(const YAML::Node & yaml)
-: Node("thread_configurator_node"), unapplied_num_(0), cgroup_num_(0)
+ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
+: Node("thread_configurator_node", options), unapplied_num_(0), cgroup_num_(0)
 {
+  const auto config_file = this->declare_parameter<std::string>("config_file", "");
+  if (config_file.empty()) {
+    throw std::runtime_error(
+      "'config_file' parameter must be provided with a valid YAML file path.");
+  }
+
+  YAML::Node yaml;
+  try {
+    yaml = YAML::LoadFile(config_file);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(this->get_logger(), "Error reading the YAML file: %s", e.what());
+    throw;
+  }
+
+  validate_hardware_info(yaml);
   validate_rt_throttling(yaml);
+
+  RCLCPP_INFO(this->get_logger(), "Loaded config from: %s", config_file.c_str());
 
   YAML::Node callback_groups = yaml["callback_groups"];
   YAML::Node non_ros_threads = yaml["non_ros_threads"];
@@ -218,6 +235,43 @@ void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
     }
 
     RCLCPP_ERROR(this->get_logger(), "%s", message.c_str());
+  }
+}
+
+void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
+{
+  if (!yaml["hardware_info"]) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "No hardware_info section found in configuration file. Skipping hardware validation.");
+    return;
+  }
+
+  const YAML::Node & yaml_hw_info = yaml["hardware_info"];
+  auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
+
+  std::vector<std::string> mismatches;
+
+  for (const auto & [key, current_value] : current_hw_info) {
+    if (!yaml_hw_info[key]) {
+      continue;
+    }
+
+    std::string yaml_value = yaml_hw_info[key].as<std::string>();
+    if (yaml_value != current_value) {
+      mismatches.push_back(key + ": expected '" + yaml_value + "', got '" + current_value + "'");
+    }
+  }
+
+  if (!mismatches.empty()) {
+    std::string error_msg = "Hardware validation failed with the following mismatches:\n";
+    for (const auto & mismatch : mismatches) {
+      error_msg += "  - " + mismatch + "\n";
+    }
+    throw std::runtime_error(error_msg);
+  } else {
+    RCLCPP_INFO(
+      this->get_logger(), "Hardware validation successful. Configuration matches this system.");
   }
 }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -248,7 +248,7 @@ void ThreadConfiguratorNode::validate_hardware_info(const YAML::Node & yaml)
   }
 
   const YAML::Node & yaml_hw_info = yaml["hardware_info"];
-  auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
+  const auto current_hw_info = agnocast_cie_thread_configurator::get_hardware_info();
 
   std::vector<std::string> mismatches;
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -31,8 +31,6 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
   try {
     yaml = YAML::LoadFile(config_file);
   } catch (const std::exception & e) {
-    RCLCPP_ERROR(
-      this->get_logger(), "Error reading the YAML file '%s': %s", config_file.c_str(), e.what());
     throw std::runtime_error("Error reading the YAML file '" + config_file + "': " + e.what());
   }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -31,8 +31,9 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
   try {
     yaml = YAML::LoadFile(config_file);
   } catch (const std::exception & e) {
-    RCLCPP_ERROR(this->get_logger(), "Error reading the YAML file: %s", e.what());
-    throw;
+    RCLCPP_ERROR(
+      this->get_logger(), "Error reading the YAML file '%s': %s", config_file.c_str(), e.what());
+    throw std::runtime_error("Error reading the YAML file '" + config_file + "': " + e.what());
   }
 
   validate_hardware_info(yaml);

--- a/src/agnocast_e2e_test/test/functional/test_agnocast_callback_isolated_executor_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_agnocast_callback_isolated_executor_launch.py
@@ -11,10 +11,9 @@ import launch_testing.asserts
 def generate_test_description():
     thread_configurator_node = launch_ros.actions.Node(
         package='agnocast_cie_thread_configurator',
-        executable='thread_configurator_node',
-        name='thread_configurator_node',
-        output='screen',
-        arguments=['--prerun']
+        executable='prerun_node',
+        name='prerun_node',
+        output='screen'
     )
 
     # Standalone executable with CallbackIsolatedAgnocastExecutor

--- a/src/agnocast_e2e_test/test/functional/test_agnocast_component_container_cie_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_agnocast_component_container_cie_launch.py
@@ -13,10 +13,9 @@ from launch_ros.descriptions import ComposableNode
 def generate_test_description():
     thread_configurator_node = launch_ros.actions.Node(
         package='agnocast_cie_thread_configurator',
-        executable='thread_configurator_node',
-        name='thread_configurator_node',
-        output='screen',
-        arguments=['--prerun']
+        executable='prerun_node',
+        name='prerun_node',
+        output='screen'
     )
 
     component_container = ComposableNodeContainer(

--- a/src/agnocast_e2e_test/test/functional/test_multi_domain_cie_talker_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_multi_domain_cie_talker_launch.py
@@ -12,10 +12,10 @@ import launch_testing.asserts
 def generate_test_description():
     prerun_node = launch_ros.actions.Node(
         package='agnocast_cie_thread_configurator',
-        executable='thread_configurator_node',
+        executable='prerun_node',
         name='prerun_node',
         output='screen',
-        arguments=['--prerun', '--domains', '0,1'],
+        parameters=[{'domains': [0, 1]}],
         additional_env={'ROS_DOMAIN_ID': '0'}
     )
 


### PR DESCRIPTION
## Description

Refactor `agnocast_cie_thread_configurator` to split `thread_configurator_node` and `prerun_node` into independent executables, and use ROS parameters (`config_file`, `domains`) instead of CLI arguments. This enables canonical launch file usage and aligns with ROS 2 best practices.

Key changes:
- **Separate executables**: `prerun_node` is now its own executable (previously a `--prerun` mode of `thread_configurator_node`)
- **ROS parameters**: `config_file` and `domains` are now ROS parameters, enabling declarative launch file configuration
- **Launch file**: Added `thread_configurator.launch.xml` as the canonical way to launch either node
- **Direct `ros2 run` support**: `prerun_node` can also be run directly with `ros2 run ... --ros-args -p domains:=[0,1]` to avoid the extra launcher process
- **CLI backward compatibility**: `main.cpp` still accepts `--prerun`, `--config-file`, `--domains` with a deprecation warning. This is because breaking changes to the public API are not expected within the same ROS distribution.
- **Validation moved into nodes**: `validate_hardware_info` and YAML loading moved from `main.cpp` into `ThreadConfiguratorNode` constructor
- **Error handling**: Node construction/spin wrapped in try/catch for clean shutdown on failure; YAML load errors include the config file path for easier diagnosis
- **Portability**: Fixed non-portable `%ld` format specifier for `int64_t` in `prerun_node.cpp`

## Related links

[JIRA ticket (TIER IV internal)](https://tier4.atlassian.net/browse/T4DEV-51207)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.