### PR TITLE
fix(cie): fix cancel_executor race condition

### DIFF
--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -21,7 +21,7 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
   struct ExecutorWrapper
   {
     explicit ExecutorWrapper(std::shared_ptr<rclcpp::Executor> executor)
-    : executor_(std::move(executor)), thread_initialized_(false)
+    : executor_(std::move(executor))
     {
     }
 
@@ -37,7 +37,6 @@ class ComponentManagerCallbackIsolated : public rclcpp_components::ComponentMana
 
     std::shared_ptr<rclcpp::Executor> executor_;
     std::thread thread_;
-    std::atomic_bool thread_initialized_;
   };
 
 public:
@@ -182,7 +181,6 @@ void ComponentManagerCallbackIsolated::start_executor_for_callback_group(
         agnocast::publish_callback_group_info(this->client_publisher_, tid, group_id);
       }
 
-      executor_wrapper.thread_initialized_ = true;
       executor_wrapper.executor_->spin();
     });
 }
@@ -256,12 +254,18 @@ void ComponentManagerCallbackIsolated::remove_node_from_executor(uint64_t node_i
 
 void ComponentManagerCallbackIsolated::cancel_executor(ExecutorWrapper & executor_wrapper)
 {
-  if (!executor_wrapper.thread_initialized_) {
-    auto context = this->get_node_base_interface()->get_context();
+  if (!executor_wrapper.thread_.joinable()) {
+    return;
+  }
 
-    while (!executor_wrapper.executor_->is_spinning() && rclcpp::ok(context)) {
-      rclcpp::sleep_for(std::chrono::milliseconds(1));
-    }
+  // Always wait for is_spinning() before cancel(). Do not use a separate
+  // "thread_initialized" flag as a fast-path: such a flag is set before spin()
+  // sets spinning=true, creating a window where cancel() has no effect and the
+  // subsequent spin() runs indefinitely, blocking join() forever.
+  auto context = this->get_node_base_interface()->get_context();
+
+  while (!executor_wrapper.executor_->is_spinning() && rclcpp::ok(context)) {
+    rclcpp::sleep_for(std::chrono::milliseconds(1));
   }
 
   executor_wrapper.executor_->cancel();

--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -55,10 +55,10 @@ public:
 
     monitor_callback_group_ =
       this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-    monitor_timer_ =
-      this->create_wall_timer(  // NOLINT(cppcoreguidelines-prefer-member-initializer)
-        std::chrono::milliseconds(monitor_polling_interval_ms_),
-        [this]() { check_for_new_callback_groups(); }, monitor_callback_group_);
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+    monitor_timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(monitor_polling_interval_ms_),
+      [this]() { check_for_new_callback_groups(); }, monitor_callback_group_);
   }
 
   ~ComponentManagerCallbackIsolated() override;

--- a/src/agnocast_components/src/agnocast_component_container_cie.cpp
+++ b/src/agnocast_components/src/agnocast_component_container_cie.cpp
@@ -55,9 +55,10 @@ public:
 
     monitor_callback_group_ =
       this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-    monitor_timer_ = this->create_wall_timer(
-      std::chrono::milliseconds(monitor_polling_interval_ms_),
-      [this]() { check_for_new_callback_groups(); }, monitor_callback_group_);
+    monitor_timer_ =
+      this->create_wall_timer(  // NOLINT(cppcoreguidelines-prefer-member-initializer)
+        std::chrono::milliseconds(monitor_polling_interval_ms_),
+        [this]() { check_for_new_callback_groups(); }, monitor_callback_group_);
   }
 
   ~ComponentManagerCallbackIsolated() override;
@@ -215,10 +216,11 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
 {
   std::lock_guard<std::mutex> lock{executor_wrappers_mutex_};
   for (auto & [node_id, node_wrapper] : node_wrappers_) {
+    const auto nid = node_id;
     auto node = node_wrapper.get_node_base_interface();
 
     node->for_each_callback_group(
-      [node_id, &node, this](const rclcpp::CallbackGroup::SharedPtr & callback_group) {
+      [nid, &node, this](const rclcpp::CallbackGroup::SharedPtr & callback_group) {
         if (!callback_group->automatically_add_to_executor_with_node()) {
           return;
         }
@@ -232,7 +234,7 @@ void ComponentManagerCallbackIsolated::check_for_new_callback_groups()
           return;
         }
 
-        start_executor_for_callback_group(node_id, callback_group, node);
+        start_executor_for_callback_group(nid, callback_group, node);
       });
   }
 }


### PR DESCRIPTION
## Description

Port race condition fix from upstream [callback_isolated_executor#52](https://github.com/autowarefoundation/callback_isolated_executor/pull/52).

The `thread_initialized_` flag was set to `true` before `spin()` internally sets `spinning=true`. If `cancel_executor` observed `thread_initialized_==true` and skipped the `is_spinning()` wait, it could call `cancel()` (which sets `spinning=false`) before `spin()` set `spinning=true`. The subsequent `spin()` would override the cancellation and run indefinitely, blocking `thread.join()` forever.

The fix:
- Remove the `thread_initialized_` fast-path and always wait for `is_spinning()` before calling `cancel()`.
- Remove the `thread_initialized_` field from `ExecutorWrapper` entirely.
- Add a `joinable()` guard to avoid undefined behavior if the thread was never started.

## Related links

- Upstream PR: https://github.com/autowarefoundation/callback_isolated_executor/pull/52

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.