### PR TITLE
fix(sample_application): use dedicated callback groups

### DIFF
--- a/src/agnocast_sample_application/src/minimal_client.cpp
+++ b/src/agnocast_sample_application/src/minimal_client.cpp
@@ -19,8 +19,9 @@ int main(int argc, char * argv[])
     executor.spin();
   });
 
+  auto callback_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   auto client = agnocast::create_client<agnocast_sample_interfaces::srv::SumIntArray>(
-    node.get(), "sum_int_array");
+    node.get(), "sum_int_array", rclcpp::ServicesQoS(), callback_group);
 
   while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {

--- a/src/agnocast_sample_application/src/minimal_server.cpp
+++ b/src/agnocast_sample_application/src/minimal_server.cpp
@@ -7,11 +7,13 @@ class MinimalService : public rclcpp::Node
   using Request = agnocast_sample_interfaces::srv::SumIntArray::Request;
   using Response = agnocast_sample_interfaces::srv::SumIntArray::Response;
 
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
   typename agnocast::Service<agnocast_sample_interfaces::srv::SumIntArray>::SharedPtr service_;
 
 public:
   explicit MinimalService() : Node("minimal_server")
   {
+    callback_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     service_ = agnocast::create_service<agnocast_sample_interfaces::srv::SumIntArray>(
       this, "sum_int_array",
       [this](
@@ -22,7 +24,8 @@ public:
           response->sum += value;
         }
         RCLCPP_INFO(this->get_logger(), "Sending back response: [%ld]", response->sum);
-      });
+      },
+      rclcpp::ServicesQoS(), callback_group_);
   }
 };
 

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -4,7 +4,10 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sys/epoll.h"
 
+#include <string_view>
 #include <unordered_map>
+
+bool is_builtin_parameter_service(std::string_view service_name);
 
 namespace agnocast
 {
@@ -88,7 +91,11 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
     bool has_ros_callback = false;
     group->collect_all_ptrs(
       [&has_ros_callback](const rclcpp::SubscriptionBase::SharedPtr &) { has_ros_callback = true; },
-      [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr &) { has_ros_callback = true; },
+      [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr & service) {
+        if (!is_builtin_parameter_service(service->get_service_name())) {
+          has_ros_callback = true;
+        }
+      },
       [&has_ros_callback](const rclcpp::ClientBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::TimerBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::Waitable::SharedPtr &) { has_ros_callback = true; });
@@ -134,3 +141,22 @@ void SingleThreadedAgnocastExecutor::dedicate_to_callback_group(
 }
 
 }  // namespace agnocast
+
+bool is_builtin_parameter_service(std::string_view service_name)
+{
+  static constexpr std::string_view kParameterServiceSuffixes[] = {
+    "/describe_parameters", "/get_parameter_types", "/get_parameters",
+    "/list_parameters",     "/set_parameters",      "/set_parameters_atomically"};
+
+  for (const auto & suffix : kParameterServiceSuffixes) {
+    size_t name_len = service_name.size();
+    size_t suffix_len = suffix.size();
+    if (
+      name_len > suffix_len &&
+      service_name.substr(name_len - suffix_len, suffix_len).compare(suffix) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/agnocast_single_threaded_executor.cpp
@@ -4,10 +4,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "sys/epoll.h"
 
-#include <string_view>
 #include <unordered_map>
-
-bool is_builtin_parameter_service(std::string_view service_name);
 
 namespace agnocast
 {
@@ -91,11 +88,7 @@ void SingleThreadedAgnocastExecutor::warn_if_mixed_callback_groups()
     bool has_ros_callback = false;
     group->collect_all_ptrs(
       [&has_ros_callback](const rclcpp::SubscriptionBase::SharedPtr &) { has_ros_callback = true; },
-      [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr & service) {
-        if (!is_builtin_parameter_service(service->get_service_name())) {
-          has_ros_callback = true;
-        }
-      },
+      [&has_ros_callback](const rclcpp::ServiceBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::ClientBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::TimerBase::SharedPtr &) { has_ros_callback = true; },
       [&has_ros_callback](const rclcpp::Waitable::SharedPtr &) { has_ros_callback = true; });
@@ -141,22 +134,3 @@ void SingleThreadedAgnocastExecutor::dedicate_to_callback_group(
 }
 
 }  // namespace agnocast
-
-bool is_builtin_parameter_service(std::string_view service_name)
-{
-  static constexpr std::string_view kParameterServiceSuffixes[] = {
-    "/describe_parameters", "/get_parameter_types", "/get_parameters",
-    "/list_parameters",     "/set_parameters",      "/set_parameters_atomically"};
-
-  for (const auto & suffix : kParameterServiceSuffixes) {
-    size_t name_len = service_name.size();
-    size_t suffix_len = suffix.size();
-    if (
-      name_len > suffix_len &&
-      service_name.substr(name_len - suffix_len, suffix_len).compare(suffix) == 0) {
-      return true;
-    }
-  }
-
-  return false;
-}


### PR DESCRIPTION
## Description

`minimal_server.cpp` and `minimal_client.cpp` previously used the default callback group with CIE, which results in the "contains both ROS 2 callbacks and Agnocast callbacks" warning. This PR fixes the issue by using dedicated callback groups.

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

