### PR TITLE
feat(agnocastlib): warn when ROS 2 and Agnocast callbacks share a callback group

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
@@ -25,7 +25,7 @@ class SingleThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   bool is_dedicated_to_one_callback_group_ = false;
   rclcpp::CallbackGroup::SharedPtr dedicated_callback_group_ = nullptr;
 
-  std::set<rclcpp::CallbackGroup::SharedPtr> warned_mixed_groups_;
+  std::set<const rclcpp::CallbackGroup *> warned_mixed_groups_;
   void warn_if_mixed_callback_groups();
 
 public:

--- a/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
@@ -5,6 +5,8 @@
 #include "agnocast/agnocast_public_api.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include <set>
+
 namespace agnocast
 {
 
@@ -22,6 +24,9 @@ class SingleThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   // CallbackIsolatedAgnocastExecutor.
   bool is_dedicated_to_one_callback_group_ = false;
   rclcpp::CallbackGroup::SharedPtr dedicated_callback_group_ = nullptr;
+
+  std::set<rclcpp::CallbackGroup::SharedPtr> warned_mixed_groups_;
+  void warn_if_mixed_callback_groups();
 
 public:
   /// Construct the executor.

--- a/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_single_threaded_executor.hpp
@@ -5,7 +5,7 @@
 #include "agnocast/agnocast_public_api.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <set>
+#include <unordered_set>
 
 namespace agnocast
 {
@@ -25,7 +25,7 @@ class SingleThreadedAgnocastExecutor : public agnocast::AgnocastExecutor
   bool is_dedicated_to_one_callback_group_ = false;
   rclcpp::CallbackGroup::SharedPtr dedicated_callback_group_ = nullptr;
 
-  std::set<const rclcpp::CallbackGroup *> warned_mixed_groups_;
+  std::unordered_set<const rclcpp::CallbackGroup *> warned_mixed_groups_;
   void warn_if_mixed_callback_groups();
 
 public:

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -98,7 +98,7 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 
   // Filter out already-warned groups after releasing locks
   for (auto it = agnocast_groups.begin(); it != agnocast_groups.end();) {
-    if (warned_mixed_groups_.count(*it)) {
+    if (warned_mixed_groups_.count(it->get())) {
       it = agnocast_groups.erase(it);
     } else {
       ++it;
@@ -115,20 +115,24 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
       [&has_ros_callback](const rclcpp::Waitable::SharedPtr &) { has_ros_callback = true; });
 
     if (has_ros_callback) {
-      warned_mixed_groups_.insert(group);
+      warned_mixed_groups_.insert(group.get());
       auto agnocast_topics = get_agnocast_topics_by_group(group);
-      std::string topics_str;
-      for (const auto & t : agnocast_topics) {
-        if (!topics_str.empty()) topics_str += ", ";
-        topics_str += t;
+      std::string agnocast_entities_str = "Agnocast callbacks";
+      if (!agnocast_topics.empty()) {
+        std::string topics_str;
+        for (const auto & t : agnocast_topics) {
+          if (!topics_str.empty()) topics_str += ", ";
+          topics_str += t;
+        }
+        agnocast_entities_str += " (topics: [" + topics_str + "])";
       }
       RCLCPP_WARN(
         logger,
-        "A callback group (Agnocast topics: [%s]) contains both ROS 2 and Agnocast callbacks. "
+        "A callback group (%s) contains both ROS 2 and Agnocast callbacks. "
         "In SingleThreadedAgnocastExecutor, the Agnocast timed wait may block "
         "ROS 2 callbacks in the same callback group every spin iteration. "
         "Consider separating them into different callback groups.",
-        topics_str.c_str());
+        agnocast_entities_str.c_str());
     }
   }
 }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -4,6 +4,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sys/epoll.h"
 
+#include <unordered_map>
+
 namespace agnocast
 {
 
@@ -71,28 +73,19 @@ void SingleThreadedAgnocastExecutor::spin()
 
 void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 {
-  // Collect callback groups used by agnocast callbacks
-  std::set<rclcpp::CallbackGroup::SharedPtr> agnocast_groups;
+  // Single pass: collect group → topics, skipping already-warned groups
+  std::unordered_map<rclcpp::CallbackGroup::SharedPtr, std::vector<std::string>> group_topics;
 
   {
     std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
     for (const auto & [id, info] : id2_callback_info) {
-      if (info.callback_group) {
-        agnocast_groups.insert(info.callback_group);
+      if (info.callback_group && !warned_mixed_groups_.count(info.callback_group.get())) {
+        group_topics[info.callback_group].push_back(info.topic_name);
       }
     }
   }
 
-  // Filter out already-warned groups after releasing locks
-  for (auto it = agnocast_groups.begin(); it != agnocast_groups.end();) {
-    if (warned_mixed_groups_.count(it->get())) {
-      it = agnocast_groups.erase(it);
-    } else {
-      ++it;
-    }
-  }
-
-  for (const auto & group : agnocast_groups) {
+  for (auto & [group, topics] : group_topics) {
     bool has_ros_callback = false;
     group->collect_all_ptrs(
       [&has_ros_callback](const rclcpp::SubscriptionBase::SharedPtr &) { has_ros_callback = true; },
@@ -103,11 +96,11 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 
     if (has_ros_callback) {
       warned_mixed_groups_.insert(group.get());
-      auto agnocast_topics = get_agnocast_topics_by_group(group);
+      std::sort(topics.begin(), topics.end());
       std::string agnocast_entities_str = "Agnocast callbacks";
-      if (!agnocast_topics.empty()) {
+      if (!topics.empty()) {
         std::string topics_str;
-        for (const auto & t : agnocast_topics) {
+        for (const auto & t : topics) {
           if (!topics_str.empty()) topics_str += ", ";
           topics_str += t;
         }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -73,7 +73,6 @@ void SingleThreadedAgnocastExecutor::spin()
 
 void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 {
-  // Single pass: collect group → topics, skipping already-warned groups
   std::unordered_map<rclcpp::CallbackGroup::SharedPtr, std::vector<std::string>> group_topics;
 
   {
@@ -96,7 +95,6 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 
     if (has_ros_callback) {
       warned_mixed_groups_.insert(group.get());
-      std::sort(topics.begin(), topics.end());
       std::string agnocast_entities_str = "Agnocast callbacks";
       if (!topics.empty()) {
         std::string topics_str;

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -53,6 +53,7 @@ void SingleThreadedAgnocastExecutor::spin()
   while (rclcpp::ok(this->context_) && spinning.load()) {
     if (need_epoll_updates.load()) {
       prepare_epoll();
+      warn_if_mixed_callback_groups();
     }
 
     agnocast::AgnocastExecutable agnocast_executable;
@@ -64,6 +65,54 @@ void SingleThreadedAgnocastExecutor::spin()
     rclcpp::AnyExecutable any_executable;
     if (get_next_executable(any_executable, std::chrono::nanoseconds(0) /*non-blocking*/)) {
       execute_any_executable(any_executable);
+    }
+  }
+}
+
+void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
+{
+  if (is_dedicated_to_one_callback_group_) {
+    return;
+  }
+
+  // Collect callback groups used by agnocast callbacks that haven't been warned about yet
+  std::set<rclcpp::CallbackGroup::SharedPtr> agnocast_groups;
+
+  {
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+    for (const auto & [id, info] : id2_callback_info) {
+      if (info.callback_group && warned_mixed_groups_.count(info.callback_group) == 0) {
+        agnocast_groups.insert(info.callback_group);
+      }
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+    for (const auto & [id, info] : id2_timer_info) {
+      if (info->callback_group && warned_mixed_groups_.count(info->callback_group) == 0) {
+        agnocast_groups.insert(info->callback_group);
+      }
+    }
+  }
+
+  for (const auto & group : agnocast_groups) {
+    bool has_ros_callback = false;
+    group->collect_all_ptrs(
+      [&has_ros_callback](const rclcpp::SubscriptionBase::SharedPtr &) { has_ros_callback = true; },
+      [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr &) { has_ros_callback = true; },
+      [&has_ros_callback](const rclcpp::ClientBase::SharedPtr &) { has_ros_callback = true; },
+      [&has_ros_callback](const rclcpp::TimerBase::SharedPtr &) { has_ros_callback = true; },
+      [](const rclcpp::Waitable::SharedPtr &) {});
+
+    if (has_ros_callback) {
+      warned_mixed_groups_.insert(group);
+      RCLCPP_WARN(
+        logger,
+        "A callback group contains both ROS 2 and Agnocast callbacks. "
+        "In SingleThreadedAgnocastExecutor, the Agnocast timed wait may block "
+        "ROS 2 callbacks in the same callback group every spin iteration. "
+        "Consider separating them into different callback groups.");
     }
   }
 }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -78,7 +78,7 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
   {
     std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
     for (const auto & [id, info] : id2_callback_info) {
-      if (info.callback_group && !warned_mixed_groups_.count(info.callback_group.get())) {
+      if (info.callback_group && warned_mixed_groups_.count(info.callback_group.get()) == 0) {
         group_topics[info.callback_group].push_back(info.topic_name);
       }
     }
@@ -99,7 +99,9 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
       if (!topics.empty()) {
         std::string topics_str;
         for (const auto & t : topics) {
-          if (!topics_str.empty()) topics_str += ", ";
+          if (!topics_str.empty()) {
+            topics_str += ", ";
+          }
           topics_str += t;
         }
         agnocast_entities_str += " (topics: [" + topics_str + "])";

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -75,13 +75,13 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
     return;
   }
 
-  // Collect callback groups used by agnocast callbacks that haven't been warned about yet
+  // Collect callback groups used by agnocast callbacks
   std::set<rclcpp::CallbackGroup::SharedPtr> agnocast_groups;
 
   {
     std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
     for (const auto & [id, info] : id2_callback_info) {
-      if (info.callback_group && warned_mixed_groups_.count(info.callback_group) == 0) {
+      if (info.callback_group) {
         agnocast_groups.insert(info.callback_group);
       }
     }
@@ -90,9 +90,18 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
   {
     std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
     for (const auto & [id, info] : id2_timer_info) {
-      if (info->callback_group && warned_mixed_groups_.count(info->callback_group) == 0) {
+      if (info->callback_group) {
         agnocast_groups.insert(info->callback_group);
       }
+    }
+  }
+
+  // Filter out already-warned groups after releasing locks
+  for (auto it = agnocast_groups.begin(); it != agnocast_groups.end();) {
+    if (warned_mixed_groups_.count(*it)) {
+      it = agnocast_groups.erase(it);
+    } else {
+      ++it;
     }
   }
 
@@ -103,16 +112,23 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
       [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::ClientBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::TimerBase::SharedPtr &) { has_ros_callback = true; },
-      [](const rclcpp::Waitable::SharedPtr &) {});
+      [&has_ros_callback](const rclcpp::Waitable::SharedPtr &) { has_ros_callback = true; });
 
     if (has_ros_callback) {
       warned_mixed_groups_.insert(group);
+      auto agnocast_topics = get_agnocast_topics_by_group(group);
+      std::string topics_str;
+      for (const auto & t : agnocast_topics) {
+        if (!topics_str.empty()) topics_str += ", ";
+        topics_str += t;
+      }
       RCLCPP_WARN(
         logger,
-        "A callback group contains both ROS 2 and Agnocast callbacks. "
+        "A callback group (Agnocast topics: [%s]) contains both ROS 2 and Agnocast callbacks. "
         "In SingleThreadedAgnocastExecutor, the Agnocast timed wait may block "
         "ROS 2 callbacks in the same callback group every spin iteration. "
-        "Consider separating them into different callback groups.");
+        "Consider separating them into different callback groups.",
+        topics_str.c_str());
     }
   }
 }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -71,10 +71,6 @@ void SingleThreadedAgnocastExecutor::spin()
 
 void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
 {
-  if (is_dedicated_to_one_callback_group_) {
-    return;
-  }
-
   // Collect callback groups used by agnocast callbacks
   std::set<rclcpp::CallbackGroup::SharedPtr> agnocast_groups;
 
@@ -83,15 +79,6 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
     for (const auto & [id, info] : id2_callback_info) {
       if (info.callback_group) {
         agnocast_groups.insert(info.callback_group);
-      }
-    }
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
-    for (const auto & [id, info] : id2_timer_info) {
-      if (info->callback_group) {
-        agnocast_groups.insert(info->callback_group);
       }
     }
   }

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -106,11 +106,11 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
       }
       RCLCPP_WARN(
         logger,
-        "A callback group (%s) contains both ROS 2 and Agnocast callbacks. "
+        "Callback group %p contains both ROS 2 callbacks and %s. "
         "In SingleThreadedAgnocastExecutor, the Agnocast timed wait may block "
         "ROS 2 callbacks in the same callback group every spin iteration. "
         "Consider separating them into different callback groups.",
-        agnocast_entities_str.c_str());
+        static_cast<const void *>(group.get()), agnocast_entities_str.c_str());
     }
   }
 }


### PR DESCRIPTION
## Description

Add a runtime warning in `SingleThreadedAgnocastExecutor` when a callback group contains both ROS 2 and Agnocast callbacks. In the spin loop, the Agnocast timed wait (`get_next_agnocast_executable`) may block ROS 2 callbacks in the same callback group every iteration. The warning guides users toward separating them into different callback groups.

The check runs only when new callbacks are registered (`need_epoll_updates`) and uses `collect_all_ptrs` to detect ROS 2 entities (subscriptions, services, clients, timers, waitables) in agnocast callback groups. It collects groups and their topic names in a single pass over `id2_callback_info`, emits the warning at most once per group, and tracks warned groups by raw pointer to avoid extending callback group lifetime.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.