### PR TITLE
feat[needs minor version update]: replace POSIX MQ publish notification with eventfd

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -60,6 +60,7 @@ union ioctl_add_subscriber_args {
     bool is_take_sub;
     bool ignore_local_publications;
     bool is_bridge;
+    int32_t eventfd;  // eventfd created by userspace, passed to kernel for publish notification
   };
   struct
   {
@@ -116,11 +117,6 @@ union ioctl_publish_msg_args {
     struct name_info topic_name;
     topic_local_id_t publisher_id;
     uint64_t msg_virtual_address;
-    // Unlike ret_* fields which are returned via the union copy, subscriber IDs are written
-    // directly to this user-space buffer via copy_to_user. The caller must ensure the buffer
-    // remains valid until the ioctl returns.
-    uint64_t subscriber_ids_buffer_addr;
-    uint32_t subscriber_ids_buffer_size;
   };
   struct
   {
@@ -371,7 +367,7 @@ int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   const bool qos_is_reliable, const bool is_take_sub, const bool ignore_local_publications,
-  const bool is_bridge, union ioctl_add_subscriber_args * ioctl_ret);
+  const bool is_bridge, const int32_t eventfd, union ioctl_add_subscriber_args * ioctl_ret);
 
 int agnocast_ioctl_add_publisher(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
@@ -389,8 +385,7 @@ int agnocast_ioctl_receive_msg(
 
 int agnocast_ioctl_publish_msg(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id,
-  const uint64_t msg_virtual_address, topic_local_id_t * subscriber_ids_out,
-  uint32_t subscriber_ids_buffer_size, union ioctl_publish_msg_args * ioctl_ret);
+  const uint64_t msg_virtual_address, union ioctl_publish_msg_args * ioctl_ret);
 
 int agnocast_ioctl_take_msg(
   const char * topic_name, const struct ipc_namespace * ipc_ns,

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -33,6 +33,9 @@ static void remove_all_topics(void)
     hash_for_each_safe(wrapper->topic.sub_info_htable, bkt_sub_info, tmp_sub_info, sub_info, node)
     {
       hash_del(&sub_info->node);
+      if (sub_info->notify_ctx) {
+        eventfd_ctx_put(sub_info->notify_ctx);
+      }
       kfree(sub_info->node_name);
       kfree(sub_info);
     }

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -59,6 +59,9 @@ static void pre_handler_subscriber_exit(
     }
 
     hash_del(&sub_info->node);
+    if (sub_info->notify_ctx) {
+      eventfd_ctx_put(sub_info->notify_ctx);
+    }
     kfree(sub_info->node_name);
     kfree(sub_info);
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -5,6 +5,7 @@
 #include "agnocast_memory_allocator.h"
 
 #include <linux/device.h>
+#include <linux/eventfd.h>
 #include <linux/fs.h>
 #include <linux/hashtable.h>
 #include <linux/kernel.h>
@@ -99,6 +100,7 @@ struct subscriber_info
   bool ignore_local_publications;
   bool need_mmap_update;
   bool is_bridge;
+  struct eventfd_ctx * notify_ctx;  // eventfd for publish notifications (NULL for take_sub)
   struct hlist_node node;
 };
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -114,6 +114,20 @@ static inline long copy_name_from_user(char * dst, size_t dst_size, const struct
   return 0;
 }
 
+// eventfd_signal API changed in 6.8: single-arg (before: two-arg with count)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+static inline void agnocast_eventfd_signal(struct eventfd_ctx * ctx)
+{
+  eventfd_signal(ctx, 1);
+}
+#else
+#define agnocast_eventfd_signal(ctx) eventfd_signal(ctx)
+#endif
+
+// Stack buffer size for notify_ctx pointer collection in publish_msg.
+// Heap allocation is used as fallback when subscriber count exceeds this.
+#define NOTIFY_CTX_STACK_SIZE 64
+
 struct topic_struct
 {
   struct rb_root entries;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -125,7 +125,10 @@ static inline void agnocast_eventfd_signal(struct eventfd_ctx * ctx)
 #endif
 
 // Stack buffer size for notify_ctx pointer collection in publish_msg.
-// Heap allocation is used as fallback when subscriber count exceeds this.
+// Sized to cover common ROS 2 fan-out (typical N <= 10, with outliers like
+// /tf reaching 100+) while keeping stack usage bounded: 64 * sizeof(void *) =
+// 512 B, well within the 16 KB default kernel stack. Heap allocation via
+// kcalloc(GFP_ATOMIC) is used as fallback when subscriber count exceeds this.
 #define NOTIFY_CTX_STACK_SIZE 64
 
 struct topic_struct

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -109,7 +109,7 @@ static int insert_subscriber_info(
   struct topic_wrapper * wrapper, const char * node_name, const pid_t subscriber_pid,
   const uint32_t qos_depth, const bool qos_is_transient_local, const bool qos_is_reliable,
   const bool is_take_sub, bool ignore_local_publications, const bool is_bridge,
-  struct subscriber_info ** new_info)
+  struct eventfd_ctx * notify_ctx, struct subscriber_info ** new_info)
 {
   int count = agnocast_get_size_sub_info_htable(wrapper);
   if (count == MAX_SUBSCRIBER_NUM) {
@@ -163,6 +163,7 @@ static int insert_subscriber_info(
   (*new_info)->ignore_local_publications = ignore_local_publications;
   (*new_info)->need_mmap_update = true;
   (*new_info)->is_bridge = is_bridge;
+  (*new_info)->notify_ctx = notify_ctx;
   INIT_HLIST_NODE(&(*new_info)->node);
   uint32_t hash_val = hash_min(new_id, SUB_INFO_HASH_BITS);
   hash_add(wrapper->topic.sub_info_htable, &(*new_info)->node, hash_val);
@@ -595,9 +596,20 @@ int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
   const bool qos_is_reliable, const bool is_take_sub, const bool ignore_local_publications,
-  const bool is_bridge, union ioctl_add_subscriber_args * ioctl_ret)
+  const bool is_bridge, const int32_t eventfd, union ioctl_add_subscriber_args * ioctl_ret)
 {
   int ret;
+  struct eventfd_ctx * notify_ctx = NULL;
+
+  // For non-take subscribers, acquire eventfd context for publish notification.
+  // eventfd < 0 means no notification (used in kunit tests).
+  if (!is_take_sub && eventfd >= 0) {
+    notify_ctx = eventfd_ctx_fdget(eventfd);
+    if (IS_ERR(notify_ctx)) {
+      dev_warn(agnocast_device, "eventfd_ctx_fdget failed.\n");
+      return PTR_ERR(notify_ctx);
+    }
+  }
 
   down_write(&global_htables_rwsem);
 
@@ -610,7 +622,7 @@ int agnocast_ioctl_add_subscriber(
   struct subscriber_info * sub_info;
   ret = insert_subscriber_info(
     wrapper, node_name, subscriber_pid, qos_depth, qos_is_transient_local, qos_is_reliable,
-    is_take_sub, ignore_local_publications, is_bridge, &sub_info);
+    is_take_sub, ignore_local_publications, is_bridge, notify_ctx, &sub_info);
   if (ret < 0) {
     goto unlock;
   }
@@ -619,6 +631,9 @@ int agnocast_ioctl_add_subscriber(
 
 unlock:
   up_write(&global_htables_rwsem);
+  if (ret < 0 && notify_ctx) {
+    eventfd_ctx_put(notify_ctx);
+  }
   return ret;
 }
 
@@ -744,19 +759,9 @@ static int release_msgs_to_meet_depth(
 
 int agnocast_ioctl_publish_msg(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id,
-  const uint64_t msg_virtual_address, topic_local_id_t * subscriber_ids_out,
-  uint32_t subscriber_ids_buffer_size, union ioctl_publish_msg_args * ioctl_ret)
+  const uint64_t msg_virtual_address, union ioctl_publish_msg_args * ioctl_ret)
 {
   int ret = 0;
-
-  if (subscriber_ids_buffer_size != MAX_SUBSCRIBER_NUM) {
-    dev_warn(
-      agnocast_device,
-      "subscriber_ids_buffer_size must be MAX_SUBSCRIBER_NUM (%d), but got %u. "
-      "(%s)\n",
-      MAX_SUBSCRIBER_NUM, subscriber_ids_buffer_size, __func__);
-    return -EINVAL;
-  }
 
   down_read(&global_htables_rwsem);
 
@@ -812,7 +817,9 @@ int agnocast_ioctl_publish_msg(
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
       continue;
     }
-    subscriber_ids_out[subscriber_num] = sub_info->id;
+    if (sub_info->notify_ctx) {
+      eventfd_signal(sub_info->notify_ctx);
+    }
     subscriber_num++;
   }
   ioctl_ret->ret_subscriber_num = subscriber_num;
@@ -1784,6 +1791,9 @@ int agnocast_ioctl_remove_subscriber(
   }
 
   hash_del(&sub_info->node);
+  if (sub_info->notify_ctx) {
+    eventfd_ctx_put(sub_info->notify_ctx);
+  }
   kfree(sub_info->node_name);
   kfree(sub_info);
 
@@ -2166,7 +2176,7 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     ret = agnocast_ioctl_add_subscriber(
       topic_name_buf, ipc_ns, node_name_buf, pid, sub_args.qos_depth,
       sub_args.qos_is_transient_local, sub_args.qos_is_reliable, sub_args.is_take_sub,
-      sub_args.ignore_local_publications, sub_args.is_bridge, &sub_args);
+      sub_args.ignore_local_publications, sub_args.is_bridge, sub_args.eventfd, &sub_args);
     if (ret == 0) {
       if (copy_to_user((union ioctl_add_subscriber_args __user *)arg, &sub_args, sizeof(sub_args)))
         return -EFAULT;
@@ -2255,36 +2265,9 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &publish_msg_args.topic_name);
     if (ret) return ret;
 
-    // Allocate kernel buffer for subscriber IDs
-    uint32_t buffer_size = publish_msg_args.subscriber_ids_buffer_size;
-    if (buffer_size != MAX_SUBSCRIBER_NUM) {
-      return -EINVAL;
-    }
-    topic_local_id_t * subscriber_ids_buf =
-      kcalloc(buffer_size, sizeof(topic_local_id_t), GFP_KERNEL);
-    if (!subscriber_ids_buf) {
-      return -ENOMEM;
-    }
-
-    uint64_t subscriber_ids_buffer_addr = publish_msg_args.subscriber_ids_buffer_addr;
-
     ret = agnocast_ioctl_publish_msg(
       topic_name_buf, ipc_ns, publish_msg_args.publisher_id, publish_msg_args.msg_virtual_address,
-      subscriber_ids_buf, buffer_size, &publish_msg_args);
-
-    if (ret == 0) {
-      // Copy subscriber IDs to user-space buffer
-      uint32_t copy_count = min(publish_msg_args.ret_subscriber_num, buffer_size);
-      if (copy_count > 0) {
-        if (copy_to_user(
-              (topic_local_id_t __user *)subscriber_ids_buffer_addr, subscriber_ids_buf,
-              copy_count * sizeof(topic_local_id_t))) {
-          kfree(subscriber_ids_buf);
-          return -EFAULT;
-        }
-      }
-    }
-    kfree(subscriber_ids_buf);
+      &publish_msg_args);
 
     if (ret == 0) {
       if (copy_to_user(

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -808,13 +808,21 @@ int agnocast_ioctl_publish_msg(
     goto unlock_all;
   }
 
-  // Signal subscriber eventfds directly from kernel (replaces userspace mq_send loop).
-  // NOTE: eventfd_signal() is called under topic_rwsem write lock. Each call is ~100-200 ns
-  // (spin_lock + counter increment + wake_up). For the current max subscriber count (~6-7),
-  // this adds ~1 us which is acceptable. If subscriber count grows significantly, consider
-  // copying notify_ctx pointers (with eventfd_ctx_get) under lock, releasing the lock, then
-  // signaling and putting outside the lock.
+  // Collect notify_ctx pointers under topic_rwsem write lock, then signal outside the lock
+  // to avoid lock contention. eventfd_signal() takes ~100-200 ns each (spin_lock + counter
+  // increment + wake_up), and for topics with many subscribers (e.g., /tf with 100+), signaling
+  // under lock would block other publish/receive/take operations on the same topic.
+  //
+  // Safety: notify_ctx pointers remain valid after releasing topic_rwsem because we still hold
+  // global_htables_rwsem read lock, and subscriber removal requires global_htables_rwsem write
+  // lock. No eventfd_ctx refcount management is needed.
+  struct eventfd_ctx * notify_ctx_stack[NOTIFY_CTX_STACK_SIZE];
+  struct eventfd_ctx ** notify_ctxs = notify_ctx_stack;
+  bool notify_ctxs_allocated = false;
+  bool notify_alloc_failed = false;
+  uint32_t notify_num = 0;
   uint32_t subscriber_num = 0;
+
   struct subscriber_info * sub_info;
   int bkt_sub_info;
   hash_for_each(wrapper->topic.sub_info_htable, bkt_sub_info, sub_info, node)
@@ -824,7 +832,25 @@ int agnocast_ioctl_publish_msg(
       continue;
     }
     if (sub_info->notify_ctx) {
-      eventfd_signal(sub_info->notify_ctx);
+      if (notify_num == NOTIFY_CTX_STACK_SIZE && !notify_ctxs_allocated && !notify_alloc_failed) {
+        // Stack buffer full, switch to heap allocation
+        uint32_t sub_count = agnocast_get_size_sub_info_htable(wrapper);
+        struct eventfd_ctx ** heap_ctxs =
+          kcalloc(sub_count, sizeof(struct eventfd_ctx *), GFP_ATOMIC);
+        if (heap_ctxs) {
+          memcpy(heap_ctxs, notify_ctx_stack, notify_num * sizeof(struct eventfd_ctx *));
+          notify_ctxs = heap_ctxs;
+          notify_ctxs_allocated = true;
+        } else {
+          notify_alloc_failed = true;
+        }
+      }
+      if (notify_num < NOTIFY_CTX_STACK_SIZE || notify_ctxs_allocated) {
+        notify_ctxs[notify_num++] = sub_info->notify_ctx;
+      } else {
+        // Fallback: signal under lock if heap allocation failed
+        agnocast_eventfd_signal(sub_info->notify_ctx);
+      }
     }
     subscriber_num++;
   }
@@ -832,6 +858,15 @@ int agnocast_ioctl_publish_msg(
 
 unlock_all:
   up_write(&wrapper->topic_rwsem);
+
+  // Signal subscriber eventfds outside topic_rwsem (but still under global_htables_rwsem read lock)
+  for (uint32_t i = 0; i < notify_num; i++) {
+    agnocast_eventfd_signal(notify_ctxs[i]);
+  }
+  if (notify_ctxs_allocated) {
+    kfree(notify_ctxs);
+  }
+
 unlock_only_global:
   up_read(&global_htables_rwsem);
   return ret;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -808,6 +808,12 @@ int agnocast_ioctl_publish_msg(
     goto unlock_all;
   }
 
+  // Signal subscriber eventfds directly from kernel (replaces userspace mq_send loop).
+  // NOTE: eventfd_signal() is called under topic_rwsem write lock. Each call is ~100-200 ns
+  // (spin_lock + counter increment + wake_up). For the current max subscriber count (~6-7),
+  // this adds ~1 us which is acceptable. If subscriber count grows significantly, consider
+  // copying notify_ctx pointers (with eventfd_ctx_get) under lock, releasing the lock, then
+  // signaling and putting outside the lock.
   uint32_t subscriber_num = 0;
   struct subscriber_info * sub_info;
   int bkt_sub_info;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -819,7 +819,8 @@ int agnocast_ioctl_publish_msg(
   struct eventfd_ctx * notify_ctx_stack[NOTIFY_CTX_STACK_SIZE];
   struct eventfd_ctx ** notify_ctxs = notify_ctx_stack;
   bool notify_ctxs_allocated = false;
-  bool notify_alloc_failed = false;
+  bool notify_within_lock =
+    false;  // Fallback to this when stack is exceeded AND heap allocation fails
   uint32_t notify_num = 0;
   uint32_t subscriber_num = 0;
 
@@ -828,32 +829,39 @@ int agnocast_ioctl_publish_msg(
   hash_for_each(wrapper->topic.sub_info_htable, bkt_sub_info, sub_info, node)
   {
     if (sub_info->is_take_sub) continue;
-    if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+    if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
+
+    subscriber_num++;
+
+    if (!sub_info->notify_ctx) continue;
+
+    if (notify_within_lock) {
+      agnocast_eventfd_signal(sub_info->notify_ctx);
       continue;
     }
-    if (sub_info->notify_ctx) {
-      if (notify_num == NOTIFY_CTX_STACK_SIZE && !notify_ctxs_allocated && !notify_alloc_failed) {
-        // Stack buffer full, switch to heap allocation
-        uint32_t sub_count = agnocast_get_size_sub_info_htable(wrapper);
-        struct eventfd_ctx ** heap_ctxs =
-          kcalloc(sub_count, sizeof(struct eventfd_ctx *), GFP_ATOMIC);
-        if (heap_ctxs) {
-          memcpy(heap_ctxs, notify_ctx_stack, notify_num * sizeof(struct eventfd_ctx *));
-          notify_ctxs = heap_ctxs;
-          notify_ctxs_allocated = true;
-        } else {
-          notify_alloc_failed = true;
-        }
-      }
-      if (notify_num < NOTIFY_CTX_STACK_SIZE || notify_ctxs_allocated) {
+
+    if (notify_num < NOTIFY_CTX_STACK_SIZE || notify_ctxs_allocated) {
+      // Store the context in the stack or already-allocated heap
+      notify_ctxs[notify_num++] = sub_info->notify_ctx;
+    } else {
+      // Stack is full but we haven't allocated heap yet
+      uint32_t sub_count = agnocast_get_size_sub_info_htable(wrapper);
+      struct eventfd_ctx ** heap = kcalloc(sub_count, sizeof(*heap), GFP_ATOMIC);
+      if (heap) {
+        notify_ctxs_allocated = true;
+
+        // Copy the contexts stored in the stack to the heap
+        memcpy(heap, notify_ctx_stack, notify_num * sizeof(*heap));
+        notify_ctxs = heap;
         notify_ctxs[notify_num++] = sub_info->notify_ctx;
       } else {
-        // Fallback: signal under lock if heap allocation failed
+        // Stack is full and heap allocation failed. Fallback to signaling within the lock
+        notify_within_lock = true;
         agnocast_eventfd_signal(sub_info->notify_ctx);
       }
     }
-    subscriber_num++;
   }
+
   ioctl_ret->ret_subscriber_num = subscriber_num;
 
 unlock_all:

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -34,7 +34,7 @@ void test_case_add_subscriber_normal(struct kunit * test)
   // Act
   int ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
 
   // Assert
@@ -63,13 +63,13 @@ void test_case_add_subscriber_too_many_subscribers(struct kunit * test)
     agnocast_ioctl_add_subscriber(
       TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
       QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
-      &add_subscriber_args);
+      -1, &add_subscriber_args);
   }
 
   // Act
   int ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
 
   // Assert

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -11,8 +11,6 @@
 
 static const pid_t PID_BASE = 1000;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const uint32_t QOS_DEPTH = 1;
@@ -67,7 +65,7 @@ static topic_local_id_t setup_one_subscriber_on_topic(
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -89,8 +87,7 @@ static uint64_t setup_one_entry(
 {
   union ioctl_publish_msg_args publish_msg_args;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_msg_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_TRUE(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -29,7 +29,7 @@ void test_case_get_node_sub_topics_exact_match(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // copy_to_user inside ioctl_get_node_subscriber_topics returns -EFAULT in KUnit (kernel thread)
@@ -50,7 +50,7 @@ void test_case_get_node_sub_topics_prefix_no_match(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME_WITH_SUFFIX, PID, QOS_DEPTH, false, false,
-    false, false, IS_BRIDGE, &add_sub_args);
+    false, false, IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
@@ -72,7 +72,7 @@ void test_case_get_node_sub_topics_buffer_size_exceeded(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // Set topic_name_buffer_size to 0 so the buffer cannot hold any entry.

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -24,7 +24,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -190,7 +190,7 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true, -1,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -24,7 +24,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -42,7 +42,7 @@ static void setup_one_subscriber_with_bridge(struct kunit * test, char * topic_n
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -77,7 +77,7 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, intra_pid, qos_depth, qos_is_transient_local,
-    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, &add_subscriber_args);
+    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1, &add_subscriber_args);
 
   KUNIT_ASSERT_TRUE(test, ret1 == 0 || ret1 == -EEXIST);
   KUNIT_ASSERT_EQ(test, ret2, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -28,7 +28,7 @@ static void verify_subscriber_qos(struct kunit * test, bool is_transient, bool i
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, QOS_DEPTH, is_transient,
-    is_reliable, false, false, IS_BRIDGE, &add_sub_args);
+    is_reliable, false, false, IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   ret = agnocast_ioctl_get_subscriber_qos(
@@ -87,7 +87,7 @@ void test_case_error_subscriber_not_found(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, QOS_DEPTH, false, false, false,
-    false, IS_BRIDGE, &add_sub_args);
+    false, IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   topic_local_id_t invalid_id = add_sub_args.ret_id + 999;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -52,7 +52,7 @@ void test_case_get_topic_pub_info_no_publishers(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   topic_info_args.topic_info_ret_buffer_size = MAX_PUBLISHER_NUM;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -29,7 +29,7 @@ void test_case_get_topic_sub_info_one_subscriber(struct kunit * test)
 
   ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    IS_BRIDGE, -1, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // copy_to_user inside agnocast_ioctl_get_topic_subscriber_info returns -EFAULT in KUnit

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -16,8 +16,6 @@ static pid_t common_pid = 3000;
 static bool is_take_sub = false;
 static bool is_bridge = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 static void setup_one_subscriber(
   struct kunit * test, topic_local_id_t * subscriber_id, bool ignore_local_publications)
 {
@@ -30,7 +28,7 @@ static void setup_one_subscriber(
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
     &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
 
@@ -84,7 +82,7 @@ static void setup_pub_sub_same_process(
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret_sub = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, common_pid, qos_depth, qos_is_transient_local,
-    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, &add_subscriber_args);
+    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1, &add_subscriber_args);
 
   if (subscriber_id) {
     *subscriber_id = add_subscriber_args.ret_id;
@@ -105,8 +103,7 @@ void test_case_publish_msg_no_topic(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &ioctl_publish_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -126,8 +123,8 @@ void test_case_publish_msg_no_publisher(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address,
+    &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_ASSERT_EQ(test, ret, -EINVAL);
@@ -144,8 +141,7 @@ void test_case_publish_msg_simple_publish_without_any_release(struct kunit * tes
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -171,16 +167,14 @@ void test_case_publish_msg_different_publisher_no_release(struct kunit * test)
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id1, ret_addr1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    topic_name, current->nsproxy->ipc_ns, publisher_id1, ret_addr1, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
 
   // Act
   int ret2 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id2, ret_addr2, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    topic_name, current->nsproxy->ipc_ns, publisher_id2, ret_addr2, &ioctl_publish_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -212,8 +206,7 @@ void test_case_publish_msg_referenced_node_not_released(struct kunit * test)
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   // Subscriber takes a reference to entry1
@@ -225,8 +218,7 @@ void test_case_publish_msg_referenced_node_not_released(struct kunit * test)
 
   // Act
   int ret2 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
 
   // Assert: entry1 is not released because subscriber holds a reference
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -255,16 +247,14 @@ void test_case_publish_msg_single_release_return(struct kunit * test)
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
 
   // Act: entry1 should be released to meet qos_depth=1
   int ret2 = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret2, 0);
@@ -301,8 +291,7 @@ void test_case_publish_msg_excessive_release_count(struct kunit * test)
   for (int i = 0; i < MAX_RELEASE_NUM + 1; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     entry_ids[i] = ioctl_publish_msg_ret.ret_entry_id;
     KUNIT_ASSERT_EQ(test, ret, 0);
 
@@ -323,8 +312,7 @@ void test_case_publish_msg_excessive_release_count(struct kunit * test)
 
   // Act: Publish one more message; GC should release up to MAX_RELEASE_NUM entries
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert: GC is limited to MAX_RELEASE_NUM entries per publish call
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -346,14 +334,12 @@ void test_case_publish_msg_ret_one_subscriber(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 1);
-  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], subscriber_id);
 }
 
 void test_case_publish_msg_ret_many_subscribers(struct kunit * test)
@@ -375,32 +361,12 @@ void test_case_publish_msg_ret_many_subscribers(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_released_num, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, num_subscribers);
-}
-
-void test_case_publish_msg_buffer_smaller_than_subscriber_count(struct kunit * test)
-{
-  // Arrange
-  topic_local_id_t publisher_id;
-  uint64_t ret_addr;
-  setup_one_publisher(test, &publisher_id, &ret_addr);
-
-  topic_local_id_t small_buf[2];
-  union ioctl_publish_msg_args ioctl_publish_msg_ret;
-
-  // Act: pass a buffer smaller than MAX_SUBSCRIBER_NUM
-  int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, small_buf, ARRAY_SIZE(small_buf),
-    &ioctl_publish_msg_ret);
-
-  // Assert: ioctl_publish_msg rejects buffers that are not MAX_SUBSCRIBER_NUM
-  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
 }
 
 void test_case_ignore_local_same_pid_enabled(struct kunit * test)
@@ -418,8 +384,7 @@ void test_case_ignore_local_same_pid_enabled(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -441,13 +406,11 @@ void test_case_ignore_local_same_pid_disabled(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 1);
-  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], subscriber_id);
 }
 
 void test_case_ignore_local_diff_pid_enabled(struct kunit * test)
@@ -465,13 +428,11 @@ void test_case_ignore_local_diff_pid_enabled(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 1);
-  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], subscriber_id);
 }
 
 void test_case_ignore_local_diff_pid_disabled(struct kunit * test)
@@ -489,11 +450,9 @@ void test_case_ignore_local_diff_pid_disabled(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_publish_msg(
-    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, ioctl_publish_msg_ret.ret_subscriber_num, 1);
-  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], subscriber_id);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -11,7 +11,6 @@
     KUNIT_CASE(test_case_publish_msg_excessive_release_count),                                \
     KUNIT_CASE(test_case_publish_msg_ret_one_subscriber),                                     \
     KUNIT_CASE(test_case_publish_msg_ret_many_subscribers),                                   \
-    KUNIT_CASE(test_case_publish_msg_buffer_smaller_than_subscriber_count),                   \
     KUNIT_CASE(test_case_ignore_local_same_pid_enabled),                                      \
     KUNIT_CASE(test_case_ignore_local_same_pid_disabled),                                     \
     KUNIT_CASE(test_case_ignore_local_diff_pid_enabled),                                      \
@@ -26,7 +25,6 @@ void test_case_publish_msg_single_release_return(struct kunit * test);
 void test_case_publish_msg_excessive_release_count(struct kunit * test);
 void test_case_publish_msg_ret_one_subscriber(struct kunit * test);
 void test_case_publish_msg_ret_many_subscribers(struct kunit * test);
-void test_case_publish_msg_buffer_smaller_than_subscriber_count(struct kunit * test);
 void test_case_ignore_local_same_pid_enabled(struct kunit * test);
 void test_case_ignore_local_same_pid_disabled(struct kunit * test);
 void test_case_ignore_local_diff_pid_enabled(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -14,8 +14,6 @@ static bool IS_RELIABLE = true;
 static bool IGNORE_LOCAL_PUBLICATIONS = false;
 static bool IS_BRIDGE = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 // Small buffer size for KUnit tests to avoid exceeding kernel stack frame limits.
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
@@ -30,7 +28,7 @@ static void setup_one_subscriber(
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -136,8 +134,7 @@ void test_case_receive_msg_receive_one(struct kunit * test)
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -181,13 +178,11 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_p
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -232,8 +227,7 @@ void test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_p
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -278,14 +272,13 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than
   for (int i = 0; i < publisher_qos_depth; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + publisher_qos_depth + 1,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -330,14 +323,12 @@ void test_case_receive_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_a
   for (int i = 0; i < MAX_RECEIVE_NUM - 1; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   union ioctl_receive_msg_args ioctl_receive_msg_ret;
@@ -380,8 +371,7 @@ void test_case_receive_msg_qos_depth_larger_than_max_receive_num(struct kunit * 
   for (uint32_t i = 0; i < qos_depth; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     if (i == 0) {
       first_entry_id = ioctl_publish_msg_ret.ret_entry_id;
@@ -439,8 +429,7 @@ void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_a
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   topic_local_id_t subscriber_id;
@@ -485,20 +474,17 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret3;
   int ret3 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret3);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret3);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   topic_local_id_t subscriber_id;
@@ -544,14 +530,12 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smal
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -597,14 +581,12 @@ void test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smal
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -681,7 +663,7 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, subscriber_qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
   union ioctl_add_publisher_args add_publisher_args;
   const uint32_t publisher_qos_depth = 10;
   int ret3 = agnocast_ioctl_add_publisher(
@@ -762,13 +744,13 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth1,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args1);
   union ioctl_add_subscriber_args add_subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth2,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -855,8 +837,7 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test)
   uint64_t msg_addr = ret_addr;
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);
 
   topic_local_id_t subscriber_id1;
   const pid_t subscriber_pid1 = 2000;
@@ -997,14 +978,14 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1, &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret4 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, add_publisher_args.ret_id, add_process_args.ret_addr,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
 
   // Act: receive_msg should not return the message from the same process
@@ -1040,14 +1021,14 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1, &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret4 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, add_publisher_args.ret_id, add_process_args.ret_addr,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
 
   // Act: receive_msg should return the message from the same process

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -13,8 +13,6 @@ static const bool IGNORE_LOCAL_PUBLICATIONS = false;
 static const uint32_t QOS_DEPTH = 1;
 static const bool IS_BRIDGE = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 // Small buffer size for KUnit tests to avoid exceeding kernel stack frame limits.
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
@@ -75,8 +73,7 @@ void test_case_release_sub_ref_no_pubsub_id(struct kunit * test)
 
   union ioctl_publish_msg_args publish_msg_args;
   int ret0 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, &publish_msg_args);
   KUNIT_ASSERT_EQ(test, ret0, 0);
 
   // Act: Attempt to release a reference using the publisher's local ID.
@@ -100,8 +97,7 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
 
   union ioctl_publish_msg_args publish_msg_args;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, &publish_msg_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   const pid_t subscriber_pid = 1000;
@@ -113,7 +109,7 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
@@ -148,8 +144,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
 
   union ioctl_publish_msg_args publish_msg_args;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, &publish_msg_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   // First subscriber
@@ -162,7 +157,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args1;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid1, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args1);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
@@ -181,7 +176,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args2;
   int ret6 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid2, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret6, 0);
 
@@ -226,8 +221,7 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
 
   union ioctl_publish_msg_args publish_msg_args;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, ret_publisher_id, ret_addr, &publish_msg_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const pid_t subscriber_pid = 1000;
@@ -239,7 +233,7 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -17,8 +17,6 @@ static const bool IS_TAKE_SUB = false;
 static const bool IGNORE_LOCAL_PUBLICATIONS = false;
 static const bool IS_BRIDGE = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
@@ -46,7 +44,7 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -60,8 +58,7 @@ static uint64_t setup_one_entry(
 {
   union ioctl_publish_msg_args publish_msg_args;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_msg_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_TRUE(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -17,8 +17,6 @@ static const bool IS_TAKE_SUB = false;
 static const bool IGNORE_LOCAL_PUBLICATIONS = false;
 static const bool IS_BRIDGE = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
@@ -46,7 +44,7 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
-    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -63,8 +61,7 @@ static uint64_t setup_one_entry(
 {
   union ioctl_publish_msg_args publish_msg_args;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &publish_msg_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_virtual_address, &publish_msg_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_TRUE(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -23,7 +23,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -14,8 +14,6 @@ static const bool IS_RELIABLE = true;
 static const bool IGNORE_LOCAL_PUBLICATIONS = false;
 static const bool IS_BRIDGE = false;
 
-static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
-
 // Small buffer size for KUnit tests to avoid exceeding kernel stack frame limits.
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
@@ -30,7 +28,7 @@ static void setup_one_subscriber(
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -143,8 +141,7 @@ void test_case_take_msg_take_one(struct kunit * test)
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
@@ -187,13 +184,11 @@ void test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two(struct kuni
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool allow_same_message = true;
@@ -236,8 +231,7 @@ void test_case_take_msg_take_one_again_with_allow_same_message(struct kunit * te
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
@@ -292,8 +286,7 @@ void test_case_take_msg_take_one_again_not_allow_same_message(struct kunit * tes
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_take_msg_args ioctl_take_msg_ret1;
@@ -343,13 +336,11 @@ void test_case_take_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool allow_same_message = true;
@@ -393,8 +384,7 @@ void test_case_take_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
@@ -440,14 +430,13 @@ void test_case_take_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_pu
   for (uint32_t i = 0; i < qos_depth; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + i, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + qos_depth + 1,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   const bool allow_same_message = true;
@@ -492,15 +481,13 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   for (uint32_t i = 0; i < qos_depth - 1; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
-      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-      ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
   }
 
@@ -539,8 +526,7 @@ void test_case_take_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   topic_local_id_t subscriber_id;
@@ -581,20 +567,17 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_tha
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret3;
   int ret3 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret3);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret3);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   topic_local_id_t subscriber_id;
@@ -640,14 +623,12 @@ void test_case_take_msg_transient_local_sub_qos_smaller_than_publish_num_smaller
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -692,14 +673,12 @@ void test_case_take_msg_transient_local_publish_num_smaller_than_sub_qos_smaller
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret1;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret1);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret2;
   int ret2 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr + 1, &ioctl_publish_msg_ret2);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   topic_local_id_t subscriber_id;
@@ -779,7 +758,7 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, subscriber_qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   const uint32_t publisher_qos_depth = 10;
@@ -867,14 +846,14 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth1,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args1);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth2,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1,
     &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
@@ -926,8 +905,7 @@ void test_case_take_msg_with_exited_publisher(struct kunit * test)
   uint64_t msg_addr = ret_addr;
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret1 = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, subscriber_ids_buf,
-    ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, msg_addr, &ioctl_publish_msg_ret);
 
   topic_local_id_t subscriber_id1;
   const pid_t subscriber_pid1 = 2000;
@@ -1034,14 +1012,14 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1, &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret4 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, add_publisher_args.ret_id, add_process_args.ret_addr,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
 
   // Act: take_msg should not return the message from the same process
@@ -1079,14 +1057,14 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, -1, &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
   int ret4 = agnocast_ioctl_publish_msg(
     TOPIC_NAME, current->nsproxy->ipc_ns, add_publisher_args.ret_id, add_process_args.ret_addr,
-    subscriber_ids_buf, ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
+    &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret4, 0);
 
   // Act: take_msg should return the message from the same process

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -40,7 +40,7 @@ struct CallbackInfo
   std::string topic_name;
   topic_local_id_t subscriber_id;
   bool is_transient_local;
-  mqd_t mqdes;
+  int notify_eventfd;
   rclcpp::CallbackGroup::SharedPtr callback_group;
   TypeErasedCallback callback;
   std::function<std::unique_ptr<AnyObject>(
@@ -80,7 +80,8 @@ TypeErasedCallback get_erased_callback(Func && callback)
 template <typename MessageT, typename Func>
 uint32_t register_callback(
   Func && callback, const std::string & topic_name, const topic_local_id_t subscriber_id,
-  const bool is_transient_local, mqd_t mqdes, const rclcpp::CallbackGroup::SharedPtr callback_group)
+  const bool is_transient_local, int notify_eventfd,
+  const rclcpp::CallbackGroup::SharedPtr callback_group)
 {
   // NOTE: ipc_shared_ptr<MessageT> and ipc_shared_ptr<MessageT>&& make no difference in the
   // assertion expression below, but we go with ipc_shared_ptr<MessageT>&&.
@@ -105,7 +106,7 @@ uint32_t register_callback(
   {
     std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
     id2_callback_info[callback_info_id] =
-      CallbackInfo{topic_name,     subscriber_id,   is_transient_local, mqdes,
+      CallbackInfo{topic_name,     subscriber_id,   is_transient_local, notify_eventfd,
                    callback_group, erased_callback, message_creator};
   }
 

--- a/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_epoll.hpp
@@ -53,7 +53,7 @@ void prepare_epoll_impl(
       ev.events = EPOLLIN;
       ev.data.u32 = callback_info_id;
 
-      if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, callback_info.mqdes, &ev) == -1) {
+      if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, callback_info.notify_eventfd, &ev) == -1) {
         RCLCPP_ERROR(logger, "epoll_ctl failed: %s", strerror(errno));
         close(agnocast_fd);
         exit(EXIT_FAILURE);

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -79,6 +79,7 @@ union ioctl_add_subscriber_args {
     bool is_take_sub;
     bool ignore_local_publications;
     bool is_bridge;
+    int32_t eventfd;
   };
   struct
   {
@@ -147,11 +148,6 @@ union ioctl_publish_msg_args {
     struct name_info topic_name;
     topic_local_id_t publisher_id;
     uint64_t msg_virtual_address;
-    // Unlike ret_* fields which are returned via the union copy, subscriber IDs are written
-    // directly to this user-space buffer via copy_to_user. The caller must ensure the buffer
-    // remains valid until the ioctl returns.
-    uint64_t subscriber_ids_buffer_addr;
-    uint32_t subscriber_ids_buffer_size;
   };
   struct
   {

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -19,10 +19,6 @@ inline constexpr const char * MAIN_EXECUTABLE_SYMBOL = "__MAIN_EXECUTABLE__";
 
 enum class BridgeDirection : uint32_t { ROS2_TO_AGNOCAST = 0, AGNOCAST_TO_ROS2 = 1 };
 
-struct MqMsgAgnocast
-{
-};
-
 struct MqMsgROS2Publish
 {
   bool should_terminate;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
@@ -10,7 +9,6 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -37,8 +35,7 @@ topic_local_id_t initialize_publisher(
   const bool is_bridge);
 union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle, /* for CARET */ const std::string & topic_name,
-  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> & opened_mqs);
+  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address);
 uint32_t get_subscription_count_core(const std::string & topic_name);
 uint32_t get_intra_subscription_count_core(const std::string & topic_name);
 void increment_borrowed_publisher_num();
@@ -65,7 +62,6 @@ class BasicPublisher
 {
   topic_local_id_t id_ = -1;
   std::string topic_name_;
-  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> opened_mqs_;
   rmw_gid_t gid_;
 
   void generate_gid()
@@ -154,14 +150,6 @@ public:
 
   ~BasicPublisher()
   {
-    for (auto & [_, t] : opened_mqs_) {
-      mqd_t mq = std::get<0>(t);
-      if (mq_close(mq) == -1) {
-        RCLCPP_ERROR_STREAM(
-          logger, "mq_close failed for topic '" << topic_name_ << "': " << strerror(errno));
-      }
-    }
-
     // NOTE: When a publisher is destroyed, subscribers should unmap its memory, but this is not yet
     // implemented. Since multiple publishers in the same process share a mempool, process-level
     // reference counting in kmod is needed. Leaving memory mapped causes no functional issues, so
@@ -216,7 +204,7 @@ public:
     decrement_borrowed_publisher_num();
 
     const union ioctl_publish_msg_args publish_msg_args =
-      publish_core(this, topic_name_, id_, msg_virtual_address, opened_mqs_);
+      publish_core(this, topic_name_, id_, msg_virtual_address);
 
     for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
       MessageT * release_ptr = reinterpret_cast<MessageT *>(publish_msg_args.ret_released_addrs[i]);

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -2,7 +2,6 @@
 
 #include "agnocast/agnocast_callback_info.hpp"
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_public_api.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
@@ -11,7 +10,6 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -55,10 +53,7 @@ struct SubscriptionOptions
 };
 
 // These are cut out of the class for information hiding.
-mqd_t open_mq_for_subscription(
-  const std::string & topic_name, const topic_local_id_t subscriber_id,
-  std::pair<mqd_t, std::string> & mq_subscription);
-void remove_mq(const std::pair<mqd_t, std::string> & mq_subscription);
+void close_notify_eventfd(int eventfd);
 uint32_t get_publisher_count_core(const std::string & topic_name);
 
 template <typename NodeT>
@@ -85,6 +80,7 @@ class SubscriptionBase
 protected:
   topic_local_id_t id_;
   const std::string topic_name_;
+  int notify_eventfd_ = -1;
   union ioctl_add_subscriber_args initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     const bool is_bridge, const std::string & node_name);
@@ -116,7 +112,6 @@ public:
 template <typename MessageT, typename BridgeRequestPolicy>
 class BasicSubscription : public SubscriptionBase
 {
-  std::pair<mqd_t, std::string> mq_subscription_;
   uint32_t callback_info_id_;
 
   template <typename NodeT, typename Func>
@@ -142,12 +137,11 @@ class BasicSubscription : public SubscriptionBase
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
 
-    mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
-
     const bool is_transient_local =
       actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
     callback_info_id_ = agnocast::register_callback<MessageT>(
-      std::forward<Func>(callback), topic_name_, id_, is_transient_local, mq, callback_group);
+      std::forward<Func>(callback), topic_name_, id_, is_transient_local, notify_eventfd_,
+      callback_group);
 
     return actual_qos;
   }
@@ -207,15 +201,15 @@ public:
   ~BasicSubscription()
   {
     // Remove from callback info map to prevent stale references on re-subscription and to avoid
-    // fd reuse conflicts. When mq_close() is called in remove_mq(), the OS may later reuse the
-    // same fd number for a new subscription. If the old entry remains in id2_callback_info,
-    // adding the new fd to epoll (EPOLL_CTL_ADD) can fail with EEXIST because epoll still
-    // associates that fd number with the stale entry.
+    // fd reuse conflicts. When close() is called on the eventfd, the OS may later reuse the same
+    // fd number for a new subscription. If the old entry remains in id2_callback_info, adding the
+    // new fd to epoll (EPOLL_CTL_ADD) can fail with EEXIST because epoll still associates that fd
+    // number with the stale entry.
     {
       std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
       id2_callback_info.erase(callback_info_id_);
     }
-    remove_mq(mq_subscription_);
+    close_notify_eventfd(notify_eventfd_);
   }
 };
 

--- a/src/agnocastlib/src/agnocast_epoll.cpp
+++ b/src/agnocastlib/src/agnocast_epoll.cpp
@@ -166,17 +166,17 @@ bool wait_and_handle_epoll_event(
       callback_info = it->second;
     }
 
-    MqMsgAgnocast mq_msg = {};
-
-    // non-blocking
-    auto ret =
-      mq_receive(callback_info.mqdes, reinterpret_cast<char *>(&mq_msg), sizeof(mq_msg), nullptr);
+    // Read the eventfd to clear the notification. The read is non-blocking (EFD_NONBLOCK).
+    // NOTE: There is a TOCTOU race between epoll_wait reporting the fd as readable and
+    // this read, but eventfd semantics guarantee that a spurious EAGAIN is the worst case.
+    uint64_t eventfd_val = 0;
+    auto ret = read(callback_info.notify_eventfd, &eventfd_val, sizeof(eventfd_val));
     if (ret < 0) {
       if (errno != EAGAIN) {
         RCLCPP_ERROR_STREAM(
-          logger, "mq_receive failed for topic '" << callback_info.topic_name << "' (subscriber_id="
-                                                  << callback_info.subscriber_id
-                                                  << "): " << strerror(errno));
+          logger, "eventfd read failed for topic '"
+                    << callback_info.topic_name << "' (subscriber_id="
+                    << callback_info.subscriber_id << "): " << strerror(errno));
         close(agnocast_fd);
         exit(EXIT_FAILURE);
       }

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -56,20 +56,12 @@ topic_local_id_t initialize_publisher(
 
 union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle /* for CARET */, const std::string & topic_name,
-  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
-  std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> & opened_mqs)
+  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address)
 {
-  std::array<topic_local_id_t, MAX_SUBSCRIBER_NUM> subscriber_ids_buffer{};
-
   union ioctl_publish_msg_args publish_msg_args = {};
   publish_msg_args.topic_name = {topic_name.c_str(), topic_name.size()};
   publish_msg_args.publisher_id = publisher_id;
   publish_msg_args.msg_virtual_address = msg_virtual_address;
-  // The kernel writes subscriber IDs directly to this buffer via copy_to_user,
-  // unlike ret_* fields which are copied back through the union.
-  publish_msg_args.subscriber_ids_buffer_addr =
-    reinterpret_cast<uint64_t>(subscriber_ids_buffer.data());
-  publish_msg_args.subscriber_ids_buffer_size = MAX_SUBSCRIBER_NUM;
 
   if (ioctl(agnocast_fd, AGNOCAST_PUBLISH_MSG_CMD, &publish_msg_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_PUBLISH_MSG_CMD failed: %s", strerror(errno));
@@ -78,63 +70,6 @@ union ioctl_publish_msg_args publish_core(
   }
 
   TRACEPOINT(agnocast_publish, publisher_handle, publish_msg_args.ret_entry_id);
-
-  for (uint32_t i = 0; i < publish_msg_args.ret_subscriber_num; i++) {
-    const topic_local_id_t subscriber_id = subscriber_ids_buffer[i];
-    mqd_t mq = 0;
-    if (opened_mqs.find(subscriber_id) != opened_mqs.end()) {
-      std::tuple<mqd_t, bool> & t = opened_mqs[subscriber_id];
-      mq = std::get<0>(t);
-      // The boolean in the tuple indicates whether the mq is used in this publication round.
-      // An unused mq means that its corresponding subscribers have exited, so we close such mqs
-      // later.
-      std::get<1>(t) = true;
-    } else {
-      const std::string mq_name = create_mq_name_for_agnocast_publish(topic_name, subscriber_id);
-      mq = mq_open(mq_name.c_str(), O_WRONLY | O_NONBLOCK);
-      if (mq == -1) {
-        // Right after a subscriber is added, its message queue has not been created yet. Therefore,
-        // the `mq_open` call above might fail. In that case, we just continue.
-        RCLCPP_DEBUG_STREAM(
-          logger, "mq_open failed for topic '" << topic_name << "' (subscriber_id=" << subscriber_id
-                                               << ", mq_name='" << mq_name
-                                               << "'): " << strerror(errno));
-        continue;
-      }
-      opened_mqs.insert({subscriber_id, {mq, true}});
-    }
-
-    struct MqMsgAgnocast mq_msg = {};
-    // Although the size of the struct is 1, we deliberately send a zero-length message
-    if (mq_send(mq, reinterpret_cast<char *>(&mq_msg), 0 /*msg_len*/, 0) == -1) {
-      // If it returns EAGAIN, it means mq_send has already been executed, but the subscriber
-      // hasn't received it yet. Thus, there's no need to send it again since the notification has
-      // already been sent.
-      if (errno != EAGAIN) {
-        RCLCPP_ERROR_STREAM(
-          logger, "mq_send failed for topic '" << topic_name << "' (subscriber_id=" << subscriber_id
-                                               << "): " << strerror(errno));
-      }
-    }
-  }
-
-  // Close mqs that are no longer needed and update `opened_mqs`
-  for (auto it = opened_mqs.begin(); it != opened_mqs.end();) {
-    bool & keep = std::get<1>(it->second);
-    if (!keep) {
-      mqd_t mq = std::get<0>(it->second);
-      if (mq_close(mq) == -1) {
-        RCLCPP_ERROR_STREAM(
-          logger, "mq_close failed for topic '" << topic_name << "' (subscriber_id=" << it->first
-                                                << "): " << strerror(errno));
-      }
-      it = opened_mqs.erase(it);
-    } else {
-      // Update the value for the next publication round
-      keep = false;
-      ++it;
-    }
-  }
 
   return publish_msg_args;
 }

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -1,6 +1,8 @@
 #include "agnocast/agnocast.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
+#include <sys/eventfd.h>
+
 namespace agnocast
 {
 
@@ -21,6 +23,16 @@ union ioctl_add_subscriber_args SubscriptionBase::initialize(
   const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
   const bool is_bridge, const std::string & node_name)
 {
+  int efd = -1;
+  if (!is_take_sub) {
+    efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    if (efd == -1) {
+      RCLCPP_ERROR(logger, "eventfd creation failed: %s", strerror(errno));
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+  }
+
   union ioctl_add_subscriber_args add_subscriber_args = {};
   add_subscriber_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
   add_subscriber_args.node_name = {node_name.c_str(), node_name.size()};
@@ -31,11 +43,17 @@ union ioctl_add_subscriber_args SubscriptionBase::initialize(
   add_subscriber_args.is_take_sub = is_take_sub;
   add_subscriber_args.ignore_local_publications = ignore_local_publications;
   add_subscriber_args.is_bridge = is_bridge;
+  add_subscriber_args.eventfd = efd;
   if (ioctl(agnocast_fd, AGNOCAST_ADD_SUBSCRIBER_CMD, &add_subscriber_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_SUBSCRIBER_CMD failed: %s", strerror(errno));
+    if (efd >= 0) {
+      close(efd);
+    }
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+
+  notify_eventfd_ = efd;
 
   return add_subscriber_args;
 }
@@ -65,44 +83,10 @@ uint32_t get_publisher_count_core(const std::string & topic_name)
   return count + ros2_count;
 }
 
-mqd_t open_mq_for_subscription(
-  const std::string & topic_name, const topic_local_id_t subscriber_id,
-  std::pair<mqd_t, std::string> & mq_subscription)
+void close_notify_eventfd(int eventfd)
 {
-  std::string mq_name = create_mq_name_for_agnocast_publish(topic_name, subscriber_id);
-  struct mq_attr attr = {};
-  attr.mq_flags = 0;                        // Blocking queue
-  attr.mq_msgsize = sizeof(MqMsgAgnocast);  // Maximum message size
-  attr.mq_curmsgs = 0;  // Number of messages currently in the queue (not set by mq_open)
-  attr.mq_maxmsg = 1;
-
-  const int mq_mode = 0666;
-  mqd_t mq = mq_open(mq_name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK, mq_mode, &attr);
-  if (mq == -1) {
-    RCLCPP_ERROR_STREAM(
-      logger, "mq_open failed for topic '" << topic_name << "' (subscriber_id=" << subscriber_id
-                                           << ", mq_name='" << mq_name
-                                           << "'): " << strerror(errno));
-    close(agnocast_fd);
-    exit(EXIT_FAILURE);
-  }
-  mq_subscription = std::make_pair(mq, mq_name);
-
-  return mq;
-}
-
-void remove_mq(const std::pair<mqd_t, std::string> & mq_subscription)
-{
-  /* The message queue is destroyed after all the publisher processes close it. */
-  if (mq_close(mq_subscription.first) == -1) {
-    RCLCPP_ERROR_STREAM(
-      logger,
-      "mq_close failed for mq_name='" << mq_subscription.second << "': " << strerror(errno));
-  }
-  if (mq_unlink(mq_subscription.second.c_str()) == -1) {
-    RCLCPP_ERROR_STREAM(
-      logger,
-      "mq_unlink failed for mq_name='" << mq_subscription.second << "': " << strerror(errno));
+  if (eventfd >= 0) {
+    close(eventfd);
   }
 }
 

--- a/src/agnocastlib/test/integration/include/node_for_executor_test.hpp
+++ b/src/agnocastlib/test/integration/include/node_for_executor_test.hpp
@@ -20,12 +20,11 @@ private:
   std::unique_ptr<std::atomic<bool>[]> agnocast_sub_cbs_called_;
   size_t num_total_agnocast_sub_cbs_ = 0;
   std::string agnocast_topic_name_ = "/dummy_agnocast_topic";
-  // These mqueues are used to execute the agnocast callbacks without Publisher and Subscription.
-  std::vector<std::pair<mqd_t, std::string>> mq_receivers_;
-  std::unordered_map<std::string, mqd_t> mq_senders_;
+  // These eventfds are used to execute the agnocast callbacks without Publisher and Subscription.
+  std::vector<int> eventfds_;
 
   void add_agnocast_sub_cb();
-  mqd_t open_mq_for_receiver(const int64_t cb_i);
+  int open_eventfd_for_receiver();
   void dummy_work(std::chrono::milliseconds exec_time);
   void agnocast_timer_cb();
   void agnocast_sub_cb(const agnocast::ipc_shared_ptr<std_msgs::msg::Bool> & msg, int64_t cb_i);

--- a/src/agnocastlib/test/integration/src/node_for_executor_test.cpp
+++ b/src/agnocastlib/test/integration/src/node_for_executor_test.cpp
@@ -1,5 +1,8 @@
 #include "node_for_executor_test.hpp"
 
+#include <sys/eventfd.h>
+#include <unistd.h>
+
 NodeForExecutorTest::NodeForExecutorTest(
   const int64_t num_agnocast_sub_cbs, const int64_t num_ros2_sub_cbs,
   const int64_t num_agnocast_cbs_to_be_added, const std::chrono::milliseconds pub_period,
@@ -51,63 +54,43 @@ NodeForExecutorTest::NodeForExecutorTest(
 
 NodeForExecutorTest::~NodeForExecutorTest()
 {
-  for (auto & mq_sender : mq_senders_) {
-    if (mq_close(mq_sender.second) == -1) {
-      std::cerr << "mq_close failed for mq_name='" << mq_sender.first << "': " << strerror(errno)
-                << std::endl;
-    }
-  }
-
-  for (auto & mq_receiver : mq_receivers_) {
-    if (mq_close(mq_receiver.first) == -1) {
-      std::cerr << "mq_close failed for mq_name='" << mq_receiver.second << "': " << strerror(errno)
-                << std::endl;
-    }
-    if (mq_unlink(mq_receiver.second.c_str()) == -1) {
-      std::cerr << "mq_unlink failed for mq_name='" << mq_receiver.second
-                << "': " << strerror(errno) << std::endl;
+  for (auto & efd : eventfds_) {
+    if (efd >= 0) {
+      close(efd);
     }
   }
 }
 
 void NodeForExecutorTest::add_agnocast_sub_cb()
 {
-  int64_t cb_i = mq_receivers_.size();
+  int64_t cb_i = eventfds_.size();
   rclcpp::SubscriptionOptions options;
   auto cbg = (agnocast_common_cbg_)
                ? agnocast_common_cbg_
                : create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   options.callback_group = cbg;
-  auto mq = open_mq_for_receiver(cb_i);
+  auto efd = open_eventfd_for_receiver();
   std::function<void(const agnocast::ipc_shared_ptr<std_msgs::msg::Bool> &)> callback =
     [this, cb_i](const agnocast::ipc_shared_ptr<std_msgs::msg::Bool> & msg) {
       agnocast_sub_cb(msg, cb_i);
     };
   const bool is_transient_local = false;
   agnocast::register_callback<std_msgs::msg::Bool>(
-    callback, agnocast_topic_name_, cb_i, is_transient_local, mq, cbg);
+    callback, agnocast_topic_name_, cb_i, is_transient_local, efd, cbg);
 }
 
 // NOTE: If the implementation of agnocast is changed, this function does not
 // necessarily have to be changed as well, because this test is for the Executor.
-mqd_t NodeForExecutorTest::open_mq_for_receiver(const int64_t cb_i)
+int NodeForExecutorTest::open_eventfd_for_receiver()
 {
-  std::string mq_name = agnocast_topic_name_ + "@" + std::to_string(cb_i);
-  struct mq_attr attr = {};
-  attr.mq_flags = 0;                                  // Blocking queue
-  attr.mq_msgsize = sizeof(agnocast::MqMsgAgnocast);  // Maximum message size
-  attr.mq_curmsgs = 0;  // Number of messages currently in the queue (not set by mq_open)
-  attr.mq_maxmsg = 1;
-
-  const int mq_mode = 0666;
-  mqd_t mq = mq_open(mq_name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK, mq_mode, &attr);
-  if (mq == -1) {
-    std::cerr << "mq_open failed for mq_name='" << mq_name << "': " << strerror(errno) << std::endl;
+  int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (efd == -1) {
+    std::cerr << "eventfd creation failed: " << strerror(errno) << std::endl;
     exit(EXIT_FAILURE);
   }
-  mq_receivers_.push_back(std::make_pair(mq, mq_name));
+  eventfds_.push_back(efd);
 
-  return mq;
+  return efd;
 }
 
 void NodeForExecutorTest::dummy_work(std::chrono::milliseconds exec_time)
@@ -121,33 +104,19 @@ void NodeForExecutorTest::dummy_work(std::chrono::milliseconds exec_time)
 // necessarily have to be changed as well, because this test is for the Executor.
 void NodeForExecutorTest::agnocast_timer_cb()
 {
-  // mq_send()
-  for (auto & mq_receiver : mq_receivers_) {
-    mqd_t mq = 0;
-    if (mq_senders_.find(mq_receiver.second) != mq_senders_.end()) {
-      mq = mq_senders_[mq_receiver.second];
-    } else {
-      mq = mq_open(mq_receiver.second.c_str(), O_WRONLY | O_NONBLOCK);
-      if (mq == -1) {
-        std::cerr << "mq_open failed for mq_name='" << mq_receiver.second
-                  << "': " << strerror(errno) << std::endl;
-        exit(EXIT_FAILURE);
-      }
-      mq_senders_.insert({mq_receiver.second, mq});
-    }
-
-    agnocast::MqMsgAgnocast mq_msg = {};
-    if (mq_send(mq, reinterpret_cast<char *>(&mq_msg), 0 /*msg_len*/, 0) == -1) {
+  // Write to eventfds to trigger callbacks
+  for (auto & efd : eventfds_) {
+    uint64_t val = 1;
+    if (write(efd, &val, sizeof(val)) == -1) {
       if (errno != EAGAIN) {
-        std::cerr << "mq_send failed for mq_name='" << mq_receiver.second
-                  << "': " << strerror(errno) << std::endl;
+        std::cerr << "eventfd write failed: " << strerror(errno) << std::endl;
         exit(EXIT_FAILURE);
       }
     }
   }
 
   // Add new agnocast sub callbacks
-  if (mq_receivers_.size() < num_total_agnocast_sub_cbs_) {
+  if (eventfds_.size() < num_total_agnocast_sub_cbs_) {
     add_agnocast_sub_cb();
   }
 }


### PR DESCRIPTION
## Description

Replace the POSIX MQ-based publish notification mechanism with kernel-managed eventfd.
The previous MQ path required the publisher to call `mq_send()` once per subscriber
in userspace (N+1 syscalls per publish including the PUBLISH ioctl). With eventfd,
the kernel module signals subscriber eventfds directly within `ioctl(PUBLISH)`,
reducing the cost to a single syscall regardless of subscriber count.

Key changes:
- Kernel: `subscriber_info` stores `eventfd_ctx`. `publish_msg` collects notify_ctx
  pointers under `topic_rwsem` write lock, then signals outside the lock to avoid
  contention. Stack buffer (64 entries) with heap fallback for larger subscriber counts.
- Userspace: Subscriber creates eventfd and passes to kernel via `ioctl(ADD_SUBSCRIBER)`.
  Publisher's `publish_core` is simplified from ~80 to ~15 lines (MQ send loop removed).
- Compatibility: `agnocast_eventfd_signal` wrapper for kernel < 6.8 API difference.

Detailed design, benchmark analysis, and alternative considered: see design doc (linked below).

## Benchmark Results

Measured with [isorc26_tmp](https://github.com/sykwer/isorc26_tmp),
10 topics, 100Hz, 3-iter mean of per-iter p50/p99, `--no-rt`. Test machine: 32 logical CPUs.

### Publish latency (publisher wall-clock, from `loan()` to `publish()` completion)

| Subs | MQ p50 / p99 | eventfd p50 / p99 | p50 diff |
|------|-------------|-------------------|----------|
| 4    | 11.5 / 37.1 us | 7.1 / 20.9 us | -38% |
| 8    | 17.0 / 51.3 us | 8.3 / 30.3 us | -51% |
| 16   | 24.5 / 61.6 us | 18.4 / 47.4 us | -25% |
| 32   | 56.9 / 133.5 us | 58.7 / 138.2 us | +3% |
| 64   | 186.4 / 404.2 us | 141.5 / 330.0 us | -24% |
| 128  | 674.2 / 1084.4 us | 594.4 / 1206.2 us | -12% |

### E2E latency (from publisher timestamp just before `loan()` to subscriber callback entry)

| Subs | MQ p50 / p99 | eventfd p50 / p99 | p50 diff |
|------|-------------|-------------------|----------|
| 4    | 61.3 / 210.4 us | 30.2 / 183.2 us | -51% |
| 8    | 36.3 / 220.0 us | 26.1 / 204.7 us | -28% |
| 16   | 27.8 / 119.1 us | 22.4 / 124.4 us | -19% |
| 32   | 45.4 / 156.4 us | 55.3 / 195.1 us | +22% |
| 64   | 119.6 / 521.6 us | 96.6 / 412.6 us | -19% |
| 128  | 387.8 / 1454.9 us | 340.0 / 1803.7 us | -12% |

### Observations

- eventfd is clearly faster at low-to-mid N (p50 improvement up to -51%).
- Around N ≈ number of logical CPUs (32) the two approaches converge — the
  scheduler's wake_up O(N) cost dominates and the mechanism difference gets buried.
- At high N, E2E p50 is smaller than publish latency p50 (e.g. N=128: E2E=340 us <
  publish=594 us). This is because there is 1 publish-latency sample but N E2E samples
  per publish, so the E2E median points to the "middle-woken" subscriber. In the p99
  column the last-woken subscriber's scheduling latency dominates, so the ordering
  reverses (E2E p99 > publish p99 at high N).
- See design doc for details.

## Alternative explored: per-topic shared eventfd

We also prototyped a per-topic shared eventfd (one eventfd shared by all subscribers
of a topic, signaled once per publish) to test whether consolidating N `eventfd_signal`
calls into one would improve high-N latency. Contrary to the hypothesis, the single
`wake_up_poll()` iterating N `ep_poll_callback`s under one spin_lock showed similar
or slightly worse latency due to concentrated scheduler contention.

- Prototype branch: [`experiment/shared-eventfd`](https://github.com/autowarefoundation/agnocast/tree/experiment/shared-eventfd)
- Analysis: see design doc

## Related links

- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/1QDsMQE

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] isorc26_tmp benchmark (subs = 4, 8, 16, 32, 64, 128)

## Notes for reviewers

MQ usage in other paths (bridge request and bridge delegation) remains unchanged.
Dead code from the old subscription MQ cleanup path (daemon mq_unlink loop) will be
removed in a follow-up PR.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
