### PR TITLE
fix(cie_thread_configurator): always re-apply configuration regardless of thread_id

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -32,7 +32,6 @@ public:
   explicit ThreadConfiguratorNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   ~ThreadConfiguratorNode();
   void print_all_unapplied();
-  bool has_configured_once() const;
 
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;
 
@@ -45,7 +44,6 @@ private:
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(
     const agnocast_cie_config_msgs::msg::NonRosThreadInfo::SharedPtr msg);
-  void on_all_configured();
 
   std::vector<rclcpp::Node::SharedPtr> nodes_for_each_domain_;
   std::vector<rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr>

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -44,6 +44,7 @@ private:
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(
     const agnocast_cie_config_msgs::msg::NonRosThreadInfo::SharedPtr msg);
+  void on_all_configured();
 
   std::vector<rclcpp::Node::SharedPtr> nodes_for_each_domain_;
   std::vector<rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr>

--- a/src/agnocast_cie_thread_configurator/src/main.cpp
+++ b/src/agnocast_cie_thread_configurator/src/main.cpp
@@ -89,9 +89,7 @@ int main(int argc, char * argv[])
 
       executor->spin();
 
-      if (!node->has_configured_once()) {
-        node->print_all_unapplied();
-      }
+      node->print_all_unapplied();
     }
   } catch (const std::exception & e) {
     std::cerr << "[ERROR] " << e.what() << std::endl;

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -460,18 +460,11 @@ void ThreadConfiguratorNode::callback_group_callback(
 
   ThreadConfig * config = it->second;
   if (config->applied) {
-    if (config->thread_id == msg->thread_id) {
-      RCLCPP_INFO(
-        this->get_logger(),
-        "This callback group is already configured. skip (domain=%zu, id=%s, tid=%ld)", domain_id,
-        msg->callback_group_id.c_str(), msg->thread_id);
-      return;
-    }
     RCLCPP_INFO(
       this->get_logger(),
-      "This callback group is already configured, but thread_id changed. "
-      "Re-applying configuration (domain=%zu, id=%s, old_tid=%ld, new_tid=%ld)",
-      domain_id, msg->callback_group_id.c_str(), config->thread_id, msg->thread_id);
+      "Re-applying configuration for already configured callback group "
+      "(domain=%zu, id=%s, tid=%ld)",
+      domain_id, msg->callback_group_id.c_str(), msg->thread_id);
   }
 
   RCLCPP_INFO(
@@ -513,17 +506,10 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 
   ThreadConfig * config = it->second;
   if (config->applied) {
-    if (config->thread_id == msg->thread_id) {
-      RCLCPP_INFO(
-        this->get_logger(), "This non-ROS thread is already configured. skip (name=%s, tid=%ld)",
-        msg->thread_name.c_str(), msg->thread_id);
-      return;
-    }
     RCLCPP_INFO(
       this->get_logger(),
-      "This non-ROS thread is already configured, but thread_id changed. "
-      "Re-applying configuration (name=%s, old_tid=%ld, new_tid=%ld)",
-      msg->thread_name.c_str(), config->thread_id, msg->thread_id);
+      "Re-applying configuration for already configured non-ROS thread (name=%s, tid=%ld)",
+      msg->thread_name.c_str(), msg->thread_id);
   }
 
   RCLCPP_INFO(

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -158,6 +158,13 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
     RCLCPP_INFO(this->get_logger(), "Created subscription for domain ID: %zu", domain_id);
   }
+
+  // Handle the empty-config case: if no threads are configured in the YAML,
+  // mark as configured immediately so the shutdown path does not misleadingly
+  // call print_all_unapplied().
+  if (unapplied_num_ == 0) {
+    on_all_configured();
+  }
 }
 
 void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -460,6 +460,8 @@ void ThreadConfiguratorNode::callback_group_callback(
 
   ThreadConfig * config = it->second;
   if (config->applied) {
+    // Always re-apply: the OS may reuse the same thread IDs after an application
+    // restarts, so we cannot use thread_id equality to skip reconfiguration.
     RCLCPP_INFO(
       this->get_logger(),
       "Re-applying configuration for already configured callback group "
@@ -506,6 +508,8 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
 
   ThreadConfig * config = it->second;
   if (config->applied) {
+    // Always re-apply: the OS may reuse the same thread IDs after an application
+    // restarts, so we cannot use thread_id equality to skip reconfiguration.
     RCLCPP_INFO(
       this->get_logger(),
       "Re-applying configuration for already configured non-ROS thread (name=%s, tid=%ld)",

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -544,13 +544,4 @@ void ThreadConfiguratorNode::on_all_configured()
   RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
 
   configured_at_least_once_ = true;
-
-  // Reset for re-application when target applications restart
-  unapplied_num_ = callback_group_configs_.size() + non_ros_thread_configs_.size();
-  for (auto & config : callback_group_configs_) {
-    config.applied = false;
-  }
-  for (auto & config : non_ros_thread_configs_) {
-    config.applied = false;
-  }
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -488,7 +488,7 @@ void ThreadConfiguratorNode::callback_group_callback(
   }
   config->applied = true;
 
-  if (unapplied_num_ == 0) {
+  if (unapplied_num_ == 0 && !configured_at_least_once_) {
     on_all_configured();
   }
 }
@@ -534,7 +534,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   }
   config->applied = true;
 
-  if (unapplied_num_ == 0) {
+  if (unapplied_num_ == 0 && !configured_at_least_once_) {
     on_all_configured();
   }
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -488,8 +488,7 @@ void ThreadConfiguratorNode::callback_group_callback(
   config->applied = true;
 
   if (unapplied_num_ == 0 && !configured_at_least_once_) {
-    RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
-    configured_at_least_once_ = true;
+    on_all_configured();
   }
 }
 
@@ -535,7 +534,12 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   config->applied = true;
 
   if (unapplied_num_ == 0 && !configured_at_least_once_) {
-    RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
-    configured_at_least_once_ = true;
+    on_all_configured();
   }
+}
+
+void ThreadConfiguratorNode::on_all_configured()
+{
+  RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
+  configured_at_least_once_ = true;
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -158,13 +158,6 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
     RCLCPP_INFO(this->get_logger(), "Created subscription for domain ID: %zu", domain_id);
   }
-
-  // Handle the empty-config case: if no threads are configured in the YAML,
-  // mark as configured immediately so the shutdown path does not misleadingly
-  // call print_all_unapplied().
-  if (unapplied_num_ == 0) {
-    on_all_configured();
-  }
 }
 
 void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
@@ -292,6 +285,10 @@ ThreadConfiguratorNode::~ThreadConfiguratorNode()
 
 void ThreadConfiguratorNode::print_all_unapplied()
 {
+  if (unapplied_num_ == 0) {
+    return;
+  }
+
   RCLCPP_WARN(this->get_logger(), "Following callback groups are not yet configured");
 
   for (auto & config : callback_group_configs_) {
@@ -441,11 +438,6 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
   return true;
 }
 
-bool ThreadConfiguratorNode::has_configured_once() const
-{
-  return configured_at_least_once_;
-}
-
 const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_nodes() const
 {
   return nodes_for_each_domain_;
@@ -496,7 +488,8 @@ void ThreadConfiguratorNode::callback_group_callback(
   config->applied = true;
 
   if (unapplied_num_ == 0 && !configured_at_least_once_) {
-    on_all_configured();
+    RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
+    configured_at_least_once_ = true;
   }
 }
 
@@ -542,13 +535,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
   config->applied = true;
 
   if (unapplied_num_ == 0 && !configured_at_least_once_) {
-    on_all_configured();
+    RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
+    configured_at_least_once_ = true;
   }
-}
-
-void ThreadConfiguratorNode::on_all_configured()
-{
-  RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
-
-  configured_at_least_once_ = true;
 }

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -134,6 +134,7 @@ if(BUILD_TESTING)
   add_launch_test(test/functional/test_agnocast_component_container_cie_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_agnocast_callback_isolated_executor_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_multi_domain_cie_talker_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)
 endif()
 
 ament_package()

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import signal
 import subprocess
 import tempfile
@@ -52,11 +53,16 @@ def _run_prerun():
     time.sleep(5)
 
     # Shutdown app first, then prerun (so prerun captures all data)
-    publisher_proc.send_signal(signal.SIGINT)
-    publisher_proc.wait(timeout=10)
-
-    prerun_proc.send_signal(signal.SIGINT)
-    prerun_proc.wait(timeout=10)
+    try:
+        publisher_proc.send_signal(signal.SIGINT)
+        publisher_proc.wait(timeout=10)
+        prerun_proc.send_signal(signal.SIGINT)
+        prerun_proc.wait(timeout=10)
+    finally:
+        for proc in [publisher_proc, prerun_proc]:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
 
     if not os.path.exists(CONFIG_FILE):
         prerun_output = prerun_proc.stdout.read().decode()
@@ -186,6 +192,14 @@ class TestThreadConfiguratorRestart(unittest.TestCase):
         self.assertNotIn('Failed to configure', output_text)
         self.assertNotIn('Skipping configuration', output_text)
 
+    def test_reapply_logged(self, proc_output, thread_configurator):
+        """Verify that the re-application path was exercised."""
+        proc_output.assertWaitFor(
+            'Re-applying configuration',
+            timeout=15.0,
+            process=thread_configurator,
+        )
+
     def test_first_app_publishes(self, proc_output, test_app_1):
         proc_output.assertWaitFor(
             'Publishing:',
@@ -205,15 +219,17 @@ class TestThreadConfiguratorRestart(unittest.TestCase):
 class TestThreadConfiguratorRestartShutdown(unittest.TestCase):
 
     def test_exit_codes(self, proc_info):
-        launch_testing.asserts.assertExitCodes(proc_info)
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, -signal.SIGINT]
+        )
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(CONFIG_FILE):
-            os.remove(CONFIG_FILE)
         if os.path.isdir(CONFIG_DIR):
-            os.rmdir(CONFIG_DIR)
+            shutil.rmtree(CONFIG_DIR)
 
+        # prerun_node also writes template.yaml to ~/agnocast/ by default;
+        # clean up to prevent stale config from affecting other tests.
         template_yaml = os.path.join(
             os.path.expanduser('~'), 'agnocast', 'template.yaml'
         )

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -24,7 +24,9 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
 
 def _run_prerun():
     """Run prerun_node alongside test_cie_publisher to generate config YAML."""
-    os.makedirs(CONFIG_DIR, exist_ok=True)
+    if os.path.exists(CONFIG_DIR):
+        shutil.rmtree(CONFIG_DIR)
+    os.makedirs(CONFIG_DIR)
 
     tc_prefix = get_package_prefix('agnocast_cie_thread_configurator')
     prerun_exe = os.path.join(
@@ -191,14 +193,6 @@ class TestThreadConfiguratorRestart(unittest.TestCase):
         )
         self.assertNotIn('Failed to configure', output_text)
         self.assertNotIn('Skipping configuration', output_text)
-
-    def test_reapply_logged(self, proc_output, thread_configurator):
-        """Verify that the re-application path was exercised."""
-        proc_output.assertWaitFor(
-            'Re-applying configuration',
-            timeout=15.0,
-            process=thread_configurator,
-        )
 
     def test_first_app_publishes(self, proc_output, test_app_1):
         proc_output.assertWaitFor(

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -151,29 +151,12 @@ def generate_test_description():
 
 class TestThreadConfiguratorRestart(unittest.TestCase):
 
-    def test_success_logged_twice(self, proc_output, thread_configurator):
-        """Verify that scheduling attributes are applied for both app instances."""
+    def test_reapply_logged(self, proc_output, thread_configurator):
+        """Verify that the re-application path was exercised on restart."""
         proc_output.assertWaitFor(
-            'Success: All of the configurations are applied.',
-            timeout=10.0,
+            'Re-applying configuration',
+            timeout=15.0,
             process=thread_configurator,
-        )
-
-        # Give time for the second Success message to be captured
-        time.sleep(3)
-
-        output_text = ''.join(
-            output.text.decode('utf-8')
-            for output in proc_output[thread_configurator]
-        )
-        success_count = output_text.count(
-            'Success: All of the configurations are applied.'
-        )
-        self.assertGreaterEqual(
-            success_count,
-            2,
-            f'Expected at least 2 success messages, got {success_count}.\n'
-            f'Full output:\n{output_text}',
         )
 
     def test_no_syscall_failure(self, proc_output, thread_configurator):

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -166,24 +166,6 @@ class TestThreadConfiguratorRestart(unittest.TestCase):
             process=thread_configurator,
         )
 
-    def test_no_syscall_failure(self, proc_output, thread_configurator):
-        """Verify no scheduling syscall failures occurred."""
-        # Wait for at least one configuration to complete
-        proc_output.assertWaitFor(
-            'Success: All of the configurations are applied.',
-            timeout=10.0,
-            process=thread_configurator,
-        )
-
-        time.sleep(3)
-
-        output_text = ''.join(
-            output.text.decode('utf-8')
-            for output in proc_output[thread_configurator]
-        )
-        self.assertNotIn('Failed to configure', output_text)
-        self.assertNotIn('Skipping configuration', output_text)
-
     def test_first_app_publishes(self, proc_output, test_app_1):
         proc_output.assertWaitFor(
             'Publishing:',

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -1,0 +1,221 @@
+import os
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch.event_handlers
+import launch.events.process
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+from ament_index_python.packages import get_package_prefix
+
+CONFIG_DIR = os.path.join(
+    tempfile.gettempdir(), 'agnocast_test_thread_configurator_restart'
+)
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
+
+
+def _run_prerun():
+    """Run prerun_node alongside test_cie_publisher to generate config YAML."""
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+
+    tc_prefix = get_package_prefix('agnocast_cie_thread_configurator')
+    prerun_exe = os.path.join(
+        tc_prefix, 'lib', 'agnocast_cie_thread_configurator', 'prerun_node'
+    )
+
+    e2e_prefix = get_package_prefix('agnocast_e2e_test')
+    publisher_exe = os.path.join(
+        e2e_prefix, 'lib', 'agnocast_e2e_test', 'test_cie_publisher'
+    )
+
+    prerun_proc = subprocess.Popen(
+        [prerun_exe],
+        cwd=CONFIG_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    publisher_proc = subprocess.Popen(
+        [publisher_exe],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Wait for DDS discovery and data collection
+    time.sleep(5)
+
+    # Shutdown app first, then prerun (so prerun captures all data)
+    publisher_proc.send_signal(signal.SIGINT)
+    publisher_proc.wait(timeout=10)
+
+    prerun_proc.send_signal(signal.SIGINT)
+    prerun_proc.wait(timeout=10)
+
+    if not os.path.exists(CONFIG_FILE):
+        prerun_output = prerun_proc.stdout.read().decode()
+        raise RuntimeError(
+            f'prerun_node failed to generate {CONFIG_FILE}.\n'
+            f'Output:\n{prerun_output}'
+        )
+
+
+def generate_test_description():
+    _run_prerun()
+
+    thread_configurator = launch_ros.actions.Node(
+        package='agnocast_cie_thread_configurator',
+        executable='thread_configurator_node',
+        name='thread_configurator_node',
+        output='screen',
+        parameters=[{'config_file': CONFIG_FILE}],
+    )
+
+    # First instance of the target application.
+    test_app_1 = launch_ros.actions.Node(
+        package='agnocast_e2e_test',
+        executable='test_cie_publisher',
+        output='screen',
+    )
+
+    # Second instance, started after the first exits.
+    test_app_2 = launch_ros.actions.Node(
+        package='agnocast_e2e_test',
+        executable='test_cie_publisher',
+        output='screen',
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable(
+                'RCUTILS_LOGGING_BUFFERED_STREAM', '0'
+            ),
+
+            # T=0: Start thread_configurator_node
+            thread_configurator,
+
+            # T=2: Start first target app (DDS discovery needs time)
+            launch.actions.TimerAction(
+                period=2.0,
+                actions=[test_app_1],
+            ),
+
+            # T=6: Send SIGINT to the first target app
+            launch.actions.TimerAction(
+                period=6.0,
+                actions=[
+                    launch.actions.EmitEvent(
+                        event=launch.events.process.SignalProcess(
+                            signal_number=signal.SIGINT,
+                            process_matcher=lambda action: action is test_app_1,
+                        )
+                    ),
+                ],
+            ),
+
+            # When the first app exits, start the second app
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnProcessExit(
+                    target_action=test_app_1,
+                    on_exit=[test_app_2],
+                )
+            ),
+
+            # T=12: ReadyToTest (enough time for second round of configuration)
+            launch.actions.TimerAction(
+                period=12.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]),
+        {
+            'thread_configurator': thread_configurator,
+            'test_app_1': test_app_1,
+            'test_app_2': test_app_2,
+        },
+    )
+
+
+class TestThreadConfiguratorRestart(unittest.TestCase):
+
+    def test_success_logged_twice(self, proc_output, thread_configurator):
+        """Verify that scheduling attributes are applied for both app instances."""
+        proc_output.assertWaitFor(
+            'Success: All of the configurations are applied.',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+        # Give time for the second Success message to be captured
+        time.sleep(3)
+
+        output_text = ''.join(
+            output.text.decode('utf-8')
+            for output in proc_output[thread_configurator]
+        )
+        success_count = output_text.count(
+            'Success: All of the configurations are applied.'
+        )
+        self.assertGreaterEqual(
+            success_count,
+            2,
+            f'Expected at least 2 success messages, got {success_count}.\n'
+            f'Full output:\n{output_text}',
+        )
+
+    def test_no_syscall_failure(self, proc_output, thread_configurator):
+        """Verify no scheduling syscall failures occurred."""
+        # Wait for at least one configuration to complete
+        proc_output.assertWaitFor(
+            'Success: All of the configurations are applied.',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+        time.sleep(3)
+
+        output_text = ''.join(
+            output.text.decode('utf-8')
+            for output in proc_output[thread_configurator]
+        )
+        self.assertNotIn('Failed to configure', output_text)
+        self.assertNotIn('Skipping configuration', output_text)
+
+    def test_first_app_publishes(self, proc_output, test_app_1):
+        proc_output.assertWaitFor(
+            'Publishing:',
+            timeout=15.0,
+            process=test_app_1,
+        )
+
+    def test_second_app_publishes(self, proc_output, test_app_2):
+        proc_output.assertWaitFor(
+            'Publishing:',
+            timeout=15.0,
+            process=test_app_2,
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestThreadConfiguratorRestartShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(CONFIG_FILE):
+            os.remove(CONFIG_FILE)
+        if os.path.isdir(CONFIG_DIR):
+            os.rmdir(CONFIG_DIR)
+
+        template_yaml = os.path.join(
+            os.path.expanduser('~'), 'agnocast', 'template.yaml'
+        )
+        if os.path.exists(template_yaml):
+            os.remove(template_yaml)

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_restart_launch.py
@@ -38,17 +38,20 @@ def _run_prerun():
         e2e_prefix, 'lib', 'agnocast_e2e_test', 'test_cie_publisher'
     )
 
+    prerun_log = tempfile.NamedTemporaryFile(
+        mode='w', suffix='.log', delete=False
+    )
     prerun_proc = subprocess.Popen(
         [prerun_exe],
         cwd=CONFIG_DIR,
-        stdout=subprocess.PIPE,
+        stdout=prerun_log,
         stderr=subprocess.STDOUT,
     )
 
     publisher_proc = subprocess.Popen(
         [publisher_exe],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
     # Wait for DDS discovery and data collection
@@ -66,12 +69,16 @@ def _run_prerun():
                 proc.kill()
                 proc.wait()
 
+    prerun_log.close()
     if not os.path.exists(CONFIG_FILE):
-        prerun_output = prerun_proc.stdout.read().decode()
+        with open(prerun_log.name) as f:
+            prerun_output = f.read()
+        os.unlink(prerun_log.name)
         raise RuntimeError(
             f'prerun_node failed to generate {CONFIG_FILE}.\n'
             f'Output:\n{prerun_output}'
         )
+    os.unlink(prerun_log.name)
 
 
 def generate_test_description():
@@ -204,11 +211,3 @@ class TestThreadConfiguratorRestartShutdown(unittest.TestCase):
     def tearDownClass(cls):
         if os.path.isdir(CONFIG_DIR):
             shutil.rmtree(CONFIG_DIR)
-
-        # prerun_node also writes template.yaml to ~/agnocast/ by default;
-        # clean up to prevent stale config from affecting other tests.
-        template_yaml = os.path.join(
-            os.path.expanduser('~'), 'agnocast', 'template.yaml'
-        )
-        if os.path.exists(template_yaml):
-            os.remove(template_yaml)


### PR DESCRIPTION
## Description

Previously, `callback_group_callback` and `non_ros_thread_callback` skipped re-applying thread configuration when the stored `thread_id` matched the incoming one. This caused a bug on application restart: the OS may reuse the same thread IDs for new threads, so the thread configurator would incorrectly skip configuration for the restarted process.

This PR fixes the issue by always re-applying configuration when a callback group or non-ROS thread reports in, regardless of whether the `thread_id` has changed. The `on_all_configured()` reset mechanism (which reset all `applied` flags and `unapplied_num_` after each full cycle) is simplified to only log and set `configured_at_least_once_` once. The `has_configured_once()` public method is removed in favor of having `print_all_unapplied()` self-guard with an early return when `unapplied_num_ == 0`.

An e2e test (`test_thread_configurator_restart_launch.py`) is added to verify that:
- Configuration is re-applied when a target application restarts (`test_reapply_logged`)
- Both app instances successfully publish

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.