### PR TITLE
refactor(agnocastlib): Refactor epoll processing and clean up hardcoded event-specific logic

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(glog REQUIRED)
 
 add_library(agnocast SHARED
   src/agnocast.cpp src/agnocast_utils.cpp src/agnocast_publisher.cpp src/agnocast_subscription.cpp
-  src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_epoll.cpp src/agnocast_epoll_update_dispatcher.cpp src/agnocast_timer_info.cpp src/agnocast_timer.cpp src/agnocast_executor.cpp
+  src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_epoll.cpp src/agnocast_epoll_event.cpp src/agnocast_epoll_update_dispatcher.cpp src/agnocast_timer_info.cpp src/agnocast_timer.cpp src/agnocast_executor.cpp
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp
   src/agnocast_callback_isolated_executor.cpp
   src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(glog REQUIRED)
 
 add_library(agnocast SHARED
   src/agnocast.cpp src/agnocast_utils.cpp src/agnocast_publisher.cpp src/agnocast_subscription.cpp
-  src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_epoll.cpp src/agnocast_timer_info.cpp src/agnocast_timer.cpp src/agnocast_executor.cpp
+  src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_epoll.cpp src/agnocast_epoll_update_dispatcher.cpp src/agnocast_timer_info.cpp src/agnocast_timer.cpp src/agnocast_executor.cpp
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp
   src/agnocast_callback_isolated_executor.cpp
   src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 
 #include <mutex>
@@ -57,7 +58,6 @@ std::vector<std::string> get_agnocast_topics_by_group(
 extern std::mutex id2_callback_info_mtx;
 extern std::unordered_map<uint32_t, CallbackInfo> id2_callback_info;
 extern std::atomic<uint32_t> next_callback_info_id;
-extern std::atomic<bool> need_epoll_updates;
 
 uint32_t allocate_callback_info_id();
 
@@ -109,7 +109,7 @@ uint32_t register_callback(
                    callback_group, erased_callback, message_creator};
   }
 
-  need_epoll_updates.store(true);
+  EpollUpdateDispatcher::get_instance().notify_all();
 
   return callback_info_id;
 }

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -10,6 +10,8 @@
 namespace agnocast
 {
 
+// Capped slightly below UINT32_MAX to provide a safe margin against
+// atomic wrap-around (overflow back to 0) during concurrent fetch_add calls.
 constexpr uint32_t MAX_CALLBACK_INFO_ID = 0x10000000;
 
 struct AgnocastExecutable;

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast/agnocast_epoll.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 
@@ -8,6 +9,8 @@
 
 namespace agnocast
 {
+
+constexpr uint32_t MAX_CALLBACK_INFO_ID = 0x10000000;
 
 struct AgnocastExecutable;
 
@@ -123,5 +126,29 @@ void enqueue_receive_and_execute(
   uint32_t callback_info_id, pid_t my_pid, const CallbackInfo & callback_info,
   std::mutex & ready_agnocast_executables_mutex,
   std::vector<AgnocastExecutable> & ready_agnocast_executables);
+
+class SubscriptionEventSource : public EpollEventSource
+{
+  pid_t my_pid_;
+  std::mutex * ready_agnocast_executables_mutex_;
+  std::vector<AgnocastExecutable> * ready_agnocast_executables_;
+
+public:
+  SubscriptionEventSource(
+    const pid_t my_pid, std::mutex * ready_agnocast_executables_mutex,
+    std::vector<AgnocastExecutable> * ready_agnocast_executables)
+  : my_pid_(my_pid),
+    ready_agnocast_executables_mutex_(ready_agnocast_executables_mutex),
+    ready_agnocast_executables_(ready_agnocast_executables)
+  {
+  }
+
+  [[nodiscard]] EpollEventType get_type() const override { return EpollEventType::Subscription; }
+
+  void prepare_epoll(
+    Epoll & epoll, const CallbackGroupValidator & validate_callback_group) override;
+
+  bool handle(EpollEventLocalID event_local_id) override;
+};
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
@@ -14,8 +14,6 @@ namespace agnocast
 
 struct AgnocastExecutable;
 
-extern std::atomic<bool> need_epoll_updates;
-
 constexpr uint32_t TIMER_EVENT_FLAG = 0x80000000;
 constexpr uint32_t CLOCK_EVENT_FLAG = 0x40000000;     // For clock_eventfd events (ROS_TIME timers)
 constexpr uint32_t SHUTDOWN_EVENT_FLAG = 0x20000000;  // For shutdown events (AgnocastOnlyExecutor)
@@ -114,28 +112,6 @@ void prepare_epoll_impl(
       }
 
       timer_info.need_epoll_update = false;
-    }
-  }
-
-  // Check if all updates are done. Both locks must be held simultaneously to prevent
-  // a TOCTOU race: without this, a new subscription could set need_epoll_updates=true
-  // between the two checks (or between the last check and the store), and that update
-  // would be lost when need_epoll_updates is overwritten to false.
-  // Lock ordering: id2_callback_info_mtx before id2_timer_info_mtx (see declarations).
-  {
-    std::lock_guard<std::mutex> cb_lock(id2_callback_info_mtx);
-    std::lock_guard<std::mutex> timer_lock(id2_timer_info_mtx);
-
-    const bool all_callbacks_updated = std::none_of(
-      id2_callback_info.begin(), id2_callback_info.end(),
-      [](const auto & it) { return it.second.need_epoll_update; });
-
-    const bool all_timers_updated = std::none_of(
-      id2_timer_info.begin(), id2_timer_info.end(),
-      [](const auto & it) { return it.second->need_epoll_update; });
-
-    if (all_callbacks_updated && all_timers_updated) {
-      need_epoll_updates.store(false);
     }
   }
 }

--- a/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
@@ -4,7 +4,10 @@
 
 #include <rclcpp/callback_group.hpp>
 
+#include <array>
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <vector>

--- a/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "agnocast/agnocast_callback_info.hpp"
-#include "agnocast/agnocast_timer_info.hpp"
-#include "sys/epoll.h"
+#include "agnocast/agnocast_epoll_event.hpp"
+
+#include <rclcpp/callback_group.hpp>
 
 #include <atomic>
 #include <mutex>
@@ -12,108 +12,67 @@
 namespace agnocast
 {
 
-struct AgnocastExecutable;
+using CallbackGroupValidator = std::function<bool(const rclcpp::CallbackGroup::SharedPtr &)>;
 
-constexpr uint32_t TIMER_EVENT_FLAG = 0x80000000;
-constexpr uint32_t CLOCK_EVENT_FLAG = 0x40000000;     // For clock_eventfd events (ROS_TIME timers)
-constexpr uint32_t SHUTDOWN_EVENT_FLAG = 0x20000000;  // For shutdown events (AgnocastOnlyExecutor)
-constexpr uint32_t EPOLL_EVENT_ID_RESERVED_MASK =
-  TIMER_EVENT_FLAG | CLOCK_EVENT_FLAG | SHUTDOWN_EVENT_FLAG;
-
-// @return true if shutdown event detected, false otherwise
-bool wait_and_handle_epoll_event(
-  int epoll_fd, pid_t my_pid, int timeout_ms, std::mutex & ready_agnocast_executables_mutex,
-  std::vector<AgnocastExecutable> & ready_agnocast_executables);
-
-template <class ValidateFn>
-void prepare_epoll_impl(
-  const int epoll_fd, const pid_t my_pid, std::mutex & ready_agnocast_executables_mutex,
-  std::vector<AgnocastExecutable> & ready_agnocast_executables,
-  ValidateFn && validate_callback_group)
+class EpollEventSource
 {
-  // Register subscription callbacks to epoll
+public:
+  EpollEventSource() = default;
+
+  virtual ~EpollEventSource() = default;
+
+  EpollEventSource(const EpollEventSource &) = delete;
+  EpollEventSource & operator=(const EpollEventSource &) = delete;
+
+  EpollEventSource(EpollEventSource &&) = delete;
+  EpollEventSource & operator=(EpollEventSource &&) = delete;
+
+  [[nodiscard]] virtual EpollEventType get_type() const = 0;
+
+  virtual void prepare_epoll(
+    Epoll & epoll, const CallbackGroupValidator & validate_callback_group) = 0;
+
+  virtual bool handle(EpollEventLocalID event_local_id) = 0;
+};
+
+// Shutdown event - only used by AgnocastOnlyExecutor
+class ShutdownEventSource : public EpollEventSource
+{
+public:
+  ShutdownEventSource() = default;
+
+  [[nodiscard]] EpollEventType get_type() const override { return EpollEventType::Shutdown; }
+
+  void prepare_epoll(Epoll & epoll, const CallbackGroupValidator & validate_callback_group) override
   {
-    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-
-    for (auto & it : id2_callback_info) {
-      const uint32_t callback_info_id = it.first;
-      CallbackInfo & callback_info = it.second;
-
-      if (!callback_info.need_epoll_update) {
-        continue;
-      }
-
-      if (!validate_callback_group(callback_info.callback_group)) {
-        continue;
-      }
-
-      struct epoll_event ev = {};
-      ev.events = EPOLLIN;
-      ev.data.u32 = callback_info_id;
-
-      if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, callback_info.mqdes, &ev) == -1) {
-        RCLCPP_ERROR(logger, "epoll_ctl failed: %s", strerror(errno));
-        close(agnocast_fd);
-        exit(EXIT_FAILURE);
-      }
-
-      if (callback_info.is_transient_local) {
-        agnocast::enqueue_receive_and_execute(
-          callback_info_id, my_pid, callback_info, ready_agnocast_executables_mutex,
-          ready_agnocast_executables);
-      }
-
-      callback_info.need_epoll_update = false;
-    }
+    (void)epoll;
+    (void)validate_callback_group;
   }
 
-  // Register timers to epoll
+  bool handle(EpollEventLocalID /*event_local_id*/) override { return true; }
+};
+
+using EventSourceArray =
+  std::array<std::unique_ptr<EpollEventSource>, static_cast<size_t>(EpollEventType::NrEventType)>;
+
+class EpollManager
+{
+public:
+  explicit EpollManager(EventSourceArray sources);
+
+  int add_event(int fd, EpollEventType type, EpollEventLocalID local_id)
   {
-    std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
-
-    for (auto & it : id2_timer_info) {
-      const uint32_t timer_id = it.first;
-      TimerInfo & timer_info = *it.second;
-
-      if (!timer_info.need_epoll_update) {
-        continue;
-      }
-
-      if (!timer_info.timer.lock() || !validate_callback_group(timer_info.callback_group)) {
-        continue;
-      }
-
-      std::shared_lock fd_lock(timer_info.fd_mutex);
-
-      // Register clock_eventfd for ROS_TIME timers (simulation time support)
-      if (timer_info.clock_eventfd >= 0) {
-        struct epoll_event clock_ev = {};
-        clock_ev.events = EPOLLIN;
-        clock_ev.data.u32 = timer_id | CLOCK_EVENT_FLAG;
-
-        if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, timer_info.clock_eventfd, &clock_ev) == -1) {
-          RCLCPP_ERROR(logger, "epoll_ctl failed for clock_eventfd: %s", strerror(errno));
-          close(agnocast_fd);
-          exit(EXIT_FAILURE);
-        }
-      }
-
-      // Register timerfd (wall clock based firing)
-      if (timer_info.timer_fd >= 0) {
-        struct epoll_event ev = {};
-        ev.events = EPOLLIN;
-        ev.data.u32 = timer_id | TIMER_EVENT_FLAG;
-
-        if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, timer_info.timer_fd, &ev) == -1) {
-          RCLCPP_ERROR(logger, "epoll_ctl failed for timer: %s", strerror(errno));
-          close(agnocast_fd);
-          exit(EXIT_FAILURE);
-        }
-      }
-
-      timer_info.need_epoll_update = false;
-    }
+    return epoll_.add_source(fd, type, local_id);
   }
-}
+
+  void prepare_epoll(const CallbackGroupValidator & validate_callback_group);
+
+  /// @return true if shutdown event detected, false otherwise
+  bool wait_and_handle_epoll_event(int timeout_ms);
+
+private:
+  Epoll epoll_;
+  EventSourceArray sources_{nullptr};
+};
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace agnocast
+{
+
+enum class EpollEventType : uint32_t {
+  Subscription = 0,
+  Timer = 1,
+  Shutdown = 2,
+  NrEventType,
+};
+
+using EpollEventLocalID = uint32_t;
+
+constexpr uint32_t EPOLL_DATA_TYPE_SHIFT = 32;
+constexpr uint32_t EPOLL_DATA_ID_BITMASK = 0xFFFFFFFF;
+
+inline uint64_t pack_epoll_data(EpollEventType type, EpollEventLocalID id)
+{
+  return (static_cast<uint64_t>(type) << EPOLL_DATA_TYPE_SHIFT) | id;
+}
+
+inline std::pair<EpollEventType, EpollEventLocalID> unpack_epoll_data(uint64_t data)
+{
+  auto type = static_cast<EpollEventType>(data >> EPOLL_DATA_TYPE_SHIFT);
+  auto id = static_cast<uint32_t>(data & EPOLL_DATA_ID_BITMASK);
+  return {type, id};
+}
+
+using EpollResult = std::pair<EpollEventType, EpollEventLocalID>;
+
+class Epoll
+{
+  static constexpr int EPOLL_WAIT_MAX_EVENTS = 1;
+  int epoll_fd_;
+
+public:
+  Epoll();
+
+  Epoll(const Epoll &) = delete;
+  Epoll & operator=(const Epoll &) = delete;
+
+  Epoll(Epoll && other) noexcept : epoll_fd_(other.epoll_fd_) { other.epoll_fd_ = -1; }
+  Epoll & operator=(Epoll && other) noexcept;
+
+  ~Epoll();
+
+  [[nodiscard]] int add_source(int fd, EpollEventType type, EpollEventLocalID local_id) const;
+
+  void remove(int fd) const;
+
+  int wait(std::vector<EpollResult> & results, int timeout_ms) const;
+
+  [[nodiscard]] int fd() const { return epoll_fd_; }
+
+  [[nodiscard]] bool is_valid() const { return epoll_fd_ >= 0; }
+};
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
@@ -9,8 +9,9 @@ namespace agnocast
 
 enum class EpollEventType : uint32_t {
   Subscription = 0,
-  Timer = 1,
-  Shutdown = 2,
+  Timer,
+  Clock,
+  Shutdown,
   NrEventType,
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_event.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
@@ -26,6 +26,8 @@ public:
 
   void notify_all();
 
+  void notify(int tracker_id);
+
   EpollUpdateTracker create_tracker();
 
 private:
@@ -52,6 +54,8 @@ public:
   ~EpollUpdateTracker();
 
   [[nodiscard]] bool need_update() const;
+
+  [[nodiscard]] int id() const { return id_; }
 
 private:
   friend class EpollUpdateDispatcher;

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "sys/epoll.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace agnocast
+{
+
+class EpollUpdateTracker;
+
+struct TrackerContext
+{
+  std::atomic<bool> need_update{true};
+};
+
+class EpollUpdateDispatcher
+{
+public:
+  static EpollUpdateDispatcher & get_instance()
+  {
+    static EpollUpdateDispatcher instance;
+    return instance;
+  }
+
+  void notify_all();
+
+  EpollUpdateTracker create_tracker();
+
+private:
+  EpollUpdateDispatcher() = default;
+  friend class EpollUpdateTracker;
+
+  void unregister(int tracker_id);
+
+  std::atomic<int> next_tracker_id_{1};
+
+  std::mutex mutex_;
+  std::unordered_map<int, std::shared_ptr<TrackerContext>> trackers_;
+};
+
+class EpollUpdateTracker
+{
+public:
+  EpollUpdateTracker(const EpollUpdateTracker &) = delete;
+  EpollUpdateTracker & operator=(const EpollUpdateTracker &) = delete;
+
+  EpollUpdateTracker(EpollUpdateTracker && other) noexcept;
+  EpollUpdateTracker & operator=(EpollUpdateTracker && other) noexcept;
+
+  ~EpollUpdateTracker();
+
+  [[nodiscard]] bool need_update() const;
+
+private:
+  friend class EpollUpdateDispatcher;
+
+  EpollUpdateTracker(int tracker_id, std::shared_ptr<TrackerContext> context)
+  : id_(tracker_id), context_(std::move(context))
+  {
+  }
+
+  int id_;
+  std::shared_ptr<TrackerContext> context_;
+};
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll_update_dispatcher.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "sys/epoll.h"
-
 #include <atomic>
 #include <memory>
 #include <mutex>

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -41,6 +41,8 @@ protected:
   bool get_next_agnocast_executable(AgnocastExecutable & agnocast_executable, const int timeout_ms);
   static void execute_agnocast_executable(AgnocastExecutable & agnocast_executable);
 
+  EpollUpdateTracker epoll_update_tracker_;
+
 public:
   /// Construct the executor.
   /// @param options Executor options.

--- a/src/agnocastlib/include/agnocast/agnocast_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_executor.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_epoll_event.hpp"
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include <memory>
 
 namespace agnocast
 {
@@ -33,7 +37,7 @@ class AgnocastExecutor : public rclcpp::Executor
   virtual bool validate_callback_group(const rclcpp::CallbackGroup::SharedPtr & group) const = 0;
 
 protected:
-  int epoll_fd_;
+  std::unique_ptr<EpollManager> epoll_manager_;
   pid_t my_pid_;
   std::mutex wait_mutex_;
 

--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -16,6 +16,8 @@ namespace agnocast
 {
 
 constexpr int64_t NANOSECONDS_PER_SECOND = 1000000000;
+// Capped slightly below UINT32_MAX to provide a safe margin against
+// atomic wrap-around (overflow back to 0) during concurrent fetch_add calls.
 constexpr uint32_t MAX_TIMER_ID = 0x10000000;
 
 struct AgnocastExecutable;

--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -31,7 +31,9 @@ struct TimerInfo
 
   uint32_t timer_id = 0;
   int timer_fd = -1;
+  bool timer_fd_need_update = false;
   int clock_eventfd = -1;  // eventfd to wake epoll on clock updates (ROS_TIME only)
+  bool clock_eventfd_need_update = false;
   std::weak_ptr<TimerBase> timer;
   rclcpp::CallbackGroup::SharedPtr callback_group;
   std::atomic<int64_t> last_call_time_ns;
@@ -80,6 +82,30 @@ public:
   }
 
   [[nodiscard]] EpollEventType get_type() const override { return EpollEventType::Timer; }
+
+  void prepare_epoll(
+    Epoll & epoll, const CallbackGroupValidator & validate_callback_group) override;
+
+  bool handle(EpollEventLocalID event_local_id) override;
+};
+
+class ClockEventSource : public EpollEventSource
+{
+  pid_t my_pid_;
+  std::mutex * ready_agnocast_executables_mutex_;
+  std::vector<AgnocastExecutable> * ready_agnocast_executables_;
+
+public:
+  ClockEventSource(
+    const pid_t my_pid, std::mutex * ready_agnocast_executables_mutex,
+    std::vector<AgnocastExecutable> * ready_agnocast_executables)
+  : my_pid_(my_pid),
+    ready_agnocast_executables_mutex_(ready_agnocast_executables_mutex),
+    ready_agnocast_executables_(ready_agnocast_executables)
+  {
+  }
+
+  [[nodiscard]] EpollEventType get_type() const override { return EpollEventType::Clock; }
 
   void prepare_epoll(
     Epoll & epoll, const CallbackGroupValidator & validate_callback_group) override;

--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast/agnocast_epoll.hpp"
 #include "agnocast/agnocast_timer.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -15,6 +16,9 @@ namespace agnocast
 {
 
 constexpr int64_t NANOSECONDS_PER_SECOND = 1000000000;
+constexpr uint32_t MAX_TIMER_ID = 0x10000000;
+
+struct AgnocastExecutable;
 
 struct TimerInfo
 {
@@ -58,5 +62,29 @@ void register_timer_info(
   const rclcpp::CallbackGroup::SharedPtr & callback_group, const rclcpp::Clock::SharedPtr & clock);
 
 void unregister_timer_info(uint32_t timer_id);
+
+class TimerEventSource : public EpollEventSource
+{
+  pid_t my_pid_;
+  std::mutex * ready_agnocast_executables_mutex_;
+  std::vector<AgnocastExecutable> * ready_agnocast_executables_;
+
+public:
+  TimerEventSource(
+    const pid_t my_pid, std::mutex * ready_agnocast_executables_mutex,
+    std::vector<AgnocastExecutable> * ready_agnocast_executables)
+  : my_pid_(my_pid),
+    ready_agnocast_executables_mutex_(ready_agnocast_executables_mutex),
+    ready_agnocast_executables_(ready_agnocast_executables)
+  {
+  }
+
+  [[nodiscard]] EpollEventType get_type() const override { return EpollEventType::Timer; }
+
+  void prepare_epoll(
+    Epoll & epoll, const CallbackGroupValidator & validate_callback_group) override;
+
+  bool handle(EpollEventLocalID event_local_id) override;
+};
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
@@ -32,6 +33,8 @@ protected:
   int epoll_fd_;
   int shutdown_event_fd_;
   pid_t my_pid_;
+
+  EpollUpdateTracker epoll_update_tracker_;
 
   // Lock ordering: When both mutexes are needed, always acquire
   // ready_agnocast_executables_mutex_ before mutex_ to prevent deadlocks.

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "rclcpp/callback_group.hpp"
@@ -30,7 +32,7 @@ class AgnocastOnlyExecutor
 {
 protected:
   std::atomic_bool spinning_;
-  int epoll_fd_;
+  std::unique_ptr<EpollManager> epoll_manager_;
   int shutdown_event_fd_;
   pid_t my_pid_;
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -37,6 +37,7 @@ protected:
   pid_t my_pid_;
 
   EpollUpdateTracker epoll_update_tracker_;
+  int epoll_update_tracker_id_;
 
   // Lock ordering: When both mutexes are needed, always acquire
   // ready_agnocast_executables_mutex_ before mutex_ to prevent deadlocks.

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -18,7 +18,7 @@ std::atomic<uint32_t> next_callback_info_id;
 uint32_t allocate_callback_info_id()
 {
   const uint32_t callback_info_id = next_callback_info_id.fetch_add(1);
-  if ((callback_info_id & EPOLL_EVENT_ID_RESERVED_MASK) != 0U) {
+  if (callback_info_id >= MAX_CALLBACK_INFO_ID) {
     throw std::runtime_error("Callback info ID overflow: too many callbacks registered");
   }
   return callback_info_id;
@@ -137,6 +137,80 @@ std::vector<std::string> get_agnocast_topics_by_group(
   std::sort(topic_names.begin(), topic_names.end());
 
   return topic_names;
+}
+
+void SubscriptionEventSource::prepare_epoll(
+  Epoll & epoll, const CallbackGroupValidator & validate_callback_group)
+{
+  std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+
+  for (auto & it : id2_callback_info) {
+    const uint32_t callback_info_id = it.first;
+    CallbackInfo & callback_info = it.second;
+
+    if (!callback_info.need_epoll_update) {
+      continue;
+    }
+
+    if (!validate_callback_group(callback_info.callback_group)) {
+      continue;
+    }
+
+    if (
+      epoll.add_source(callback_info.mqdes, EpollEventType::Subscription, callback_info_id) == -1) {
+      RCLCPP_ERROR(logger, "epoll_ctl failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    if (callback_info.is_transient_local) {
+      agnocast::enqueue_receive_and_execute(
+        callback_info_id, my_pid_, callback_info, *ready_agnocast_executables_mutex_,
+        *ready_agnocast_executables_);
+    }
+
+    callback_info.need_epoll_update = false;
+  }
+}
+
+bool SubscriptionEventSource::handle(EpollEventLocalID event_local_id)
+{
+  // Subscription callback event
+  const uint32_t callback_info_id = event_local_id;
+  CallbackInfo callback_info;
+
+  {
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+
+    const auto it = id2_callback_info.find(callback_info_id);
+    if (it == id2_callback_info.end()) {
+      // Callback was unregistered (subscription destroyed) - this is normal
+      return false;
+    }
+
+    callback_info = it->second;
+  }
+
+  MqMsgAgnocast mq_msg = {};
+
+  // non-blocking
+  auto ret =
+    mq_receive(callback_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), nullptr);
+  if (ret < 0) {
+    if (errno != EAGAIN) {
+      RCLCPP_ERROR(logger, "mq_receive failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    return false;
+  }
+
+  agnocast::enqueue_receive_and_execute(
+    callback_info_id, my_pid_, callback_info, *ready_agnocast_executables_mutex_,
+    *ready_agnocast_executables_);
+
+  return false;
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_epoll.cpp
+++ b/src/agnocastlib/src/agnocast_epoll.cpp
@@ -7,8 +7,6 @@
 namespace agnocast
 {
 
-std::atomic<bool> need_epoll_updates{false};
-
 bool wait_and_handle_epoll_event(
   const int epoll_fd, const pid_t my_pid, const int timeout_ms,
   std::mutex & ready_agnocast_executables_mutex,

--- a/src/agnocastlib/src/agnocast_epoll.cpp
+++ b/src/agnocastlib/src/agnocast_epoll.cpp
@@ -1,25 +1,43 @@
 #include "agnocast/agnocast_epoll.hpp"
 
 #include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_epoll_event.hpp"
+#include "agnocast/agnocast_mq.hpp"
 
 #include <unistd.h>
+
+#include <vector>
 
 namespace agnocast
 {
 
-bool wait_and_handle_epoll_event(
-  const int epoll_fd, const pid_t my_pid, const int timeout_ms,
-  std::mutex & ready_agnocast_executables_mutex,
-  std::vector<AgnocastExecutable> & ready_agnocast_executables)
+struct AgnocastExecutable;
+
+EpollManager::EpollManager(EventSourceArray sources) : sources_(std::move(sources))
 {
-  struct epoll_event event = {};
+  for (uint32_t type = 0; type < static_cast<size_t>(EpollEventType::NrEventType); type++) {
+    if (!sources_[type]) {
+      RCLCPP_ERROR(logger, "invalid epoll event source array: sources_[%d] is nullptr", type);
+      exit(EXIT_FAILURE);
+    }
+  }
+}
 
-  // blocking with timeout
-  const int nfds = epoll_wait(epoll_fd, &event, 1 /*maxevents*/, timeout_ms);
+void EpollManager::prepare_epoll(const CallbackGroupValidator & validate_callback_group)
+{
+  for (uint32_t type = 0; type < static_cast<uint32_t>(EpollEventType::NrEventType); type++) {
+    sources_[type]->prepare_epoll(epoll_, validate_callback_group);
+  }
+}
 
-  if (nfds == -1) {
+bool EpollManager::wait_and_handle_epoll_event(const int timeout_ms)
+{
+  std::vector<EpollResult> results;
+  const int nr_results = epoll_.wait(results, timeout_ms);
+
+  if (nr_results == -1) {
     if (errno != EINTR) {  // signal handler interruption is not error
-      RCLCPP_ERROR(logger, "epoll_wait failed: %s", strerror(errno));
+      RCLCPP_ERROR(logger, "Epoll::wait failed: %s", strerror(errno));
       close(agnocast_fd);
       exit(EXIT_FAILURE);
     }
@@ -28,166 +46,24 @@ bool wait_and_handle_epoll_event(
   }
 
   // timeout
-  if (nfds == 0) {
+  if (nr_results == 0) {
     return false;
   }
 
-  const uint32_t event_id = event.data.u32;
+  bool should_shutdown = false;
+  for (auto [event_type, event_local_id] : results) {
+    if (EpollEventType::NrEventType <= event_type) {
+      RCLCPP_ERROR(
+        logger, "Agnocast internal implementation error: invalid epoll event type %d",
+        static_cast<uint32_t>(event_type));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
 
-  // Shutdown event - only used by AgnocastOnlyExecutor
-  if ((event_id & SHUTDOWN_EVENT_FLAG) != 0U) {
-    return true;
+    bool ret = sources_[static_cast<uint32_t>(event_type)]->handle(event_local_id);
+    should_shutdown = should_shutdown || ret;
   }
-
-  if ((event_id & TIMER_EVENT_FLAG) != 0U) {
-    // Timer event (timerfd fired)
-    const uint32_t timer_id = event_id & ~TIMER_EVENT_FLAG;
-    rclcpp::CallbackGroup::SharedPtr callback_group;
-    std::shared_ptr<agnocast::TimerBase> timer_ptr;
-
-    std::shared_ptr<TimerInfo> timer_info;
-    {
-      std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
-      const auto it = id2_timer_info.find(timer_id);
-      if (it == id2_timer_info.end()) {
-        RCLCPP_ERROR(logger, "Agnocast internal implementation error: timer info cannot be found");
-        close(agnocast_fd);
-        exit(EXIT_FAILURE);
-      }
-      timer_info = it->second;
-      timer_ptr = timer_info->timer.lock();
-      if (!timer_ptr) {
-        return false;  // Timer object has been destroyed
-      }
-      callback_group = timer_info->callback_group;
-    }
-
-    // Read the number of expirations to clear the event
-    uint64_t expirations = 0;
-    {
-      std::shared_lock fd_lock(timer_info->fd_mutex);
-      if (timer_info->timer_fd < 0) {
-        return false;  // Timer fd was closed (ROS time activated)
-      }
-      const ssize_t ret = read(timer_info->timer_fd, &expirations, sizeof(expirations));
-      if (ret == -1 || expirations == 0) {
-        return false;
-      }
-    }
-
-    auto callable = std::make_shared<std::function<void()>>();
-    // For tracepoints.
-    const void * callable_ptr = callable.get();
-    // Create a callable that handles the timer event
-    *callable = [timer_info, callable_ptr]() {
-      TRACEPOINT(agnocast_callable_start, callable_ptr);
-      handle_timer_event(*timer_info);
-      TRACEPOINT(agnocast_callable_end, callable_ptr);
-    };
-
-    TRACEPOINT(
-      agnocast_create_timer_callable, static_cast<const void *>(callable_ptr),
-      static_cast<const void *>(timer_ptr.get()));
-
-    {
-      std::lock_guard<std::mutex> ready_lock{ready_agnocast_executables_mutex};
-      ready_agnocast_executables.emplace_back(AgnocastExecutable{callable, callback_group});
-    }
-  } else if ((event_id & CLOCK_EVENT_FLAG) != 0U) {
-    // Clock event (ROS_TIME clock updated via time jump callback)
-    const uint32_t timer_id = event_id & ~CLOCK_EVENT_FLAG;
-    rclcpp::CallbackGroup::SharedPtr callback_group;
-    std::shared_ptr<agnocast::TimerBase> timer_ptr;
-
-    std::shared_ptr<TimerInfo> timer_info;
-    {
-      std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
-      const auto it = id2_timer_info.find(timer_id);
-      if (it == id2_timer_info.end()) {
-        RCLCPP_ERROR(logger, "Agnocast internal implementation error: timer info cannot be found");
-        close(agnocast_fd);
-        exit(EXIT_FAILURE);
-      }
-      timer_info = it->second;
-      timer_ptr = timer_info->timer.lock();
-      if (!timer_ptr) {
-        return false;  // Timer object has been destroyed
-      }
-      callback_group = timer_info->callback_group;
-    }
-
-    uint64_t val = 0;
-    const ssize_t ret = read(timer_info->clock_eventfd, &val, sizeof(val));
-    if (ret == -1 || val == 0) {
-      return false;
-    }
-
-    // Check if timer is ready (corresponds to rcl_timer_is_ready)
-    const int64_t now_ns = timer_info->clock->now().nanoseconds();
-    const int64_t next_call_ns = timer_info->next_call_time_ns.load(std::memory_order_relaxed);
-    if (now_ns < next_call_ns) {
-      return false;
-    }
-
-    // Create a callable that handles the clock event
-    auto callable = std::make_shared<std::function<void()>>();
-    const void * callable_ptr = callable.get();
-
-    *callable = [timer_info, callable_ptr]() {
-      TRACEPOINT(agnocast_callable_start, callable_ptr);
-      handle_timer_event(*timer_info);
-      TRACEPOINT(agnocast_callable_end, callable_ptr);
-    };
-
-    TRACEPOINT(
-      agnocast_create_timer_callable, static_cast<const void *>(callable_ptr),
-      static_cast<const void *>(timer_ptr.get()));
-
-    {
-      std::lock_guard<std::mutex> ready_lock{ready_agnocast_executables_mutex};
-      ready_agnocast_executables.emplace_back(AgnocastExecutable{callable, callback_group});
-    }
-  } else {
-    // Subscription callback event
-    const uint32_t callback_info_id = event_id;
-    CallbackInfo callback_info;
-
-    {
-      std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-
-      const auto it = id2_callback_info.find(callback_info_id);
-      if (it == id2_callback_info.end()) {
-        // Callback was unregistered (subscription destroyed) - this is normal
-        return false;
-      }
-
-      callback_info = it->second;
-    }
-
-    MqMsgAgnocast mq_msg = {};
-
-    // non-blocking
-    auto ret =
-      mq_receive(callback_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), nullptr);
-    if (ret < 0) {
-      if (errno != EAGAIN) {
-        RCLCPP_ERROR_STREAM(
-          logger, "mq_receive failed for topic '" << callback_info.topic_name << "' (subscriber_id="
-                                                  << callback_info.subscriber_id
-                                                  << "): " << strerror(errno));
-        close(agnocast_fd);
-        exit(EXIT_FAILURE);
-      }
-
-      return false;
-    }
-
-    agnocast::enqueue_receive_and_execute(
-      callback_info_id, my_pid, callback_info, ready_agnocast_executables_mutex,
-      ready_agnocast_executables);
-  }
-
-  return false;
+  return should_shutdown;
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_epoll.cpp
+++ b/src/agnocastlib/src/agnocast_epoll.cpp
@@ -17,7 +17,7 @@ EpollManager::EpollManager(EventSourceArray sources) : sources_(std::move(source
 {
   for (uint32_t type = 0; type < static_cast<size_t>(EpollEventType::NrEventType); type++) {
     if (!sources_[type]) {
-      RCLCPP_ERROR(logger, "invalid epoll event source array: sources_[%d] is nullptr", type);
+      RCLCPP_ERROR(logger, "invalid epoll event source array: sources_[%u] is nullptr", type);
       exit(EXIT_FAILURE);
     }
   }
@@ -54,7 +54,7 @@ bool EpollManager::wait_and_handle_epoll_event(const int timeout_ms)
   for (auto [event_type, event_local_id] : results) {
     if (EpollEventType::NrEventType <= event_type) {
       RCLCPP_ERROR(
-        logger, "Agnocast internal implementation error: invalid epoll event type %d",
+        logger, "Agnocast internal implementation error: invalid epoll event type %u",
         static_cast<uint32_t>(event_type));
       close(agnocast_fd);
       exit(EXIT_FAILURE);

--- a/src/agnocastlib/src/agnocast_epoll_event.cpp
+++ b/src/agnocastlib/src/agnocast_epoll_event.cpp
@@ -3,6 +3,12 @@
 #include "agnocast/agnocast_utils.hpp"
 
 #include <sys/epoll.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 
 namespace agnocast
 {

--- a/src/agnocastlib/src/agnocast_epoll_event.cpp
+++ b/src/agnocastlib/src/agnocast_epoll_event.cpp
@@ -63,10 +63,6 @@ int Epoll::wait(std::vector<EpollResult> & results, int timeout_ms) const
     return -1;
   }
 
-  if (!results.empty()) {
-    return -1;
-  }
-
   results.clear();
   for (int i = 0; i < nfds; ++i) {
     auto [type, id] = unpack_epoll_data(events[i].data.u64);

--- a/src/agnocastlib/src/agnocast_epoll_event.cpp
+++ b/src/agnocastlib/src/agnocast_epoll_event.cpp
@@ -1,0 +1,72 @@
+#include "agnocast/agnocast_epoll_event.hpp"
+
+#include "agnocast/agnocast_utils.hpp"
+
+#include <sys/epoll.h>
+
+namespace agnocast
+{
+
+Epoll::Epoll() : epoll_fd_(epoll_create1(0))
+{
+  if (epoll_fd_ == -1) {
+    RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));
+    exit(EXIT_FAILURE);
+  }
+}
+
+Epoll::~Epoll()
+{
+  if (epoll_fd_ >= 0) {
+    close(epoll_fd_);
+  }
+}
+
+Epoll & Epoll::operator=(Epoll && other) noexcept
+{
+  if (this != &other) {
+    if (epoll_fd_ >= 0) {
+      close(epoll_fd_);
+    }
+
+    epoll_fd_ = other.epoll_fd_;
+    other.epoll_fd_ = -1;
+  }
+  return *this;
+}
+
+[[nodiscard]] int Epoll::add_source(int fd, EpollEventType type, EpollEventLocalID local_id) const
+{
+  struct epoll_event ev = {};
+  ev.events = EPOLLIN;
+  ev.data.u64 = pack_epoll_data(type, local_id);
+  return epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev);
+}
+
+void Epoll::remove(int fd) const
+{
+  epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
+}
+
+int Epoll::wait(std::vector<EpollResult> & results, int timeout_ms) const
+{
+  std::array<epoll_event, EPOLL_WAIT_MAX_EVENTS> events{};
+  const int nfds = epoll_wait(epoll_fd_, events.data(), events.size(), timeout_ms);
+
+  if (nfds < 0 || EPOLL_WAIT_MAX_EVENTS < nfds) {
+    return -1;
+  }
+
+  if (!results.empty()) {
+    return -1;
+  }
+
+  results.clear();
+  for (int i = 0; i < nfds; ++i) {
+    auto [type, id] = unpack_epoll_data(events[i].data.u64);
+    results.emplace_back(type, id);
+  }
+  return nfds;
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_epoll_update_dispatcher.cpp
+++ b/src/agnocastlib/src/agnocast_epoll_update_dispatcher.cpp
@@ -1,0 +1,71 @@
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
+
+#include <atomic>
+
+namespace agnocast
+{
+
+EpollUpdateTracker EpollUpdateDispatcher::create_tracker()
+{
+  int new_id = next_tracker_id_.fetch_add(1, std::memory_order_relaxed);
+
+  auto context = std::make_shared<TrackerContext>();
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    trackers_.emplace(new_id, context);
+  }
+
+  return {new_id, context};
+}
+
+void EpollUpdateDispatcher::notify_all()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto & [id, context] : trackers_) {
+    context->need_update.store(true, std::memory_order_release);
+  }
+}
+
+void EpollUpdateDispatcher::unregister(int tracker_id)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  trackers_.erase(tracker_id);
+}
+
+EpollUpdateTracker::EpollUpdateTracker(EpollUpdateTracker && other) noexcept
+: id_(other.id_), context_(std::move(other.context_))
+{
+  other.id_ = 0;
+}
+
+EpollUpdateTracker & EpollUpdateTracker::operator=(EpollUpdateTracker && other) noexcept
+{
+  if (this != &other) {
+    if (id_ != 0) {
+      EpollUpdateDispatcher::get_instance().unregister(id_);
+    }
+    id_ = other.id_;
+    context_ = std::move(other.context_);
+
+    other.id_ = 0;
+  }
+  return *this;
+}
+
+EpollUpdateTracker::~EpollUpdateTracker()
+{
+  if (id_ != 0) {
+    EpollUpdateDispatcher::get_instance().unregister(id_);
+  }
+}
+
+bool EpollUpdateTracker::need_update() const
+{
+  if (!context_) {
+    return false;
+  }
+  return context_->need_update.exchange(false, std::memory_order_acquire);
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_epoll_update_dispatcher.cpp
+++ b/src/agnocastlib/src/agnocast_epoll_update_dispatcher.cpp
@@ -27,6 +27,15 @@ void EpollUpdateDispatcher::notify_all()
   }
 }
 
+void EpollUpdateDispatcher::notify(int tracker_id)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = trackers_.find(tracker_id);
+  if (it != trackers_.end()) {
+    it->second->need_update.store(true, std::memory_order_release);
+  }
+}
+
 void EpollUpdateDispatcher::unregister(int tracker_id)
 {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -26,6 +26,8 @@ AgnocastExecutor::AgnocastExecutor(const rclcpp::ExecutorOptions & options)
       my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
   sources[static_cast<uint32_t>(EpollEventType::Timer)] = std::make_unique<TimerEventSource>(
     my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Clock)] = std::make_unique<ClockEventSource>(
+    my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
   sources[static_cast<uint32_t>(EpollEventType::Shutdown)] =
     std::make_unique<ShutdownEventSource>();
 

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -1,6 +1,8 @@
 #include "agnocast/agnocast_executor.hpp"
 
 #include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "rclcpp/rclcpp.hpp"
@@ -8,34 +10,35 @@
 #include "sys/epoll.h"
 
 #include <algorithm>
+#include <memory>
 
 namespace agnocast
 {
 
 AgnocastExecutor::AgnocastExecutor(const rclcpp::ExecutorOptions & options)
 : rclcpp::Executor(options),
-  epoll_fd_(epoll_create1(0)),
   my_pid_(getpid()),
   epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker())
 {
-  if (epoll_fd_ == -1) {
-    RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));
-    exit(EXIT_FAILURE);
-  }
+  EventSourceArray sources;
+  sources[static_cast<uint32_t>(EpollEventType::Subscription)] =
+    std::make_unique<SubscriptionEventSource>(
+      my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Timer)] = std::make_unique<TimerEventSource>(
+    my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Shutdown)] =
+    std::make_unique<ShutdownEventSource>();
+
+  epoll_manager_ = std::make_unique<EpollManager>(std::move(sources));
 }
 
-AgnocastExecutor::~AgnocastExecutor()
-{
-  close(epoll_fd_);
-}
+AgnocastExecutor::~AgnocastExecutor() = default;
 
 void AgnocastExecutor::prepare_epoll()
 {
-  agnocast::prepare_epoll_impl(
-    epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,
-    [this](const rclcpp::CallbackGroup::SharedPtr & group) {
-      return validate_callback_group(group);
-    });
+  epoll_manager_->prepare_epoll([this](const rclcpp::CallbackGroup::SharedPtr & group) {
+    return validate_callback_group(group);
+  });
 }
 
 bool AgnocastExecutor::get_next_agnocast_executable(
@@ -45,8 +48,7 @@ bool AgnocastExecutor::get_next_agnocast_executable(
     return true;
   }
 
-  agnocast::wait_and_handle_epoll_event(
-    epoll_fd_, my_pid_, timeout_ms, ready_agnocast_executables_mutex_, ready_agnocast_executables_);
+  epoll_manager_->wait_and_handle_epoll_event(timeout_ms);
 
   // Try again
   return get_next_ready_agnocast_executable(agnocast_executable);

--- a/src/agnocastlib/src/agnocast_executor.cpp
+++ b/src/agnocastlib/src/agnocast_executor.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/agnocast_executor.hpp"
 
 #include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/version.h"
@@ -12,7 +13,10 @@ namespace agnocast
 {
 
 AgnocastExecutor::AgnocastExecutor(const rclcpp::ExecutorOptions & options)
-: rclcpp::Executor(options), epoll_fd_(epoll_create1(0)), my_pid_(getpid())
+: rclcpp::Executor(options),
+  epoll_fd_(epoll_create1(0)),
+  my_pid_(getpid()),
+  epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker())
 {
   if (epoll_fd_ == -1) {
     RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));

--- a/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_multi_threaded_executor.cpp
@@ -156,7 +156,7 @@ void MultiThreadedAgnocastExecutor::ros2_spin()
 void MultiThreadedAgnocastExecutor::agnocast_spin()
 {
   while (rclcpp::ok(this->context_) && spinning.load()) {
-    if (need_epoll_updates.load()) {
+    if (epoll_update_tracker_.need_update()) {
       prepare_epoll();
     }
 

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -51,7 +51,7 @@ void SingleThreadedAgnocastExecutor::spin()
   RCPPUTILS_SCOPE_EXIT(this->spinning.store(false););
 
   while (rclcpp::ok(this->context_) && spinning.load()) {
-    if (need_epoll_updates.load()) {
+    if (epoll_update_tracker_.need_update()) {
       prepare_epoll();
     }
 

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -1,5 +1,6 @@
 #include "agnocast/agnocast_timer_info.hpp"
 
+#include "agnocast/agnocast.hpp"
 #include "agnocast/agnocast_epoll.hpp"
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_executor.hpp"
@@ -237,6 +238,14 @@ void register_timer_info(
 
   setup_time_jump_callback(timer_info, clock);
 
+  if (timer_info->timer_fd >= 0) {
+    timer_info->timer_fd_need_update = true;
+  }
+
+  if (timer_info->clock_eventfd >= 0) {
+    timer_info->clock_eventfd_need_update = true;
+  }
+
   {
     std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
     id2_timer_info[timer_id] = std::move(timer_info);
@@ -303,21 +312,29 @@ void TimerEventSource::prepare_epoll(
       continue;
     }
 
-    if (epoll.add_source(timer_info.timer_fd, EpollEventType::Timer, timer_id) == -1) {
-      RCLCPP_ERROR(logger, "epoll_ctl failed for timer: %s", strerror(errno));
-      close(agnocast_fd);
-      exit(EXIT_FAILURE);
+    std::shared_lock fd_lock(timer_info.fd_mutex);
+
+    // Register timerfd (wall clock based firing)
+    if (timer_info.timer_fd >= 0 && timer_info.timer_fd_need_update) {
+      if (epoll.add_source(timer_info.timer_fd, EpollEventType::Timer, timer_id) == -1) {
+        RCLCPP_ERROR(logger, "epoll_ctl failed for timer: %s", strerror(errno));
+        close(agnocast_fd);
+        exit(EXIT_FAILURE);
+      }
+      timer_info.timer_fd_need_update = false;
     }
 
-    timer_info.need_epoll_update = false;
+    timer_info.need_epoll_update =
+      timer_info.timer_fd_need_update || timer_info.clock_eventfd_need_update;
   }
 }
 
 bool TimerEventSource::handle(EpollEventLocalID event_local_id)
 {
-  // Timer event
+  // Timer event (timerfd fired)
   const uint32_t timer_id = event_local_id;
   rclcpp::CallbackGroup::SharedPtr callback_group;
+  std::shared_ptr<agnocast::TimerBase> timer_ptr;
 
   std::shared_ptr<TimerInfo> timer_info;
   {
@@ -329,21 +346,137 @@ bool TimerEventSource::handle(EpollEventLocalID event_local_id)
       exit(EXIT_FAILURE);
     }
     timer_info = it->second;
-    if (!timer_info->timer.lock()) {
+    timer_ptr = timer_info->timer.lock();
+    if (!timer_ptr) {
       return false;  // Timer object has been destroyed
     }
     callback_group = timer_info->callback_group;
   }
 
+  // Read the number of expirations to clear the event
+  uint64_t expirations = 0;
+  {
+    std::shared_lock fd_lock(timer_info->fd_mutex);
+    if (timer_info->timer_fd < 0) {
+      return false;  // Timer fd was closed (ROS time activated)
+    }
+    const ssize_t ret = read(timer_info->timer_fd, &expirations, sizeof(expirations));
+    if (ret == -1 || expirations == 0) {
+      return false;
+    }
+  }
+
+  auto callable = std::make_shared<std::function<void()>>();
+  // For tracepoints.
+  const void * callable_ptr = callable.get();
   // Create a callable that handles the timer event
-  const std::shared_ptr<std::function<void()>> callable =
-    std::make_shared<std::function<void()>>([timer_info]() { handle_timer_event(*timer_info); });
+  *callable = [timer_info, callable_ptr]() {
+    TRACEPOINT(agnocast_callable_start, callable_ptr);
+    handle_timer_event(*timer_info);
+    TRACEPOINT(agnocast_callable_end, callable_ptr);
+  };
+
+  TRACEPOINT(
+    agnocast_create_timer_callable, static_cast<const void *>(callable_ptr),
+    static_cast<const void *>(timer_ptr.get()));
 
   {
     std::lock_guard<std::mutex> ready_lock{*ready_agnocast_executables_mutex_};
     ready_agnocast_executables_->emplace_back(AgnocastExecutable{callable, callback_group});
   }
 
+  return false;
+}
+
+void ClockEventSource::prepare_epoll(
+  Epoll & epoll, const CallbackGroupValidator & validate_callback_group)
+{
+  std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+
+  for (auto & it : id2_timer_info) {
+    const uint32_t timer_id = it.first;
+    TimerInfo & timer_info = *it.second;
+
+    if (!timer_info.need_epoll_update) {
+      continue;
+    }
+
+    if (!timer_info.timer.lock() || !validate_callback_group(timer_info.callback_group)) {
+      continue;
+    }
+
+    std::shared_lock fd_lock(timer_info.fd_mutex);
+
+    // Register clock_eventfd for ROS_TIME timers (simulation time support)
+    if (timer_info.clock_eventfd >= 0 && timer_info.clock_eventfd_need_update) {
+      if (epoll.add_source(timer_info.clock_eventfd, EpollEventType::Clock, timer_id) == -1) {
+        RCLCPP_ERROR(logger, "epoll_ctl failed for clock_eventfd: %s", strerror(errno));
+        close(agnocast_fd);
+        exit(EXIT_FAILURE);
+      }
+      timer_info.clock_eventfd_need_update = false;
+    }
+
+    timer_info.need_epoll_update =
+      timer_info.timer_fd_need_update || timer_info.clock_eventfd_need_update;
+  }
+}
+
+bool ClockEventSource::handle(EpollEventLocalID event_local_id)
+{
+  // Clock event (ROS_TIME clock updated via time jump callback)
+  const uint32_t timer_id = event_local_id;
+  rclcpp::CallbackGroup::SharedPtr callback_group;
+  std::shared_ptr<agnocast::TimerBase> timer_ptr;
+
+  std::shared_ptr<TimerInfo> timer_info;
+  {
+    std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+    const auto it = id2_timer_info.find(timer_id);
+    if (it == id2_timer_info.end()) {
+      RCLCPP_ERROR(logger, "Agnocast internal implementation error: timer info cannot be found");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+    timer_info = it->second;
+    timer_ptr = timer_info->timer.lock();
+    if (!timer_ptr) {
+      return false;  // Timer object has been destroyed
+    }
+    callback_group = timer_info->callback_group;
+  }
+
+  uint64_t val = 0;
+  const ssize_t ret = read(timer_info->clock_eventfd, &val, sizeof(val));
+  if (ret == -1 || val == 0) {
+    return false;
+  }
+
+  // Check if timer is ready (corresponds to rcl_timer_is_ready)
+  const int64_t now_ns = timer_info->clock->now().nanoseconds();
+  const int64_t next_call_ns = timer_info->next_call_time_ns.load(std::memory_order_relaxed);
+  if (now_ns < next_call_ns) {
+    return false;
+  }
+
+  // Create a callable that handles the clock event
+  auto callable = std::make_shared<std::function<void()>>();
+  const void * callable_ptr = callable.get();
+
+  *callable = [timer_info, callable_ptr]() {
+    TRACEPOINT(agnocast_callable_start, callable_ptr);
+    handle_timer_event(*timer_info);
+    TRACEPOINT(agnocast_callable_end, callable_ptr);
+  };
+
+  TRACEPOINT(
+    agnocast_create_timer_callable, static_cast<const void *>(callable_ptr),
+    static_cast<const void *>(timer_ptr.get()));
+
+  {
+    std::lock_guard<std::mutex> ready_lock{*ready_agnocast_executables_mutex_};
+    ready_agnocast_executables_->emplace_back(AgnocastExecutable{callable, callback_group});
+  }
   return false;
 }
 

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/agnocast_timer_info.hpp"
 
 #include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_executor.hpp"
 #include "agnocast/agnocast_utils.hpp"
 
 #include <sys/eventfd.h>
@@ -191,7 +192,7 @@ int create_timer_fd(uint32_t timer_id, std::chrono::nanoseconds period, rcl_cloc
 uint32_t allocate_timer_id()
 {
   const uint32_t timer_id = next_timer_id.fetch_add(1);
-  if ((timer_id & EPOLL_EVENT_ID_RESERVED_MASK) != 0U) {
+  if (timer_id >= MAX_TIMER_ID) {
     throw std::runtime_error("Timer ID overflow: too many timers created");
   }
   return timer_id;
@@ -282,6 +283,67 @@ void unregister_timer_info(uint32_t timer_id)
 {
   std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
   id2_timer_info.erase(timer_id);
+}
+
+void TimerEventSource::prepare_epoll(
+  Epoll & epoll, const CallbackGroupValidator & validate_callback_group)
+{
+  std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+
+  for (auto & it : id2_timer_info) {
+    const uint32_t timer_id = it.first;
+    TimerInfo & timer_info = *it.second;
+
+    if (!timer_info.need_epoll_update) {
+      continue;
+    }
+
+    if (!timer_info.timer.lock() || !validate_callback_group(timer_info.callback_group)) {
+      continue;
+    }
+
+    if (epoll.add_source(timer_info.timer_fd, EpollEventType::Timer, timer_id) == -1) {
+      RCLCPP_ERROR(logger, "epoll_ctl failed for timer: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    timer_info.need_epoll_update = false;
+  }
+}
+
+bool TimerEventSource::handle(EpollEventLocalID event_local_id)
+{
+  // Timer event
+  const uint32_t timer_id = event_local_id;
+  rclcpp::CallbackGroup::SharedPtr callback_group;
+
+  std::shared_ptr<TimerInfo> timer_info;
+  {
+    std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+    const auto it = id2_timer_info.find(timer_id);
+    if (it == id2_timer_info.end()) {
+      RCLCPP_ERROR(logger, "Agnocast internal implementation error: timer info cannot be found");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+    timer_info = it->second;
+    if (!timer_info->timer.lock()) {
+      return false;  // Timer object has been destroyed
+    }
+    callback_group = timer_info->callback_group;
+  }
+
+  // Create a callable that handles the timer event
+  const std::shared_ptr<std::function<void()>> callable =
+    std::make_shared<std::function<void()>>([timer_info]() { handle_timer_event(*timer_info); });
+
+  {
+    std::lock_guard<std::mutex> ready_lock{*ready_agnocast_executables_mutex_};
+    ready_agnocast_executables_->emplace_back(AgnocastExecutable{callable, callback_group});
+  }
+
+  return false;
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/agnocast_timer_info.hpp"
 
 #include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_executor.hpp"
 #include "agnocast/agnocast_utils.hpp"
 

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -240,7 +240,7 @@ void register_timer_info(
     id2_timer_info[timer_id] = std::move(timer_info);
   }
 
-  need_epoll_updates.store(true);
+  EpollUpdateDispatcher::get_instance().notify_all();
 }
 
 void handle_timer_event(TimerInfo & timer_info)

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -27,6 +27,8 @@ AgnocastOnlyExecutor::AgnocastOnlyExecutor()
       my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
   sources[static_cast<uint32_t>(EpollEventType::Timer)] = std::make_unique<TimerEventSource>(
     my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Clock)] = std::make_unique<ClockEventSource>(
+    my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
   sources[static_cast<uint32_t>(EpollEventType::Shutdown)] =
     std::make_unique<ShutdownEventSource>();
 

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -17,31 +17,29 @@ namespace agnocast
 
 AgnocastOnlyExecutor::AgnocastOnlyExecutor()
 : spinning_(false),
-  epoll_fd_(epoll_create1(0)),
   shutdown_event_fd_(eventfd(0, EFD_NONBLOCK)),
   my_pid_(getpid()),
   epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker())
 {
-  if (epoll_fd_ == -1) {
-    RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));
-    exit(EXIT_FAILURE);
-  }
+  EventSourceArray sources;
+  sources[static_cast<uint32_t>(EpollEventType::Subscription)] =
+    std::make_unique<SubscriptionEventSource>(
+      my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Timer)] = std::make_unique<TimerEventSource>(
+    my_pid_, &ready_agnocast_executables_mutex_, &ready_agnocast_executables_);
+  sources[static_cast<uint32_t>(EpollEventType::Shutdown)] =
+    std::make_unique<ShutdownEventSource>();
+
+  epoll_manager_ = std::make_unique<EpollManager>(std::move(sources));
 
   if (shutdown_event_fd_ == -1) {
     RCLCPP_ERROR(logger, "eventfd failed: %s", strerror(errno));
-    close(epoll_fd_);
     exit(EXIT_FAILURE);
   }
 
-  struct epoll_event ev
-  {
-  };
-  ev.events = EPOLLIN;
-  ev.data.u32 = SHUTDOWN_EVENT_FLAG;
-  if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, shutdown_event_fd_, &ev) == -1) {
+  if (epoll_manager_->add_event(shutdown_event_fd_, EpollEventType::Shutdown, 0) == -1) {
     RCLCPP_ERROR(logger, "epoll_ctl for shutdown_event_fd failed: %s", strerror(errno));
     close(shutdown_event_fd_);
-    close(epoll_fd_);
     exit(EXIT_FAILURE);
   }
 
@@ -81,7 +79,6 @@ AgnocastOnlyExecutor::~AgnocastOnlyExecutor()
 
   SignalHandler::unregister_shutdown_event(shutdown_event_fd_);
   close(shutdown_event_fd_);
-  close(epoll_fd_);
 }
 
 bool AgnocastOnlyExecutor::get_next_agnocast_executable(
@@ -93,8 +90,7 @@ bool AgnocastOnlyExecutor::get_next_agnocast_executable(
     return true;
   }
 
-  shutdown_detected = agnocast::wait_and_handle_epoll_event(
-    epoll_fd_, my_pid_, timeout_ms, ready_agnocast_executables_mutex_, ready_agnocast_executables_);
+  shutdown_detected = epoll_manager_->wait_and_handle_epoll_event(timeout_ms);
 
   if (shutdown_detected) {
     return false;

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -19,7 +19,8 @@ AgnocastOnlyExecutor::AgnocastOnlyExecutor()
 : spinning_(false),
   epoll_fd_(epoll_create1(0)),
   shutdown_event_fd_(eventfd(0, EFD_NONBLOCK)),
-  my_pid_(getpid())
+  my_pid_(getpid()),
+  epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker())
 {
   if (epoll_fd_ == -1) {
     RCLCPP_ERROR(logger, "epoll_create1 failed: %s", strerror(errno));

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast/agnocast.hpp"
 #include "agnocast/agnocast_epoll.hpp"
+#include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 #include "agnocast_signal_handler.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -19,7 +20,8 @@ AgnocastOnlyExecutor::AgnocastOnlyExecutor()
 : spinning_(false),
   shutdown_event_fd_(eventfd(0, EFD_NONBLOCK)),
   my_pid_(getpid()),
-  epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker())
+  epoll_update_tracker_(EpollUpdateDispatcher::get_instance().create_tracker()),
+  epoll_update_tracker_id_(epoll_update_tracker_.id())
 {
   EventSourceArray sources;
   sources[static_cast<uint32_t>(EpollEventType::Subscription)] =
@@ -179,6 +181,8 @@ void AgnocastOnlyExecutor::add_callback_group(
     agnocast_add_callback_group, static_cast<const void *>(this),
     static_cast<const void *>(node_ptr.get()), static_cast<const void *>(group_ptr.get()),
     group_type_str);
+
+  EpollUpdateDispatcher::get_instance().notify(epoll_update_tracker_id_);
 }
 
 void AgnocastOnlyExecutor::remove_callback_group(
@@ -201,6 +205,8 @@ void AgnocastOnlyExecutor::remove_callback_group(
   }
   weak_groups_associated_with_executor_to_nodes_.erase(it);
   group_ptr->get_associated_with_executor_atomic().store(false);
+
+  EpollUpdateDispatcher::get_instance().notify(epoll_update_tracker_id_);
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr> AgnocastOnlyExecutor::get_all_callback_groups()
@@ -319,6 +325,8 @@ void AgnocastOnlyExecutor::add_node(
       }
     });
   weak_nodes_.push_back(node_ptr);
+
+  EpollUpdateDispatcher::get_instance().notify(epoll_update_tracker_id_);
 }
 
 void AgnocastOnlyExecutor::add_node(const std::shared_ptr<agnocast::Node> & node, bool notify)
@@ -369,6 +377,8 @@ void AgnocastOnlyExecutor::remove_node(
   }
 
   node_ptr->get_associated_with_executor_atomic().store(false);
+
+  EpollUpdateDispatcher::get_instance().notify(epoll_update_tracker_id_);
 }
 
 void AgnocastOnlyExecutor::remove_node(const std::shared_ptr<agnocast::Node> & node, bool notify)

--- a/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
@@ -47,7 +47,7 @@ void AgnocastOnlyMultiThreadedExecutor::spin()
 void AgnocastOnlyMultiThreadedExecutor::agnocast_spin()
 {
   while (spinning_.load()) {
-    if (need_epoll_updates.load()) {
+    if (epoll_update_tracker_.need_update()) {
       add_callback_groups_from_nodes_associated_to_executor();
       agnocast::prepare_epoll_impl(
         epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,

--- a/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
@@ -49,11 +49,9 @@ void AgnocastOnlyMultiThreadedExecutor::agnocast_spin()
   while (spinning_.load()) {
     if (epoll_update_tracker_.need_update()) {
       add_callback_groups_from_nodes_associated_to_executor();
-      agnocast::prepare_epoll_impl(
-        epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,
-        [this](const rclcpp::CallbackGroup::SharedPtr & group) {
-          return is_callback_group_associated(group);
-        });
+      epoll_manager_->prepare_epoll([this](const rclcpp::CallbackGroup::SharedPtr & group) {
+        return is_callback_group_associated(group);
+      });
     }
 
     agnocast::AgnocastExecutable agnocast_executable;

--- a/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
@@ -34,11 +34,9 @@ void AgnocastOnlySingleThreadedExecutor::spin()
   while (spinning_.load()) {
     if (epoll_update_tracker_.need_update()) {
       add_callback_groups_from_nodes_associated_to_executor();
-      agnocast::prepare_epoll_impl(
-        epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,
-        [this](const rclcpp::CallbackGroup::SharedPtr & group) {
-          return is_callback_group_associated(group);
-        });
+      epoll_manager_->prepare_epoll([this](const rclcpp::CallbackGroup::SharedPtr & group) {
+        return is_callback_group_associated(group);
+      });
     }
 
     agnocast::AgnocastExecutable agnocast_executable;

--- a/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
@@ -32,7 +32,7 @@ void AgnocastOnlySingleThreadedExecutor::spin()
   RCPPUTILS_SCOPE_EXIT(this->spinning_.store(false););
 
   while (spinning_.load()) {
-    if (need_epoll_updates.load()) {
+    if (epoll_update_tracker_.need_update()) {
       add_callback_groups_from_nodes_associated_to_executor();
       agnocast::prepare_epoll_impl(
         epoll_fd_, my_pid_, ready_agnocast_executables_mutex_, ready_agnocast_executables_,

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -720,7 +720,7 @@ TEST(AllocateCallbackInfoIdTest, throws_when_id_has_reserved_epoll_flag_bits)
 {
   // Arrange: Set next_callback_info_id so the next allocation hits SHUTDOWN_EVENT_FLAG (bit 29).
   const uint32_t original = next_callback_info_id.load();
-  next_callback_info_id.store(SHUTDOWN_EVENT_FLAG);
+  next_callback_info_id.store(MAX_CALLBACK_INFO_ID);
 
   // Act & Assert
   EXPECT_THROW(allocate_callback_info_id(), std::runtime_error);
@@ -733,10 +733,10 @@ TEST(AllocateCallbackInfoIdTest, succeeds_just_below_reserved_range)
 {
   // Arrange: Set next_callback_info_id to the maximum valid value (one below SHUTDOWN_EVENT_FLAG).
   const uint32_t original = next_callback_info_id.load();
-  next_callback_info_id.store(SHUTDOWN_EVENT_FLAG - 1);
+  next_callback_info_id.store(MAX_CALLBACK_INFO_ID - 1);
 
   // Act & Assert
-  EXPECT_EQ(allocate_callback_info_id(), SHUTDOWN_EVENT_FLAG - 1);
+  EXPECT_EQ(allocate_callback_info_id(), MAX_CALLBACK_INFO_ID - 1);
 
   // Cleanup
   next_callback_info_id.store(original);
@@ -748,7 +748,7 @@ TEST(AllocateTimerIdTest, throws_when_id_has_reserved_epoll_flag_bits)
   // This covers the bug where timer IDs OR'd with CLOCK_EVENT_FLAG/TIMER_EVENT_FLAG
   // could collide with reserved flags.
   const uint32_t original = next_timer_id.load();
-  next_timer_id.store(SHUTDOWN_EVENT_FLAG);
+  next_timer_id.store(MAX_TIMER_ID);
 
   // Act & Assert
   EXPECT_THROW(allocate_timer_id(), std::runtime_error);
@@ -761,10 +761,10 @@ TEST(AllocateTimerIdTest, succeeds_just_below_reserved_range)
 {
   // Arrange: Set next_timer_id to the maximum valid value.
   const uint32_t original = next_timer_id.load();
-  next_timer_id.store(SHUTDOWN_EVENT_FLAG - 1);
+  next_timer_id.store(MAX_TIMER_ID - 1);
 
   // Act & Assert
-  EXPECT_EQ(allocate_timer_id(), SHUTDOWN_EVENT_FLAG - 1);
+  EXPECT_EQ(allocate_timer_id(), MAX_TIMER_ID - 1);
 
   // Cleanup
   next_timer_id.store(original);

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -718,7 +718,8 @@ TEST_F(CreateTimerFreeFunctionTest, callback_is_invoked)
 
 TEST(AllocateCallbackInfoIdTest, throws_when_id_has_reserved_epoll_flag_bits)
 {
-  // Arrange: Set next_callback_info_id so the next allocation hits SHUTDOWN_EVENT_FLAG (bit 29).
+  // Arrange: Set next_callback_info_id to MAX_CALLBACK_INFO_ID so the next allocation overflows the
+  // boundary.
   const uint32_t original = next_callback_info_id.load();
   next_callback_info_id.store(MAX_CALLBACK_INFO_ID);
 
@@ -731,7 +732,7 @@ TEST(AllocateCallbackInfoIdTest, throws_when_id_has_reserved_epoll_flag_bits)
 
 TEST(AllocateCallbackInfoIdTest, succeeds_just_below_reserved_range)
 {
-  // Arrange: Set next_callback_info_id to the maximum valid value (one below SHUTDOWN_EVENT_FLAG).
+  // Arrange: Set next_callback_info_id to the maximum valid value (one below MAX_CALLBACK_INFO_ID).
   const uint32_t original = next_callback_info_id.load();
   next_callback_info_id.store(MAX_CALLBACK_INFO_ID - 1);
 
@@ -744,9 +745,7 @@ TEST(AllocateCallbackInfoIdTest, succeeds_just_below_reserved_range)
 
 TEST(AllocateTimerIdTest, throws_when_id_has_reserved_epoll_flag_bits)
 {
-  // Arrange: Set next_timer_id so the returned ID includes a reserved epoll flag bit.
-  // This covers the bug where timer IDs OR'd with CLOCK_EVENT_FLAG/TIMER_EVENT_FLAG
-  // could collide with reserved flags.
+  // Arrange: Set next_timer_id to MAX_TIMER_ID so the next allocation overflows the boundary.
   const uint32_t original = next_timer_id.load();
   next_timer_id.store(MAX_TIMER_ID);
 


### PR DESCRIPTION
## Description

This PR refactors `agnocast_epoll.cpp` and `.hpp` to eliminate tight dependencies, improve code extensibility, and optimize how Executors handle epoll updates.

### Key Changes & Motivations

**Replaced Global Polling with Individual Notifications**
* Changes: Removed the `need_epoll_updates` global variable. Replaced the polling approach with a new mechanism that notifies each Executor individually when an update is needed.
* Impact: Previously, Executors had to poll the global variable, forcing all Executors to process updates until every single Executor was finished. This was inefficient.

**Decoupled Event Handling**
* Changes: Removed hardcoded, event-specific implementations from `agnocast_epoll.cpp` and `.hpp` and moved them into their respective, event-specific files.
* Impact: The previous tight coupling made it difficult to add new events. This change significantly improves the code's extensibility for future updates.

**Future-proofing**
* This change lays the groundwork for a future architecture where epoll update notifications can be sent exclusively to specific, targeted Executors rather than all of them.

## Related links

close #969 

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
