### PR TITLE
chore: add sparse check for agnocast-kmod

### DIFF
--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -9,13 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Set PR fetch depth
-        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+          fetch-depth: 0
 
       - name: Check for agnocast_kmod changes
         id: check_changes

--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -1,0 +1,24 @@
+name: sparse-check
+
+on:
+  pull_request:
+    paths:
+      - 'agnocast_kmod/**'
+
+jobs:
+  sparse-check:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install sparse
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sparse
+
+      - name: Run sparse
+        run: |
+          cd agnocast_kmod
+          make sparse

--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -2,23 +2,39 @@ name: sparse-check
 
 on:
   pull_request:
-    paths:
-      - 'agnocast_kmod/**'
+    types: [opened, synchronize]
 
 jobs:
   sparse-check:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Set PR fetch depth
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Check for agnocast_kmod changes
+        id: check_changes
+        run: |
+          set -e
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^agnocast_kmod/'; then
+            echo "kmod_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "kmod_changed=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install sparse
+        if: steps.check_changes.outputs.kmod_changed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y sparse
 
       - name: Run sparse
+        if: steps.check_changes.outputs.kmod_changed == 'true'
         run: |
           cd agnocast_kmod
           make sparse

--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -54,7 +54,8 @@ test:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) KUNIT_BUILD=y modules
 
 sparse:
-	! make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules 2>&1 | grep 'agnocast_kmod/.*warning'
+	set -o pipefail; make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules 2>&1 | tee sparse.log
+	! grep 'agnocast_kmod/.*warning' sparse.log
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -54,8 +54,8 @@ test:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) KUNIT_BUILD=y modules
 
 sparse:
-	set -o pipefail; make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules 2>&1 | tee sparse.log
-	! grep 'agnocast_kmod/.*warning' sparse.log
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules > sparse.log 2>&1 || { cat sparse.log; exit 1; }
+	! grep 'agnocast_kmod/.*warning' sparse.log && rm -f sparse.log
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -53,7 +53,10 @@ all:
 test:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) KUNIT_BUILD=y modules
 
+sparse:
+	! make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules 2>&1 | grep 'agnocast_kmod/.*warning'
+
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 
-.PHONY: all test clean
+.PHONY: all test sparse clean

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1601,7 +1601,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
   int bkt_sub_info;
 
   struct topic_info_ret __user * user_buffer =
-    (struct topic_info_ret *)topic_info_args->topic_info_ret_buffer_addr;
+    (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
   // Count actual subscribers first
   uint32_t subscriber_num = 0;
@@ -1687,7 +1687,7 @@ int agnocast_ioctl_get_topic_publisher_info(
   int bkt_pub_info;
 
   struct topic_info_ret __user * user_buffer =
-    (struct topic_info_ret *)topic_info_args->topic_info_ret_buffer_addr;
+    (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
   // Count actual publishers first
   uint32_t publisher_num = 0;


### PR DESCRIPTION
## Description
Add `make sparse` target to `agnocast_kmod/Makefile` for running the Linux kernel sparse static analysis tool                                                                                                                                                                                                                                                                                                                        
  - Fix sparse warnings in `agnocast_ioctl.c`: add missing `__user` annotation to casts at lines 1604 and 1690                                                                                                                                                                                                                                                                                                                           
  - Add `sparse-check.yaml` CI workflow that runs automatically on PRs with `agnocast_kmod/` changes (required)                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                         
### Background                                                                                                                                                                                                                                                                                                                                                                                                                          
sparse (`C=2`) detects address space annotation mismatches (e.g., mixing `__user` and kernel pointers) that the compiler does not catch. The two warnings were caused by casting to `struct topic_info_ret *` instead of `struct topic_info_ret __user *`.

## Related links
https://docs.kernel.org/dev-tools/sparse.html

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
