### PR TITLE
fix(cie_thread_configurator): address misc code quality issues

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_deadline.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/sched_deadline.hpp
@@ -26,7 +26,7 @@ struct sched_attr
 };
 #endif
 
-int sched_setattr(pid_t pid, const struct sched_attr * attr, unsigned int flags)
+inline int sched_setattr(pid_t pid, const struct sched_attr * attr, unsigned int flags)
 {
   return syscall(__NR_sched_setattr, pid, attr, flags);
 }

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -18,12 +18,12 @@ class ThreadConfiguratorNode : public rclcpp::Node
     int64_t thread_id = -1;
     std::vector<int> affinity;
     std::string policy;
-    int priority;
+    int priority = 0;
 
     // For SCHED_DEADLINE
-    unsigned int runtime;
-    unsigned int period;
-    unsigned int deadline;
+    unsigned int runtime = 0;
+    unsigned int period = 0;
+    unsigned int deadline = 0;
 
     bool applied = false;
   };

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -14,7 +14,7 @@ class ThreadConfiguratorNode : public rclcpp::Node
   struct ThreadConfig
   {
     std::string thread_str;  // callback_group_id or thread_name
-    size_t domain_id;
+    size_t domain_id = 0;
     int64_t thread_id = -1;
     std::vector<int> affinity;
     std::string policy;

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options), unapplied_num_(0), cgroup_num_(0)
@@ -64,6 +65,10 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     return s;
   };
 
+  static const std::unordered_set<std::string> valid_policies = {
+    "SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE", "SCHED_FIFO", "SCHED_RR", "SCHED_DEADLINE",
+  };
+
   std::set<size_t> domain_ids;
   for (size_t i = 0; i < callback_groups.size(); i++) {
     const auto & callback_group = callback_groups[i];
@@ -83,6 +88,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
       config.affinity.push_back(cpu.as<int>());
     }
     config.policy = callback_group["policy"].as<std::string>();
+
+    if (valid_policies.find(config.policy) == valid_policies.end()) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str);
+    }
 
     if (config.policy == "SCHED_DEADLINE") {
       config.runtime = callback_group["runtime"].as<unsigned int>();
@@ -107,6 +117,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
       config.affinity.push_back(cpu.as<int>());
     }
     config.policy = non_ros_thread["policy"].as<std::string>();
+
+    if (valid_policies.find(config.policy) == valid_policies.end()) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str);
+    }
 
     if (config.policy == "SCHED_DEADLINE") {
       config.runtime = non_ros_thread["runtime"].as<unsigned int>();
@@ -316,8 +331,11 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
 
   std::string cpus_path = cgroup_path + "/cpuset.cpus";
   if (std::ofstream cpus_file{cpus_path}) {
-    for (int cpu : cpus) {
-      cpus_file << cpu << ",";
+    for (size_t i = 0; i < cpus.size(); i++) {
+      if (i > 0) {
+        cpus_file << ",";
+      }
+      cpus_file << cpus[i];
     }
   } else {
     return false;
@@ -408,6 +426,11 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
         config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Unknown scheduling policy '%s' (id=%s, tid=%ld)", config.policy.c_str(),
+      config.thread_str.c_str(), config.thread_id);
+    return false;
   }
 
   if (config.affinity.size() > 0) {

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -20,7 +20,7 @@
 
 namespace
 {
-const std::unordered_map<std::string, int> kPolicyToSchedConst = {
+const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
 };
@@ -92,7 +92,7 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = callback_group["policy"].as<std::string>();
 
-    if (kPolicyToSchedConst.count(config.policy) == 0) {
+    if (policy_to_sched_const.count(config.policy) == 0) {
       throw std::runtime_error(
         "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str +
         ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
@@ -123,7 +123,7 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = non_ros_thread["policy"].as<std::string>();
 
-    if (kPolicyToSchedConst.count(config.policy) == 0) {
+    if (policy_to_sched_const.count(config.policy) == 0) {
       throw std::runtime_error(
         "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str +
         ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
@@ -373,7 +373,8 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = 0;
 
-    if (sched_setscheduler(config.thread_id, kPolicyToSchedConst.at(config.policy), &param) == -1) {
+    if (
+      sched_setscheduler(config.thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));
@@ -392,7 +393,8 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = config.priority;
 
-    if (sched_setscheduler(config.thread_id, kPolicyToSchedConst.at(config.policy), &param) == -1) {
+    if (
+      sched_setscheduler(config.thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -17,7 +17,14 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
+
+namespace
+{
+const std::unordered_map<std::string, int> kPolicyToSchedConst = {
+  {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
+  {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
+};
+}  // namespace
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options), unapplied_num_(0), cgroup_num_(0)
@@ -65,10 +72,6 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     return s;
   };
 
-  static const std::unordered_set<std::string> valid_policies = {
-    "SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE", "SCHED_FIFO", "SCHED_RR", "SCHED_DEADLINE",
-  };
-
   std::set<size_t> domain_ids;
   for (size_t i = 0; i < callback_groups.size(); i++) {
     const auto & callback_group = callback_groups[i];
@@ -89,9 +92,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = callback_group["policy"].as<std::string>();
 
-    if (valid_policies.count(config.policy) == 0) {
+    if (kPolicyToSchedConst.count(config.policy) == 0) {
       throw std::runtime_error(
-        "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str);
+        "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
     }
 
     if (config.policy == "SCHED_DEADLINE") {
@@ -118,9 +123,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = non_ros_thread["policy"].as<std::string>();
 
-    if (valid_policies.count(config.policy) == 0) {
+    if (kPolicyToSchedConst.count(config.policy) == 0) {
       throw std::runtime_error(
-        "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str);
+        "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
     }
 
     if (config.policy == "SCHED_DEADLINE") {
@@ -366,15 +373,9 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = 0;
 
-    static std::unordered_map<std::string, int> m = {
-      {"SCHED_OTHER", SCHED_OTHER},
-      {"SCHED_BATCH", SCHED_BATCH},
-      {"SCHED_IDLE", SCHED_IDLE},
-    };
-
-    if (sched_setscheduler(config.thread_id, m[config.policy], &param) == -1) {
+    if (sched_setscheduler(config.thread_id, kPolicyToSchedConst.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (id=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
@@ -382,7 +383,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     // Specify nice value
     if (setpriority(PRIO_PROCESS, config.thread_id, config.priority) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure nice value (id=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure nice value (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
@@ -391,14 +392,9 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = config.priority;
 
-    static std::unordered_map<std::string, int> m = {
-      {"SCHED_FIFO", SCHED_FIFO},
-      {"SCHED_RR", SCHED_RR},
-    };
-
-    if (sched_setscheduler(config.thread_id, m[config.policy], &param) == -1) {
+    if (sched_setscheduler(config.thread_id, kPolicyToSchedConst.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (id=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
@@ -422,14 +418,14 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
 
     if (sched_setattr(config.thread_id, &attr, 0) == -1) {
       RCLCPP_ERROR(
-        this->get_logger(), "Failed to configure policy (id=%s, tid=%ld): %s",
+        this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), config.thread_id, strerror(errno));
       return false;
     }
   } else {
     RCLCPP_ERROR(
-      this->get_logger(), "Unknown scheduling policy '%s' (id=%s, tid=%ld)", config.policy.c_str(),
-      config.thread_str.c_str(), config.thread_id);
+      this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%ld)",
+      config.policy.c_str(), config.thread_str.c_str(), config.thread_id);
     return false;
   }
 
@@ -437,7 +433,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     if (config.policy == "SCHED_DEADLINE") {
       if (!set_affinity_by_cgroup(config.thread_id, config.affinity)) {
         RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure affinity (id=%s, tid=%ld): %s",
+          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
           config.thread_str.c_str(), config.thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
@@ -451,7 +447,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
       }
       if (sched_setaffinity(config.thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
-          this->get_logger(), "Failed to configure affinity (id=%s, tid=%ld): %s",
+          this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
           config.thread_str.c_str(), config.thread_id, strerror(errno));
         return false;
       }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -89,7 +89,7 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = callback_group["policy"].as<std::string>();
 
-    if (valid_policies.find(config.policy) == valid_policies.end()) {
+    if (valid_policies.count(config.policy) == 0) {
       throw std::runtime_error(
         "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str);
     }
@@ -118,7 +118,7 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
     }
     config.policy = non_ros_thread["policy"].as<std::string>();
 
-    if (valid_policies.find(config.policy) == valid_policies.end()) {
+    if (valid_policies.count(config.policy) == 0) {
       throw std::runtime_error(
         "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str);
     }


### PR DESCRIPTION
## Description

Port code quality fixes from upstream [callback_isolated_executor#51](https://github.com/autowarefoundation/callback_isolated_executor/pull/51), plus additional cleanups:

- **Add `inline` to `sched_setattr()` in header:** Prevents ODR violation if `sched_deadline.hpp` is included from multiple translation units.
- **Zero-initialize `ThreadConfig` members:** `domain_id`, `priority`, `runtime`, `period`, and `deadline` now have default initializers to avoid uninitialized reads.
- **Reject unknown scheduling policies at YAML load time:** The policy string is validated when loading the config so that typos (e.g. `SCHED_OTEHR`) cause an immediate `std::runtime_error` at startup.
- **Add `else` error path in `issue_syscalls()`:** An unrecognized policy that somehow reaches `issue_syscalls()` now returns `false` and logs an error instead of silently succeeding with only CPU affinity applied.
- **Unify policy map:** Replace three separate per-branch `static std::unordered_map` instances with a single file-scope `policy_to_sched_const` map in an anonymous namespace, using `.at()` for safe lookup.
- **Rename map to snake_case:** `kPolicyToSchedConst` → `policy_to_sched_const` to follow the project's naming convention.
- **Fix trailing comma in cpuset.cpus:** `set_affinity_by_cgroup()` now writes `"0,1,2"` instead of `"0,1,2,"` for canonical cpuset format.
- **Improve error log labels:** Replace `id=` with `thread=` in error messages for clarity.

## Related links

- Upstream PR: https://github.com/autowarefoundation/callback_isolated_executor/pull/51

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.