### PR TITLE
refactor(kmod): move `increment_message_entry_rc` in `KUNIT_BUILD`

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -377,10 +377,6 @@ int agnocast_ioctl_add_publisher(
   const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   const bool is_bridge, union ioctl_add_publisher_args * ioctl_ret);
 
-int agnocast_increment_message_entry_rc(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
-  const int64_t entry_id);
-
 int agnocast_ioctl_release_message_entry_reference(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
   const int64_t entry_id);
@@ -485,6 +481,9 @@ bool is_agnocast_pid(const pid_t pid);
 // helper functions for KUnit test
 
 #ifdef KUNIT_BUILD
+int agnocast_increment_message_entry_rc(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
+  const int64_t entry_id);
 int agnocast_get_alive_proc_num(void);
 bool agnocast_is_proc_exited(const pid_t pid);
 int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -331,60 +331,6 @@ static struct entry_node * find_message_entry(
   return NULL;
 }
 
-// Add subscriber reference to message entry (set boolean flag to true).
-// Called when subscriber first receives/takes the message.
-int agnocast_increment_message_entry_rc(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
-  const int64_t entry_id)
-{
-  int ret = 0;
-
-  down_read(&global_htables_rwsem);
-
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
-  if (!wrapper) {
-    dev_warn(
-      agnocast_device, "Topic (topic_name=%s) not found. (increment_message_entry_rc)\n",
-      topic_name);
-    ret = -EINVAL;
-    goto unlock_only_global;
-  }
-
-  down_read(&wrapper->topic_rwsem);
-
-  struct entry_node * en = find_message_entry(wrapper, entry_id);
-  if (!en) {
-    dev_warn(
-      agnocast_device,
-      "Message entry (topic_name=%s entry_id=%lld) not found. "
-      "(increment_message_entry_rc)\n",
-      topic_name, entry_id);
-    ret = -EINVAL;
-    goto unlock_all;
-  }
-
-  // Adding reference is allowed only for subscribers
-  if (!find_subscriber_info(wrapper, pubsub_id)) {
-    dev_warn(
-      agnocast_device,
-      "Subscriber (id=%d) not found in the topic (topic_name=%s). (increment_message_entry_rc)\n",
-      pubsub_id, wrapper->key);
-    ret = -EINVAL;
-    goto unlock_all;
-  }
-
-  ret = add_subscriber_reference(en, pubsub_id);
-  if (ret < 0) {
-    goto unlock_all;
-  }
-
-unlock_all:
-  up_read(&wrapper->topic_rwsem);
-unlock_only_global:
-  up_read(&global_htables_rwsem);
-  return ret;
-}
-
 // Forward declaration
 static int get_process_num(const struct ipc_namespace * ipc_ns);
 
@@ -2840,6 +2786,60 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
 // helper functions for KUnit test
 
 #ifdef KUNIT_BUILD
+
+// Add subscriber reference to message entry (set boolean flag to true).
+// Called when subscriber first receives/takes the message.
+int agnocast_increment_message_entry_rc(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
+  const int64_t entry_id)
+{
+  int ret = 0;
+
+  down_read(&global_htables_rwsem);
+
+  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  if (!wrapper) {
+    dev_warn(
+      agnocast_device, "Topic (topic_name=%s) not found. (increment_message_entry_rc)\n",
+      topic_name);
+    ret = -EINVAL;
+    goto unlock_only_global;
+  }
+
+  down_read(&wrapper->topic_rwsem);
+
+  struct entry_node * en = find_message_entry(wrapper, entry_id);
+  if (!en) {
+    dev_warn(
+      agnocast_device,
+      "Message entry (topic_name=%s entry_id=%lld) not found. "
+      "(increment_message_entry_rc)\n",
+      topic_name, entry_id);
+    ret = -EINVAL;
+    goto unlock_all;
+  }
+
+  // Adding reference is allowed only for subscribers
+  if (!find_subscriber_info(wrapper, pubsub_id)) {
+    dev_warn(
+      agnocast_device,
+      "Subscriber (id=%d) not found in the topic (topic_name=%s). (increment_message_entry_rc)\n",
+      pubsub_id, wrapper->key);
+    ret = -EINVAL;
+    goto unlock_all;
+  }
+
+  ret = add_subscriber_reference(en, pubsub_id);
+  if (ret < 0) {
+    goto unlock_all;
+  }
+
+unlock_all:
+  up_read(&wrapper->topic_rwsem);
+unlock_only_global:
+  up_read(&global_htables_rwsem);
+  return ret;
+}
 
 // No locking needed for the following KUnit helper functions.
 // These are only called from single-threaded KUnit context.


### PR DESCRIPTION
## Description
Move `increment_message_entry_rc` inside #`ifdef KUNIT_BUILD`.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
