### PR TITLE
fix(cie_thread_configurator): make spawn_non_ros2_thread node name unique using thread_name

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -45,4 +45,10 @@ install(TARGETS thread_configurator_node DESTINATION lib/${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_${PROJECT_NAME} test/test_sanitize_node_name.cpp)
+  target_link_libraries(test_${PROJECT_NAME} thread_configurator)
+endif()
+
 ament_package()

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -7,7 +7,6 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#include <cctype>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -34,7 +33,9 @@ inline std::string sanitize_node_name(const std::string & name)
   std::string result;
   result.reserve(name.size());
   for (char c : name) {
-    result += (std::isalnum(static_cast<unsigned char>(c)) || c == '_') ? c : '_';
+    const bool is_alnum =
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+    result += (is_alnum || c == '_') ? c : '_';
   }
   return result;
 }

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -27,6 +27,8 @@ size_t get_default_domain_id();
 // Create a node for a different domain
 rclcpp::Node::SharedPtr create_node_for_domain(size_t domain_id);
 
+// Replace characters that are not alphanumeric or '_' with '_',
+// producing a valid ROS 2 node name token.
 inline std::string sanitize_node_name(const std::string & name)
 {
   std::string result;

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/cie_thread_configurator.hpp
@@ -7,6 +7,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#include <cctype>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -25,6 +26,16 @@ size_t get_default_domain_id();
 
 // Create a node for a different domain
 rclcpp::Node::SharedPtr create_node_for_domain(size_t domain_id);
+
+inline std::string sanitize_node_name(const std::string & name)
+{
+  std::string result;
+  result.reserve(name.size());
+  for (char c : name) {
+    result += (std::isalnum(static_cast<unsigned char>(c)) || c == '_') ? c : '_';
+  }
+  return result;
+}
 
 /// Spawn a thread whose scheduling policy can be managed through
 /// cie_thread_configurator.
@@ -45,7 +56,8 @@ std::thread spawn_non_ros2_thread(const char * thread_name, F && f, Args &&... a
     rclcpp::NodeOptions options;
     options.context(context);
     auto node = std::make_shared<rclcpp::Node>(
-      "cie_thread_client", "/agnocast_cie_thread_configurator", options);
+      "cie_thread_client_" + sanitize_node_name(thread_name), "/agnocast_cie_thread_configurator",
+      options);
 
     auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::NonRosThreadInfo>(
       "/agnocast_cie_thread_configurator/non_ros_thread_info", rclcpp::QoS(5000).reliable());

--- a/src/agnocast_cie_thread_configurator/package.xml
+++ b/src/agnocast_cie_thread_configurator/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/agnocast_cie_thread_configurator/test/test_sanitize_node_name.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_sanitize_node_name.cpp
@@ -1,0 +1,30 @@
+#include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
+
+#include <gtest/gtest.h>
+
+using agnocast_cie_thread_configurator::sanitize_node_name;
+
+TEST(SanitizeNodeName, AlphanumericPassthrough)
+{
+  EXPECT_EQ(sanitize_node_name("abc123"), "abc123");
+}
+
+TEST(SanitizeNodeName, UnderscorePreserved)
+{
+  EXPECT_EQ(sanitize_node_name("my_thread"), "my_thread");
+}
+
+TEST(SanitizeNodeName, SpecialCharsReplaced)
+{
+  EXPECT_EQ(sanitize_node_name("my-thread.1"), "my_thread_1");
+}
+
+TEST(SanitizeNodeName, AllSpecialChars)
+{
+  EXPECT_EQ(sanitize_node_name("---"), "___");
+}
+
+TEST(SanitizeNodeName, EmptyString)
+{
+  EXPECT_EQ(sanitize_node_name(""), "");
+}


### PR DESCRIPTION
## Description

`spawn_non_ros2_thread` hardcoded the internal ROS 2 node name to `"cie_thread_client"`. When called multiple times (potentially concurrently), this created multiple DDS participants with the same node name in the ROS 2 graph, which can cause warnings and undefined behavior at the DDS level.

This fix appends a sanitized version of the `thread_name` parameter to the node name (e.g., `cie_thread_client_my_worker`). Since `thread_name` is already documented as needing to be unique, this guarantees unique node names. A `sanitize_node_name` helper replaces non-alphanumeric characters with underscores to comply with ROS 2 node naming rules.

### Changes
- Add `sanitize_node_name()` helper that replaces non-alphanumeric/underscore characters with `_`
- Use `"cie_thread_client_" + sanitize_node_name(thread_name)` as the node name in `spawn_non_ros2_thread`
- Add unit tests for `sanitize_node_name` (5 test cases)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.