### PR TITLE
feat(cie_thread_configurator): add verify_thread_config.py script

### DIFF
--- a/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
+++ b/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Verify that agnocast_cie_thread_configurator YAML settings are correctly applied.
+
+Uses Linux /proc filesystem and syscalls to check each thread's actual scheduling
+policy, priority/nice, and CPU affinity against the YAML config.
+
+Run while both agnocast_cie_thread_configurator and the target application are running.
+
+Usage:
+    python3 verify_thread_config.py <config.yaml> [--pid <pid>]
+"""
+
+import argparse
+import ctypes
+import ctypes.util
+import os
+import platform
+import re
+import sys
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Scheduling policy constants
+# ---------------------------------------------------------------------------
+SCHED_POLICY_NAMES = {
+    0: "SCHED_OTHER",
+    1: "SCHED_FIFO",
+    2: "SCHED_RR",
+    3: "SCHED_BATCH",
+    5: "SCHED_IDLE",
+    6: "SCHED_DEADLINE",
+}
+
+SCHED_POLICY_NUMBERS = {v: k for k, v in SCHED_POLICY_NAMES.items()}
+
+# ---------------------------------------------------------------------------
+# sched_getattr via syscall -- needed to read SCHED_DEADLINE params
+# ---------------------------------------------------------------------------
+_ARCH = platform.machine()
+_SYS_SCHED_GETATTR = {"x86_64": 315, "aarch64": 275}.get(_ARCH)
+
+
+class _SchedAttr(ctypes.Structure):
+    _fields_ = [
+        ("size", ctypes.c_uint32),
+        ("sched_policy", ctypes.c_uint32),
+        ("sched_flags", ctypes.c_uint64),
+        ("sched_nice", ctypes.c_int32),
+        ("sched_priority", ctypes.c_uint32),
+        ("sched_runtime", ctypes.c_uint64),
+        ("sched_deadline", ctypes.c_uint64),
+        ("sched_period", ctypes.c_uint64),
+    ]
+
+
+def _sched_getattr(tid):
+    if _SYS_SCHED_GETATTR is None:
+        return None
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    attr = _SchedAttr()
+    attr.size = ctypes.sizeof(_SchedAttr)
+    ret = libc.syscall(
+        _SYS_SCHED_GETATTR, tid, ctypes.byref(attr), ctypes.sizeof(_SchedAttr), 0
+    )
+    if ret != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    return attr
+
+
+# ---------------------------------------------------------------------------
+# Read actual thread scheduling state from Linux
+# ---------------------------------------------------------------------------
+def get_thread_sched_info(tid):
+    """Return dict with actual scheduling info for *tid*, or None if the thread is gone."""
+    try:
+        attr = _sched_getattr(tid)
+    except OSError:
+        return None
+
+    if attr is None:
+        # Fallback when sched_getattr syscall number is unknown
+        try:
+            policy_int = os.sched_getscheduler(tid)
+        except OSError:
+            return None
+        return {
+            "policy": SCHED_POLICY_NAMES.get(policy_int, f"UNKNOWN({policy_int})"),
+            "priority": os.sched_getparam(tid).sched_priority,
+            "nice": os.getpriority(os.PRIO_PROCESS, tid),
+        }
+
+    return {
+        "policy": SCHED_POLICY_NAMES.get(
+            attr.sched_policy, f"UNKNOWN({attr.sched_policy})"
+        ),
+        "priority": attr.sched_priority,
+        "nice": attr.sched_nice,
+        "runtime": attr.sched_runtime,
+        "deadline": attr.sched_deadline,
+        "period": attr.sched_period,
+    }
+
+
+def get_thread_affinity(tid):
+    try:
+        return os.sched_getaffinity(tid)
+    except OSError:
+        return None
+
+
+def get_thread_comm(tid):
+    """Read the thread's comm name from /proc."""
+    try:
+        with open(f"/proc/{tid}/comm") as f:
+            return f.read().strip()
+    except (IOError, PermissionError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Process / thread discovery
+# ---------------------------------------------------------------------------
+def find_pids_by_node_name(node_name):
+    """Find PIDs whose cmdline contains the node name."""
+    pids = []
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/cmdline", "rb") as f:
+                cmdline = f.read().decode("utf-8", errors="replace")
+            # cmdline has null-separated arguments
+            args = cmdline.split("\0")
+            for arg in args:
+                if node_name in arg:
+                    pids.append(int(entry))
+                    break
+        except (IOError, PermissionError):
+            continue
+    return pids
+
+
+def get_all_tids(pid):
+    """Get all thread TIDs for a given PID."""
+    task_dir = f"/proc/{pid}/task"
+    try:
+        return [int(tid) for tid in os.listdir(task_dir) if tid.isdigit()]
+    except (IOError, PermissionError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers
+# ---------------------------------------------------------------------------
+def remove_trailing_waitable(s):
+    suffix = "@Waitable"
+    while s.endswith(suffix):
+        s = s[: -len(suffix)]
+    return s
+
+
+def extract_node_names_from_config(yaml_config):
+    """Extract unique node names from callback group IDs.
+
+    Callback group IDs have format: /<node_name>@<entries...>
+    """
+    names = set()
+    for cbg in yaml_config.get("callback_groups") or []:
+        cbg_id = remove_trailing_waitable(cbg["id"])
+        match = re.match(r"^/([^@/]+)", cbg_id)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Matching logic
+# ---------------------------------------------------------------------------
+def config_matches_thread(expected, actual_info, actual_affinity):
+    """Check if an expected config matches an actual thread's state."""
+    expected_policy = expected["policy"]
+    actual_policy = actual_info["policy"]
+
+    if actual_policy != expected_policy:
+        return False
+
+    if expected_policy in ("SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"):
+        exp_nice = expected.get("priority", 0)
+        act_nice = actual_info.get("nice", 0)
+        if act_nice != exp_nice:
+            return False
+    elif expected_policy in ("SCHED_FIFO", "SCHED_RR"):
+        if actual_info.get("priority", 0) != expected.get("priority", 0):
+            return False
+    elif expected_policy == "SCHED_DEADLINE":
+        for param in ("runtime", "deadline", "period"):
+            if actual_info.get(param, 0) != expected.get(param, 0):
+                return False
+
+    expected_affinity = expected.get("affinity") or []
+    if expected_affinity:
+        if actual_affinity is None:
+            return False
+        if set(expected_affinity) != actual_affinity:
+            return False
+
+    return True
+
+
+def describe_config(expected):
+    """Human-readable summary of expected config."""
+    policy = expected["policy"]
+    parts = [policy]
+    if policy in ("SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"):
+        parts.append(f"nice={expected.get('priority', 0)}")
+    elif policy in ("SCHED_FIFO", "SCHED_RR"):
+        parts.append(f"priority={expected.get('priority', 0)}")
+    elif policy == "SCHED_DEADLINE":
+        parts.append(f"runtime={expected.get('runtime', 0)}")
+        parts.append(f"deadline={expected.get('deadline', 0)}")
+        parts.append(f"period={expected.get('period', 0)}")
+    aff = expected.get("affinity") or []
+    if aff:
+        parts.append(f"affinity={sorted(aff)}")
+    return ", ".join(parts)
+
+
+def describe_actual(info, affinity):
+    """Human-readable summary of actual thread state."""
+    policy = info["policy"]
+    parts = [policy]
+    if policy in ("SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"):
+        parts.append(f"nice={info.get('nice', 0)}")
+    elif policy in ("SCHED_FIFO", "SCHED_RR"):
+        parts.append(f"priority={info.get('priority', 0)}")
+    elif policy == "SCHED_DEADLINE":
+        parts.append(f"runtime={info.get('runtime', 0)}")
+        parts.append(f"deadline={info.get('deadline', 0)}")
+        parts.append(f"period={info.get('period', 0)}")
+    if affinity is not None:
+        parts.append(f"affinity={sorted(affinity)}")
+    return ", ".join(parts)
+
+
+def get_mismatch_details(expected, actual_info, actual_affinity):
+    """Return list of mismatch details between expected and actual."""
+    errors = []
+    expected_policy = expected["policy"]
+    actual_policy = actual_info["policy"]
+
+    if actual_policy != expected_policy:
+        errors.append(f"policy: expected={expected_policy}, actual={actual_policy}")
+
+    if expected_policy in ("SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"):
+        exp_nice = expected.get("priority", 0)
+        act_nice = actual_info.get("nice", 0)
+        if act_nice != exp_nice:
+            errors.append(f"nice: expected={exp_nice}, actual={act_nice}")
+    elif expected_policy in ("SCHED_FIFO", "SCHED_RR"):
+        exp_prio = expected.get("priority", 0)
+        act_prio = actual_info.get("priority", 0)
+        if act_prio != exp_prio:
+            errors.append(f"priority: expected={exp_prio}, actual={act_prio}")
+    elif expected_policy == "SCHED_DEADLINE":
+        for param in ("runtime", "deadline", "period"):
+            exp_val = expected.get(param, 0)
+            act_val = actual_info.get(param, 0)
+            if act_val != exp_val:
+                errors.append(f"{param}: expected={exp_val}, actual={act_val}")
+
+    expected_affinity = expected.get("affinity") or []
+    if expected_affinity:
+        if actual_affinity is None:
+            errors.append(f"affinity: expected={sorted(expected_affinity)}, actual=unavailable")
+        elif set(expected_affinity) != actual_affinity:
+            errors.append(
+                f"affinity: expected={sorted(expected_affinity)}, "
+                f"actual={sorted(actual_affinity)}"
+            )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+def verify(yaml_config, pids):
+    """Verify YAML config against actual thread states found in the given PIDs."""
+    # Collect all thread info
+    all_threads = []  # list of (tid, sched_info, affinity, comm)
+    for pid in pids:
+        for tid in get_all_tids(pid):
+            info = get_thread_sched_info(tid)
+            if info is None:
+                continue
+            affinity = get_thread_affinity(tid)
+            comm = get_thread_comm(tid)
+            all_threads.append((tid, info, affinity, comm))
+
+    results = []
+    available_threads = list(all_threads)
+
+    # Check callback groups
+    for cbg in yaml_config.get("callback_groups") or []:
+        expected = dict(cbg)
+        expected["id"] = remove_trailing_waitable(expected["id"])
+        entry = {
+            "type": "callback_group",
+            "id": expected["id"],
+            "domain_id": expected.get("domain_id", 0),
+            "expected": describe_config(expected),
+        }
+
+        # Find a matching thread
+        matched_idx = None
+        for i, (tid, info, affinity, _comm) in enumerate(available_threads):
+            if config_matches_thread(expected, info, affinity):
+                matched_idx = i
+                break
+
+        if matched_idx is not None:
+            tid, info, affinity, comm = available_threads.pop(matched_idx)
+            entry["status"] = "OK"
+            entry["tid"] = tid
+            entry["comm"] = comm
+            entry["actual"] = describe_actual(info, affinity)
+        else:
+            entry["status"] = "FAIL"
+            # Find the closest thread to show mismatch details
+            entry["message"] = "No thread found matching expected configuration"
+        results.append(entry)
+
+    # Check non-ROS threads
+    for nrt in yaml_config.get("non_ros_threads") or []:
+        expected = dict(nrt)
+        entry = {
+            "type": "non_ros_thread",
+            "name": expected["name"],
+            "expected": describe_config(expected),
+        }
+
+        matched_idx = None
+        for i, (tid, info, affinity, _comm) in enumerate(available_threads):
+            if config_matches_thread(expected, info, affinity):
+                matched_idx = i
+                break
+
+        if matched_idx is not None:
+            tid, info, affinity, comm = available_threads.pop(matched_idx)
+            entry["status"] = "OK"
+            entry["tid"] = tid
+            entry["comm"] = comm
+            entry["actual"] = describe_actual(info, affinity)
+        else:
+            entry["status"] = "FAIL"
+            entry["message"] = "No thread found matching expected configuration"
+        results.append(entry)
+
+    return results, all_threads
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+def print_results(results, all_threads):
+    all_ok = True
+
+    print("Verification results:")
+    for r in results:
+        label = r.get("id") or r.get("name")
+        domain_str = f" [domain={r['domain_id']}]" if "domain_id" in r else ""
+        tid_str = f" (tid={r['tid']})" if "tid" in r else ""
+
+        if r["status"] == "OK":
+            print(f"  OK    {r['type']}: {label}{domain_str}{tid_str}")
+            print(f"          config: {r['expected']}")
+        else:
+            print(f"  FAIL  {r['type']}: {label}{domain_str}")
+            print(f"          config: {r['expected']}")
+            print(f"          {r.get('message', 'Unknown error')}")
+            all_ok = False
+
+    # Show all threads for debugging
+    print(f"\nAll threads ({len(all_threads)} total):")
+    for tid, info, affinity, comm in sorted(all_threads, key=lambda t: t[0]):
+        print(f"  tid={tid:>7}  comm={comm or '?':<20}  {describe_actual(info, affinity)}")
+
+    return all_ok
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify thread configurator YAML against actual thread state"
+    )
+    parser.add_argument("config_file", help="Path to thread configurator YAML config")
+    parser.add_argument(
+        "--pid",
+        type=int,
+        action="append",
+        default=None,
+        help="PID of the target process (can be specified multiple times). "
+        "If not specified, auto-detected from node names in the YAML config.",
+    )
+    args = parser.parse_args()
+
+    with open(args.config_file) as f:
+        yaml_config = yaml.safe_load(f)
+
+    if args.pid:
+        pids = args.pid
+        for pid in pids:
+            if not os.path.isdir(f"/proc/{pid}"):
+                print(f"Error: PID {pid} does not exist.", file=sys.stderr)
+                return 1
+        print(f"Using specified PID(s): {pids}")
+    else:
+        node_names = extract_node_names_from_config(yaml_config)
+        if not node_names:
+            print("Error: No node names found in YAML config and no --pid specified.", file=sys.stderr)
+            return 1
+
+        pids = []
+        for name in sorted(node_names):
+            found = find_pids_by_node_name(name)
+            if not found:
+                print(f"Warning: No process found for node '{name}'", file=sys.stderr)
+            else:
+                pids.extend(found)
+                print(f"Found PID(s) {found} for node '{name}'")
+
+        # Deduplicate
+        pids = sorted(set(pids))
+        if not pids:
+            print("Error: No target processes found.", file=sys.stderr)
+            return 1
+
+    print(f"Checking {len(pids)} process(es)...\n")
+
+    results, all_threads = verify(yaml_config, pids)
+    all_ok = print_results(results, all_threads)
+    print()
+
+    if all_ok:
+        print("All configurations verified successfully.")
+        return 0
+    else:
+        print("Some configurations could not be verified or have mismatches.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
+++ b/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
@@ -17,12 +17,16 @@ Usage:
 import argparse
 import ctypes
 import ctypes.util
+import errno
 import os
 import platform
 import re
 import sys
 
 import yaml
+
+# Linux TASK_COMM_LEN is 16; the visible comm string is at most 15 characters.
+_TASK_COMM_LEN = 15
 
 # ---------------------------------------------------------------------------
 # Scheduling policy constants
@@ -79,11 +83,22 @@ def _sched_getattr(tid):
 # ---------------------------------------------------------------------------
 # Read actual thread scheduling state from Linux
 # ---------------------------------------------------------------------------
+_permission_warned = False
+
+
 def get_thread_sched_info(tid):
     """Return dict with actual scheduling info for *tid*, or None if the thread is gone."""
+    global _permission_warned
     try:
         attr = _sched_getattr(tid)
-    except OSError:
+    except OSError as e:
+        if e.errno in (errno.EPERM, errno.EACCES) and not _permission_warned:
+            print(
+                f"Warning: Permission denied reading scheduling info for tid {tid}. "
+                "Run with elevated privileges for accurate results.",
+                file=sys.stderr,
+            )
+            _permission_warned = True
         return None
 
     if attr is None:
@@ -92,7 +107,14 @@ def get_thread_sched_info(tid):
             policy_int = os.sched_getscheduler(tid)
             priority = os.sched_getparam(tid).sched_priority
             nice = os.getpriority(os.PRIO_PROCESS, tid)
-        except OSError:
+        except OSError as e:
+            if e.errno in (errno.EPERM, errno.EACCES) and not _permission_warned:
+                print(
+                    f"Warning: Permission denied reading scheduling info for tid {tid}. "
+                    "Run with elevated privileges for accurate results.",
+                    file=sys.stderr,
+                )
+                _permission_warned = True
             return None
         return {
             "policy": SCHED_POLICY_NAMES.get(policy_int, f"UNKNOWN({policy_int})"),
@@ -294,6 +316,12 @@ def get_mismatch_details(expected, actual_info, actual_affinity):
     return errors
 
 
+def _extract_node_name_from_id(cbg_id):
+    """Extract node name from a callback group ID like /node_name@..."""
+    match = re.match(r"^/([^@/]+)", cbg_id)
+    return match.group(1) if match else None
+
+
 def _find_best_mismatch(expected, all_threads):
     """Find the thread with fewest mismatches and return a diagnostic message."""
     if not all_threads:
@@ -318,10 +346,19 @@ def _find_best_mismatch(expected, all_threads):
 # ---------------------------------------------------------------------------
 # Verification
 # ---------------------------------------------------------------------------
-def verify(yaml_config, pids):
-    """Verify YAML config against actual thread states found in the given PIDs."""
+def verify(yaml_config, pids, node_to_pids=None):
+    """Verify YAML config against actual thread states found in the given PIDs.
+
+    Args:
+        node_to_pids: Optional mapping of node_name -> set of PIDs. When provided,
+            callback group matching is restricted to threads from the associated
+            node's PIDs, preventing cross-process false positives.
+    """
+    default_domain_id = int(os.environ.get("ROS_DOMAIN_ID", "0"))
+
     # Collect all thread info
     all_threads = []  # list of (tid, sched_info, affinity, comm)
+    tid_to_pid = {}
     for pid in pids:
         for tid in get_all_tids(pid):
             info = get_thread_sched_info(tid)
@@ -330,6 +367,7 @@ def verify(yaml_config, pids):
             affinity = get_thread_affinity(tid)
             comm = get_thread_comm(tid)
             all_threads.append((tid, info, affinity, comm))
+            tid_to_pid[tid] = pid
 
     results = []
     available_threads = list(all_threads)
@@ -341,13 +379,22 @@ def verify(yaml_config, pids):
         entry = {
             "type": "callback_group",
             "id": expected["id"],
-            "domain_id": expected.get("domain_id", 0),
+            "domain_id": expected.get("domain_id", default_domain_id),
             "expected": describe_config(expected),
         }
+
+        # Determine allowed PIDs for this callback group
+        allowed_pids = None
+        if node_to_pids is not None:
+            node_name = _extract_node_name_from_id(expected["id"])
+            if node_name and node_name in node_to_pids:
+                allowed_pids = node_to_pids[node_name]
 
         # Find a matching thread
         matched_idx = None
         for i, (tid, info, affinity, _comm) in enumerate(available_threads):
+            if allowed_pids is not None and tid_to_pid.get(tid) not in allowed_pids:
+                continue
             if config_matches_thread(expected, info, affinity):
                 matched_idx = i
                 break
@@ -369,6 +416,8 @@ def verify(yaml_config, pids):
     for nrt in yaml_config.get("non_ros_threads") or []:
         expected = dict(nrt)
         expected_name = expected["name"]
+        # Linux comm is truncated to TASK_COMM_LEN-1 (15) characters
+        comm_name = expected_name[:_TASK_COMM_LEN]
         entry = {
             "type": "non_ros_thread",
             "name": expected_name,
@@ -377,7 +426,7 @@ def verify(yaml_config, pids):
 
         matched_idx = None
         for i, (tid, info, affinity, comm) in enumerate(available_threads):
-            if comm == expected_name and config_matches_thread(expected, info, affinity):
+            if comm == comm_name and config_matches_thread(expected, info, affinity):
                 matched_idx = i
                 break
 
@@ -391,17 +440,32 @@ def verify(yaml_config, pids):
             entry["status"] = "FAIL"
             # Check if any thread has the right name but wrong params
             name_matched = [
-                (tid, info, aff) for tid, info, aff, c in all_threads if c == expected_name
+                (tid, info, aff) for tid, info, aff, c in all_threads if c == comm_name
             ]
             if name_matched:
                 tid, info, aff = name_matched[0]
                 details = get_mismatch_details(expected, info, aff)
+                truncation_note = ""
+                if len(expected_name) > _TASK_COMM_LEN:
+                    truncation_note = (
+                        f" (note: name truncated from '{expected_name}' to "
+                        f"'{comm_name}' for /proc/comm matching)"
+                    )
                 entry["message"] = (
-                    f"Thread '{expected_name}' (tid={tid}) found but mismatched: "
+                    f"Thread '{comm_name}' (tid={tid}) found but mismatched: "
                     + "; ".join(details)
+                    + truncation_note
                 )
             else:
-                entry["message"] = f"No thread with comm name '{expected_name}' found"
+                truncation_note = ""
+                if len(expected_name) > _TASK_COMM_LEN:
+                    truncation_note = (
+                        f" (note: name was truncated to '{comm_name}' for matching "
+                        f"due to Linux TASK_COMM_LEN limit)"
+                    )
+                entry["message"] = (
+                    f"No thread with comm name '{comm_name}' found" + truncation_note
+                )
         results.append(entry)
 
     return results, all_threads
@@ -454,9 +518,31 @@ def main():
     )
     args = parser.parse_args()
 
-    with open(args.config_file) as f:
-        yaml_config = yaml.safe_load(f)
+    try:
+        with open(args.config_file) as f:
+            yaml_config = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Error: Config file '{args.config_file}' not found.", file=sys.stderr)
+        return 1
+    except yaml.YAMLError as e:
+        print(f"Error: Failed to parse YAML config: {e}", file=sys.stderr)
+        return 1
 
+    # Warn if SCHED_DEADLINE configs exist but sched_getattr is unavailable
+    if _libc is None:
+        has_deadline = any(
+            cbg.get("policy") == "SCHED_DEADLINE"
+            for cbg in yaml_config.get("callback_groups") or []
+        )
+        if has_deadline:
+            print(
+                f"Warning: SCHED_DEADLINE configs found but sched_getattr syscall is "
+                f"unavailable on this architecture ({_ARCH}). SCHED_DEADLINE "
+                f"verification will be unreliable.",
+                file=sys.stderr,
+            )
+
+    node_to_pids = None
     if args.pid:
         pids = args.pid
         for pid in pids:
@@ -471,11 +557,13 @@ def main():
             return 1
 
         pids = []
+        node_to_pids = {}
         for name in sorted(node_names):
             found = find_pids_by_node_name(name)
             if not found:
                 print(f"Warning: No process found for node '{name}'", file=sys.stderr)
             else:
+                node_to_pids[name] = set(found)
                 pids.extend(found)
                 print(f"Found PID(s) {found} for node '{name}'")
 
@@ -487,7 +575,7 @@ def main():
 
     print(f"Checking {len(pids)} process(es)...\n")
 
-    results, all_threads = verify(yaml_config, pids)
+    results, all_threads = verify(yaml_config, pids, node_to_pids)
     all_ok = print_results(results, all_threads)
     print()
 

--- a/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
+++ b/src/agnocast_cie_thread_configurator/scripts/verify_thread_config.py
@@ -6,6 +6,10 @@ policy, priority/nice, and CPU affinity against the YAML config.
 
 Run while both agnocast_cie_thread_configurator and the target application are running.
 
+Note: Reading scheduling parameters of threads owned by another user requires
+root privileges or CAP_SYS_PTRACE/CAP_SYS_NICE. Run with 'sudo' if the target
+process is owned by a different user.
+
 Usage:
     python3 verify_thread_config.py <config.yaml> [--pid <pid>]
 """
@@ -32,13 +36,17 @@ SCHED_POLICY_NAMES = {
     6: "SCHED_DEADLINE",
 }
 
-SCHED_POLICY_NUMBERS = {v: k for k, v in SCHED_POLICY_NAMES.items()}
-
 # ---------------------------------------------------------------------------
 # sched_getattr via syscall -- needed to read SCHED_DEADLINE params
 # ---------------------------------------------------------------------------
 _ARCH = platform.machine()
 _SYS_SCHED_GETATTR = {"x86_64": 315, "aarch64": 275}.get(_ARCH)
+
+_libc = None
+if _SYS_SCHED_GETATTR is not None:
+    _lib_name = ctypes.util.find_library("c")
+    if _lib_name:
+        _libc = ctypes.CDLL(_lib_name, use_errno=True)
 
 
 class _SchedAttr(ctypes.Structure):
@@ -55,12 +63,11 @@ class _SchedAttr(ctypes.Structure):
 
 
 def _sched_getattr(tid):
-    if _SYS_SCHED_GETATTR is None:
+    if _libc is None:
         return None
-    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
     attr = _SchedAttr()
     attr.size = ctypes.sizeof(_SchedAttr)
-    ret = libc.syscall(
+    ret = _libc.syscall(
         _SYS_SCHED_GETATTR, tid, ctypes.byref(attr), ctypes.sizeof(_SchedAttr), 0
     )
     if ret != 0:
@@ -83,12 +90,14 @@ def get_thread_sched_info(tid):
         # Fallback when sched_getattr syscall number is unknown
         try:
             policy_int = os.sched_getscheduler(tid)
+            priority = os.sched_getparam(tid).sched_priority
+            nice = os.getpriority(os.PRIO_PROCESS, tid)
         except OSError:
             return None
         return {
             "policy": SCHED_POLICY_NAMES.get(policy_int, f"UNKNOWN({policy_int})"),
-            "priority": os.sched_getparam(tid).sched_priority,
-            "nice": os.getpriority(os.PRIO_PROCESS, tid),
+            "priority": priority,
+            "nice": nice,
         }
 
     return {
@@ -104,6 +113,7 @@ def get_thread_sched_info(tid):
 
 
 def get_thread_affinity(tid):
+    """Return the set of CPU indices the thread is allowed to run on, or None if unavailable."""
     try:
         return os.sched_getaffinity(tid)
     except OSError:
@@ -252,6 +262,7 @@ def get_mismatch_details(expected, actual_info, actual_affinity):
 
     if actual_policy != expected_policy:
         errors.append(f"policy: expected={expected_policy}, actual={actual_policy}")
+        return errors
 
     if expected_policy in ("SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"):
         exp_nice = expected.get("priority", 0)
@@ -281,6 +292,27 @@ def get_mismatch_details(expected, actual_info, actual_affinity):
             )
 
     return errors
+
+
+def _find_best_mismatch(expected, all_threads):
+    """Find the thread with fewest mismatches and return a diagnostic message."""
+    if not all_threads:
+        return "No threads found in target process(es)"
+    best_errors = None
+    best_tid = None
+    best_comm = None
+    for tid, info, affinity, comm in all_threads:
+        errors = get_mismatch_details(expected, info, affinity)
+        if best_errors is None or len(errors) < len(best_errors):
+            best_errors = errors
+            best_tid = tid
+            best_comm = comm
+    if best_errors:
+        return (
+            f"Closest thread: tid={best_tid} comm='{best_comm}' — "
+            + "; ".join(best_errors)
+        )
+    return "No thread found matching expected configuration"
 
 
 # ---------------------------------------------------------------------------
@@ -329,21 +361,23 @@ def verify(yaml_config, pids):
         else:
             entry["status"] = "FAIL"
             # Find the closest thread to show mismatch details
-            entry["message"] = "No thread found matching expected configuration"
+            best_details = _find_best_mismatch(expected, all_threads)
+            entry["message"] = best_details
         results.append(entry)
 
     # Check non-ROS threads
     for nrt in yaml_config.get("non_ros_threads") or []:
         expected = dict(nrt)
+        expected_name = expected["name"]
         entry = {
             "type": "non_ros_thread",
-            "name": expected["name"],
+            "name": expected_name,
             "expected": describe_config(expected),
         }
 
         matched_idx = None
-        for i, (tid, info, affinity, _comm) in enumerate(available_threads):
-            if config_matches_thread(expected, info, affinity):
+        for i, (tid, info, affinity, comm) in enumerate(available_threads):
+            if comm == expected_name and config_matches_thread(expected, info, affinity):
                 matched_idx = i
                 break
 
@@ -355,7 +389,19 @@ def verify(yaml_config, pids):
             entry["actual"] = describe_actual(info, affinity)
         else:
             entry["status"] = "FAIL"
-            entry["message"] = "No thread found matching expected configuration"
+            # Check if any thread has the right name but wrong params
+            name_matched = [
+                (tid, info, aff) for tid, info, aff, c in all_threads if c == expected_name
+            ]
+            if name_matched:
+                tid, info, aff = name_matched[0]
+                details = get_mismatch_details(expected, info, aff)
+                entry["message"] = (
+                    f"Thread '{expected_name}' (tid={tid}) found but mismatched: "
+                    + "; ".join(details)
+                )
+            else:
+                entry["message"] = f"No thread with comm name '{expected_name}' found"
         results.append(entry)
 
     return results, all_threads


### PR DESCRIPTION
## Description

Add a standalone Python script (`verify_thread_config.py`) that verifies whether `agnocast_cie_thread_configurator` YAML settings have been correctly applied to running threads. The script uses Linux `/proc` filesystem and `sched_getattr` syscall directly, eliminating any ROS 2 runtime dependency (`rclpy`, `agnocast_cie_config_msgs`).

Key features:
- Accepts a thread configurator YAML config file as input
- Auto-detects target process PIDs from node names in callback group IDs, or accepts explicit `--pid` arguments
- Enumerates all threads via `/proc/<pid>/task/` and reads scheduling attributes using `sched_getattr` syscall
- Matches expected configurations (policy, priority/nice, affinity, SCHED_DEADLINE params) against actual thread states
- Reports OK/FAIL per config entry with detailed mismatch diagnostics (closest-thread analysis on FAIL)
- Supports all scheduling policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, SCHED_DEADLINE
- The script is NOT installed as a ROS 2 executable — run directly with `python3`

Robustness:
- Non-ROS thread matching uses thread `comm` name for identity verification, with TASK_COMM_LEN (15 char) truncation handling
- Callback group matching restricts candidates to PIDs associated with the node name, preventing cross-process false positives
- `domain_id` defaults to `ROS_DOMAIN_ID` environment variable (not hardcoded 0)
- EPERM/EACCES errors are distinguished from ESRCH, with a clear warning about privilege requirements
- SCHED_DEADLINE config warns when `sched_getattr` syscall is unavailable on the current architecture
- YAML load errors and file-not-found produce user-friendly messages instead of tracebacks
- `libc` handle is cached at module level for performance

Tested with `cie_tutorial_node`:
- Verified OK detection: all 3 callback groups correctly reported as OK when config matches
- Verified FAIL detection: intentional mismatches (wrong policy, wrong priority, wrong affinity) correctly detected and reported

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.