### PR TITLE
refactor(agnocast_kmod): replace kmalloc with stack buffers for ioctl name copies

### DIFF
--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -101,6 +101,16 @@ struct subscriber_info
   struct hlist_node node;
 };
 
+// Helper to copy a name_info string from userspace to a kernel stack buffer.
+// Returns 0 on success, -EINVAL if too long, -EFAULT on copy failure.
+static inline long copy_name_from_user(char * dst, size_t dst_size, const struct name_info * src)
+{
+  if (src->len >= dst_size) return -EINVAL;
+  if (copy_from_user(dst, (const char __user *)src->ptr, src->len)) return -EFAULT;
+  dst[src->len] = '\0';
+  return 0;
+}
+
 struct topic_struct
 {
   struct rb_root entries;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2171,31 +2171,19 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     union ioctl_add_subscriber_args sub_args;
     if (copy_from_user(&sub_args, (union ioctl_add_subscriber_args __user *)arg, sizeof(sub_args)))
       return -EFAULT;
-    if (
-      sub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE ||
-      sub_args.node_name.len >= NODE_NAME_BUFFER_SIZE)
-      return -EINVAL;
-    char * combined_buf = kmalloc(sub_args.topic_name.len + sub_args.node_name.len + 2, GFP_KERNEL);
-    if (!combined_buf) return -ENOMEM;
-    char * topic_name_buf = combined_buf;
-    char * node_name_buf = combined_buf + sub_args.topic_name.len + 1;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)sub_args.topic_name.ptr, sub_args.topic_name.len)) {
-      kfree(combined_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[sub_args.topic_name.len] = '\0';
-    if (copy_from_user(
-          node_name_buf, (char __user *)sub_args.node_name.ptr, sub_args.node_name.len)) {
-      kfree(combined_buf);
-      return -EFAULT;
-    }
-    node_name_buf[sub_args.node_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    char node_name_buf[NODE_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &sub_args.topic_name);
+    if (ret) return ret;
+
+    ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &sub_args.node_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_add_subscriber(
       topic_name_buf, ipc_ns, node_name_buf, pid, sub_args.qos_depth,
       sub_args.qos_is_transient_local, sub_args.qos_is_reliable, sub_args.is_take_sub,
       sub_args.ignore_local_publications, sub_args.is_bridge, &sub_args);
-    kfree(combined_buf);
     if (ret == 0) {
       if (copy_to_user((union ioctl_add_subscriber_args __user *)arg, &sub_args, sizeof(sub_args)))
         return -EFAULT;
@@ -2204,30 +2192,18 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     union ioctl_add_publisher_args pub_args;
     if (copy_from_user(&pub_args, (union ioctl_add_publisher_args __user *)arg, sizeof(pub_args)))
       return -EFAULT;
-    if (
-      pub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE ||
-      pub_args.node_name.len >= NODE_NAME_BUFFER_SIZE)
-      return -EINVAL;
-    char * combined_buf = kmalloc(pub_args.topic_name.len + pub_args.node_name.len + 2, GFP_KERNEL);
-    if (!combined_buf) return -ENOMEM;
-    char * topic_name_buf = combined_buf;
-    char * node_name_buf = combined_buf + pub_args.topic_name.len + 1;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)pub_args.topic_name.ptr, pub_args.topic_name.len)) {
-      kfree(combined_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[pub_args.topic_name.len] = '\0';
-    if (copy_from_user(
-          node_name_buf, (char __user *)pub_args.node_name.ptr, pub_args.node_name.len)) {
-      kfree(combined_buf);
-      return -EFAULT;
-    }
-    node_name_buf[pub_args.node_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    char node_name_buf[NODE_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &pub_args.topic_name);
+    if (ret) return ret;
+
+    ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &pub_args.node_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_add_publisher(
       topic_name_buf, ipc_ns, node_name_buf, pid, pub_args.qos_depth,
       pub_args.qos_is_transient_local, pub_args.is_bridge, &pub_args);
-    kfree(combined_buf);
     if (ret == 0) {
       if (copy_to_user((union ioctl_add_publisher_args __user *)arg, &pub_args, sizeof(pub_args)))
         return -EFAULT;
@@ -2237,52 +2213,38 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     if (copy_from_user(
           &entry_args, (struct ioctl_update_entry_args __user *)arg, sizeof(entry_args)))
       return -EFAULT;
-    if (entry_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(entry_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)entry_args.topic_name.ptr, entry_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[entry_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &entry_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_release_message_entry_reference(
       topic_name_buf, ipc_ns, entry_args.pubsub_id, entry_args.entry_id);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_RECEIVE_MSG_CMD) {
     union ioctl_receive_msg_args receive_msg_args;
     if (copy_from_user(
           &receive_msg_args, (union ioctl_receive_msg_args __user *)arg, sizeof(receive_msg_args)))
       return -EFAULT;
-    if (receive_msg_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(receive_msg_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)receive_msg_args.topic_name.ptr,
-          receive_msg_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[receive_msg_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &receive_msg_args.topic_name);
+    if (ret) return ret;
 
     uint64_t pub_shm_info_addr = receive_msg_args.pub_shm_info_addr;
     uint32_t pub_shm_info_size = receive_msg_args.pub_shm_info_size;
     if (pub_shm_info_size > MAX_PUBLISHER_NUM) {
-      kfree(topic_name_buf);
       return -EINVAL;
     }
 
     struct publisher_shm_info * pub_shm_infos =
       kcalloc(pub_shm_info_size, sizeof(struct publisher_shm_info), GFP_KERNEL);
     if (!pub_shm_infos) {
-      kfree(topic_name_buf);
       return -ENOMEM;
     }
 
     ret = agnocast_ioctl_receive_msg(
       topic_name_buf, ipc_ns, receive_msg_args.subscriber_id, pub_shm_infos, pub_shm_info_size,
       &receive_msg_args);
-    kfree(topic_name_buf);
 
     if (ret == 0 && receive_msg_args.ret_pub_shm_num > 0) {
       if (copy_to_user(
@@ -2305,27 +2267,19 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     if (copy_from_user(
           &publish_msg_args, (union ioctl_publish_msg_args __user *)arg, sizeof(publish_msg_args)))
       return -EFAULT;
-    if (publish_msg_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(publish_msg_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)publish_msg_args.topic_name.ptr,
-          publish_msg_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[publish_msg_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &publish_msg_args.topic_name);
+    if (ret) return ret;
 
     // Allocate kernel buffer for subscriber IDs
     uint32_t buffer_size = publish_msg_args.subscriber_ids_buffer_size;
     if (buffer_size != MAX_SUBSCRIBER_NUM) {
-      kfree(topic_name_buf);
       return -EINVAL;
     }
     topic_local_id_t * subscriber_ids_buf =
       kcalloc(buffer_size, sizeof(topic_local_id_t), GFP_KERNEL);
     if (!subscriber_ids_buf) {
-      kfree(topic_name_buf);
       return -ENOMEM;
     }
 
@@ -2334,7 +2288,6 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     ret = agnocast_ioctl_publish_msg(
       topic_name_buf, ipc_ns, publish_msg_args.publisher_id, publish_msg_args.msg_virtual_address,
       subscriber_ids_buf, buffer_size, &publish_msg_args);
-    kfree(topic_name_buf);
 
     if (ret == 0) {
       // Copy subscriber IDs to user-space buffer
@@ -2360,34 +2313,26 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     union ioctl_take_msg_args take_args;
     if (copy_from_user(&take_args, (union ioctl_take_msg_args __user *)arg, sizeof(take_args)))
       return -EFAULT;
-    if (take_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(take_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)take_args.topic_name.ptr, take_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[take_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &take_args.topic_name);
+    if (ret) return ret;
 
     uint64_t pub_shm_info_addr = take_args.pub_shm_info_addr;
     uint32_t pub_shm_info_size = take_args.pub_shm_info_size;
     if (pub_shm_info_size > MAX_PUBLISHER_NUM) {
-      kfree(topic_name_buf);
       return -EINVAL;
     }
 
     struct publisher_shm_info * pub_shm_infos =
       kcalloc(pub_shm_info_size, sizeof(struct publisher_shm_info), GFP_KERNEL);
     if (!pub_shm_infos) {
-      kfree(topic_name_buf);
       return -ENOMEM;
     }
 
     ret = agnocast_ioctl_take_msg(
       topic_name_buf, ipc_ns, take_args.subscriber_id, take_args.allow_same_message, pub_shm_infos,
       pub_shm_info_size, &take_args);
-    kfree(topic_name_buf);
 
     if (ret == 0 && take_args.ret_pub_shm_num > 0) {
       if (copy_to_user(
@@ -2409,18 +2354,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &get_subscriber_num_args, (union ioctl_get_subscriber_num_args __user *)arg,
           sizeof(get_subscriber_num_args)))
       return -EFAULT;
-    if (get_subscriber_num_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(get_subscriber_num_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)get_subscriber_num_args.topic_name.ptr,
-          get_subscriber_num_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[get_subscriber_num_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(
+      topic_name_buf, sizeof(topic_name_buf), &get_subscriber_num_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_subscriber_num(topic_name_buf, ipc_ns, pid, &get_subscriber_num_args);
-    kfree(topic_name_buf);
     if (copy_to_user(
           (union ioctl_get_subscriber_num_args __user *)arg, &get_subscriber_num_args,
           sizeof(get_subscriber_num_args)))
@@ -2431,18 +2371,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &get_publisher_num_args, (union ioctl_get_publisher_num_args __user *)arg,
           sizeof(get_publisher_num_args)))
       return -EFAULT;
-    if (get_publisher_num_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(get_publisher_num_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)get_publisher_num_args.topic_name.ptr,
-          get_publisher_num_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[get_publisher_num_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(
+      topic_name_buf, sizeof(topic_name_buf), &get_publisher_num_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_publisher_num(topic_name_buf, ipc_ns, &get_publisher_num_args);
-    kfree(topic_name_buf);
     if (copy_to_user(
           (union ioctl_get_publisher_num_args __user *)arg, &get_publisher_num_args,
           sizeof(get_publisher_num_args)))
@@ -2519,18 +2454,12 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &node_info_sub_args, (union ioctl_node_info_args __user *)arg,
           sizeof(node_info_sub_args)))
       return -EFAULT;
-    if (node_info_sub_args.node_name.len >= NODE_NAME_BUFFER_SIZE) return -EINVAL;
-    char * node_name_buf = kmalloc(node_info_sub_args.node_name.len + 1, GFP_KERNEL);
-    if (!node_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          node_name_buf, (char __user *)node_info_sub_args.node_name.ptr,
-          node_info_sub_args.node_name.len)) {
-      kfree(node_name_buf);
-      return -EFAULT;
-    }
-    node_name_buf[node_info_sub_args.node_name.len] = '\0';
+
+    char node_name_buf[NODE_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_sub_args.node_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_node_subscriber_topics(ipc_ns, node_name_buf, &node_info_sub_args);
-    kfree(node_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (union ioctl_node_info_args __user *)arg, &node_info_sub_args,
@@ -2543,18 +2472,12 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &node_info_pub_args, (union ioctl_node_info_args __user *)arg,
           sizeof(node_info_pub_args)))
       return -EFAULT;
-    if (node_info_pub_args.node_name.len >= NODE_NAME_BUFFER_SIZE) return -EINVAL;
-    char * node_name_buf = kmalloc(node_info_pub_args.node_name.len + 1, GFP_KERNEL);
-    if (!node_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          node_name_buf, (char __user *)node_info_pub_args.node_name.ptr,
-          node_info_pub_args.node_name.len)) {
-      kfree(node_name_buf);
-      return -EFAULT;
-    }
-    node_name_buf[node_info_pub_args.node_name.len] = '\0';
+
+    char node_name_buf[NODE_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &node_info_pub_args.node_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_node_publisher_topics(ipc_ns, node_name_buf, &node_info_pub_args);
-    kfree(node_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (union ioctl_node_info_args __user *)arg, &node_info_pub_args,
@@ -2567,18 +2490,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &topic_info_sub_args, (union ioctl_topic_info_args __user *)arg,
           sizeof(topic_info_sub_args)))
       return -EFAULT;
-    if (topic_info_sub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(topic_info_sub_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)topic_info_sub_args.topic_name.ptr,
-          topic_info_sub_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[topic_info_sub_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret =
+      copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &topic_info_sub_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_topic_subscriber_info(topic_name_buf, ipc_ns, &topic_info_sub_args);
-    kfree(topic_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (union ioctl_topic_info_args __user *)arg, &topic_info_sub_args,
@@ -2591,18 +2509,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &topic_info_pub_args, (union ioctl_topic_info_args __user *)arg,
           sizeof(topic_info_pub_args)))
       return -EFAULT;
-    if (topic_info_pub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(topic_info_pub_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)topic_info_pub_args.topic_name.ptr,
-          topic_info_pub_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[topic_info_pub_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret =
+      copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &topic_info_pub_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_topic_publisher_info(topic_name_buf, ipc_ns, &topic_info_pub_args);
-    kfree(topic_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (union ioctl_topic_info_args __user *)arg, &topic_info_pub_args,
@@ -2615,19 +2528,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &get_sub_qos_args, (struct ioctl_get_subscriber_qos_args __user *)arg,
           sizeof(get_sub_qos_args)))
       return -EFAULT;
-    if (get_sub_qos_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(get_sub_qos_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)get_sub_qos_args.topic_name.ptr,
-          get_sub_qos_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[get_sub_qos_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &get_sub_qos_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_subscriber_qos(
       topic_name_buf, ipc_ns, get_sub_qos_args.subscriber_id, &get_sub_qos_args);
-    kfree(topic_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (struct ioctl_get_subscriber_qos_args __user *)arg, &get_sub_qos_args,
@@ -2640,19 +2547,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &get_pub_qos_args, (struct ioctl_get_publisher_qos_args __user *)arg,
           sizeof(get_pub_qos_args)))
       return -EFAULT;
-    if (get_pub_qos_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(get_pub_qos_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)get_pub_qos_args.topic_name.ptr,
-          get_pub_qos_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[get_pub_qos_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &get_pub_qos_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_get_publisher_qos(
       topic_name_buf, ipc_ns, get_pub_qos_args.publisher_id, &get_pub_qos_args);
-    kfree(topic_name_buf);
     if (ret == 0) {
       if (copy_to_user(
             (struct ioctl_get_publisher_qos_args __user *)arg, &get_pub_qos_args,
@@ -2665,51 +2566,36 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
           &remove_subscriber_args, (void __user *)arg, sizeof(remove_subscriber_args))) {
       return -EFAULT;
     }
-    if (remove_subscriber_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(remove_subscriber_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)remove_subscriber_args.topic_name.ptr,
-          remove_subscriber_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[remove_subscriber_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(
+      topic_name_buf, sizeof(topic_name_buf), &remove_subscriber_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_remove_subscriber(
       topic_name_buf, ipc_ns, remove_subscriber_args.subscriber_id);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_REMOVE_PUBLISHER_CMD) {
     struct ioctl_remove_publisher_args remove_publisher_args;
     if (copy_from_user(&remove_publisher_args, (void __user *)arg, sizeof(remove_publisher_args))) {
       return -EFAULT;
     }
-    if (remove_publisher_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(remove_publisher_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)remove_publisher_args.topic_name.ptr,
-          remove_publisher_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[remove_publisher_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(
+      topic_name_buf, sizeof(topic_name_buf), &remove_publisher_args.topic_name);
+    if (ret) return ret;
+
     ret =
       agnocast_ioctl_remove_publisher(topic_name_buf, ipc_ns, remove_publisher_args.publisher_id);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_ADD_BRIDGE_CMD) {
     struct ioctl_add_bridge_args bridge_args;
     if (copy_from_user(&bridge_args, (void __user *)arg, sizeof(bridge_args))) return -EFAULT;
-    if (bridge_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(bridge_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)bridge_args.topic_name.ptr, bridge_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[bridge_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &bridge_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_add_bridge(topic_name_buf, pid, bridge_args.is_r2a, ipc_ns, &bridge_args);
-    kfree(topic_name_buf);
     if (ret == 0 || ret == -EEXIST) {
       if (copy_to_user(
             (struct ioctl_add_bridge_args __user *)arg, &bridge_args, sizeof(bridge_args)))
@@ -2719,18 +2605,13 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     struct ioctl_remove_bridge_args remove_bridge_args;
     if (copy_from_user(&remove_bridge_args, (void __user *)arg, sizeof(remove_bridge_args)))
       return -EFAULT;
-    if (remove_bridge_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(remove_bridge_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)remove_bridge_args.topic_name.ptr,
-          remove_bridge_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[remove_bridge_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret =
+      copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &remove_bridge_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_remove_bridge(topic_name_buf, pid, remove_bridge_args.is_r2a, ipc_ns);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_CHECK_AND_REQUEST_BRIDGE_SHUTDOWN_CMD) {
     struct ioctl_check_and_request_bridge_shutdown_args shutdown_args;
     memset(&shutdown_args, 0, sizeof(shutdown_args));
@@ -2743,36 +2624,26 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     struct ioctl_set_ros2_subscriber_num_args set_ros2_sub_args;
     if (copy_from_user(&set_ros2_sub_args, (void __user *)arg, sizeof(set_ros2_sub_args)))
       return -EFAULT;
-    if (set_ros2_sub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(set_ros2_sub_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)set_ros2_sub_args.topic_name.ptr,
-          set_ros2_sub_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[set_ros2_sub_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret =
+      copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &set_ros2_sub_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_set_ros2_subscriber_num(
       topic_name_buf, ipc_ns, set_ros2_sub_args.ros2_subscriber_num);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_SET_ROS2_PUBLISHER_NUM_CMD) {
     struct ioctl_set_ros2_publisher_num_args set_ros2_pub_args;
     if (copy_from_user(&set_ros2_pub_args, (void __user *)arg, sizeof(set_ros2_pub_args)))
       return -EFAULT;
-    if (set_ros2_pub_args.topic_name.len >= TOPIC_NAME_BUFFER_SIZE) return -EINVAL;
-    char * topic_name_buf = kmalloc(set_ros2_pub_args.topic_name.len + 1, GFP_KERNEL);
-    if (!topic_name_buf) return -ENOMEM;
-    if (copy_from_user(
-          topic_name_buf, (char __user *)set_ros2_pub_args.topic_name.ptr,
-          set_ros2_pub_args.topic_name.len)) {
-      kfree(topic_name_buf);
-      return -EFAULT;
-    }
-    topic_name_buf[set_ros2_pub_args.topic_name.len] = '\0';
+
+    char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+    ret =
+      copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &set_ros2_pub_args.topic_name);
+    if (ret) return ret;
+
     ret = agnocast_ioctl_set_ros2_publisher_num(
       topic_name_buf, ipc_ns, set_ros2_pub_args.ros2_publisher_num);
-    kfree(topic_name_buf);
   } else if (cmd == AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD) {
     ret = agnocast_ioctl_notify_bridge_shutdown(pid);
   } else {


### PR DESCRIPTION

## Description

### What?

Replace all kmalloc/kfree for topic_name/node_name buffers in the ioctl dispatch
with stack-allocated arrays and a new `copy_name_from_user()` inline helper.

- 20 kmalloc sites replaced with stack buffers (256B each)
- 48 kfree calls removed (including error-path kfrees)
- Redundant pre-call length checks removed (copy_name_from_user validates internally)
- Net -119 lines

### Why?

1. **Code simplification**: Each ioctl handler had 6-10 lines of boilerplate
   (kmalloc, null check, copy_from_user, error-path kfree, NUL-terminate, kfree).
   Now 2-3 lines with the helper.
2. **Error-path safety**: 48 kfree calls in error paths are gone. No more risk of
   forgetting kfree when adding new error paths or ioctls.

### How?

Added `copy_name_from_user()` to `agnocast_internal.h`:
- Validates length against buffer size
- `copy_from_user` from userspace pointer
- NUL-terminates
- Returns `-EINVAL` or `-EFAULT` (caller propagates the error code)

Each ioctl case now declares a stack array and calls the helper:
```c
char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &args.topic_name);
if (ret) return ret;
```

Stack usage: max 512B per ioctl call (topic 256B + node 256B) on 16KB kernel stack.
The ioctl call stack is shallow (syscall -> agnocast_ioctl -> handler). This is a
common pattern in upstream kernel drivers.

### Benchmark ([isorc26_tmp](https://github.com/sykwer/isorc26_tmp), 10 topics, 4 subs, 100Hz, 3-iter avg, --no-rt)

| Metric | main p50 | stack buf p50 | diff |
|--------|----------|---------------|------|
| Pub ioctl | 3.9 us | 3.7 us | -0.1 us (-3.7%) |
| Publish | 12.6 us | 11.3 us | -1.3 us (-10.2%) |

--no-rt used to match pilot-auto.x2 production conditions (CFS, not SCHED_FIFO).
Differences did not reach statistical significance (Welch's t-test, p > 0.78, n=3).
This is a code simplification PR — latency improvement is a secondary benefit.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] [isorc26_tmp](https://github.com/sykwer/isorc26_tmp) benchmark suite

## Notes for reviewers

Changes are limited to the ioctl dispatch function in `agnocast_ioctl.c` and a new
inline helper in `agnocast_internal.h`. No functional change.

The redundant `len >= BUFFER_SIZE` validation checks before `copy_name_from_user()` calls
have been removed, as `copy_name_from_user()` performs the same check internally.