### PR TITLE
refactor(bridge): reduce standard bridge manager's memory usage

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -209,17 +209,15 @@ public:
 
 template <typename MessageT>
 std::shared_ptr<BridgeBase> start_ros_to_agno_node(
-  rclcpp::Node::SharedPtr node, const BridgeTargetInfo & info, const rclcpp::QoS & qos)
+  rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
-  std::string topic_name(static_cast<const char *>(info.topic_name));
   return std::make_shared<RosToAgnocastBridge<MessageT>>(node, topic_name, qos);
 }
 
 template <typename MessageT>
 std::shared_ptr<BridgeBase> start_agno_to_ros_node(
-  rclcpp::Node::SharedPtr node, const BridgeTargetInfo & info, const rclcpp::QoS & qos)
+  rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
-  std::string topic_name(static_cast<const char *>(info.topic_name));
   return std::make_shared<AgnocastToRosBridge<MessageT>>(node, topic_name, qos);
 }
 

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
@@ -14,7 +14,7 @@ namespace agnocast
 class BridgeBase;
 
 using BridgeFn = std::shared_ptr<BridgeBase> (*)(
-  rclcpp::Node::SharedPtr, const BridgeTargetInfo &, const rclcpp::QoS &);
+  rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &);
 
 class StandardBridgeLoader
 {
@@ -26,8 +26,9 @@ public:
   StandardBridgeLoader & operator=(const StandardBridgeLoader &) = delete;
 
   std::shared_ptr<BridgeBase> create(
-    const MqMsgBridge & req, const std::string & topic_name_with_direction,
-    const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos);
+    const std::string & topic_name, BridgeDirection direction,
+    const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
+    uintptr_t fn_offset_a2r, const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos);
 
 private:
   rclcpp::Logger logger_;
@@ -36,10 +37,13 @@ private:
 
   std::shared_ptr<BridgeBase> create_bridge_instance(
     BridgeFn entry_func, const std::shared_ptr<void> & lib_handle,
-    const rclcpp::Node::SharedPtr & node, const BridgeTargetInfo & target, const rclcpp::QoS & qos);
-  static std::pair<void *, uintptr_t> load_library(const char * lib_path, const char * symbol_name);
+    const rclcpp::Node::SharedPtr & node, const std::string & topic_name, const rclcpp::QoS & qos);
+  static std::pair<void *, uintptr_t> load_library(
+    const std::optional<std::string> & shared_lib_path);
   std::pair<BridgeFn, std::shared_ptr<void>> resolve_factory_function(
-    const MqMsgBridge & req, const std::string & topic_name_with_direction);
+    const std::string & topic_name, BridgeDirection direction,
+    const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
+    uintptr_t fn_offset_a2r);
   static bool is_address_in_library_code_segment(void * handle, uintptr_t addr);
 };
 

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -16,10 +17,19 @@ class BridgeBase;
 using BridgeFn = std::shared_ptr<BridgeBase> (*)(
   rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &);
 
+struct BridgeFactorySpec
+{
+  // If set to std::nullopt, the factory functions reside in the main executable.
+  std::optional<std::string> shared_lib_path;
+  uintptr_t fn_offset_r2a;
+  uintptr_t fn_offset_a2r;
+};
+
 class StandardBridgeLoader
 {
 public:
-  explicit StandardBridgeLoader(const rclcpp::Logger & logger);
+  explicit StandardBridgeLoader(
+    const rclcpp::Node::SharedPtr & container_node, const rclcpp::Logger & logger);
   ~StandardBridgeLoader();
 
   StandardBridgeLoader(const StandardBridgeLoader &) = delete;
@@ -27,23 +37,22 @@ public:
 
   std::shared_ptr<BridgeBase> create(
     const std::string & topic_name, BridgeDirection direction,
-    const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
-    uintptr_t fn_offset_a2r, const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos);
+    const BridgeFactorySpec & factory_spec, const rclcpp::QoS & qos);
 
 private:
+  rclcpp::Node::SharedPtr container_node_;
   rclcpp::Logger logger_;
 
   std::map<std::string, std::pair<BridgeFn, std::shared_ptr<void>>> cached_factories_;
 
   std::shared_ptr<BridgeBase> create_bridge_instance(
-    BridgeFn entry_func, const std::shared_ptr<void> & lib_handle,
-    const rclcpp::Node::SharedPtr & node, const std::string & topic_name, const rclcpp::QoS & qos);
+    BridgeFn entry_func, const std::shared_ptr<void> & lib_handle, const std::string & topic_name,
+    const rclcpp::QoS & qos);
   static std::pair<void *, uintptr_t> load_library(
     const std::optional<std::string> & shared_lib_path);
   std::pair<BridgeFn, std::shared_ptr<void>> resolve_factory_function(
     const std::string & topic_name, BridgeDirection direction,
-    const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
-    uintptr_t fn_offset_a2r);
+    const BridgeFactorySpec & factory_spec);
   static bool is_address_in_library_code_segment(void * handle, uintptr_t addr);
 };
 

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
@@ -37,6 +37,7 @@ private:
   struct ManagedBridgeEntry
   {
     BridgeFactorySpec factory_spec;
+    // Use -1 when not requested. Valid topic_local_id_t values are [0..MAX_TOPIC_LOCAL_ID).
     topic_local_id_t target_id_r2a;
     topic_local_id_t target_id_a2r;
     bool is_requested_r2a;
@@ -44,12 +45,12 @@ private:
 
     void reset_r2a()
     {
-      target_id_r2a = 0;
+      target_id_r2a = -1;
       is_requested_r2a = false;
     }
     void reset_a2r()
     {
-      target_id_a2r = 0;
+      target_id_a2r = -1;
       is_requested_a2r = false;
     }
   };

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
@@ -36,8 +36,25 @@ private:
 
   struct BridgeInfo
   {
-    std::optional<MqMsgBridge> req_r2a;
-    std::optional<MqMsgBridge> req_a2r;
+    // If set to std::nullopt, the factory functions reside in the main executable.
+    std::optional<std::string> shared_lib_path;
+    uintptr_t fn_offset_r2a;
+    uintptr_t fn_offset_a2r;
+    topic_local_id_t target_id_r2a;
+    topic_local_id_t target_id_a2r;
+    bool is_requested_r2a;
+    bool is_requested_a2r;
+
+    void reset_r2a()
+    {
+      target_id_r2a = 0;
+      is_requested_r2a = false;
+    }
+    void reset_a2r()
+    {
+      target_id_a2r = 0;
+      is_requested_a2r = false;
+    }
   };
 
   const pid_t target_pid_;
@@ -65,10 +82,13 @@ private:
 
   static BridgeKernelResult try_add_bridge_to_kernel(const std::string & topic_name, bool is_r2a);
   void rollback_bridge_from_kernel(const std::string & topic_name, bool is_r2a);
-  bool activate_bridge(const MqMsgBridge & req, const std::string & topic_name);
-  void send_delegation(const MqMsgBridge & req, pid_t owner_pid);
+  bool activate_bridge(
+    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction);
+  void send_delegation(
+    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction,
+    pid_t owner_pid);
   void process_managed_bridge(
-    const std::string & topic_name, const std::optional<MqMsgBridge> & req);
+    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction);
   bool should_remove_bridge(const std::string & topic_name, bool is_r2a);
 
   void check_parent_alive();

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
@@ -34,12 +34,9 @@ private:
     bool has_a2r;
   };
 
-  struct BridgeInfo
+  struct ManagedBridgeEntry
   {
-    // If set to std::nullopt, the factory functions reside in the main executable.
-    std::optional<std::string> shared_lib_path;
-    uintptr_t fn_offset_r2a;
-    uintptr_t fn_offset_a2r;
+    BridgeFactorySpec factory_spec;
     topic_local_id_t target_id_r2a;
     topic_local_id_t target_id_a2r;
     bool is_requested_r2a;
@@ -57,11 +54,18 @@ private:
     }
   };
 
+  struct DirectedBridgeRef
+  {
+    const std::string & topic_name;
+    const ManagedBridgeEntry & entry;
+    BridgeDirection direction;
+  };
+
   const pid_t target_pid_;
   rclcpp::Logger logger_;
 
   StandardBridgeIpcEventLoop event_loop_;
-  StandardBridgeLoader loader_;
+  std::unique_ptr<StandardBridgeLoader> loader_;
 
   bool is_parent_alive_ = true;
   std::atomic_bool shutdown_requested_ = false;
@@ -71,7 +75,7 @@ private:
   std::thread executor_thread_;
 
   std::map<std::string, std::shared_ptr<BridgeBase>> active_bridges_;
-  std::map<std::string, BridgeInfo> managed_bridges_;
+  std::map<std::string, ManagedBridgeEntry> managed_bridges_;
 
   void start_ros_execution();
 
@@ -82,13 +86,9 @@ private:
 
   static BridgeKernelResult try_add_bridge_to_kernel(const std::string & topic_name, bool is_r2a);
   void rollback_bridge_from_kernel(const std::string & topic_name, bool is_r2a);
-  bool activate_bridge(
-    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction);
-  void send_delegation(
-    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction,
-    pid_t owner_pid);
-  void process_managed_bridge(
-    const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction);
+  bool activate_bridge(const DirectedBridgeRef bridge_ref);
+  void send_delegation(const DirectedBridgeRef bridge_ref, pid_t owner_pid);
+  void process_managed_bridge(const DirectedBridgeRef bridge_ref);
   bool should_remove_bridge(const std::string & topic_name, bool is_r2a);
 
   void check_parent_alive();

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_loader.cpp
@@ -25,28 +25,31 @@ StandardBridgeLoader::~StandardBridgeLoader()
 }
 
 std::shared_ptr<BridgeBase> StandardBridgeLoader::create(
-  const MqMsgBridge & req, const std::string & topic_name_with_direction,
-  const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos)
+  const std::string & topic_name, BridgeDirection direction,
+  const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
+  uintptr_t fn_offset_a2r, const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos)
 {
-  auto [entry_func, lib_handle] = resolve_factory_function(req, topic_name_with_direction);
+  auto [entry_func, lib_handle] =
+    resolve_factory_function(topic_name, direction, shared_lib_path, fn_offset_r2a, fn_offset_a2r);
 
   if (entry_func == nullptr) {
     const char * err = dlerror();
     RCLCPP_ERROR(
-      logger_, "Failed to resolve factory for '%s': %s", topic_name_with_direction.c_str(),
+      logger_, "Failed to resolve %s factory for '%s': %s",
+      (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? "R2A" : "A2R", topic_name.c_str(),
       err ? err : "Unknown error");
     return nullptr;
   }
 
-  return create_bridge_instance(entry_func, lib_handle, node, req.target, qos);
+  return create_bridge_instance(entry_func, lib_handle, node, topic_name, qos);
 }
 
 std::shared_ptr<BridgeBase> StandardBridgeLoader::create_bridge_instance(
   BridgeFn entry_func, const std::shared_ptr<void> & lib_handle,
-  const rclcpp::Node::SharedPtr & node, const BridgeTargetInfo & target, const rclcpp::QoS & qos)
+  const rclcpp::Node::SharedPtr & node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
   try {
-    auto bridge_resource = entry_func(node, target, qos);
+    auto bridge_resource = entry_func(node, topic_name, qos);
     if (!bridge_resource) {
       return nullptr;
     }
@@ -68,14 +71,14 @@ std::shared_ptr<BridgeBase> StandardBridgeLoader::create_bridge_instance(
 }
 
 std::pair<void *, uintptr_t> StandardBridgeLoader::load_library(
-  const char * lib_path, const char * symbol_name)
+  const std::optional<std::string> & shared_lib_path)
 {
   void * handle = nullptr;
 
-  if (std::strcmp(symbol_name, MAIN_EXECUTABLE_SYMBOL) == 0) {
+  if (!shared_lib_path.has_value()) {
     handle = dlopen(nullptr, RTLD_NOW);
   } else {
-    handle = dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
+    handle = dlopen(shared_lib_path.value().c_str(), RTLD_NOW | RTLD_LOCAL);
   }
 
   if (handle == nullptr) {
@@ -91,9 +94,18 @@ std::pair<void *, uintptr_t> StandardBridgeLoader::load_library(
 }
 
 std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory_function(
-  const MqMsgBridge & req, const std::string & topic_name_with_direction)
+  const std::string & topic_name, BridgeDirection direction,
+  const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
+  uintptr_t fn_offset_a2r)
 {
-  if (auto it = cached_factories_.find(topic_name_with_direction); it != cached_factories_.end()) {
+  std::string key_r2a = topic_name;
+  key_r2a += SUFFIX_R2A;
+  std::string key_a2r = topic_name;
+  key_a2r += SUFFIX_A2R;
+
+  const bool is_r2a = (direction == BridgeDirection::ROS2_TO_AGNOCAST);
+
+  if (auto it = cached_factories_.find(is_r2a ? key_r2a : key_a2r); it != cached_factories_.end()) {
     // Return the cached pair of the factory function and the shared library handle.
     return it->second;
   }
@@ -102,9 +114,7 @@ std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory
   // symbol. This ensures that a subsequent call to dlerror() will report only errors that occurred
   // after this point.
   dlerror();
-  auto [raw_handle, base_addr] = load_library(
-    static_cast<const char *>(req.factory.shared_lib_path),
-    static_cast<const char *>(req.factory.symbol_name));
+  auto [raw_handle, base_addr] = load_library(shared_lib_path);
 
   if ((raw_handle == nullptr) || (base_addr == 0)) {
     if (raw_handle != nullptr) {
@@ -120,41 +130,36 @@ std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory
     }
   });
 
-  // Resolve Main Function
-  uintptr_t entry_addr = base_addr + req.factory.fn_offset;
-  BridgeFn entry_func = nullptr;
-
-  if (is_address_in_library_code_segment(raw_handle, entry_addr)) {
-    entry_func = reinterpret_cast<BridgeFn>(entry_addr);
+  // Add R2A function.
+  uintptr_t addr_r2a = base_addr + fn_offset_r2a;
+  BridgeFn func_r2a = nullptr;
+  if (is_address_in_library_code_segment(raw_handle, addr_r2a)) {
+    func_r2a = reinterpret_cast<BridgeFn>(addr_r2a);
   } else {
     RCLCPP_ERROR(
-      logger_, "Main factory function pointer for '%s' is out of bounds: 0x%lx",
-      topic_name_with_direction.c_str(), static_cast<unsigned long>(entry_addr));
+      logger_, "R2A factory function pointer for '%s' is out of bounds: 0x%lx", key_r2a.c_str(),
+      static_cast<unsigned long>(addr_r2a));
     return {nullptr, nullptr};
   }
+  cached_factories_[key_r2a] = {func_r2a, lib_handle_ptr};
 
-  // Register Reverse Function
-  std::string_view suffix =
-    (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? SUFFIX_A2R : SUFFIX_R2A;
-  std::string topic_name_with_reverse(static_cast<const char *>(req.target.topic_name));
-  topic_name_with_reverse += suffix;
-
-  uintptr_t reverse_addr = base_addr + req.factory.fn_offset_reverse;
-  BridgeFn reverse_func = nullptr;
-
-  if (is_address_in_library_code_segment(raw_handle, reverse_addr)) {
-    reverse_func = reinterpret_cast<BridgeFn>(reverse_addr);
+  // Add A2R function.
+  uintptr_t addr_a2r = base_addr + fn_offset_a2r;
+  BridgeFn func_a2r = nullptr;
+  if (is_address_in_library_code_segment(raw_handle, addr_a2r)) {
+    func_a2r = reinterpret_cast<BridgeFn>(addr_a2r);
   } else {
     RCLCPP_ERROR(
-      logger_, "Reverse function pointer for '%s' is out of bounds: 0x%lx",
-      topic_name_with_reverse.c_str(), static_cast<unsigned long>(reverse_addr));
+      logger_, "A2R factory function pointer for '%s' is out of bounds: 0x%lx", key_a2r.c_str(),
+      static_cast<unsigned long>(addr_a2r));
     return {nullptr, nullptr};
   }
+  cached_factories_[key_a2r] = {func_a2r, lib_handle_ptr};
 
-  cached_factories_[topic_name_with_direction] = {entry_func, lib_handle_ptr};
-  cached_factories_[topic_name_with_reverse] = {reverse_func, lib_handle_ptr};
-
-  return {entry_func, lib_handle_ptr};
+  if (is_r2a) {
+    return {func_r2a, lib_handle_ptr};
+  }
+  return {func_a2r, lib_handle_ptr};
 }
 
 bool StandardBridgeLoader::is_address_in_library_code_segment(void * handle, uintptr_t addr)

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_loader.cpp
@@ -15,7 +15,9 @@
 namespace agnocast
 {
 
-StandardBridgeLoader::StandardBridgeLoader(const rclcpp::Logger & logger) : logger_(logger)
+StandardBridgeLoader::StandardBridgeLoader(
+  const rclcpp::Node::SharedPtr & container_node, const rclcpp::Logger & logger)
+: container_node_(container_node), logger_(logger)
 {
 }
 
@@ -25,12 +27,10 @@ StandardBridgeLoader::~StandardBridgeLoader()
 }
 
 std::shared_ptr<BridgeBase> StandardBridgeLoader::create(
-  const std::string & topic_name, BridgeDirection direction,
-  const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
-  uintptr_t fn_offset_a2r, const rclcpp::Node::SharedPtr & node, const rclcpp::QoS & qos)
+  const std::string & topic_name, BridgeDirection direction, const BridgeFactorySpec & factory_spec,
+  const rclcpp::QoS & qos)
 {
-  auto [entry_func, lib_handle] =
-    resolve_factory_function(topic_name, direction, shared_lib_path, fn_offset_r2a, fn_offset_a2r);
+  auto [entry_func, lib_handle] = resolve_factory_function(topic_name, direction, factory_spec);
 
   if (entry_func == nullptr) {
     const char * err = dlerror();
@@ -41,15 +41,15 @@ std::shared_ptr<BridgeBase> StandardBridgeLoader::create(
     return nullptr;
   }
 
-  return create_bridge_instance(entry_func, lib_handle, node, topic_name, qos);
+  return create_bridge_instance(entry_func, lib_handle, topic_name, qos);
 }
 
 std::shared_ptr<BridgeBase> StandardBridgeLoader::create_bridge_instance(
-  BridgeFn entry_func, const std::shared_ptr<void> & lib_handle,
-  const rclcpp::Node::SharedPtr & node, const std::string & topic_name, const rclcpp::QoS & qos)
+  BridgeFn entry_func, const std::shared_ptr<void> & lib_handle, const std::string & topic_name,
+  const rclcpp::QoS & qos)
 {
   try {
-    auto bridge_resource = entry_func(node, topic_name, qos);
+    auto bridge_resource = entry_func(container_node_, topic_name, qos);
     if (!bridge_resource) {
       return nullptr;
     }
@@ -94,9 +94,7 @@ std::pair<void *, uintptr_t> StandardBridgeLoader::load_library(
 }
 
 std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory_function(
-  const std::string & topic_name, BridgeDirection direction,
-  const std::optional<std::string> & shared_lib_path, uintptr_t fn_offset_r2a,
-  uintptr_t fn_offset_a2r)
+  const std::string & topic_name, BridgeDirection direction, const BridgeFactorySpec & factory_spec)
 {
   std::string key_r2a = topic_name;
   key_r2a += SUFFIX_R2A;
@@ -114,7 +112,7 @@ std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory
   // symbol. This ensures that a subsequent call to dlerror() will report only errors that occurred
   // after this point.
   dlerror();
-  auto [raw_handle, base_addr] = load_library(shared_lib_path);
+  auto [raw_handle, base_addr] = load_library(factory_spec.shared_lib_path);
 
   if ((raw_handle == nullptr) || (base_addr == 0)) {
     if (raw_handle != nullptr) {
@@ -131,7 +129,7 @@ std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory
   });
 
   // Add R2A function.
-  uintptr_t addr_r2a = base_addr + fn_offset_r2a;
+  uintptr_t addr_r2a = base_addr + factory_spec.fn_offset_r2a;
   BridgeFn func_r2a = nullptr;
   if (is_address_in_library_code_segment(raw_handle, addr_r2a)) {
     func_r2a = reinterpret_cast<BridgeFn>(addr_r2a);
@@ -144,7 +142,7 @@ std::pair<BridgeFn, std::shared_ptr<void>> StandardBridgeLoader::resolve_factory
   cached_factories_[key_r2a] = {func_r2a, lib_handle_ptr};
 
   // Add A2R function.
-  uintptr_t addr_a2r = base_addr + fn_offset_a2r;
+  uintptr_t addr_a2r = base_addr + factory_spec.fn_offset_a2r;
   BridgeFn func_a2r = nullptr;
   if (is_address_in_library_code_segment(raw_handle, addr_a2r)) {
     func_a2r = reinterpret_cast<BridgeFn>(addr_a2r);

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -135,6 +135,16 @@ void StandardBridgeManager::register_request(const MqMsgBridge & req)
 
   auto it = managed_bridges_.find(topic_name);
   if (it == managed_bridges_.end()) {
+    if (*static_cast<const char *>(req.factory.shared_lib_path) == '\0') {
+      RCLCPP_WARN(
+        logger_,
+        "Skipping %s bridge request for new topic '%s' due to missing factory information. "
+        "This occurs when delegating a request to a bridge manager that has already removed "
+        "the topic from its managed bridges.",
+        req.direction == BridgeDirection::ROS2_TO_AGNOCAST ? "R2A" : "A2R", topic_name.c_str());
+      return;
+    }
+
     auto & entry = managed_bridges_[topic_name];
 
     if (
@@ -150,16 +160,14 @@ void StandardBridgeManager::register_request(const MqMsgBridge & req)
       entry.factory_spec.fn_offset_r2a = req.factory.fn_offset;
       entry.factory_spec.fn_offset_a2r = req.factory.fn_offset_reverse;
       entry.target_id_r2a = req.target.target_id;
-      entry.target_id_a2r = -1;
       entry.is_requested_r2a = true;
-      entry.is_requested_a2r = false;
+      entry.reset_a2r();
     } else {
       entry.factory_spec.fn_offset_r2a = req.factory.fn_offset_reverse;
       entry.factory_spec.fn_offset_a2r = req.factory.fn_offset;
-      entry.target_id_r2a = -1;
       entry.target_id_a2r = req.target.target_id;
-      entry.is_requested_r2a = false;
       entry.is_requested_a2r = true;
+      entry.reset_r2a();
     }
   } else {
     auto & entry = it->second;
@@ -273,16 +281,14 @@ void StandardBridgeManager::send_delegation(const DirectedBridgeRef bridge_ref, 
     return;
   }
 
-  /* --- Construct message --- */
+  /* --- Construct request --- */
   MqMsgBridge req{};
   req.direction = direction;
   req.target.target_id =
     (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? entry.target_id_r2a : entry.target_id_a2r;
   snprintf(
     static_cast<char *>(req.target.topic_name), TOPIC_NAME_BUFFER_SIZE, "%s", topic_name.c_str());
-  // req.factory can be left uninitialized because it is not going to be used.
-
-  // NOTE(bdm-k): What if the owner has removed the target entry in `managed_bridges_`?
+  // req.factory can be left zeroed because it is not going to be used.
   /* ------------------------- */
 
   if (mq_send(mq, reinterpret_cast<const char *>(&req), sizeof(req), 0) < 0) {

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -133,9 +133,44 @@ void StandardBridgeManager::register_request(const MqMsgBridge & req)
     return;
   }
 
-  auto & info = managed_bridges_[topic_name];
-  bool is_r2a = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST);
-  (is_r2a ? info.req_r2a : info.req_a2r) = req;
+  auto it = managed_bridges_.find(topic_name);
+  if (it == managed_bridges_.end()) {
+    auto & info = managed_bridges_[topic_name];
+
+    if (
+      std::strcmp(static_cast<const char *>(req.factory.symbol_name), MAIN_EXECUTABLE_SYMBOL) ==
+      0) {
+      info.shared_lib_path = std::nullopt;
+    } else {
+      info.shared_lib_path = std::string(static_cast<const char *>(req.factory.shared_lib_path));
+    }
+
+    if (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) {
+      info.fn_offset_r2a = req.factory.fn_offset;
+      info.fn_offset_a2r = req.factory.fn_offset_reverse;
+      info.target_id_r2a = req.target.target_id;
+      info.target_id_a2r = -1;
+      info.is_requested_r2a = true;
+      info.is_requested_a2r = false;
+    } else {
+      info.fn_offset_r2a = req.factory.fn_offset_reverse;
+      info.fn_offset_a2r = req.factory.fn_offset;
+      info.target_id_r2a = -1;
+      info.target_id_a2r = req.target.target_id;
+      info.is_requested_r2a = false;
+      info.is_requested_a2r = true;
+    }
+  } else {
+    auto & info = it->second;
+
+    if (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) {
+      info.target_id_r2a = req.target.target_id;
+      info.is_requested_r2a = true;
+    } else {
+      info.target_id_a2r = req.target.target_id;
+      info.is_requested_a2r = true;
+    }
+  }
 }
 
 StandardBridgeManager::BridgeKernelResult StandardBridgeManager::try_add_bridge_to_kernel(
@@ -173,9 +208,10 @@ void StandardBridgeManager::rollback_bridge_from_kernel(const std::string & topi
   }
 }
 
-bool StandardBridgeManager::activate_bridge(const MqMsgBridge & req, const std::string & topic_name)
+bool StandardBridgeManager::activate_bridge(
+  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction)
 {
-  bool is_r2a = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST);
+  bool is_r2a = (direction == BridgeDirection::ROS2_TO_AGNOCAST);
   std::string_view suffix = is_r2a ? SUFFIX_R2A : SUFFIX_A2R;
   std::string topic_name_with_direction = topic_name + std::string(suffix);
 
@@ -184,10 +220,12 @@ bool StandardBridgeManager::activate_bridge(const MqMsgBridge & req, const std::
   }
 
   try {
-    rclcpp::QoS target_qos = is_r2a ? get_subscriber_qos(topic_name, req.target.target_id)
-                                    : get_publisher_qos(topic_name, req.target.target_id);
+    rclcpp::QoS target_qos = is_r2a ? get_subscriber_qos(topic_name, info.target_id_r2a)
+                                    : get_publisher_qos(topic_name, info.target_id_a2r);
 
-    auto bridge = loader_.create(req, topic_name_with_direction, container_node_, target_qos);
+    auto bridge = loader_.create(
+      topic_name, direction, info.shared_lib_path, info.fn_offset_r2a, info.fn_offset_a2r,
+      container_node_, target_qos);
 
     if (!bridge) {
       RCLCPP_ERROR(logger_, "Failed to create bridge for '%s'", topic_name_with_direction.c_str());
@@ -221,7 +259,9 @@ bool StandardBridgeManager::activate_bridge(const MqMsgBridge & req, const std::
   }
 }
 
-void StandardBridgeManager::send_delegation(const MqMsgBridge & req, pid_t owner_pid)
+void StandardBridgeManager::send_delegation(
+  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction,
+  pid_t owner_pid)
 {
   std::string mq_name = create_mq_name_for_bridge(owner_pid);
 
@@ -232,6 +272,18 @@ void StandardBridgeManager::send_delegation(const MqMsgBridge & req, pid_t owner
       strerror(errno));
     return;
   }
+
+  /* --- Construct message --- */
+  MqMsgBridge req{};
+  req.direction = direction;
+  req.target.target_id =
+    (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? info.target_id_r2a : info.target_id_a2r;
+  snprintf(
+    static_cast<char *>(req.target.topic_name), TOPIC_NAME_BUFFER_SIZE, "%s", topic_name.c_str());
+  // req.factory can be left uninitialized because it is not going to be used.
+
+  // NOTE(bdm-k): What if the owner has removed the target entry in `managed_bridges_`?
+  /* ------------------------- */
 
   if (mq_send(mq, reinterpret_cast<const char *>(&req), sizeof(req), 0) < 0) {
     RCLCPP_WARN(
@@ -245,13 +297,16 @@ void StandardBridgeManager::send_delegation(const MqMsgBridge & req, pid_t owner
 }
 
 void StandardBridgeManager::process_managed_bridge(
-  const std::string & topic_name, const std::optional<MqMsgBridge> & req)
+  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction)
 {
-  if (!req) {
+  bool is_r2a = (direction == BridgeDirection::ROS2_TO_AGNOCAST);
+
+  if (is_r2a && !info.is_requested_r2a) {
     return;
   }
-
-  bool is_r2a = (req->direction == BridgeDirection::ROS2_TO_AGNOCAST);
+  if (!is_r2a && !info.is_requested_a2r) {
+    return;
+  }
 
   // Check demand before adding bridge to kernel to avoid unnecessary add+remove cycles
   if (
@@ -271,7 +326,7 @@ void StandardBridgeManager::process_managed_bridge(
 
   switch (status) {
     case AddBridgeResult::SUCCESS:
-      if (!activate_bridge(*req, topic_name)) {
+      if (!activate_bridge(topic_name, info, direction)) {
         // Rollback: remove bridge from kernel if activation failed
         rollback_bridge_from_kernel(topic_name, is_r2a);
       }
@@ -279,7 +334,7 @@ void StandardBridgeManager::process_managed_bridge(
 
     case AddBridgeResult::EXIST:
       if (!is_active_in_owner) {
-        send_delegation(*req, owner_pid);
+        send_delegation(topic_name, info, direction, owner_pid);
       }
       break;
 
@@ -389,20 +444,20 @@ void StandardBridgeManager::check_managed_bridges()
 
     // Clean up requests when Agnocast entity no longer exists (count == 0)
     // Note: count < 0 indicates an error, so we keep the request in that case
-    if (info.req_r2a && get_agnocast_subscriber_count(topic_name).count == 0) {
-      info.req_r2a.reset();
+    if (info.is_requested_r2a && get_agnocast_subscriber_count(topic_name).count == 0) {
+      info.reset_r2a();
     }
-    if (info.req_a2r && get_agnocast_publisher_count(topic_name).count == 0) {
-      info.req_a2r.reset();
+    if (info.is_requested_a2r && get_agnocast_publisher_count(topic_name).count == 0) {
+      info.reset_a2r();
     }
 
-    if (!info.req_r2a && !info.req_a2r) {
+    if (!info.is_requested_r2a && !info.is_requested_a2r) {
       it = managed_bridges_.erase(it);
       continue;
     }
 
-    process_managed_bridge(topic_name, info.req_r2a);
-    process_managed_bridge(topic_name, info.req_a2r);
+    process_managed_bridge(topic_name, info, BridgeDirection::ROS2_TO_AGNOCAST);
+    process_managed_bridge(topic_name, info, BridgeDirection::AGNOCAST_TO_ROS2);
     ++it;
   }
 }

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -16,8 +16,7 @@ namespace agnocast
 StandardBridgeManager::StandardBridgeManager(pid_t target_pid)
 : target_pid_(target_pid),
   logger_(rclcpp::get_logger("agnocast_standard_bridge_manager")),
-  event_loop_(logger_),
-  loader_(logger_)
+  event_loop_(logger_)
 {
   if (rclcpp::ok()) {
     rclcpp::shutdown();
@@ -82,6 +81,7 @@ void StandardBridgeManager::start_ros_execution()
 {
   std::string node_name = "agnocast_bridge_node_" + std::to_string(getpid());
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
+  loader_ = std::make_unique<StandardBridgeLoader>(container_node_, logger_);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges
   // require two callback groups to execute concurrently. If a single-threaded executor is used, it
@@ -135,40 +135,41 @@ void StandardBridgeManager::register_request(const MqMsgBridge & req)
 
   auto it = managed_bridges_.find(topic_name);
   if (it == managed_bridges_.end()) {
-    auto & info = managed_bridges_[topic_name];
+    auto & entry = managed_bridges_[topic_name];
 
     if (
       std::strcmp(static_cast<const char *>(req.factory.symbol_name), MAIN_EXECUTABLE_SYMBOL) ==
       0) {
-      info.shared_lib_path = std::nullopt;
+      entry.factory_spec.shared_lib_path = std::nullopt;
     } else {
-      info.shared_lib_path = std::string(static_cast<const char *>(req.factory.shared_lib_path));
+      entry.factory_spec.shared_lib_path =
+        std::string(static_cast<const char *>(req.factory.shared_lib_path));
     }
 
     if (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) {
-      info.fn_offset_r2a = req.factory.fn_offset;
-      info.fn_offset_a2r = req.factory.fn_offset_reverse;
-      info.target_id_r2a = req.target.target_id;
-      info.target_id_a2r = -1;
-      info.is_requested_r2a = true;
-      info.is_requested_a2r = false;
+      entry.factory_spec.fn_offset_r2a = req.factory.fn_offset;
+      entry.factory_spec.fn_offset_a2r = req.factory.fn_offset_reverse;
+      entry.target_id_r2a = req.target.target_id;
+      entry.target_id_a2r = -1;
+      entry.is_requested_r2a = true;
+      entry.is_requested_a2r = false;
     } else {
-      info.fn_offset_r2a = req.factory.fn_offset_reverse;
-      info.fn_offset_a2r = req.factory.fn_offset;
-      info.target_id_r2a = -1;
-      info.target_id_a2r = req.target.target_id;
-      info.is_requested_r2a = false;
-      info.is_requested_a2r = true;
+      entry.factory_spec.fn_offset_r2a = req.factory.fn_offset_reverse;
+      entry.factory_spec.fn_offset_a2r = req.factory.fn_offset;
+      entry.target_id_r2a = -1;
+      entry.target_id_a2r = req.target.target_id;
+      entry.is_requested_r2a = false;
+      entry.is_requested_a2r = true;
     }
   } else {
-    auto & info = it->second;
+    auto & entry = it->second;
 
     if (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) {
-      info.target_id_r2a = req.target.target_id;
-      info.is_requested_r2a = true;
+      entry.target_id_r2a = req.target.target_id;
+      entry.is_requested_r2a = true;
     } else {
-      info.target_id_a2r = req.target.target_id;
-      info.is_requested_a2r = true;
+      entry.target_id_a2r = req.target.target_id;
+      entry.is_requested_a2r = true;
     }
   }
 }
@@ -208,9 +209,10 @@ void StandardBridgeManager::rollback_bridge_from_kernel(const std::string & topi
   }
 }
 
-bool StandardBridgeManager::activate_bridge(
-  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction)
+bool StandardBridgeManager::activate_bridge(const DirectedBridgeRef bridge_ref)
 {
+  const auto & [topic_name, entry, direction] = bridge_ref;
+
   bool is_r2a = (direction == BridgeDirection::ROS2_TO_AGNOCAST);
   std::string_view suffix = is_r2a ? SUFFIX_R2A : SUFFIX_A2R;
   std::string topic_name_with_direction = topic_name + std::string(suffix);
@@ -220,12 +222,10 @@ bool StandardBridgeManager::activate_bridge(
   }
 
   try {
-    rclcpp::QoS target_qos = is_r2a ? get_subscriber_qos(topic_name, info.target_id_r2a)
-                                    : get_publisher_qos(topic_name, info.target_id_a2r);
+    rclcpp::QoS target_qos = is_r2a ? get_subscriber_qos(topic_name, entry.target_id_r2a)
+                                    : get_publisher_qos(topic_name, entry.target_id_a2r);
 
-    auto bridge = loader_.create(
-      topic_name, direction, info.shared_lib_path, info.fn_offset_r2a, info.fn_offset_a2r,
-      container_node_, target_qos);
+    auto bridge = loader_->create(topic_name, direction, entry.factory_spec, target_qos);
 
     if (!bridge) {
       RCLCPP_ERROR(logger_, "Failed to create bridge for '%s'", topic_name_with_direction.c_str());
@@ -259,10 +259,10 @@ bool StandardBridgeManager::activate_bridge(
   }
 }
 
-void StandardBridgeManager::send_delegation(
-  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction,
-  pid_t owner_pid)
+void StandardBridgeManager::send_delegation(const DirectedBridgeRef bridge_ref, pid_t owner_pid)
 {
+  const auto & [topic_name, entry, direction] = bridge_ref;
+
   std::string mq_name = create_mq_name_for_bridge(owner_pid);
 
   mqd_t mq = mq_open(mq_name.c_str(), O_WRONLY | O_NONBLOCK);
@@ -277,7 +277,7 @@ void StandardBridgeManager::send_delegation(
   MqMsgBridge req{};
   req.direction = direction;
   req.target.target_id =
-    (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? info.target_id_r2a : info.target_id_a2r;
+    (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? entry.target_id_r2a : entry.target_id_a2r;
   snprintf(
     static_cast<char *>(req.target.topic_name), TOPIC_NAME_BUFFER_SIZE, "%s", topic_name.c_str());
   // req.factory can be left uninitialized because it is not going to be used.
@@ -296,15 +296,16 @@ void StandardBridgeManager::send_delegation(
   mq_close(mq);
 }
 
-void StandardBridgeManager::process_managed_bridge(
-  const std::string & topic_name, const BridgeInfo & info, BridgeDirection direction)
+void StandardBridgeManager::process_managed_bridge(const DirectedBridgeRef bridge_ref)
 {
+  const auto & [topic_name, entry, direction] = bridge_ref;
+
   bool is_r2a = (direction == BridgeDirection::ROS2_TO_AGNOCAST);
 
-  if (is_r2a && !info.is_requested_r2a) {
+  if (is_r2a && !entry.is_requested_r2a) {
     return;
   }
-  if (!is_r2a && !info.is_requested_a2r) {
+  if (!is_r2a && !entry.is_requested_a2r) {
     return;
   }
 
@@ -326,7 +327,7 @@ void StandardBridgeManager::process_managed_bridge(
 
   switch (status) {
     case AddBridgeResult::SUCCESS:
-      if (!activate_bridge(topic_name, info, direction)) {
+      if (!activate_bridge(bridge_ref)) {
         // Rollback: remove bridge from kernel if activation failed
         rollback_bridge_from_kernel(topic_name, is_r2a);
       }
@@ -334,7 +335,7 @@ void StandardBridgeManager::process_managed_bridge(
 
     case AddBridgeResult::EXIST:
       if (!is_active_in_owner) {
-        send_delegation(topic_name, info, direction, owner_pid);
+        send_delegation(bridge_ref, owner_pid);
       }
       break;
 
@@ -440,24 +441,24 @@ void StandardBridgeManager::check_managed_bridges()
     }
 
     const auto & topic_name = it->first;
-    auto & info = it->second;
+    auto & entry = it->second;
 
     // Clean up requests when Agnocast entity no longer exists (count == 0)
     // Note: count < 0 indicates an error, so we keep the request in that case
-    if (info.is_requested_r2a && get_agnocast_subscriber_count(topic_name).count == 0) {
-      info.reset_r2a();
+    if (entry.is_requested_r2a && get_agnocast_subscriber_count(topic_name).count == 0) {
+      entry.reset_r2a();
     }
-    if (info.is_requested_a2r && get_agnocast_publisher_count(topic_name).count == 0) {
-      info.reset_a2r();
+    if (entry.is_requested_a2r && get_agnocast_publisher_count(topic_name).count == 0) {
+      entry.reset_a2r();
     }
 
-    if (!info.is_requested_r2a && !info.is_requested_a2r) {
+    if (!entry.is_requested_r2a && !entry.is_requested_a2r) {
       it = managed_bridges_.erase(it);
       continue;
     }
 
-    process_managed_bridge(topic_name, info, BridgeDirection::ROS2_TO_AGNOCAST);
-    process_managed_bridge(topic_name, info, BridgeDirection::AGNOCAST_TO_ROS2);
+    process_managed_bridge(DirectedBridgeRef{topic_name, entry, BridgeDirection::ROS2_TO_AGNOCAST});
+    process_managed_bridge(DirectedBridgeRef{topic_name, entry, BridgeDirection::AGNOCAST_TO_ROS2});
     ++it;
   }
 }


### PR DESCRIPTION
Closes #1209 

## Description

The previous `BridgeInfo` struct stored two full `MqMsgBridge` instances, holding many redundant fields that are identical for both directions.

This PR replaces `BridgeInfo` with a compact struct `ManagedBridgeEntry`:
```cpp
struct ManagedBridgeEntry
{
  BridgeFactorySpec factory_spec;
  // Use -1 when not requested. Valid topic_local_id_t values are [0..MAX_TOPIC_LOCAL_ID).
  topic_local_id_t target_id_r2a;
  topic_local_id_t target_id_a2r;
  bool is_requested_r2a;
  bool is_requested_a2r;
};

struct BridgeFactorySpec
{
  // If set to std::nullopt, the factory functions reside in the main executable.
  std::optional<std::string> shared_lib_path;
  uintptr_t fn_offset_r2a;
  uintptr_t fn_offset_a2r;
};
```
`BridgeFactorySpec` takes advantage of the fact that the `symbol_name` field in `BridgeFactoryInfo` is only used to identify whether the factories are in the main executable. We set `shared_lib_path` to `nullopt` when the factories are in the main executable.

Received `MqMsgBridge` is now decomposed into `ManagedBridgeEntry` at reception time in `register_request()`, rather than being stored as is. The parameters of the related functions are updated accordingly.

This PR also adds handling of a previously ignored corner case (indeed, this can barely happen): a request is delegated to a bridge manager that has already removed the topic from its `managed_bridges_`. This is a timing issue.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

