### PR TITLE
fix(agnocastlib): override durability to Volatile in service/client

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -115,7 +115,7 @@ private:
 public:
   template <typename NodeT>
   Client(
-    NodeT * node, const std::string & service_name, const rclcpp::QoS & qos,
+    NodeT * node, const std::string & service_name, const rclcpp::QoS & qos_arg,
     rclcpp::CallbackGroup::SharedPtr group)
   : node_(node),
     logger_(node->get_logger()),
@@ -132,6 +132,9 @@ public:
       "Agnocast service/client is not officially supported yet and the API may change in the "
       "future: %s",
       service_name_.c_str());
+
+    // TransientLocal durability is not allowed for services.
+    const rclcpp::QoS qos = rclcpp::QoS(qos_arg).durability_volatile();
 
     agnocast::PublisherOptions pub_options;
     publisher_ = std::make_shared<ServiceRequestPublisher>(

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -65,7 +65,8 @@ public:
     rclcpp::CallbackGroup::SharedPtr group)
   : node_(node),
     service_name_(node->get_node_services_interface()->resolve_service_name(service_name)),
-    qos_(qos)
+    // TransientLocal durability is not allowed for services.
+    qos_(rclcpp::QoS(qos).durability_volatile())
   {
     static_assert(
       std::is_same_v<NodeT, rclcpp::Node> || std::is_same_v<NodeT, agnocast::Node>,
@@ -128,7 +129,7 @@ public:
     SubscriptionOptions options{group};
     std::string topic_name = create_service_request_topic_name(service_name_);
     subscriber_ = std::make_shared<BasicSubscription<RequestT, NoBridgeRequestPolicy>>(
-      node, topic_name, qos, std::move(subscriber_callback), options);
+      node, topic_name, qos_, std::move(subscriber_callback), options);
   }
 };
 


### PR DESCRIPTION
## Description

This PR overrides durability to Volatile in `agnocast::Service` and `agnocast::Client`, regardless of the QoS passed by the caller. Transient local has no meaningful semantics for request/response communication and also harms the integrity of the sequence number in used by `agnocast::Client`.

It also fixes `Service` request subscriber to use the stored `qos_` member instead of the raw `qos` constructor parameter (pre-existing inconsistency).

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

