### PR TITLE
fix(kmod): add spdx license for kernel module

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 
 #include <linux/ipc_namespace.h>

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_internal.h"
 
 static void remove_all_topics(void)

--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_internal.h"
 
 // =========================================

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_internal.h"
 
 int major;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 
 #include "agnocast.h"

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_internal.h"
 
 #ifndef KUNIT_BUILD

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_bridge.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_add_bridge.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_bridge.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_add_process.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_add_publisher.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_add_subscriber.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_bridge_shutdown.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_check_and_request_bridge_shutdown.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_do_exit.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_node_publisher_topics.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_node_subscriber_topics.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_publisher_num.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_publisher_qos.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_subscriber_num.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_subscriber_qos.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_topic_publisher_info.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_topic_subscriber_info.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_version.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_version.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_get_version.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_version.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_version.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_init_memory_allocator.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_init_memory_allocator.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_init_memory_allocator.h"
 
 #include "../agnocast_memory_allocator.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_init_memory_allocator.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_init_memory_allocator.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_publish_msg.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_receive_msg.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_release_sub_ref.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_bridge.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_remove_bridge.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_bridge.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_remove_publisher.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_remove_subscriber.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_set_ros2_publisher_num.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_set_ros2_subscriber_num.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_kunit_take_msg.h"
 
 #include "../agnocast.h"

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 #include <kunit/test.h>
 

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast.h"
 #include "agnocast_kunit/agnocast_kunit_add_bridge.h"
 #include "agnocast_kunit/agnocast_kunit_add_process.h"

--- a/agnocast_kmod/agnocast_main.c
+++ b/agnocast_kmod/agnocast_main.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_internal.h"
 
 #ifndef VERSION

--- a/agnocast_kmod/agnocast_memory_allocator.c
+++ b/agnocast_kmod/agnocast_memory_allocator.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast_memory_allocator.h"
 
 #include <linux/mm.h>

--- a/agnocast_kmod/agnocast_memory_allocator.h
+++ b/agnocast_kmod/agnocast_memory_allocator.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 #pragma once
 
 #include <linux/list.h>


### PR DESCRIPTION
## Description
Add SPDX license identifier tags to all C/H source files under `agnocast_kmod/`.                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                         
This addresses the `SPDX_LICENSE_TAG` warning from the remaining checkpatch warnings tracked in #1253.
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - `.c` files: `// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause`
  - `.h` files: `/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */`                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                          The license identifier aligns with the existing `MODULE_LICENSE("Dual BSD/GPL")` declarations.

### BSD-2-Clause vs BSD-3-Clause                                                                                                                                                                                                                                                                                                                                                                                                       
          
  Both require preserving the copyright notice in source and binary redistribution.                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  The only difference is the **3rd clause** (the "no-endorsement" clause):                                                                                                                                                                                                                                                                                                                                                               
                             
  > Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.                                                                                                                                                                                                                                          
                             
  | | BSD-2-Clause | BSD-3-Clause |
  |---|---|---|
  | Retain copyright in source redistribution | Yes | Yes |
  | Retain copyright in binary redistribution | Yes | Yes |                                                                                                                                                                                                                                                                                                                                                                              
  | **Prohibit using author's name for endorsement** | **No** | **Yes** |
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  **Why BSD-2-Clause was chosen:**
  - Linux kernel convention: most `Dual BSD/GPL` files in the kernel tree use BSD-2-Clause
  - Simpler and more permissive                                                                                                                                                                                                                                                                                                                                                                                                          
  - Trademark law already provides similar brand protection as the 3rd clause
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  **References:**            
  - [SPDX BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html)
  - [SPDX BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)                                                                                                                                                                                                                                                                                                                                                                     
  - [Kernel license rules](https://www.kernel.org/doc/html/latest/process/license-rules.html)

## Related links
https://github.com/autowarefoundation/agnocast/issues/1253

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
