### PR TITLE
feat: introduce tf2 for `agnocast::Node`

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(agnocast SHARED
   src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp
   src/bridge/standard/agnocast_standard_bridge_ipc_event_loop.cpp src/bridge/standard/agnocast_standard_bridge_loader.cpp src/bridge/standard/agnocast_standard_bridge_manager.cpp src/bridge/agnocast_bridge_utils.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
-  src/node/tf2/transform_broadcaster.cpp src/node/tf2/static_transform_broadcaster.cpp)
+  src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp)
 
 ament_target_dependencies(agnocast rclcpp agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs)
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -172,6 +172,17 @@ if(BUILD_TESTING)
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )
 
+  # tf2 transform listener unit tests (own subscription-side mocks for kmod / mqueue bypass)
+  ament_add_gmock(test_unit_tf2_transform_listener_${PROJECT_NAME}
+    test/unit/tf2/test_transform_listener.cpp)
+  target_include_directories(test_unit_tf2_transform_listener_${PROJECT_NAME} PRIVATE include src)
+  target_link_libraries(test_unit_tf2_transform_listener_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_unit_tf2_transform_listener_${PROJECT_NAME}
+    geometry_msgs rclcpp tf2 tf2_msgs tf2_ros)
+  set_tests_properties(test_unit_tf2_transform_listener_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
+  )
+
   # Message filters unit tests (with ioctl mock)
   ament_add_gmock(test_unit_message_filters_${PROJECT_NAME}
     test/unit/message_filters/test_simple.cpp

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -160,6 +160,17 @@ if(BUILD_TESTING)
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )
 
+  # tf2 buffer unit tests (no kmod / no publish path needed)
+  ament_add_gmock(test_unit_tf2_buffer_${PROJECT_NAME}
+    test/unit/tf2/test_buffer.cpp)
+  target_include_directories(test_unit_tf2_buffer_${PROJECT_NAME} PRIVATE include)
+  target_link_libraries(test_unit_tf2_buffer_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_unit_tf2_buffer_${PROJECT_NAME}
+    geometry_msgs rclcpp tf2 tf2_ros)
+  set_tests_properties(test_unit_tf2_buffer_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
+  )
+
   # Message filters unit tests (with ioctl mock)
   ament_add_gmock(test_unit_message_filters_${PROJECT_NAME}
     test/unit/message_filters/test_simple.cpp

--- a/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
+++ b/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
@@ -69,7 +69,8 @@ public:
   /// \param cache_time How long to keep a history of transforms
   /// \param node If passed, the buffer will use this node's logger instead of the default
   template <typename NodeT = std::shared_ptr<agnocast::Node>>
-  // cppcheck-suppress noExplicitConstructor  // matches tf2_ros::Buffer signature (upstream alignment)
+  // cppcheck-suppress noExplicitConstructor  // matches tf2_ros::Buffer signature (upstream
+  // alignment)
   Buffer(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),

--- a/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
+++ b/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Adapted from tf2_ros::Buffer for Agnocast zero-copy transport.
+
+#ifndef AGNOCAST__NODE__TF2__BUFFER_HPP_
+#define AGNOCAST__NODE__TF2__BUFFER_HPP_
+
+#include "agnocast/node/agnocast_node.hpp"
+#include "rcl/time.h"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/node_interfaces/get_node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/node_logging_interface.hpp"
+#include "rclcpp/time.hpp"
+#include "tf2/buffer_core.h"
+#include "tf2/time.h"
+#include "tf2_ros/buffer_interface.h"
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace agnocast
+{
+
+/// \warning This is NOT a drop-in replacement for tf2_ros::Buffer. The following
+/// tf2_ros::Buffer features are intentionally omitted:
+///   - AsyncBufferInterface (waitForTransform, cancel, setCreateTimerInterface)
+///   - The "tf2_frames" debug service (getFrames)
+class Buffer : public tf2::BufferCore, public tf2_ros::BufferInterface
+{
+public:
+  using tf2::BufferCore::canTransform;
+  using tf2::BufferCore::lookupTransform;
+  using SharedPtr = std::shared_ptr<Buffer>;
+
+  /// \brief Constructor for a Buffer object
+  /// \param clock A clock to use for time and sleeping
+  /// \param cache_time How long to keep a history of transforms
+  /// \param node If passed, the buffer will use this node's logger instead of the default
+  template <typename NodeT = std::shared_ptr<agnocast::Node>>
+  Buffer(
+    rclcpp::Clock::SharedPtr clock,
+    tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),
+    NodeT && node = NodeT())
+  : BufferCore(cache_time), clock_(clock)
+  {
+    if (nullptr == clock_) {
+      throw std::invalid_argument("clock must be a valid instance");
+    }
+
+    auto post_jump_cb = [this](const rcl_time_jump_t & jump_info) { onTimeJump(jump_info); };
+
+    rcl_jump_threshold_t jump_threshold;
+    // Disable forward jump callbacks
+    jump_threshold.min_forward.nanoseconds = 0;
+    // Anything backwards is a jump
+    jump_threshold.min_backward.nanoseconds = -1;
+    // Callback if the clock changes too
+    jump_threshold.on_clock_change = true;
+
+    jump_handler_ = clock_->create_jump_callback(nullptr, post_jump_cb, jump_threshold);
+
+    if (node) {
+      node_logging_interface_ = rclcpp::node_interfaces::get_node_logging_interface(node);
+    }
+  }
+
+  /// \brief Get the transform between two frames by frame ID.
+  /// \param target_frame The frame to which data should be transformed
+  /// \param source_frame The frame where the data originated
+  /// \param time The time at which the value of the transform is desired. (0 will get the latest)
+  /// \param timeout How long to block before failing
+  /// \return The transform between the frames
+  ///
+  /// Possible exceptions tf2::LookupException, tf2::ConnectivityException,
+  /// tf2::ExtrapolationException, tf2::InvalidArgumentException
+  geometry_msgs::msg::TransformStamped lookupTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration timeout) const override;
+
+  /// \brief Get the transform between two frames by frame ID.
+  /// \sa lookupTransform(const std::string&, const std::string&, const tf2::TimePoint&,
+  ///                     const tf2::Duration)
+  geometry_msgs::msg::TransformStamped lookupTransform(
+    const std::string & target_frame, const std::string & source_frame, const rclcpp::Time & time,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0)) const
+  {
+    return lookupTransform(
+      target_frame, source_frame, tf2_ros::fromRclcpp(time), tf2_ros::fromRclcpp(timeout));
+  }
+
+  /// \brief Get the transform between two frames by frame ID assuming fixed frame.
+  /// \param target_frame The frame to which data should be transformed
+  /// \param target_time The time to which the data should be transformed. (0 will get the latest)
+  /// \param source_frame The frame where the data originated
+  /// \param source_time The time at which the source_frame should be evaluated. (0 will get the
+  /// latest)
+  /// \param fixed_frame The frame in which to assume the transform is constant in time.
+  /// \param timeout How long to block before failing
+  /// \return The transform between the frames
+  ///
+  /// Possible exceptions tf2::LookupException, tf2::ConnectivityException,
+  /// tf2::ExtrapolationException, tf2::InvalidArgumentException
+  geometry_msgs::msg::TransformStamped lookupTransform(
+    const std::string & target_frame, const tf2::TimePoint & target_time,
+    const std::string & source_frame, const tf2::TimePoint & source_time,
+    const std::string & fixed_frame, const tf2::Duration timeout) const override;
+
+  /// \brief Get the transform between two frames by frame ID assuming fixed frame.
+  /// \sa lookupTransform(const std::string&, const tf2::TimePoint&,
+  ///                     const std::string&, const tf2::TimePoint&,
+  ///                     const std::string&, const tf2::Duration)
+  geometry_msgs::msg::TransformStamped lookupTransform(
+    const std::string & target_frame, const rclcpp::Time & target_time,
+    const std::string & source_frame, const rclcpp::Time & source_time,
+    const std::string & fixed_frame,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0)) const
+  {
+    return lookupTransform(
+      target_frame, tf2_ros::fromRclcpp(target_time), source_frame,
+      tf2_ros::fromRclcpp(source_time), fixed_frame, tf2_ros::fromRclcpp(timeout));
+  }
+
+  /// \brief Test if a transform is possible
+  /// \param target_frame The frame into which to transform
+  /// \param source_frame The frame from which to transform
+  /// \param target_time The time at which to transform
+  /// \param timeout How long to block before failing
+  /// \param errstr A pointer to a string which will be filled with why the transform failed, if not
+  /// NULL
+  /// \return True if the transform is possible, false otherwise
+  bool canTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration timeout, std::string * errstr = NULL) const override;
+
+  /// \brief Test if a transform is possible
+  /// \sa canTransform(const std::string&, const std::string&,
+  ///                  const tf2::TimePoint&, const tf2::Duration, std::string*)
+  bool canTransform(
+    const std::string & target_frame, const std::string & source_frame, const rclcpp::Time & time,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0),
+    std::string * errstr = NULL) const
+  {
+    return canTransform(
+      target_frame, source_frame, tf2_ros::fromRclcpp(time), tf2_ros::fromRclcpp(timeout), errstr);
+  }
+
+  /// \brief Test if a transform is possible
+  /// \param target_frame The frame into which to transform
+  /// \param target_time The time into which to transform
+  /// \param source_frame The frame from which to transform
+  /// \param source_time The time from which to transform
+  /// \param fixed_frame The frame in which to treat the transform as constant in time
+  /// \param timeout How long to block before failing
+  /// \param errstr A pointer to a string which will be filled with why the transform failed, if not
+  /// NULL
+  /// \return True if the transform is possible, false otherwise
+  bool canTransform(
+    const std::string & target_frame, const tf2::TimePoint & target_time,
+    const std::string & source_frame, const tf2::TimePoint & source_time,
+    const std::string & fixed_frame, const tf2::Duration timeout,
+    std::string * errstr = NULL) const override;
+
+  /// \brief Test if a transform is possible
+  /// \sa canTransform(const std::string&, const tf2::TimePoint&,
+  ///                  const std::string&, const tf2::TimePoint&,
+  ///                  const std::string&, const tf2::Duration, std::string*)
+  bool canTransform(
+    const std::string & target_frame, const rclcpp::Time & target_time,
+    const std::string & source_frame, const rclcpp::Time & source_time,
+    const std::string & fixed_frame,
+    const rclcpp::Duration timeout = rclcpp::Duration::from_nanoseconds(0),
+    std::string * errstr = NULL) const
+  {
+    return canTransform(
+      target_frame, tf2_ros::fromRclcpp(target_time), source_frame,
+      tf2_ros::fromRclcpp(source_time), fixed_frame, tf2_ros::fromRclcpp(timeout), errstr);
+  }
+
+  /// \brief Get the clock used by this buffer
+  rclcpp::Clock::SharedPtr getClock() const { return clock_; }
+
+private:
+  void onTimeJump(const rcl_time_jump_t & jump);
+
+  // conditionally error if dedicated_thread unset.
+  bool checkAndErrorDedicatedThreadPresent(std::string * errstr) const;
+
+  /// Get the logger to use for calls to RCLCPP log macros.
+  rclcpp::Logger getLogger() const;
+
+  /// \brief A clock to use for time and sleeping
+  rclcpp::Clock::SharedPtr clock_;
+
+  /// \brief A node logging interface to access the buffer node's logger
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_;
+
+  /// \brief Reference to a jump handler registered to the clock
+  rclcpp::JumpHandler::SharedPtr jump_handler_;
+};
+
+static const char threading_error[] =
+  "Do not call canTransform or lookupTransform with a timeout "
+  "unless you are using another thread for populating data. Without a dedicated thread it will "
+  "always timeout.  If you have a separate thread servicing tf messages, call "
+  "setUsingDedicatedThread(true) on your Buffer instance.";
+
+}  // namespace agnocast
+
+#endif  // AGNOCAST__NODE__TF2__BUFFER_HPP_

--- a/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
+++ b/src/agnocastlib/include/agnocast/node/tf2/buffer.hpp
@@ -69,6 +69,7 @@ public:
   /// \param cache_time How long to keep a history of transforms
   /// \param node If passed, the buffer will use this node's logger instead of the default
   template <typename NodeT = std::shared_ptr<agnocast::Node>>
+  // cppcheck-suppress noExplicitConstructor  // matches tf2_ros::Buffer signature (upstream alignment)
   Buffer(
     rclcpp::Clock::SharedPtr clock,
     tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME),

--- a/src/agnocastlib/include/agnocast/node/tf2/transform_listener.hpp
+++ b/src/agnocastlib/include/agnocast/node/tf2/transform_listener.hpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Adapted from tf2_ros::TransformListener for Agnocast zero-copy transport.
+
+#ifndef AGNOCAST__NODE__TF2__TRANSFORM_LISTENER_HPP_
+#define AGNOCAST__NODE__TF2__TRANSFORM_LISTENER_HPP_
+
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_only_single_threaded_executor.hpp"
+#include "rclcpp/callback_group.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_logging_interface.hpp"
+#include "rclcpp/qos_overriding_options.hpp"
+#include "tf2/buffer_core.hpp"
+#include "tf2_ros/qos.hpp"
+
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace agnocast
+{
+
+namespace detail
+{
+/// \brief Default subscription options for the dynamic /tf listener subscription.
+inline agnocast::SubscriptionOptions get_default_transform_listener_sub_options()
+{
+  agnocast::SubscriptionOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth, rclcpp::QosPolicyKind::Durability, rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
+
+/// \brief Default subscription options for the /tf_static listener subscription.
+inline agnocast::SubscriptionOptions get_default_transform_listener_static_sub_options()
+{
+  agnocast::SubscriptionOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions{
+    rclcpp::QosPolicyKind::Depth, rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability};
+  return options;
+}
+}  // namespace detail
+
+/// \brief Listens for transforms via Agnocast zero-copy IPC.
+///
+/// This class subscribes to /tf and /tf_static topics using Agnocast's
+/// zero-copy shared memory transport, and populates a tf2::BufferCore
+/// with the received transforms.
+class TransformListener
+{
+public:
+  /// \brief Simplified constructor for transform listener.
+  ///
+  /// This constructor will create a new agnocast::Node under the hood.
+  /// If you already have access to an agnocast::Node and you want to associate the
+  /// TransformListener to it, then it's recommended to use the other constructor.
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true);
+
+  /// \brief Node constructor
+  TransformListener(
+    tf2::BufferCore & buffer, agnocast::Node & node, bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS(),
+    const agnocast::SubscriptionOptions & options =
+      detail::get_default_transform_listener_sub_options(),
+    const agnocast::SubscriptionOptions & static_options =
+      detail::get_default_transform_listener_static_sub_options());
+
+  virtual ~TransformListener();
+
+  /// \brief Callback for /tf and /tf_static messages.
+  virtual void subscription_callback(
+    agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> && msg, bool is_static);
+
+private:
+  void init(
+    agnocast::Node & node, bool spin_thread, const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos, const agnocast::SubscriptionOptions & options,
+    const agnocast::SubscriptionOptions & static_options);
+
+  bool spin_thread_{false};
+  std::unique_ptr<std::thread> dedicated_listener_thread_{nullptr};
+  std::shared_ptr<agnocast::AgnocastOnlySingleThreadedExecutor> executor_{nullptr};
+
+  std::shared_ptr<agnocast::Node> optional_default_node_{nullptr};
+  agnocast::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_{nullptr};
+  agnocast::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr message_subscription_tf_static_{
+    nullptr};
+  tf2::BufferCore & buffer_;
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface_{nullptr};
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface_{nullptr};
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+};
+
+}  // namespace agnocast
+
+#endif  // AGNOCAST__NODE__TF2__TRANSFORM_LISTENER_HPP_

--- a/src/agnocastlib/src/node/tf2/buffer.cpp
+++ b/src/agnocastlib/src/node/tf2/buffer.cpp
@@ -79,7 +79,7 @@ void conditionally_append_timeout_info(
   std::string * errstr, const rclcpp::Time & start_time, const rclcpp::Time & current_time,
   const rclcpp::Duration & timeout)
 {
-  if (errstr) {
+  if (errstr != nullptr) {
     std::stringstream ss;
     ss << ". canTransform returned after "
        << tf2::durationToSec(tf2_ros::fromRclcpp(current_time - start_time)) << " timeout was "
@@ -88,6 +88,8 @@ void conditionally_append_timeout_info(
   }
 }
 
+// Mirrors upstream tf2_ros::Buffer, which calls itself with zero timeout in the poll loop.
+// NOLINTNEXTLINE(misc-no-recursion)
 bool Buffer::canTransform(
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const tf2::Duration timeout, std::string * errstr) const
@@ -109,10 +111,10 @@ bool Buffer::canTransform(
   rclcpp::Time start_time = clock_->now();
   while (
     clock_->now() < start_time + rclcpp_timeout &&
-    !canTransform(
-      target_frame, source_frame, time, tf2::Duration(std::chrono::nanoseconds::zero()), errstr) &&
+    !canTransform(target_frame, source_frame, time, std::chrono::nanoseconds::zero(), errstr) &&
     (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
     agnocast::ok()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   bool retval = canTransform(target_frame, source_frame, time, errstr);
@@ -121,6 +123,8 @@ bool Buffer::canTransform(
   return retval;
 }
 
+// Mirrors upstream tf2_ros::Buffer, which calls itself with zero timeout in the poll loop.
+// NOLINTNEXTLINE(misc-no-recursion)
 bool Buffer::canTransform(
   const std::string & target_frame, const tf2::TimePoint & target_time,
   const std::string & source_frame, const tf2::TimePoint & source_time,
@@ -144,9 +148,10 @@ bool Buffer::canTransform(
   while (clock_->now() < start_time + rclcpp_timeout &&
          !canTransform(
            target_frame, target_time, source_frame, source_time, fixed_frame,
-           tf2::Duration(std::chrono::nanoseconds::zero()), errstr) &&
+           std::chrono::nanoseconds::zero(), errstr) &&
          (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
          agnocast::ok()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   bool retval =
@@ -156,17 +161,17 @@ bool Buffer::canTransform(
   return retval;
 }
 
-bool Buffer::checkAndErrorDedicatedThreadPresent(std::string * error_str) const
+bool Buffer::checkAndErrorDedicatedThreadPresent(std::string * errstr) const
 {
   if (isUsingDedicatedThread()) {
     return true;
   }
 
-  if (error_str) {
-    *error_str = threading_error;
+  if (errstr != nullptr) {
+    *errstr = static_cast<const char *>(threading_error);
   }
 
-  RCLCPP_ERROR(getLogger(), "%s", threading_error);
+  RCLCPP_ERROR(getLogger(), "%s", static_cast<const char *>(threading_error));
   return false;
 }
 

--- a/src/agnocastlib/src/node/tf2/buffer.cpp
+++ b/src/agnocastlib/src/node/tf2/buffer.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Adapted from tf2_ros::Buffer for Agnocast zero-copy transport.
+
+#include "agnocast/node/tf2/buffer.hpp"
+
+#include "agnocast/node/agnocast_context.hpp"
+#include "rclcpp/version.h"
+
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace agnocast
+{
+
+geometry_msgs::msg::TransformStamped Buffer::lookupTransform(
+  const std::string & target_frame, const std::string & source_frame,
+  const tf2::TimePoint & lookup_time, const tf2::Duration timeout) const
+{
+  // Pass error string to suppress console spam
+  std::string error;
+  canTransform(target_frame, source_frame, lookup_time, timeout, &error);
+  return BufferCore::lookupTransform(target_frame, source_frame, lookup_time);
+}
+
+void Buffer::onTimeJump(const rcl_time_jump_t & jump)
+{
+  if (
+    RCL_ROS_TIME_ACTIVATED == jump.clock_change || RCL_ROS_TIME_DEACTIVATED == jump.clock_change) {
+    RCLCPP_WARN(getLogger(), "Detected time source change. Clearing TF buffer.");
+    clear();
+  } else if (jump.delta.nanoseconds < 0) {
+    RCLCPP_WARN(getLogger(), "Detected jump back in time. Clearing TF buffer.");
+    clear();
+  }
+}
+
+geometry_msgs::msg::TransformStamped Buffer::lookupTransform(
+  const std::string & target_frame, const tf2::TimePoint & target_time,
+  const std::string & source_frame, const tf2::TimePoint & source_time,
+  const std::string & fixed_frame, const tf2::Duration timeout) const
+{
+  // Pass error string to suppress console spam
+  std::string error;
+  canTransform(target_frame, target_time, source_frame, source_time, fixed_frame, timeout, &error);
+  return BufferCore::lookupTransform(
+    target_frame, target_time, source_frame, source_time, fixed_frame);
+}
+
+void conditionally_append_timeout_info(
+  std::string * errstr, const rclcpp::Time & start_time, const rclcpp::Time & current_time,
+  const rclcpp::Duration & timeout)
+{
+  if (errstr) {
+    std::stringstream ss;
+    ss << ". canTransform returned after "
+       << tf2::durationToSec(tf2_ros::fromRclcpp(current_time - start_time)) << " timeout was "
+       << tf2::durationToSec(tf2_ros::fromRclcpp(timeout)) << ".";
+    (*errstr) += ss.str();
+  }
+}
+
+bool Buffer::canTransform(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const tf2::Duration timeout, std::string * errstr) const
+{
+  // Humble (rclcpp 16.x) gates this unconditionally; Jazzy (rclcpp 28+) only when timeout > 0.
+#if RCLCPP_VERSION_MAJOR >= 28
+  if (timeout != tf2::durationFromSec(0.0) && !checkAndErrorDedicatedThreadPresent(errstr)) {
+    return false;
+  }
+#else
+  if (!checkAndErrorDedicatedThreadPresent(errstr)) {
+    return false;
+  }
+#endif
+
+  rclcpp::Duration rclcpp_timeout(tf2_ros::toRclcpp(timeout));
+
+  // poll for transform if timeout is set
+  rclcpp::Time start_time = clock_->now();
+  while (
+    clock_->now() < start_time + rclcpp_timeout &&
+    !canTransform(
+      target_frame, source_frame, time, tf2::Duration(std::chrono::nanoseconds::zero()), errstr) &&
+    (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
+    agnocast::ok()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  bool retval = canTransform(target_frame, source_frame, time, errstr);
+  rclcpp::Time current_time = clock_->now();
+  conditionally_append_timeout_info(errstr, start_time, current_time, rclcpp_timeout);
+  return retval;
+}
+
+bool Buffer::canTransform(
+  const std::string & target_frame, const tf2::TimePoint & target_time,
+  const std::string & source_frame, const tf2::TimePoint & source_time,
+  const std::string & fixed_frame, const tf2::Duration timeout, std::string * errstr) const
+{
+  // Humble (rclcpp 16.x) gates this unconditionally; Jazzy (rclcpp 28+) only when timeout > 0.
+#if RCLCPP_VERSION_MAJOR >= 28
+  if (timeout != tf2::durationFromSec(0.0) && !checkAndErrorDedicatedThreadPresent(errstr)) {
+    return false;
+  }
+#else
+  if (!checkAndErrorDedicatedThreadPresent(errstr)) {
+    return false;
+  }
+#endif
+
+  rclcpp::Duration rclcpp_timeout(tf2_ros::toRclcpp(timeout));
+
+  // poll for transform if timeout is set
+  rclcpp::Time start_time = clock_->now();
+  while (clock_->now() < start_time + rclcpp_timeout &&
+         !canTransform(
+           target_frame, target_time, source_frame, source_time, fixed_frame,
+           tf2::Duration(std::chrono::nanoseconds::zero()), errstr) &&
+         (clock_->now() + rclcpp::Duration(3, 0) >= start_time) &&  // don't wait bag loop detected
+         agnocast::ok()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  bool retval =
+    canTransform(target_frame, target_time, source_frame, source_time, fixed_frame, errstr);
+  rclcpp::Time current_time = clock_->now();
+  conditionally_append_timeout_info(errstr, start_time, current_time, rclcpp_timeout);
+  return retval;
+}
+
+bool Buffer::checkAndErrorDedicatedThreadPresent(std::string * error_str) const
+{
+  if (isUsingDedicatedThread()) {
+    return true;
+  }
+
+  if (error_str) {
+    *error_str = threading_error;
+  }
+
+  RCLCPP_ERROR(getLogger(), "%s", threading_error);
+  return false;
+}
+
+rclcpp::Logger Buffer::getLogger() const
+{
+  return node_logging_interface_ ? node_logging_interface_->get_logger()
+                                 : rclcpp::get_logger("tf2_buffer");
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/tf2/transform_listener.cpp
+++ b/src/agnocastlib/src/node/tf2/transform_listener.cpp
@@ -84,12 +84,12 @@ void TransformListener::init(
   node_base_interface_ = node.get_node_base_interface();
 
   using callback_t = std::function<void(agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> &&)>;
-  // NOLINTNEXTLINE(modernize-avoid-bind)
+  // NOLINTBEGIN(modernize-avoid-bind)
   callback_t cb =
     std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, false);
-  // NOLINTNEXTLINE(modernize-avoid-bind)
   callback_t static_cb =
     std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, true);
+  // NOLINTEND(modernize-avoid-bind)
 
   if (spin_thread_) {
     // Create new callback group for message_subscription of tf and tf_static
@@ -140,7 +140,6 @@ void TransformListener::subscription_callback(
   const tf2_msgs::msg::TFMessage & msg_in = *msg;
   std::string authority = "Authority undetectable";
   // NOLINTNEXTLINE(modernize-loop-convert, readability-uppercase-literal-suffix)
-  // NOLINTNEXTLINE(hicpp-uppercase-literal-suffix)
   for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
     try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);

--- a/src/agnocastlib/src/node/tf2/transform_listener.cpp
+++ b/src/agnocastlib/src/node/tf2/transform_listener.cpp
@@ -116,9 +116,13 @@ void TransformListener::init(
 
 TransformListener::~TransformListener()
 {
-  if (spin_thread_) {
+  // Diverges from upstream tf2_ros::TransformListener: defensive null checks guard
+  // against future changes that could leave these members null while spin_thread_ is true.
+  if (spin_thread_ && executor_) {
     executor_->cancel();
-    dedicated_listener_thread_->join();
+    if (dedicated_listener_thread_) {
+      dedicated_listener_thread_->join();
+    }
   }
 }
 

--- a/src/agnocastlib/src/node/tf2/transform_listener.cpp
+++ b/src/agnocastlib/src/node/tf2/transform_listener.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Adapted from tf2_ros::TransformListener for Agnocast zero-copy transport.
+
+#include "agnocast/node/tf2/transform_listener.hpp"
+
+#include "rclcpp/logging.hpp"
+
+#include <cstdio>
+#include <string>
+
+namespace agnocast
+{
+
+TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread) : buffer_(buffer)
+{
+  rclcpp::NodeOptions options;
+  // create a unique name for the node
+  // but specify its name in .arguments to override any __node passed on the command line.
+  // avoiding sstream because it's behavior can be overridden by external libraries.
+  // See this issue: https://github.com/ros2/geometry2/issues/540
+  char node_name[42];
+  snprintf(
+    node_name, sizeof(node_name), "transform_listener_impl_%zx", reinterpret_cast<size_t>(this));
+  options.arguments({"--ros-args", "-r", "__node:=" + std::string(node_name)});
+  options.start_parameter_event_publisher(false);
+  options.start_parameter_services(false);
+  optional_default_node_ = std::make_shared<agnocast::Node>("_", options);
+  init(
+    *optional_default_node_, spin_thread, tf2_ros::DynamicListenerQoS(),
+    tf2_ros::StaticListenerQoS(), detail::get_default_transform_listener_sub_options(),
+    detail::get_default_transform_listener_static_sub_options());
+}
+
+TransformListener::TransformListener(
+  tf2::BufferCore & buffer, agnocast::Node & node, bool spin_thread, const rclcpp::QoS & qos,
+  const rclcpp::QoS & static_qos, const agnocast::SubscriptionOptions & options,
+  const agnocast::SubscriptionOptions & static_options)
+: buffer_(buffer)
+{
+  init(node, spin_thread, qos, static_qos, options, static_options);
+}
+
+void TransformListener::init(
+  agnocast::Node & node, bool spin_thread, const rclcpp::QoS & qos, const rclcpp::QoS & static_qos,
+  const agnocast::SubscriptionOptions & options,
+  const agnocast::SubscriptionOptions & static_options)
+{
+  spin_thread_ = spin_thread;
+  node_logging_interface_ = node.get_node_logging_interface();
+  node_base_interface_ = node.get_node_base_interface();
+
+  using callback_t = std::function<void(agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> &&)>;
+  callback_t cb =
+    std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, false);
+  callback_t static_cb =
+    std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, true);
+
+  if (spin_thread_) {
+    // Create new callback group for message_subscription of tf and tf_static
+    callback_group_ =
+      node.create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+    // Duplicate to modify option of subscription
+    agnocast::SubscriptionOptions tf_options = options;
+    agnocast::SubscriptionOptions tf_static_options = static_options;
+    tf_options.callback_group = callback_group_;
+    tf_static_options.callback_group = callback_group_;
+
+    message_subscription_tf_ =
+      node.create_subscription<tf2_msgs::msg::TFMessage>("/tf", qos, std::move(cb), tf_options);
+    message_subscription_tf_static_ = node.create_subscription<tf2_msgs::msg::TFMessage>(
+      "/tf_static", static_qos, std::move(static_cb), tf_static_options);
+
+    // Create executor with dedicated thread to spin.
+    executor_ = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+    executor_->add_callback_group(callback_group_, node_base_interface_);
+    dedicated_listener_thread_ =
+      std::make_unique<std::thread>([executor = executor_]() { executor->spin(); });
+    // Tell the buffer we have a dedicated thread to enable timeouts
+    buffer_.setUsingDedicatedThread(true);
+  } else {
+    message_subscription_tf_ =
+      node.create_subscription<tf2_msgs::msg::TFMessage>("/tf", qos, std::move(cb), options);
+    message_subscription_tf_static_ = node.create_subscription<tf2_msgs::msg::TFMessage>(
+      "/tf_static", static_qos, std::move(static_cb), static_options);
+  }
+}
+
+TransformListener::~TransformListener()
+{
+  if (spin_thread_) {
+    executor_->cancel();
+    dedicated_listener_thread_->join();
+  }
+}
+
+void TransformListener::subscription_callback(
+  agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> && msg, bool is_static)
+{
+  const tf2_msgs::msg::TFMessage & msg_in = *msg;
+  std::string authority = "Authority undetectable";
+  for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
+    try {
+      buffer_.setTransform(msg_in.transforms[i], authority, is_static);
+    } catch (const tf2::TransformException & ex) {
+      std::string temp = ex.what();
+      RCLCPP_ERROR(
+        node_logging_interface_->get_logger(),
+        "Failure to set received transform from %s to %s with error: %s\n",
+        msg_in.transforms[i].child_frame_id.c_str(), msg_in.transforms[i].header.frame_id.c_str(),
+        temp.c_str());
+    }
+  }
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/tf2/transform_listener.cpp
+++ b/src/agnocastlib/src/node/tf2/transform_listener.cpp
@@ -139,7 +139,8 @@ void TransformListener::subscription_callback(
 {
   const tf2_msgs::msg::TFMessage & msg_in = *msg;
   std::string authority = "Authority undetectable";
-  // NOLINTNEXTLINE(modernize-loop-convert, readability-uppercase-literal-suffix)
+  // NOLINTBEGIN(modernize-loop-convert, readability-uppercase-literal-suffix)
+  // NOLINTBEGIN(hicpp-uppercase-literal-suffix)
   for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
     try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);
@@ -152,6 +153,8 @@ void TransformListener::subscription_callback(
         temp.c_str());
     }
   }
+  // NOLINTEND(hicpp-uppercase-literal-suffix)
+  // NOLINTEND(modernize-loop-convert, readability-uppercase-literal-suffix)
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/node/tf2/transform_listener.cpp
+++ b/src/agnocastlib/src/node/tf2/transform_listener.cpp
@@ -46,10 +46,16 @@ TransformListener::TransformListener(tf2::BufferCore & buffer, bool spin_thread)
   // but specify its name in .arguments to override any __node passed on the command line.
   // avoiding sstream because it's behavior can be overridden by external libraries.
   // See this issue: https://github.com/ros2/geometry2/issues/540
+  // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays, modernize-avoid-c-arrays)
+  // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, cert-err33-c)
+  // NOLINTBEGIN(cppcoreguidelines-pro-bounds-array-to-pointer-decay, hicpp-no-array-decay)
   char node_name[42];
   snprintf(
     node_name, sizeof(node_name), "transform_listener_impl_%zx", reinterpret_cast<size_t>(this));
   options.arguments({"--ros-args", "-r", "__node:=" + std::string(node_name)});
+  // NOLINTEND(cppcoreguidelines-pro-bounds-array-to-pointer-decay, hicpp-no-array-decay)
+  // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers, cert-err33-c)
+  // NOLINTEND(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays, modernize-avoid-c-arrays)
   options.start_parameter_event_publisher(false);
   options.start_parameter_services(false);
   optional_default_node_ = std::make_shared<agnocast::Node>("_", options);
@@ -78,8 +84,10 @@ void TransformListener::init(
   node_base_interface_ = node.get_node_base_interface();
 
   using callback_t = std::function<void(agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> &&)>;
+  // NOLINTNEXTLINE(modernize-avoid-bind)
   callback_t cb =
     std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, false);
+  // NOLINTNEXTLINE(modernize-avoid-bind)
   callback_t static_cb =
     std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1, true);
 
@@ -131,6 +139,8 @@ void TransformListener::subscription_callback(
 {
   const tf2_msgs::msg::TFMessage & msg_in = *msg;
   std::string authority = "Authority undetectable";
+  // NOLINTNEXTLINE(modernize-loop-convert, readability-uppercase-literal-suffix)
+  // NOLINTNEXTLINE(hicpp-uppercase-literal-suffix)
   for (size_t i = 0u; i < msg_in.transforms.size(); i++) {
     try {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);

--- a/src/agnocastlib/test/unit/tf2/test_buffer.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_buffer.cpp
@@ -1,5 +1,5 @@
-#include "agnocast/node/agnocast_node.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_node.hpp"
 #include "agnocast/node/tf2/buffer.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
@@ -128,8 +128,7 @@ TEST_F(BufferTest, lookup_unknown_frame_throws_lookup_exception)
 
   // Act / Assert
   EXPECT_THROW(
-    { buffer.lookupTransform("map", "missing", kStamp, tf2::Duration(0)); },
-    tf2::LookupException);
+    { buffer.lookupTransform("map", "missing", kStamp, tf2::Duration(0)); }, tf2::LookupException);
 }
 
 TEST_F(BufferTest, fixed_frame_lookup_composes_two_transforms)
@@ -140,8 +139,7 @@ TEST_F(BufferTest, fixed_frame_lookup_composes_two_transforms)
   buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
 
   // Act
-  auto out =
-    buffer.lookupTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
+  auto out = buffer.lookupTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
 
   // Assert: x translations compose linearly along the chain (1.0 + 2.0).
   EXPECT_DOUBLE_EQ(out.transform.translation.x, 3.0);
@@ -182,8 +180,7 @@ TEST_F(BufferTest, canTransform_fixed_frame_returns_true_for_existing_chain)
   buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
 
   // Act
-  bool result =
-    buffer.canTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
+  bool result = buffer.canTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
 
   // Assert
   EXPECT_TRUE(result);
@@ -305,8 +302,8 @@ TEST_F(BufferTest, lookupTransform_5arg_rclcpp_overload_routes_to_tf2_overload)
 
   // Act
   rclcpp::Time t(10, 0, RCL_ROS_TIME);
-  auto out = buffer.lookupTransform(
-    "map", t, "base_link", t, "odom", rclcpp::Duration::from_seconds(0));
+  auto out =
+    buffer.lookupTransform("map", t, "base_link", t, "odom", rclcpp::Duration::from_seconds(0));
 
   // Assert: composed translation reaches the rclcpp overload through fromRclcpp().
   EXPECT_DOUBLE_EQ(out.transform.translation.x, 3.0);

--- a/src/agnocastlib/test/unit/tf2/test_buffer.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_buffer.cpp
@@ -174,8 +174,11 @@ TEST_F(BufferTest, canTransform_unknown_frame_with_null_errstr_does_not_crash)
 
 TEST_F(BufferTest, canTransform_fixed_frame_returns_true_for_existing_chain)
 {
-  // Arrange
+  // Arrange: setUsingDedicatedThread(true) bypasses the threading guard that fires
+  // unconditionally on Humble (rclcpp<28) even for timeout=0. This test is about the
+  // fixed-frame chain lookup, not the guard — that behavior is covered separately.
   agnocast::Buffer buffer(clock_);
+  buffer.setUsingDedicatedThread(true);
   buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
   buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
 
@@ -311,8 +314,10 @@ TEST_F(BufferTest, lookupTransform_5arg_rclcpp_overload_routes_to_tf2_overload)
 
 TEST_F(BufferTest, canTransform_3arg_rclcpp_overload_routes_to_tf2_overload)
 {
-  // Arrange
+  // Arrange: setUsingDedicatedThread(true) bypasses the Humble (rclcpp<28) threading
+  // guard so this test exercises only the rclcpp->tf2 overload-routing path.
   agnocast::Buffer buffer(clock_);
+  buffer.setUsingDedicatedThread(true);
   buffer.setTransform(make_transform("map", "base_link", 1.0, kStamp), "test_authority");
 
   // Act
@@ -325,8 +330,9 @@ TEST_F(BufferTest, canTransform_3arg_rclcpp_overload_routes_to_tf2_overload)
 
 TEST_F(BufferTest, canTransform_5arg_rclcpp_overload_routes_to_tf2_overload)
 {
-  // Arrange
+  // Arrange: see the 3-arg routing test above for why setUsingDedicatedThread is set.
   agnocast::Buffer buffer(clock_);
+  buffer.setUsingDedicatedThread(true);
   buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
   buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
 

--- a/src/agnocastlib/test/unit/tf2/test_buffer.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_buffer.cpp
@@ -1,0 +1,349 @@
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/tf2/buffer.hpp"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/time.hpp"
+#include "tf2/exceptions.h"
+#include "tf2/time.h"
+#include "tf2_ros/buffer_interface.h"
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace
+{
+geometry_msgs::msg::TransformStamped make_transform(
+  const std::string & parent_frame, const std::string & child_frame, double tx,
+  const tf2::TimePoint & stamp)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = parent_frame;
+  t.header.stamp = tf2_ros::toMsg(stamp);
+  t.child_frame_id = child_frame;
+  t.transform.translation.x = tx;
+  t.transform.rotation.w = 1.0;
+  return t;
+}
+
+constexpr tf2::TimePoint kStamp{std::chrono::seconds(10)};
+}  // namespace
+
+class BufferTest : public ::testing::Test
+{
+protected:
+  // agnocast::init() is required so agnocast::ok() returns true; otherwise
+  // the canTransform poll loop short-circuits on the first iteration.
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    clock_ = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  }
+
+  void TearDown() override { agnocast::shutdown(); }
+
+  rclcpp::Clock::SharedPtr clock_;
+};
+
+// =========================================
+// Constructor
+// =========================================
+
+TEST_F(BufferTest, throws_when_clock_is_null)
+{
+  // Arrange / Act / Assert: a null clock must be rejected eagerly.
+  EXPECT_THROW({ agnocast::Buffer buffer(nullptr); }, std::invalid_argument);
+}
+
+TEST_F(BufferTest, getClock_returns_provided_clock)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+
+  // Act
+  auto returned = buffer.getClock();
+
+  // Assert: the buffer must hold the very same clock we passed in.
+  EXPECT_EQ(returned, clock_);
+}
+
+TEST_F(BufferTest, accepts_null_node_argument_without_logger_binding)
+{
+  // Arrange: explicit null node — covers the `if (node)` false branch.
+  std::shared_ptr<agnocast::Node> null_node;
+
+  // Act / Assert: construction must succeed and getLogger() falls back to default.
+  EXPECT_NO_THROW({
+    agnocast::Buffer buffer(clock_, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), null_node);
+  });
+}
+
+TEST_F(BufferTest, binds_node_logger_when_node_passed)
+{
+  // Arrange: spin up an Agnocast node so the logger interface can be extracted.
+  rclcpp::NodeOptions options;
+  options.start_parameter_services(false);
+  auto node = std::make_shared<agnocast::Node>("buffer_logger_test_node", options);
+
+  // Act: pass the node — buffer should bind the node's logger via NodeLoggingInterface.
+  agnocast::Buffer buffer(clock_, tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME), node);
+
+  // Assert: indirectly verify by triggering the threading-error path, which
+  // routes through getLogger(). We only care that no crash occurs and the
+  // err-string mechanism still functions when a node logger is bound.
+  std::string err;
+  EXPECT_FALSE(buffer.canTransform("a", "b", kStamp, tf2::durationFromSec(0.01), &err));
+  EXPECT_FALSE(err.empty());
+}
+
+// =========================================
+// setTransform / lookupTransform — synchronous data path
+// =========================================
+
+TEST_F(BufferTest, setTransform_then_lookup_returns_same_translation)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "base_link", 1.5, kStamp), "test_authority");
+
+  // Act
+  auto out = buffer.lookupTransform("map", "base_link", kStamp, tf2::Duration(0));
+
+  // Assert: the round-tripped transform retains frame ids and translation.
+  EXPECT_EQ(out.header.frame_id, "map");
+  EXPECT_EQ(out.child_frame_id, "base_link");
+  EXPECT_DOUBLE_EQ(out.transform.translation.x, 1.5);
+}
+
+TEST_F(BufferTest, lookup_unknown_frame_throws_lookup_exception)
+{
+  // Arrange: empty buffer — no frames known.
+  agnocast::Buffer buffer(clock_);
+
+  // Act / Assert
+  EXPECT_THROW(
+    { buffer.lookupTransform("map", "missing", kStamp, tf2::Duration(0)); },
+    tf2::LookupException);
+}
+
+TEST_F(BufferTest, fixed_frame_lookup_composes_two_transforms)
+{
+  // Arrange: chain map -> odom -> base_link via fixed frame "odom".
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
+  buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
+
+  // Act
+  auto out =
+    buffer.lookupTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
+
+  // Assert: x translations compose linearly along the chain (1.0 + 2.0).
+  EXPECT_DOUBLE_EQ(out.transform.translation.x, 3.0);
+}
+
+// =========================================
+// canTransform — direct existence check (no timeout)
+// =========================================
+
+TEST_F(BufferTest, canTransform_unknown_frame_returns_false_and_populates_errstr)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  std::string err;
+
+  // Act
+  bool result = buffer.canTransform("map", "missing", kStamp, tf2::Duration(0), &err);
+
+  // Assert: false returned and err carries explanatory text.
+  EXPECT_FALSE(result);
+  EXPECT_FALSE(err.empty());
+}
+
+TEST_F(BufferTest, canTransform_unknown_frame_with_null_errstr_does_not_crash)
+{
+  // Arrange: covers the `errstr == nullptr` branch of conditionally_append_timeout_info.
+  agnocast::Buffer buffer(clock_);
+
+  // Act / Assert: passing nullptr explicitly must not crash.
+  EXPECT_FALSE(buffer.canTransform("map", "missing", kStamp, tf2::Duration(0), nullptr));
+}
+
+TEST_F(BufferTest, canTransform_fixed_frame_returns_true_for_existing_chain)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
+  buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
+
+  // Act
+  bool result =
+    buffer.canTransform("map", kStamp, "base_link", kStamp, "odom", tf2::Duration(0));
+
+  // Assert
+  EXPECT_TRUE(result);
+}
+
+// =========================================
+// canTransform — threading guard (timeout > 0)
+// =========================================
+
+#if RCLCPP_VERSION_MAJOR >= 28
+TEST_F(BufferTest, canTransform_zero_timeout_no_dedicated_thread_is_allowed_on_jazzy)
+{
+  // On Jazzy the threading guard fires only when timeout > 0. With zero timeout
+  // and no dedicated thread, canTransform must still execute and answer false
+  // (because no transform is set).
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  std::string err;
+
+  // Act
+  bool result = buffer.canTransform("a", "b", kStamp, tf2::Duration(0), &err);
+
+  // Assert
+  EXPECT_FALSE(result);
+  EXPECT_EQ(err.find("dedicated thread"), std::string::npos)
+    << "Threading guard must NOT fire for zero-timeout calls on Jazzy.";
+}
+#endif
+
+TEST_F(BufferTest, canTransform_3arg_with_timeout_no_thread_returns_false_with_threading_error)
+{
+  // Arrange: no setUsingDedicatedThread() call.
+  agnocast::Buffer buffer(clock_);
+  std::string err;
+
+  // Act
+  bool result = buffer.canTransform("a", "b", kStamp, tf2::durationFromSec(0.05), &err);
+
+  // Assert: the threading_error sentinel must appear in the err string.
+  EXPECT_FALSE(result);
+  EXPECT_NE(err.find("dedicated thread"), std::string::npos);
+}
+
+TEST_F(BufferTest, canTransform_5arg_with_timeout_no_thread_returns_false_with_threading_error)
+{
+  // Arrange: same as above but exercises the 5-argument fixed-frame overload
+  // — its own threading-guard branch must also fire.
+  agnocast::Buffer buffer(clock_);
+  std::string err;
+
+  // Act
+  bool result =
+    buffer.canTransform("a", kStamp, "b", kStamp, "fixed", tf2::durationFromSec(0.05), &err);
+
+  // Assert
+  EXPECT_FALSE(result);
+  EXPECT_NE(err.find("dedicated thread"), std::string::npos);
+}
+
+TEST_F(BufferTest, canTransform_3arg_with_timeout_polls_then_appends_timeout_info)
+{
+  // Arrange: dedicated thread declared so the poll loop can run.
+  agnocast::Buffer buffer(clock_);
+  buffer.setUsingDedicatedThread(true);
+  std::string err;
+
+  // Act: poll for ~50ms looking for a transform that will never arrive.
+  const auto t0 = std::chrono::steady_clock::now();
+  bool result = buffer.canTransform("a", "b", kStamp, tf2::durationFromSec(0.05), &err);
+  const auto elapsed = std::chrono::steady_clock::now() - t0;
+
+  // Assert: false returned, the loop spent meaningful time, and the timeout
+  // suffix produced by conditionally_append_timeout_info is present.
+  EXPECT_FALSE(result);
+  EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 30);
+  EXPECT_NE(err.find("canTransform returned after"), std::string::npos);
+}
+
+TEST_F(BufferTest, canTransform_5arg_with_timeout_polls_then_appends_timeout_info)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setUsingDedicatedThread(true);
+  std::string err;
+
+  // Act
+  bool result =
+    buffer.canTransform("a", kStamp, "b", kStamp, "fixed", tf2::durationFromSec(0.05), &err);
+
+  // Assert
+  EXPECT_FALSE(result);
+  EXPECT_NE(err.find("canTransform returned after"), std::string::npos);
+}
+
+// =========================================
+// rclcpp::Time / rclcpp::Duration overloads
+// =========================================
+
+TEST_F(BufferTest, lookupTransform_3arg_rclcpp_overload_routes_to_tf2_overload)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "base_link", 4.5, kStamp), "test_authority");
+
+  // Act
+  rclcpp::Time t(10, 0, RCL_ROS_TIME);
+  auto out = buffer.lookupTransform("map", "base_link", t, rclcpp::Duration::from_seconds(0));
+
+  // Assert: same payload reaches the underlying tf2-typed implementation.
+  EXPECT_DOUBLE_EQ(out.transform.translation.x, 4.5);
+}
+
+TEST_F(BufferTest, lookupTransform_5arg_rclcpp_overload_routes_to_tf2_overload)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
+  buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
+
+  // Act
+  rclcpp::Time t(10, 0, RCL_ROS_TIME);
+  auto out = buffer.lookupTransform(
+    "map", t, "base_link", t, "odom", rclcpp::Duration::from_seconds(0));
+
+  // Assert: composed translation reaches the rclcpp overload through fromRclcpp().
+  EXPECT_DOUBLE_EQ(out.transform.translation.x, 3.0);
+}
+
+TEST_F(BufferTest, canTransform_3arg_rclcpp_overload_routes_to_tf2_overload)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "base_link", 1.0, kStamp), "test_authority");
+
+  // Act
+  rclcpp::Time t(10, 0, RCL_ROS_TIME);
+  bool result = buffer.canTransform("map", "base_link", t, rclcpp::Duration::from_seconds(0));
+
+  // Assert
+  EXPECT_TRUE(result);
+}
+
+TEST_F(BufferTest, canTransform_5arg_rclcpp_overload_routes_to_tf2_overload)
+{
+  // Arrange
+  agnocast::Buffer buffer(clock_);
+  buffer.setTransform(make_transform("map", "odom", 1.0, kStamp), "test_authority");
+  buffer.setTransform(make_transform("odom", "base_link", 2.0, kStamp), "test_authority");
+
+  // Act
+  rclcpp::Time t(10, 0, RCL_ROS_TIME);
+  bool result =
+    buffer.canTransform("map", t, "base_link", t, "odom", rclcpp::Duration::from_seconds(0));
+
+  // Assert
+  EXPECT_TRUE(result);
+}
+
+// onTimeJump is registered as a clock jump callback in the constructor.
+// Triggering a real jump requires driving rcl_clock through APIs not exposed
+// publicly on rclcpp::Clock; the handler logic itself (clear() on backward
+// jumps and clock-source changes, no-op on forward jumps) is unchanged from
+// upstream tf2_ros::Buffer and is covered by upstream tf2_ros tests.

--- a/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
@@ -1,0 +1,288 @@
+#include "agnocast/agnocast_callback_info.hpp"
+#include "agnocast/agnocast_smart_pointer.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/bridge/agnocast_bridge_utils.hpp"
+#include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/tf2/transform_listener.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/buffer_core.h"
+#include "tf2/time.h"
+#include "tf2_ros/buffer_interface.h"
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+// =========================================
+// Mock state — captures subscription init so the tests can assert on which topics
+// the listener subscribes to. The mocks bypass kmod / mqueue / heaphook so the test
+// runs as plain user-space code. This file is linked into its own test binary
+// (test_unit_tf2_transform_listener_agnocastlib) so it does not collide with mocks
+// in test_mocked_agnocast.cpp or test_broadcasters.cpp.
+// =========================================
+
+namespace
+{
+int initialize_subscriber_call_count = 0;
+std::vector<std::string> initialized_topic_names;
+std::vector<rclcpp::QoS> initialized_qos_values;
+
+void reset_capture_state()
+{
+  initialize_subscriber_call_count = 0;
+  initialized_topic_names.clear();
+  initialized_qos_values.clear();
+}
+}  // namespace
+
+// Override ioctl globally so the SubscriptionBase destructor's AGNOCAST_REMOVE_SUBSCRIBER_CMD
+// call does not hit the real kernel module.
+extern "C" int ioctl(int, unsigned long, ...)
+{
+  return 0;
+}
+
+namespace agnocast
+{
+// validate_ld_preload normally exits the process when libagnocast_heaphook.so is not in
+// LD_PRELOAD. Stubbed out so the unit test does not require the heaphook to be loaded.
+void validate_ld_preload()
+{
+}
+
+void release_subscriber_reference(const std::string &, const topic_local_id_t, const int64_t)
+{
+}
+
+mqd_t open_mq_for_subscription(
+  const std::string &, const topic_local_id_t, std::pair<mqd_t, std::string> & mq_subscription)
+{
+  // Returning -1 is fine here: the listener never spins (spin_thread=false) so no
+  // epoll_ctl is ever called against this fd in the unit tests.
+  mq_subscription = std::make_pair(static_cast<mqd_t>(-1), std::string{});
+  return -1;
+}
+
+void remove_mq(const std::pair<mqd_t, std::string> &)
+{
+}
+
+union ioctl_add_subscriber_args SubscriptionBase::initialize(
+  const rclcpp::QoS & qos, const bool, const bool, const bool, const std::string &)
+{
+  initialize_subscriber_call_count++;
+  initialized_topic_names.push_back(topic_name_);
+  initialized_qos_values.push_back(qos);
+  union ioctl_add_subscriber_args args
+  {
+  };
+  args.ret_id = 0;
+  return args;
+}
+
+BridgeMode get_bridge_mode()
+{
+  return BridgeMode::Off;
+}
+}  // namespace agnocast
+
+// =========================================
+// Test helpers
+// =========================================
+
+namespace
+{
+geometry_msgs::msg::TransformStamped make_transform(
+  const std::string & parent_frame, const std::string & child_frame, double tx,
+  const tf2::TimePoint & stamp)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = parent_frame;
+  t.header.stamp = tf2_ros::toMsg(stamp);
+  t.child_frame_id = child_frame;
+  t.transform.translation.x = tx;
+  t.transform.rotation.w = 1.0;
+  return t;
+}
+
+// Constructs a subscriber-side ipc_shared_ptr that owns `raw_msg` only for reference
+// counting purposes — the subscriber-side destructor does NOT delete the underlying
+// pointer (it would normally notify the kernel instead, which is mocked out above).
+// The caller is responsible for `delete`-ing raw_msg after the listener has consumed it.
+agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> make_subscriber_ipc_ptr(
+  tf2_msgs::msg::TFMessage * raw_msg, const std::string & topic_name)
+{
+  return agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage>(raw_msg, topic_name, 0, 0);
+}
+
+constexpr tf2::TimePoint kStamp{std::chrono::seconds(10)};
+}  // namespace
+
+// =========================================
+// Test fixture
+// =========================================
+
+class TransformListenerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    reset_capture_state();
+
+    rclcpp::NodeOptions options;
+    options.start_parameter_services(false);
+    options.start_parameter_event_publisher(false);
+    node_ = std::make_shared<agnocast::Node>("tf_listener_test_node", options);
+
+    buffer_ = std::make_shared<tf2::BufferCore>();
+  }
+
+  void TearDown() override { agnocast::shutdown(); }
+
+  agnocast::Node::SharedPtr node_;
+  std::shared_ptr<tf2::BufferCore> buffer_;
+};
+
+// =========================================
+// Constructor (node-based) — subscription wiring
+//
+// NOTE: All constructor tests use spin_thread=false. The spin_thread=true path spawns
+// a dedicated executor thread that calls epoll_ctl against the mocked (-1) mq fd, which
+// would exit() the process. That path is exercised by integration tests instead.
+// =========================================
+
+TEST_F(TransformListenerTest, node_constructor_subscribes_to_tf_and_tf_static)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  EXPECT_EQ(initialize_subscriber_call_count, 2);
+  // The listener's implementation does not promise an ordering between the two
+  // subscriptions, so assert membership rather than position.
+  EXPECT_NE(
+    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf"),
+    initialized_topic_names.end());
+  EXPECT_NE(
+    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf_static"),
+    initialized_topic_names.end());
+}
+
+TEST_F(TransformListenerTest, node_constructor_uses_dynamic_and_static_listener_qos_defaults)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  ASSERT_EQ(initialized_qos_values.size(), 2u);
+
+  // Static frames are TransientLocal; dynamic frames are Volatile. That distinction is
+  // the whole reason late-joining subscribers can still see /tf_static frames.
+  const rclcpp::QoS dynamic_qos = tf2_ros::DynamicListenerQoS();
+  const rclcpp::QoS static_qos = tf2_ros::StaticListenerQoS();
+
+  bool saw_dynamic = false;
+  bool saw_static = false;
+  for (size_t i = 0; i < initialized_topic_names.size(); ++i) {
+    if (initialized_topic_names[i] == "/tf") {
+      EXPECT_EQ(initialized_qos_values[i].durability(), dynamic_qos.durability());
+      saw_dynamic = true;
+    } else if (initialized_topic_names[i] == "/tf_static") {
+      EXPECT_EQ(initialized_qos_values[i].durability(), static_qos.durability());
+      saw_static = true;
+    }
+  }
+  EXPECT_TRUE(saw_dynamic);
+  EXPECT_TRUE(saw_static);
+}
+
+// =========================================
+// Constructor (simplified) — creates internal node
+// =========================================
+
+TEST_F(TransformListenerTest, simplified_constructor_subscribes_to_tf_and_tf_static)
+{
+  agnocast::TransformListener listener(*buffer_, /*spin_thread=*/false);
+
+  EXPECT_EQ(initialize_subscriber_call_count, 2);
+  EXPECT_NE(
+    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf"),
+    initialized_topic_names.end());
+  EXPECT_NE(
+    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf_static"),
+    initialized_topic_names.end());
+}
+
+// =========================================
+// subscription_callback — exercised as the public API black-box
+// =========================================
+
+TEST_F(TransformListenerTest, subscription_callback_inserts_dynamic_transform_into_buffer)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();
+  raw_msg->transforms.push_back(make_transform("map", "base_link", 1.0, kStamp));
+
+  listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false);
+
+  std::string err;
+  EXPECT_TRUE(buffer_->canTransform("map", "base_link", kStamp, &err)) << err;
+
+  delete raw_msg;
+}
+
+TEST_F(TransformListenerTest, subscription_callback_inserts_static_transform_into_buffer)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();
+  raw_msg->transforms.push_back(make_transform("map", "imu", 2.0, kStamp));
+
+  listener.subscription_callback(
+    make_subscriber_ipc_ptr(raw_msg, "/tf_static"), /*is_static=*/true);
+
+  // Static transforms must be queryable at any time, including TimePointZero
+  // (the latest-available query) — this is what `tf_static` consumers rely on.
+  std::string err;
+  EXPECT_TRUE(buffer_->canTransform("map", "imu", tf2::TimePointZero, &err)) << err;
+
+  delete raw_msg;
+}
+
+TEST_F(TransformListenerTest, subscription_callback_handles_empty_message_safely)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();  // empty transforms vector
+
+  EXPECT_NO_THROW(listener.subscription_callback(
+    make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false));
+  EXPECT_FALSE(buffer_->canTransform("map", "base_link", kStamp));
+
+  delete raw_msg;
+}
+
+TEST_F(TransformListenerTest, subscription_callback_inserts_multiple_transforms_in_one_message)
+{
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();
+  raw_msg->transforms.push_back(make_transform("map", "a", 1.0, kStamp));
+  raw_msg->transforms.push_back(make_transform("a", "b", 2.0, kStamp));
+
+  listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false);
+
+  EXPECT_TRUE(buffer_->canTransform("map", "a", kStamp));
+  EXPECT_TRUE(buffer_->canTransform("a", "b", kStamp));
+  // Transitive lookup also succeeds when both legs are in the buffer.
+  EXPECT_TRUE(buffer_->canTransform("map", "b", kStamp));
+
+  delete raw_msg;
+}

--- a/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
@@ -68,8 +68,7 @@ union ioctl_add_subscriber_args SubscriptionBase::initialize(
   initialize_subscriber_call_count++;
   initialized_topic_names.push_back(topic_name_);
   initialized_qos_values.push_back(qos);
-  union ioctl_add_subscriber_args args
-  {
+  union ioctl_add_subscriber_args args {
   };
   args.ret_id = 0;
   return args;
@@ -133,7 +132,8 @@ protected:
 // Constructor (node-based)
 // =========================================
 
-TEST_F(TransformListenerTest, node_constructor_subscribes_with_volatile_tf_and_transient_local_tf_static)
+TEST_F(
+  TransformListenerTest, node_constructor_subscribes_with_volatile_tf_and_transient_local_tf_static)
 {
   // Arrange
   const auto expected_dynamic_durability = tf2_ros::DynamicListenerQoS().durability();
@@ -175,7 +175,9 @@ TEST_F(TransformListenerTest, simplified_constructor_constructs_without_external
 // subscription_callback
 // =========================================
 
-TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_true_so_frame_answers_arbitrary_times)
+TEST_F(
+  TransformListenerTest,
+  subscription_callback_forwards_is_static_true_so_frame_answers_arbitrary_times)
 {
   // Arrange
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
@@ -194,7 +196,9 @@ TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_true_so_f
   delete raw_msg;
 }
 
-TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_false_so_frame_does_not_answer_arbitrary_times)
+TEST_F(
+  TransformListenerTest,
+  subscription_callback_forwards_is_static_false_so_frame_does_not_answer_arbitrary_times)
 {
   // Arrange
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
@@ -218,8 +222,8 @@ TEST_F(TransformListenerTest, subscription_callback_handles_empty_message_safely
   auto * raw_msg = new tf2_msgs::msg::TFMessage();
 
   // Act
-  EXPECT_NO_THROW(listener.subscription_callback(
-    make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false));
+  EXPECT_NO_THROW(
+    listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false));
 
   // Assert
   EXPECT_FALSE(buffer_->canTransform("map", "base_link", kStamp));

--- a/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
@@ -125,6 +125,9 @@ agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> make_subscriber_ipc_ptr(
 }
 
 constexpr tf2::TimePoint kStamp{std::chrono::seconds(10)};
+// A query stamp well outside the dynamic cache window for any frame stamped at kStamp.
+// Used to distinguish static (answers any time) from dynamic (answers only within data).
+constexpr tf2::TimePoint kFarFutureStamp{std::chrono::seconds(10) + std::chrono::seconds(100)};
 }  // namespace
 
 // =========================================
@@ -154,52 +157,38 @@ protected:
 };
 
 // =========================================
-// Constructor (node-based) — subscription wiring
+// Constructor (node-based) — subscription wiring & QoS contract
 //
 // NOTE: All constructor tests use spin_thread=false. The spin_thread=true path spawns
 // a dedicated executor thread that calls epoll_ctl against the mocked (-1) mq fd, which
 // would exit() the process. That path is exercised by integration tests instead.
 // =========================================
 
-TEST_F(TransformListenerTest, node_constructor_subscribes_to_tf_and_tf_static)
+TEST_F(TransformListenerTest, node_constructor_subscribes_with_volatile_tf_and_transient_local_tf_static)
 {
+  // Arrange
+  const auto expected_dynamic_durability = tf2_ros::DynamicListenerQoS().durability();
+  const auto expected_static_durability = tf2_ros::StaticListenerQoS().durability();
+
+  // Act
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
 
-  EXPECT_EQ(initialize_subscriber_call_count, 2);
-  // The listener's implementation does not promise an ordering between the two
-  // subscriptions, so assert membership rather than position.
-  EXPECT_NE(
-    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf"),
-    initialized_topic_names.end());
-  EXPECT_NE(
-    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf_static"),
-    initialized_topic_names.end());
-}
-
-TEST_F(TransformListenerTest, node_constructor_uses_dynamic_and_static_listener_qos_defaults)
-{
-  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
-
-  ASSERT_EQ(initialized_qos_values.size(), 2u);
-
-  // Static frames are TransientLocal; dynamic frames are Volatile. That distinction is
-  // the whole reason late-joining subscribers can still see /tf_static frames.
-  const rclcpp::QoS dynamic_qos = tf2_ros::DynamicListenerQoS();
-  const rclcpp::QoS static_qos = tf2_ros::StaticListenerQoS();
-
-  bool saw_dynamic = false;
-  bool saw_static = false;
+  // Assert
+  ASSERT_EQ(initialize_subscriber_call_count, 2);
+  ASSERT_EQ(initialized_topic_names.size(), 2u);
+  bool saw_tf = false;
+  bool saw_tf_static = false;
   for (size_t i = 0; i < initialized_topic_names.size(); ++i) {
     if (initialized_topic_names[i] == "/tf") {
-      EXPECT_EQ(initialized_qos_values[i].durability(), dynamic_qos.durability());
-      saw_dynamic = true;
+      EXPECT_EQ(initialized_qos_values[i].durability(), expected_dynamic_durability);
+      saw_tf = true;
     } else if (initialized_topic_names[i] == "/tf_static") {
-      EXPECT_EQ(initialized_qos_values[i].durability(), static_qos.durability());
-      saw_static = true;
+      EXPECT_EQ(initialized_qos_values[i].durability(), expected_static_durability);
+      saw_tf_static = true;
     }
   }
-  EXPECT_TRUE(saw_dynamic);
-  EXPECT_TRUE(saw_static);
+  EXPECT_TRUE(saw_tf);
+  EXPECT_TRUE(saw_tf_static);
 }
 
 // =========================================
@@ -208,8 +197,10 @@ TEST_F(TransformListenerTest, node_constructor_uses_dynamic_and_static_listener_
 
 TEST_F(TransformListenerTest, simplified_constructor_subscribes_to_tf_and_tf_static)
 {
+  // Act
   agnocast::TransformListener listener(*buffer_, /*spin_thread=*/false);
 
+  // Assert
   EXPECT_EQ(initialize_subscriber_call_count, 2);
   EXPECT_NE(
     std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf"),
@@ -223,66 +214,74 @@ TEST_F(TransformListenerTest, simplified_constructor_subscribes_to_tf_and_tf_sta
 // subscription_callback — exercised as the public API black-box
 // =========================================
 
-TEST_F(TransformListenerTest, subscription_callback_inserts_dynamic_transform_into_buffer)
+TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_true_so_frame_answers_arbitrary_times)
 {
+  // Arrange
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
-
-  auto * raw_msg = new tf2_msgs::msg::TFMessage();
-  raw_msg->transforms.push_back(make_transform("map", "base_link", 1.0, kStamp));
-
-  listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false);
-
-  std::string err;
-  EXPECT_TRUE(buffer_->canTransform("map", "base_link", kStamp, &err)) << err;
-
-  delete raw_msg;
-}
-
-TEST_F(TransformListenerTest, subscription_callback_inserts_static_transform_into_buffer)
-{
-  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
-
   auto * raw_msg = new tf2_msgs::msg::TFMessage();
   raw_msg->transforms.push_back(make_transform("map", "imu", 2.0, kStamp));
 
+  // Act
   listener.subscription_callback(
     make_subscriber_ipc_ptr(raw_msg, "/tf_static"), /*is_static=*/true);
 
-  // Static transforms must be queryable at any time, including TimePointZero
-  // (the latest-available query) — this is what `tf_static` consumers rely on.
+  // Assert
   std::string err;
-  EXPECT_TRUE(buffer_->canTransform("map", "imu", tf2::TimePointZero, &err)) << err;
+  EXPECT_TRUE(buffer_->canTransform("map", "imu", kFarFutureStamp, &err)) << err;
 
+  // Cleanup
+  delete raw_msg;
+}
+
+TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_false_so_frame_does_not_answer_arbitrary_times)
+{
+  // Arrange
+  agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();
+  raw_msg->transforms.push_back(make_transform("map", "base_link", 1.0, kStamp));
+
+  // Act
+  listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false);
+
+  // Assert
+  EXPECT_FALSE(buffer_->canTransform("map", "base_link", kFarFutureStamp));
+
+  // Cleanup
   delete raw_msg;
 }
 
 TEST_F(TransformListenerTest, subscription_callback_handles_empty_message_safely)
 {
+  // Arrange
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
+  auto * raw_msg = new tf2_msgs::msg::TFMessage();
 
-  auto * raw_msg = new tf2_msgs::msg::TFMessage();  // empty transforms vector
-
+  // Act
   EXPECT_NO_THROW(listener.subscription_callback(
     make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false));
+
+  // Assert
   EXPECT_FALSE(buffer_->canTransform("map", "base_link", kStamp));
 
+  // Cleanup
   delete raw_msg;
 }
 
-TEST_F(TransformListenerTest, subscription_callback_inserts_multiple_transforms_in_one_message)
+TEST_F(TransformListenerTest, subscription_callback_inserts_all_transforms_from_a_single_message)
 {
+  // Arrange
   agnocast::TransformListener listener(*buffer_, *node_, /*spin_thread=*/false);
-
   auto * raw_msg = new tf2_msgs::msg::TFMessage();
   raw_msg->transforms.push_back(make_transform("map", "a", 1.0, kStamp));
   raw_msg->transforms.push_back(make_transform("a", "b", 2.0, kStamp));
 
+  // Act
   listener.subscription_callback(make_subscriber_ipc_ptr(raw_msg, "/tf"), /*is_static=*/false);
 
+  // Assert
   EXPECT_TRUE(buffer_->canTransform("map", "a", kStamp));
   EXPECT_TRUE(buffer_->canTransform("a", "b", kStamp));
-  // Transitive lookup also succeeds when both legs are in the buffer.
-  EXPECT_TRUE(buffer_->canTransform("map", "b", kStamp));
 
+  // Cleanup
   delete raw_msg;
 }

--- a/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
@@ -22,14 +22,6 @@
 #include <utility>
 #include <vector>
 
-// =========================================
-// Mock state — captures subscription init so the tests can assert on which topics
-// the listener subscribes to. The mocks bypass kmod / mqueue / heaphook so the test
-// runs as plain user-space code. This file is linked into its own test binary
-// (test_unit_tf2_transform_listener_agnocastlib) so it does not collide with mocks
-// in test_mocked_agnocast.cpp or test_broadcasters.cpp.
-// =========================================
-
 namespace
 {
 int initialize_subscriber_call_count = 0;
@@ -44,8 +36,6 @@ void reset_capture_state()
 }
 }  // namespace
 
-// Override ioctl globally so the SubscriptionBase destructor's AGNOCAST_REMOVE_SUBSCRIBER_CMD
-// call does not hit the real kernel module.
 extern "C" int ioctl(int, unsigned long, ...)
 {
   return 0;
@@ -53,8 +43,6 @@ extern "C" int ioctl(int, unsigned long, ...)
 
 namespace agnocast
 {
-// validate_ld_preload normally exits the process when libagnocast_heaphook.so is not in
-// LD_PRELOAD. Stubbed out so the unit test does not require the heaphook to be loaded.
 void validate_ld_preload()
 {
 }
@@ -66,8 +54,6 @@ void release_subscriber_reference(const std::string &, const topic_local_id_t, c
 mqd_t open_mq_for_subscription(
   const std::string &, const topic_local_id_t, std::pair<mqd_t, std::string> & mq_subscription)
 {
-  // Returning -1 is fine here: the listener never spins (spin_thread=false) so no
-  // epoll_ctl is ever called against this fd in the unit tests.
   mq_subscription = std::make_pair(static_cast<mqd_t>(-1), std::string{});
   return -1;
 }
@@ -95,10 +81,6 @@ BridgeMode get_bridge_mode()
 }
 }  // namespace agnocast
 
-// =========================================
-// Test helpers
-// =========================================
-
 namespace
 {
 geometry_msgs::msg::TransformStamped make_transform(
@@ -114,10 +96,7 @@ geometry_msgs::msg::TransformStamped make_transform(
   return t;
 }
 
-// Constructs a subscriber-side ipc_shared_ptr that owns `raw_msg` only for reference
-// counting purposes — the subscriber-side destructor does NOT delete the underlying
-// pointer (it would normally notify the kernel instead, which is mocked out above).
-// The caller is responsible for `delete`-ing raw_msg after the listener has consumed it.
+// Subscriber-side ipc_shared_ptr does not delete `raw_msg` — the caller must.
 agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> make_subscriber_ipc_ptr(
   tf2_msgs::msg::TFMessage * raw_msg, const std::string & topic_name)
 {
@@ -125,14 +104,8 @@ agnocast::ipc_shared_ptr<tf2_msgs::msg::TFMessage> make_subscriber_ipc_ptr(
 }
 
 constexpr tf2::TimePoint kStamp{std::chrono::seconds(10)};
-// A query stamp well outside the dynamic cache window for any frame stamped at kStamp.
-// Used to distinguish static (answers any time) from dynamic (answers only within data).
 constexpr tf2::TimePoint kFarFutureStamp{std::chrono::seconds(10) + std::chrono::seconds(100)};
 }  // namespace
-
-// =========================================
-// Test fixture
-// =========================================
 
 class TransformListenerTest : public ::testing::Test
 {
@@ -157,11 +130,7 @@ protected:
 };
 
 // =========================================
-// Constructor (node-based) — subscription wiring & QoS contract
-//
-// NOTE: All constructor tests use spin_thread=false. The spin_thread=true path spawns
-// a dedicated executor thread that calls epoll_ctl against the mocked (-1) mq fd, which
-// would exit() the process. That path is exercised by integration tests instead.
+// Constructor (node-based)
 // =========================================
 
 TEST_F(TransformListenerTest, node_constructor_subscribes_with_volatile_tf_and_transient_local_tf_static)
@@ -192,26 +161,18 @@ TEST_F(TransformListenerTest, node_constructor_subscribes_with_volatile_tf_and_t
 }
 
 // =========================================
-// Constructor (simplified) — creates internal node
+// Constructor (simplified)
 // =========================================
 
-TEST_F(TransformListenerTest, simplified_constructor_subscribes_to_tf_and_tf_static)
+TEST_F(TransformListenerTest, simplified_constructor_constructs_without_external_node)
 {
-  // Act
-  agnocast::TransformListener listener(*buffer_, /*spin_thread=*/false);
-
-  // Assert
-  EXPECT_EQ(initialize_subscriber_call_count, 2);
-  EXPECT_NE(
-    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf"),
-    initialized_topic_names.end());
-  EXPECT_NE(
-    std::find(initialized_topic_names.begin(), initialized_topic_names.end(), "/tf_static"),
-    initialized_topic_names.end());
+  // Act / Assert: smoke test the simplified constructor — the rest of its behavior is
+  // covered by the node-based test above, which it delegates to.
+  EXPECT_NO_THROW({ agnocast::TransformListener listener(*buffer_, /*spin_thread=*/false); });
 }
 
 // =========================================
-// subscription_callback — exercised as the public API black-box
+// subscription_callback
 // =========================================
 
 TEST_F(TransformListenerTest, subscription_callback_forwards_is_static_true_so_frame_answers_arbitrary_times)


### PR DESCRIPTION
## Description
Add tf2 support for `agnocast::Node` so users can populate a `tf2::BufferCore` via Agnocast's zero-copy IPC. Provides `agnocast::Buffer` and  `agnocast::TransformListener`, both adapted from `tf2_ros` and aligned with
  ROS 2 Jazzy.

  ## Scope
  - `agnocast::Buffer` — synchronous `lookupTransform` / `canTransform` (inherits `tf2::BufferCore` and `tf2_ros::BufferInterface`). Optional per-node logger via templated constructor.
  - `agnocast::TransformListener` — subscribes to `/tf` and `/tf_static` through Agnocast subscriptions, with an optional dedicated spin threads. Provides both a node-less convenience constructor and a node-bound one.                                                                                                                                 

  ## Intentionally omitted
  - `AsyncBufferInterface` (`waitForTransform`, `cancel`,  `setCreateTimerInterface`) — would require a custom,  `CreateTimerInterface` implementation since `agnocast::Node` does not expose a `NodeTimersInterface`.
  - The `tf2_frames` debug service — depends on a `rclcpp` service server, which conflicts with the all-Agnocast process model.

## Related links

  - `tf2_ros::Buffer` —                                                                                                                                                                                     
    https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/include/tf2_ros/buffer.hpp
    https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/src/buffer.cpp                                                                                                                                     
  - `tf2_ros::TransformListener` —                                                                                                                                                                          
    https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/include/tf2_ros/transform_listener.hpp                                                                                                             
    https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/src/transform_listener.cpp          

## How was this PR tested?

- [x] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers
Will add integration tests in another PR.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
