### PR TITLE
refactor(agnocastlib): use member initializer list for Node construction

### DIFF
--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -650,13 +650,13 @@ private:
   // ParsedArguments must be stored to keep rcl_arguments_t alive
   ParsedArguments local_args_;
 
-  rclcpp::Logger logger_{rclcpp::get_logger("agnocast_node")};
   node_interfaces::NodeBase::SharedPtr node_base_;
+  rclcpp::Logger logger_;
+  node_interfaces::NodeServices::SharedPtr node_services_;
   node_interfaces::NodeParameters::SharedPtr node_parameters_;
   node_interfaces::NodeTopics::SharedPtr node_topics_;
   node_interfaces::NodeClock::SharedPtr node_clock_;
   node_interfaces::NodeTimeSource::SharedPtr node_time_source_;
-  node_interfaces::NodeServices::SharedPtr node_services_;
   node_interfaces::NodeLogging::SharedPtr node_logging_;
 };
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -652,9 +652,9 @@ private:
 
   node_interfaces::NodeBase::SharedPtr node_base_;
   rclcpp::Logger logger_;
+  node_interfaces::NodeTopics::SharedPtr node_topics_;
   node_interfaces::NodeServices::SharedPtr node_services_;
   node_interfaces::NodeParameters::SharedPtr node_parameters_;
-  node_interfaces::NodeTopics::SharedPtr node_topics_;
   node_interfaces::NodeClock::SharedPtr node_clock_;
   node_interfaces::NodeTimeSource::SharedPtr node_time_source_;
   node_interfaces::NodeLogging::SharedPtr node_logging_;

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -22,11 +22,11 @@ Node::Node(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
     options.use_intra_process_comms(), options.enable_topic_statistics())),
   logger_(rclcpp::get_logger(node_base_->get_name())),
+  node_topics_(std::make_shared<node_interfaces::NodeTopics>(node_base_)),
   node_services_(std::make_shared<node_interfaces::NodeServices>(node_base_)),
   node_parameters_(std::make_shared<node_interfaces::NodeParameters>(
     this, node_base_, options.parameter_overrides(), options.start_parameter_services(),
     local_args_.get())),
-  node_topics_(std::make_shared<node_interfaces::NodeTopics>(node_base_)),
   node_clock_(std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME)),
   node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(node_clock_, this)),
   node_logging_(std::make_shared<node_interfaces::NodeLogging>(logger_))

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -17,31 +17,23 @@ Node::Node(const std::string & node_name, const rclcpp::NodeOptions & options)
 Node::Node(
   const std::string & node_name, const std::string & namespace_,
   const rclcpp::NodeOptions & options)
-: local_args_(parse_arguments(options.arguments()))
-{
-  node_base_ = std::make_shared<node_interfaces::NodeBase>(
+: local_args_(parse_arguments(options.arguments())),
+  node_base_(std::make_shared<node_interfaces::NodeBase>(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
-    options.use_intra_process_comms(), options.enable_topic_statistics());
-
+    options.use_intra_process_comms(), options.enable_topic_statistics())),
+  logger_(rclcpp::get_logger(node_base_->get_name())),
+  node_services_(std::make_shared<node_interfaces::NodeServices>(node_base_)),
+  node_parameters_(std::make_shared<node_interfaces::NodeParameters>(
+    this, node_base_, options.parameter_overrides(), options.start_parameter_services(),
+    local_args_.get())),
+  node_topics_(std::make_shared<node_interfaces::NodeTopics>(node_base_)),
+  node_clock_(std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME)),
+  node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(node_clock_, this)),
+  node_logging_(std::make_shared<node_interfaces::NodeLogging>(logger_))
+{
   TRACEPOINT(
     agnocast_node_init, static_cast<const void *>(node_base_.get()), this->get_name().c_str(),
     this->get_namespace().c_str());
-
-  logger_ = rclcpp::get_logger(node_base_->get_name());
-
-  node_logging_ = std::make_shared<node_interfaces::NodeLogging>(logger_);
-
-  node_topics_ = std::make_shared<node_interfaces::NodeTopics>(node_base_);
-
-  node_services_ = std::make_shared<node_interfaces::NodeServices>(node_base_);
-
-  node_parameters_ = std::make_shared<node_interfaces::NodeParameters>(
-    this, node_base_, options.parameter_overrides(), options.start_parameter_services(),
-    local_args_.get());
-
-  node_clock_ = std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME);
-
-  node_time_source_ = std::make_shared<node_interfaces::NodeTimeSource>(node_clock_, this);
 }
 
 }  // namespace agnocast


### PR DESCRIPTION
## Description

This PR moves `agnocast::Node` member initialization from the constructor body to the member initializer list, and reorders member declarations to match the required initialization sequence. Basically, it tries to use the member declaration order as a single source of truth for the initialization order.

## Related links

- https://github.com/autowarefoundation/agnocast/pull/1256#issuecomment-4293462079

## How was this PR tested?

- [ ] Autoware (required)
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application
  - `no_rclcpp_server` and `no_rclcpp_client`

## Notes for reviewers
