### PR TITLE
fix(cie): upgrade executor when agnocast entities arrive after callback group registration

### DIFF
--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -275,6 +275,10 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
       cancel_executor(wrapper);
       it = executor_wrappers.erase(it);
 
+      // The executor destructor (triggered by erase above) clears associated_with_executor,
+      // but we clear it explicitly as a defensive measure.
+      callback_group->get_associated_with_executor_atomic().store(false);
+
       if (node) {
         start_executor_for_callback_group(node_id, callback_group, node);
       }

--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -38,8 +38,8 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
     std::shared_ptr<rclcpp::Executor> executor_;
     std::thread thread_;
     std::atomic_bool thread_initialized_;
-    rclcpp::CallbackGroup::SharedPtr callback_group_;
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_;
+    rclcpp::CallbackGroup::WeakPtr callback_group_;
+    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_;
   };
 
 public:
@@ -247,7 +247,8 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
     for (auto it = executor_wrappers.begin(); it != executor_wrappers.end();) {
       auto & wrapper = *it;
 
-      if (!wrapper.callback_group_) {
+      auto callback_group = wrapper.callback_group_.lock();
+      if (!callback_group) {
         ++it;
         continue;
       }
@@ -259,19 +260,18 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
         continue;
       }
 
-      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(wrapper.callback_group_);
+      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(callback_group);
       if (agnocast_topics.empty()) {
         ++it;
         continue;
       }
 
-      RCLCPP_INFO(
+      RCLCPP_WARN(
         this->get_logger(),
         "Agnocast topics detected in callback group previously assigned a ROS-only executor. "
         "Upgrading to SingleThreadedAgnocastExecutor.");
 
-      auto callback_group = wrapper.callback_group_;
-      auto node = wrapper.node_;
+      auto node = wrapper.node_.lock();
       cancel_executor(wrapper);
       it = executor_wrappers.erase(it);
 

--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -38,6 +38,8 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
     std::shared_ptr<rclcpp::Executor> executor_;
     std::thread thread_;
     std::atomic_bool thread_initialized_;
+    rclcpp::CallbackGroup::SharedPtr callback_group_;
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_;
   };
 
 public:
@@ -172,6 +174,8 @@ void ComponentManagerCallbackIsolated::start_executor_for_callback_group(
   auto it = node_id_to_executor_wrappers_[node_id].begin();
   it = node_id_to_executor_wrappers_[node_id].emplace(it, executor);
   auto & executor_wrapper = *it;
+  executor_wrapper.callback_group_ = callback_group;
+  executor_wrapper.node_ = node;
 
   executor_wrapper.thread_ =
     std::thread([&executor_wrapper, group_id = std::move(group_id), this]() {
@@ -236,6 +240,45 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
 
         start_executor_for_callback_group(node_id, callback_group, node);
       });
+  }
+
+  // Upgrade ROS-only executors that now have agnocast topics
+  for (auto & [node_id, executor_wrappers] : node_id_to_executor_wrappers_) {
+    for (auto it = executor_wrappers.begin(); it != executor_wrappers.end();) {
+      auto & wrapper = *it;
+
+      if (!wrapper.callback_group_) {
+        ++it;
+        continue;
+      }
+
+      // Only check groups running under a plain SingleThreadedExecutor
+      if (!std::dynamic_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(
+            wrapper.executor_)) {
+        ++it;
+        continue;
+      }
+
+      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(wrapper.callback_group_);
+      if (agnocast_topics.empty()) {
+        ++it;
+        continue;
+      }
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Agnocast topics detected in callback group previously assigned a ROS-only executor. "
+        "Upgrading to SingleThreadedAgnocastExecutor.");
+
+      auto callback_group = wrapper.callback_group_;
+      auto node = wrapper.node_;
+      cancel_executor(wrapper);
+      it = executor_wrappers.erase(it);
+
+      if (node) {
+        start_executor_for_callback_group(node_id, callback_group, node);
+      }
+    }
   }
 }
 

--- a/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
@@ -32,11 +32,16 @@ class CallbackIsolatedAgnocastExecutor : public rclcpp::Executor
     std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
     weak_groups_to_nodes_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
-  // Mutex to protect child_callback_groups_, weak_child_executors_, and child_threads_
+  // Mutex to protect child_callback_groups_, child_nodes_, weak_child_executors_, and
+  // child_threads_
   mutable std::mutex child_resources_mutex_;
 
   // Callback groups corresponding to each child executor, used by stop_callback_group()
   std::vector<rclcpp::CallbackGroup::WeakPtr> child_callback_groups_
+    RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
+
+  // Nodes corresponding to each child executor (parallel to child_callback_groups_)
+  std::vector<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> child_nodes_
     RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
 
   // Child executors created during spin()

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -88,6 +88,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
       }
 
       child_callback_groups_.push_back(group);
+      child_nodes_.push_back(node);
       weak_child_executors_.push_back(executor);
 
       child_threads_.emplace_back([executor, callback_group_id = std::move(callback_group_id),
@@ -144,19 +145,97 @@ void CallbackIsolatedAgnocastExecutor::spin()
       }
     }
 
-    if (new_groups.empty()) {
-      continue;
+    // Upgrade ROS-only executors that now have agnocast topics
+    struct UpgradeInfo
+    {
+      rclcpp::CallbackGroup::SharedPtr group;
+      rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node;
+      std::thread thread;
+    };
+    std::vector<UpgradeInfo> upgrades;
+
+    {
+      std::lock_guard<std::mutex> guard{child_resources_mutex_};
+      if (!spinning.load() || !rclcpp::ok()) {
+        break;
+      }
+
+      // Spawn executors for newly discovered callback groups
+      for (auto & [group, node] : new_groups) {
+        if (group->get_associated_with_executor_atomic().load()) {
+          continue;
+        }
+        spawn_child_executor(group, node);
+      }
+
+      // Check existing ROS-only executors for late-arriving agnocast entities
+      for (size_t i = 0; i < child_callback_groups_.size();) {
+        auto group = child_callback_groups_[i].lock();
+        if (!group) {
+          ++i;
+          continue;
+        }
+
+        auto executor = weak_child_executors_[i].lock();
+        if (!executor) {
+          ++i;
+          continue;
+        }
+
+        // Only check groups running under a plain SingleThreadedExecutor
+        if (!std::dynamic_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(executor)) {
+          ++i;
+          continue;
+        }
+
+        auto agnocast_topics = agnocast::get_agnocast_topics_by_group(group);
+        if (agnocast_topics.empty()) {
+          ++i;
+          continue;
+        }
+
+        // Agnocast entities appeared — schedule upgrade
+        RCLCPP_INFO(
+          logger,
+          "Agnocast topics detected in callback group previously assigned a ROS-only executor. "
+          "Upgrading to SingleThreadedAgnocastExecutor.");
+
+        auto node = child_nodes_[i].lock();
+        executor->cancel();
+
+        UpgradeInfo info;
+        info.group = group;
+        info.node = node;
+        info.thread = std::move(child_threads_[i]);
+        upgrades.push_back(std::move(info));
+
+        auto idx = static_cast<std::ptrdiff_t>(i);
+        child_callback_groups_.erase(child_callback_groups_.begin() + idx);
+        child_nodes_.erase(child_nodes_.begin() + idx);
+        weak_child_executors_.erase(weak_child_executors_.begin() + idx);
+        child_threads_.erase(child_threads_.begin() + idx);
+        // Don't increment i; the next element shifted into this position
+      }
     }
 
-    std::lock_guard<std::mutex> guard{child_resources_mutex_};
-    if (!spinning.load() || !rclcpp::ok()) {
-      break;
-    }
-    for (auto & [group, node] : new_groups) {
-      if (group->get_associated_with_executor_atomic().load()) {
-        continue;
+    // Join old threads outside the lock to avoid deadlock
+    for (auto & upgrade : upgrades) {
+      if (upgrade.thread.joinable()) {
+        upgrade.thread.join();
       }
-      spawn_child_executor(group, node);
+    }
+
+    // Re-spawn upgraded groups with SingleThreadedAgnocastExecutor
+    if (!upgrades.empty()) {
+      std::lock_guard<std::mutex> guard{child_resources_mutex_};
+      if (!spinning.load() || !rclcpp::ok()) {
+        break;
+      }
+      for (auto & upgrade : upgrades) {
+        if (upgrade.node) {
+          spawn_child_executor(upgrade.group, upgrade.node);
+        }
+      }
     }
   }
 
@@ -176,6 +255,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
     child_threads_.clear();
     weak_child_executors_.clear();
     child_callback_groups_.clear();
+    child_nodes_.clear();
   }
   for (auto & thread : threads_to_join) {
     if (thread.joinable()) {
@@ -409,7 +489,8 @@ void CallbackIsolatedAgnocastExecutor::stop_callback_group(
     std::lock_guard<std::mutex> guard{child_resources_mutex_};
     if (
       child_callback_groups_.size() != weak_child_executors_.size() ||
-      child_callback_groups_.size() != child_threads_.size()) {
+      child_callback_groups_.size() != child_threads_.size() ||
+      child_callback_groups_.size() != child_nodes_.size()) {
       RCLCPP_ERROR(
         logger, "Child executor vectors are misaligned. Skipping stop_callback_group().");
       return;
@@ -423,6 +504,7 @@ void CallbackIsolatedAgnocastExecutor::stop_callback_group(
         thread_to_join = std::move(child_threads_[i]);
         auto idx = static_cast<std::ptrdiff_t>(i);
         child_callback_groups_.erase(child_callback_groups_.begin() + idx);
+        child_nodes_.erase(child_nodes_.begin() + idx);
         weak_child_executors_.erase(weak_child_executors_.begin() + idx);
         child_threads_.erase(child_threads_.begin() + idx);
         found = true;

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -160,6 +160,11 @@ void CallbackIsolatedAgnocastExecutor::spin()
         break;
       }
 
+      // Record the count before spawning so the upgrade loop only checks pre-existing entries.
+      // Newly spawned executors may not have entered spin() yet, so cancelling them could
+      // deadlock (cancel sets spinning=false, but spin() resets it to true).
+      auto pre_existing_count = child_callback_groups_.size();
+
       // Spawn executors for newly discovered callback groups
       for (auto & [group, node] : new_groups) {
         if (group->get_associated_with_executor_atomic().load()) {
@@ -169,7 +174,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
       }
 
       // Check existing ROS-only executors for late-arriving agnocast entities
-      for (size_t i = 0; i < child_callback_groups_.size();) {
+      for (size_t i = 0; i < pre_existing_count;) {
         auto group = child_callback_groups_[i].lock();
         if (!group) {
           ++i;
@@ -214,6 +219,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
         child_nodes_.erase(child_nodes_.begin() + idx);
         weak_child_executors_.erase(weak_child_executors_.begin() + idx);
         child_threads_.erase(child_threads_.begin() + idx);
+        --pre_existing_count;
         // Don't increment i; the next element shifted into this position
       }
     }
@@ -234,6 +240,10 @@ void CallbackIsolatedAgnocastExecutor::spin()
       for (auto & upgrade : upgrades) {
         if (upgrade.node) {
           spawn_child_executor(upgrade.group, upgrade.node);
+        } else {
+          RCLCPP_WARN(
+            logger,
+            "Node expired during executor upgrade; callback group will no longer be served.");
         }
       }
     }

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -224,11 +224,15 @@ void CallbackIsolatedAgnocastExecutor::spin()
       }
     }
 
-    // Join old threads outside the lock to avoid deadlock
+    // Join old threads outside the lock to avoid deadlock.
+    // After join, the thread's lambda (which holds the last shared_ptr to the old executor) is
+    // destroyed, triggering the executor destructor that clears the associated_with_executor flag.
+    // We also clear it explicitly as a defensive measure.
     for (auto & upgrade : upgrades) {
       if (upgrade.thread.joinable()) {
         upgrade.thread.join();
       }
+      upgrade.group->get_associated_with_executor_atomic().store(false);
     }
 
     // Re-spawn upgraded groups with SingleThreadedAgnocastExecutor

--- a/src/agnocastlib/src/agnocast_component_container_cie.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_cie.cpp
@@ -274,6 +274,10 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
       cancel_executor(wrapper);
       it = executor_wrappers.erase(it);
 
+      // The executor destructor (triggered by erase above) clears associated_with_executor,
+      // but we clear it explicitly as a defensive measure.
+      callback_group->get_associated_with_executor_atomic().store(false);
+
       if (node) {
         start_executor_for_callback_group(node_id, callback_group, node);
       }

--- a/src/agnocastlib/src/agnocast_component_container_cie.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_cie.cpp
@@ -37,6 +37,8 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
 
     std::shared_ptr<rclcpp::Executor> executor_;
     std::thread thread_;
+    rclcpp::CallbackGroup::SharedPtr callback_group_;
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_;
   };
 
 public:
@@ -172,6 +174,8 @@ void ComponentManagerCallbackIsolated::start_executor_for_callback_group(
   auto it = node_id_to_executor_wrappers_[node_id].begin();
   it = node_id_to_executor_wrappers_[node_id].emplace(it, executor);
   auto & executor_wrapper = *it;
+  executor_wrapper.callback_group_ = callback_group;
+  executor_wrapper.node_ = node;
 
   executor_wrapper.thread_ =
     std::thread([&executor_wrapper, group_id = std::move(group_id), this]() {
@@ -235,6 +239,45 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
 
         start_executor_for_callback_group(nid, callback_group, node);
       });
+  }
+
+  // Upgrade ROS-only executors that now have agnocast topics
+  for (auto & [node_id, executor_wrappers] : node_id_to_executor_wrappers_) {
+    for (auto it = executor_wrappers.begin(); it != executor_wrappers.end();) {
+      auto & wrapper = *it;
+
+      if (!wrapper.callback_group_) {
+        ++it;
+        continue;
+      }
+
+      // Only check groups running under a plain SingleThreadedExecutor
+      if (!std::dynamic_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(
+            wrapper.executor_)) {
+        ++it;
+        continue;
+      }
+
+      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(wrapper.callback_group_);
+      if (agnocast_topics.empty()) {
+        ++it;
+        continue;
+      }
+
+      RCLCPP_WARN(
+        rclcpp::get_logger("agnocast_component_container_cie"),
+        "Agnocast topics detected in callback group previously assigned a ROS-only executor. "
+        "Upgrading to SingleThreadedAgnocastExecutor.");
+
+      auto callback_group = wrapper.callback_group_;
+      auto node = wrapper.node_;
+      cancel_executor(wrapper);
+      it = executor_wrappers.erase(it);
+
+      if (node) {
+        start_executor_for_callback_group(node_id, callback_group, node);
+      }
+    }
   }
 }
 

--- a/src/agnocastlib/src/agnocast_component_container_cie.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_cie.cpp
@@ -37,8 +37,8 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
 
     std::shared_ptr<rclcpp::Executor> executor_;
     std::thread thread_;
-    rclcpp::CallbackGroup::SharedPtr callback_group_;
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_;
+    rclcpp::CallbackGroup::WeakPtr callback_group_;
+    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_;
   };
 
 public:
@@ -246,7 +246,8 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
     for (auto it = executor_wrappers.begin(); it != executor_wrappers.end();) {
       auto & wrapper = *it;
 
-      if (!wrapper.callback_group_) {
+      auto callback_group = wrapper.callback_group_.lock();
+      if (!callback_group) {
         ++it;
         continue;
       }
@@ -258,7 +259,7 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
         continue;
       }
 
-      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(wrapper.callback_group_);
+      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(callback_group);
       if (agnocast_topics.empty()) {
         ++it;
         continue;
@@ -269,8 +270,7 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
         "Agnocast topics detected in callback group previously assigned a ROS-only executor. "
         "Upgrading to SingleThreadedAgnocastExecutor.");
 
-      auto callback_group = wrapper.callback_group_;
-      auto node = wrapper.node_;
+      auto node = wrapper.node_.lock();
       cancel_executor(wrapper);
       it = executor_wrappers.erase(it);
 


### PR DESCRIPTION
## Description

In `CallbackIsolatedAgnocastExecutor::spawn_child_executor` and both `ComponentManagerCallbackIsolated::start_executor_for_callback_group` implementations, the executor type (`SingleThreadedExecutor` vs `SingleThreadedAgnocastExecutor`) is decided at the moment a callback group is first detected. If agnocast entities are added to a callback group **after** the executor has already been spawned, the `SingleThreadedExecutor` is never replaced, and the agnocast entities silently fail to execute.

This PR adds a monitoring-time upgrade mechanism:
- The monitoring loop periodically re-checks callback groups that were assigned a `SingleThreadedExecutor` using `dynamic_pointer_cast`.
- When `get_agnocast_topics_by_group()` returns non-empty for such a group, the old executor is cancelled, its thread is joined, and the group is re-spawned with a `SingleThreadedAgnocastExecutor`.
- This avoids always using `SingleThreadedAgnocastExecutor` (which adds ~50ms latency per spin iteration for ROS-only groups due to `get_next_agnocast_executable` blocking).

Key design decisions:
- **Deadlock prevention**: In `CallbackIsolatedAgnocastExecutor`, the upgrade loop only checks pre-existing entries (recorded before spawning new groups). Newly spawned executors may not have entered `spin()` yet, so cancelling them could deadlock because `cancel()` sets `spinning=false` but `spin()` resets it via `spinning.exchange(true)`.
- **Thread join ordering**: In `CallbackIsolatedAgnocastExecutor`, threads are joined outside `child_resources_mutex_` to avoid deadlock (child threads' callbacks may acquire this mutex). In the component containers, the existing `cancel_executor` pattern (join under lock) is reused since the child threads don't acquire `executor_wrappers_mutex_`.
- **WeakPtr for ownership**: `ExecutorWrapper` fields (`callback_group_`, `node_`) use `WeakPtr` to avoid extending object lifetimes, consistent with `CallbackIsolatedAgnocastExecutor`'s `child_nodes_` pattern.
- **Explicit flag clearing**: `get_associated_with_executor_atomic().store(false)` is called explicitly after the old executor is destroyed, as a defensive measure (the `rclcpp::Executor` destructor also clears this flag).

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.