### PR TITLE
ci: pin clang-tidy to v14 (CI + local pre-commit)

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -13,26 +13,6 @@ env:
   RUST_TOOLCHAIN: "1.75.0"
 
 jobs:
-  # TEMPORARY: print the clang-tidy version that CI actually uses, so we can
-  # pin to the exact same binary in both CI and the local pre-commit hook.
-  # Remove this job once the version is confirmed.
-  debug-clang-tidy-version:
-    if: github.event_name == 'pull_request'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Print clang-tidy version info
-        run: |
-          set -x
-          cat /etc/os-release | head -5
-          which clang-tidy run-clang-tidy || true
-          clang-tidy --version || true
-          ls /usr/bin/clang-tidy* /usr/bin/run-clang-tidy* 2>&1 || true
-          dpkg -l | grep -E '^ii\s+(clang-tidy|llvm)' || true
-
   build-and-test-matrix:
     if: ${{ github.event_name == 'push' || github.event.label.name == 'run-build-test' }}
     strategy:
@@ -174,13 +154,21 @@ jobs:
     #   - modernize-pass-by-value: stricter about pass-by-value patterns
     # These produce many false positives with ROS/rclcpp code.
     # Until we can align the checks across versions, we only run clang-tidy on Humble.
+    #
+    # The clang-tidy version is pinned to 14 (via the version-suffixed binary)
+    # so the same major version is used in CI and in the local pre-commit hook
+    # (scripts/test/run_clang_tidy_precommit.bash). Do not switch back to the
+    # unsuffixed `run-clang-tidy` — it tracks the runner image's default and may
+    # silently change between LLVM major versions.
     - name: Run clang-tidy for agnocastlib and agnocast_components
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.cpp_changed == 'true' && env.ROS_DISTRO == 'humble'
       run: |
         set -euo pipefail
+        sudo apt-get install -y --no-install-recommends clang-tidy-14
+        clang-tidy-14 --version
         export FILES=($(echo "${{ steps.check_diff.outputs.changed_files }}" | grep -E '^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$' | grep -v '/test/' || true))
         if [ ${#FILES[@]} -gt 0 ]; then
-          run-clang-tidy -j $(nproc) -p build/ "${FILES[@]}"
+          run-clang-tidy-14 -j $(nproc) -p build/ "${FILES[@]}"
         else
           echo "No agnocastlib/agnocast_components C++ files changed, skipping clang-tidy"
         fi

--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -164,11 +164,19 @@ jobs:
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.cpp_changed == 'true' && env.ROS_DISTRO == 'humble'
       run: |
         set -euo pipefail
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends clang-tidy-14
         clang-tidy-14 --version
+        # Verify the helper script is actually on PATH — the clang-tidy-14
+        # package on Ubuntu 22.04 ships it today, but --no-install-recommends
+        # could drop it on a future packaging change. Fail loudly here rather
+        # than later with a confusing "command not found".
+        command -v run-clang-tidy-14 >/dev/null
         export FILES=($(echo "${{ steps.check_diff.outputs.changed_files }}" | grep -E '^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$' | grep -v '/test/' || true))
         if [ ${#FILES[@]} -gt 0 ]; then
-          run-clang-tidy-14 -j $(nproc) -p build/ "${FILES[@]}"
+          # Pin the underlying lint binary to clang-tidy-14 so the wrapper
+          # cannot silently fall back to an unsuffixed `clang-tidy`.
+          run-clang-tidy-14 -j $(nproc) -p build/ -clang-tidy-binary clang-tidy-14 "${FILES[@]}"
         else
           echo "No agnocastlib/agnocast_components C++ files changed, skipping clang-tidy"
         fi

--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -13,6 +13,26 @@ env:
   RUST_TOOLCHAIN: "1.75.0"
 
 jobs:
+  # TEMPORARY: print the clang-tidy version that CI actually uses, so we can
+  # pin to the exact same binary in both CI and the local pre-commit hook.
+  # Remove this job once the version is confirmed.
+  debug-clang-tidy-version:
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Print clang-tidy version info
+        run: |
+          set -x
+          cat /etc/os-release | head -5
+          which clang-tidy run-clang-tidy || true
+          clang-tidy --version || true
+          ls /usr/bin/clang-tidy* /usr/bin/run-clang-tidy* 2>&1 || true
+          dpkg -l | grep -E '^ii\s+(clang-tidy|llvm)' || true
+
   build-and-test-matrix:
     if: ${{ github.event_name == 'push' || github.event.label.name == 'run-build-test' }}
     strategy:

--- a/.github/workflows/run-pre-commit.yaml
+++ b/.github/workflows/run-pre-commit.yaml
@@ -28,5 +28,11 @@ jobs:
           python3 -m pip install pre-commit
 
       - name: Run pre-commit
+        # The clang-tidy hook needs a colcon build (compile_commands.json),
+        # which this lightweight workflow does not produce. clang-tidy is
+        # already executed in build-and-test-agnocastlib-components-heaphook.yaml,
+        # so skip it here to avoid duplicate (and impossible) work.
+        env:
+          SKIP: clang-tidy
         run: |
           pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,5 @@ repos:
         exclude: /test/
         require_serial: true
         pass_filenames: true
+        # NOTE: this id ('clang-tidy') is referenced by SKIP=clang-tidy in
+        # .github/workflows/run-pre-commit.yaml. Keep them in sync.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,13 @@ repos:
         entry: scripts/test/run_kunit.bash
         language: system
         types: [c]
+
+      - id: clang-tidy
+        name: Run clang-tidy (matches CI clang-tidy-14)
+        entry: scripts/test/run_clang_tidy_precommit.bash
+        language: system
+        types_or: [c++]
+        files: ^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$
+        exclude: /test/
+        require_serial: true
+        pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ python3 -m pip install --upgrade pre-commit identify
 pre-commit install
 ```
 
-The `clang-tidy` hook needs `compile_commands.json` produced by colcon. Run a build with the export flag at least once before committing C++ changes; if the file is absent the hook prints a warning and lets the commit proceed (CI will still run clang-tidy on the PR).
+The `clang-tidy` hook needs the `clang-tidy-14` toolchain (matching CI) and a `compile_commands.json` produced by colcon. Run a build with the export flag at least once before committing C++ changes; if the file is absent the hook prints a warning and lets the commit proceed (CI will still run clang-tidy on the PR).
 
 ```bash
+sudo apt-get install -y clang-tidy-14
+# On Ubuntu 22.04, also install libstdc++-12-dev so clang-14 can resolve
+# standard C++ headers like <atomic>:
+sudo apt-get install -y libstdc++-12-dev
 colcon build --packages-up-to agnocastlib agnocast_components \
   --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 ```

--- a/README.md
+++ b/README.md
@@ -74,12 +74,19 @@ bash scripts/dev/setup.bash
 
 ### Setup pre-commit
 
-The following command allows `clang-format`, `markdownlint`, and [KUNIT Test](./agnocast_kmod/agnocast_kunit.c) to be run before each commit.
+The following command allows `clang-format`, `markdownlint`, [KUNIT Test](./agnocast_kmod/agnocast_kunit.c), and `clang-tidy` to be run before each commit.
 
 ```bash
 python3 -m pip install pre-commit
 python3 -m pip install --upgrade pre-commit identify
 pre-commit install
+```
+
+The `clang-tidy` hook needs `compile_commands.json` produced by colcon. Run a build with the export flag at least once before committing C++ changes; if the file is absent the hook prints a warning and lets the commit proceed (CI will still run clang-tidy on the PR).
+
+```bash
+colcon build --packages-up-to agnocastlib agnocast_components \
+  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 ```
 
 If you want to disable pre-commit, please run `pre-commit uninstall`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,7 @@ Each script is a thin wrapper that runs `source install/setup.bash` followed by 
 | `test/test_rmmod_refcount.bash` | Verify `rmmod agnocast` is refused while `/dev/agnocast` is open and succeeds once the fd is closed. |
 | `test/switch_kmod.bats` | [bats](https://github.com/bats-core/bats-core) test suite for `switch_kmod.bash` (9 cases). **Destructive** — swaps installed `agnocast-kmod-v*` packages and load/unloads the module. Requires `apt install bats` and a prior run of `switch_kmod_canonical_setup.bash`. Run: `sudo bats scripts/test/switch_kmod.bats`. |
 | `test/switch_kmod_canonical_setup.bash` | One-time, idempotent setup for `switch_kmod.bats`: installs `agnocast-kmod-v${CANONICAL_VER:-2.3.3}` and caches the `.deb` for teardown recovery. |
+| `test/run_clang_tidy_precommit.bash` | Pre-commit entry-point for clang-tidy (LLVM 14, matching CI). Filters input files to `src/(agnocastlib\|agnocast_components)/**/*.{cpp,hpp}` (excluding `/test/`) and runs `run-clang-tidy-14`. Requires a prior `colcon build … -DCMAKE_EXPORT_COMPILE_COMMANDS=1`; if `compile_commands.json` is missing the script warns and skips. Invoked automatically by pre-commit; not normally run directly. |
 
 ### releases/ — maintainer-only
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,7 +67,7 @@ Each script is a thin wrapper that runs `source install/setup.bash` followed by 
 | `test/test_rmmod_refcount.bash` | Verify `rmmod agnocast` is refused while `/dev/agnocast` is open and succeeds once the fd is closed. |
 | `test/switch_kmod.bats` | [bats](https://github.com/bats-core/bats-core) test suite for `switch_kmod.bash` (9 cases). **Destructive** — swaps installed `agnocast-kmod-v*` packages and load/unloads the module. Requires `apt install bats` and a prior run of `switch_kmod_canonical_setup.bash`. Run: `sudo bats scripts/test/switch_kmod.bats`. |
 | `test/switch_kmod_canonical_setup.bash` | One-time, idempotent setup for `switch_kmod.bats`: installs `agnocast-kmod-v${CANONICAL_VER:-2.3.3}` and caches the `.deb` for teardown recovery. |
-| `test/run_clang_tidy_precommit.bash` | Pre-commit entry-point for clang-tidy (LLVM 14, matching CI). Filters input files to `src/(agnocastlib\|agnocast_components)/**/*.{cpp,hpp}` (excluding `/test/`) and runs `run-clang-tidy-14`. Requires a prior `colcon build … -DCMAKE_EXPORT_COMPILE_COMMANDS=1`; if `compile_commands.json` is missing the script warns and skips. Invoked automatically by pre-commit; not normally run directly. |
+| `test/run_clang_tidy_precommit.bash` | Pre-commit entry-point for clang-tidy (LLVM 14, matching CI). Filters input files to `src/(agnocastlib\|agnocast_components)/**/*.{cpp,hpp}` (excluding `/test/`) and runs `run-clang-tidy-14`. Requires `clang-tidy-14` (`sudo apt-get install -y clang-tidy-14`) and a prior `colcon build … -DCMAKE_EXPORT_COMPILE_COMMANDS=1`; if `compile_commands.json` is missing the script warns and skips. Invoked automatically by pre-commit; not normally run directly. |
 
 ### releases/ — maintainer-only
 

--- a/scripts/test/run_clang_tidy_precommit.bash
+++ b/scripts/test/run_clang_tidy_precommit.bash
@@ -22,7 +22,7 @@ if ! command -v "$CLANG_TIDY_BIN" >/dev/null 2>&1 || \
 fi
 
 # Sanity check: must be LLVM 14.x, matching CI.
-TIDY_VERSION="$("$CLANG_TIDY_BIN" --version | grep -oE 'version [0-9]+' | awk '{print $2}')"
+TIDY_VERSION="$("$CLANG_TIDY_BIN" --version | grep -oE 'version [0-9]+' | head -n1 | awk '{print $2}')"
 if [ "$TIDY_VERSION" != "14" ]; then
   echo "ERROR: $CLANG_TIDY_BIN reports major version '$TIDY_VERSION', expected 14." >&2
   exit 1
@@ -30,46 +30,50 @@ fi
 
 # Filter the staged files passed by pre-commit to the same set CI lints:
 #   src/(agnocastlib|agnocast_components)/**/*.{cpp,hpp}, excluding /test/.
-FILES=()
+agnocastlib_files=()
+agnocast_components_files=()
 for f in "$@"; do
   if [[ "$f" =~ ^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$ ]] && \
      [[ "$f" != *"/test/"* ]]; then
-    FILES+=("$f")
+    pkg="${f#src/}"; pkg="${pkg%%/*}"
+    case "$pkg" in
+      agnocastlib)         agnocastlib_files+=("$f") ;;
+      agnocast_components) agnocast_components_files+=("$f") ;;
+    esac
   fi
 done
 
-if [ ${#FILES[@]} -eq 0 ]; then
+if [ ${#agnocastlib_files[@]} -eq 0 ] && [ ${#agnocast_components_files[@]} -eq 0 ]; then
   exit 0
 fi
 
 # clang-tidy needs a compilation database. colcon writes one per package
 # under build/<pkg>/compile_commands.json when built with
 # -DCMAKE_EXPORT_COMPILE_COMMANDS=1. With --merge-install some setups also
-# expose build/compile_commands.json. Group files by package and run
-# clang-tidy with the matching -p directory.
-declare -A FILES_BY_PKG=()
-for f in "${FILES[@]}"; do
-  pkg="$(echo "$f" | awk -F/ '{print $2}')"
-  FILES_BY_PKG[$pkg]+="$f "
-done
-
+# expose build/compile_commands.json. If neither exists the hook prints a
+# warning and skips — CI runs clang-tidy on the PR, so a stale local build
+# should not block the commit.
 BUILD_HINT="Build with: colcon build --packages-up-to agnocastlib agnocast_components --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1"
 
+JOBS="$(nproc)"
 EXIT_CODE=0
-for pkg in "${!FILES_BY_PKG[@]}"; do
+for pkg in agnocastlib agnocast_components; do
+  declare -n pkg_files="${pkg}_files"
+  [ ${#pkg_files[@]} -eq 0 ] && continue
+
   if [ -f "build/$pkg/compile_commands.json" ]; then
     P_DIR="build/$pkg"
   elif [ -f "build/compile_commands.json" ]; then
     P_DIR="build"
   else
-    echo "ERROR: no compile_commands.json for package '$pkg'." >&2
-    echo "       Looked for build/$pkg/compile_commands.json and build/compile_commands.json." >&2
-    echo "       $BUILD_HINT" >&2
-    exit 1
+    echo "WARN: no compile_commands.json for package '$pkg' — skipping clang-tidy." >&2
+    echo "      Looked for build/$pkg/compile_commands.json and build/compile_commands.json." >&2
+    echo "      $BUILD_HINT" >&2
+    echo "      CI will still run clang-tidy on this PR." >&2
+    continue
   fi
 
-  # shellcheck disable=SC2086
-  if ! "$RUN_CLANG_TIDY_BIN" -j "$(nproc)" -p "$P_DIR" ${FILES_BY_PKG[$pkg]}; then
+  if ! "$RUN_CLANG_TIDY_BIN" -j "$JOBS" -p "$P_DIR" "${pkg_files[@]}"; then
     EXIT_CODE=1
   fi
 done

--- a/scripts/test/run_clang_tidy_precommit.bash
+++ b/scripts/test/run_clang_tidy_precommit.bash
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Pre-commit hook: run clang-tidy with the SAME version as CI.
+#
+# CI invokes `run-clang-tidy-14` (LLVM 14, Ubuntu 22.04 / Humble) — see
+# .github/workflows/build-and-test-agnocastlib-components-heaphook.yaml.
+# This script enforces the same major version locally so issues caught
+# in CI are also caught at commit time, and vice versa.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CLANG_TIDY_BIN="clang-tidy-14"
+RUN_CLANG_TIDY_BIN="run-clang-tidy-14"
+
+if ! command -v "$CLANG_TIDY_BIN" >/dev/null 2>&1 || \
+   ! command -v "$RUN_CLANG_TIDY_BIN" >/dev/null 2>&1; then
+  echo "ERROR: $CLANG_TIDY_BIN / $RUN_CLANG_TIDY_BIN not found." >&2
+  echo "Install with: sudo apt-get install -y clang-tidy-14" >&2
+  exit 1
+fi
+
+# Sanity check: must be LLVM 14.x, matching CI.
+TIDY_VERSION="$("$CLANG_TIDY_BIN" --version | grep -oE 'version [0-9]+' | awk '{print $2}')"
+if [ "$TIDY_VERSION" != "14" ]; then
+  echo "ERROR: $CLANG_TIDY_BIN reports major version '$TIDY_VERSION', expected 14." >&2
+  exit 1
+fi
+
+# Filter the staged files passed by pre-commit to the same set CI lints:
+#   src/(agnocastlib|agnocast_components)/**/*.{cpp,hpp}, excluding /test/.
+FILES=()
+for f in "$@"; do
+  if [[ "$f" =~ ^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$ ]] && \
+     [[ "$f" != *"/test/"* ]]; then
+    FILES+=("$f")
+  fi
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# clang-tidy needs a compilation database. colcon writes one per package
+# under build/<pkg>/compile_commands.json when built with
+# -DCMAKE_EXPORT_COMPILE_COMMANDS=1. With --merge-install some setups also
+# expose build/compile_commands.json. Group files by package and run
+# clang-tidy with the matching -p directory.
+declare -A FILES_BY_PKG=()
+for f in "${FILES[@]}"; do
+  pkg="$(echo "$f" | awk -F/ '{print $2}')"
+  FILES_BY_PKG[$pkg]+="$f "
+done
+
+BUILD_HINT="Build with: colcon build --packages-up-to agnocastlib agnocast_components --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1"
+
+EXIT_CODE=0
+for pkg in "${!FILES_BY_PKG[@]}"; do
+  if [ -f "build/$pkg/compile_commands.json" ]; then
+    P_DIR="build/$pkg"
+  elif [ -f "build/compile_commands.json" ]; then
+    P_DIR="build"
+  else
+    echo "ERROR: no compile_commands.json for package '$pkg'." >&2
+    echo "       Looked for build/$pkg/compile_commands.json and build/compile_commands.json." >&2
+    echo "       $BUILD_HINT" >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC2086
+  if ! "$RUN_CLANG_TIDY_BIN" -j "$(nproc)" -p "$P_DIR" ${FILES_BY_PKG[$pkg]}; then
+    EXIT_CODE=1
+  fi
+done
+
+exit "$EXIT_CODE"

--- a/scripts/test/run_clang_tidy_precommit.bash
+++ b/scripts/test/run_clang_tidy_precommit.bash
@@ -28,6 +28,23 @@ if [ "$TIDY_VERSION" != "14" ]; then
   exit 1
 fi
 
+# Sanity check: clang-14 must be able to find libstdc++ headers like <atomic>.
+# On Ubuntu 22.04 with gcc-12 present but libstdc++-12-dev missing, clang-14
+# selects the gcc-12 toolchain and fails to resolve standard C++ headers,
+# producing a flood of clang-diagnostic-error noise that masks real findings.
+# Probe with clang++-14 when available so the user sees a clear install hint
+# instead of hunting through unrelated lint errors.
+if command -v clang++-14 >/dev/null 2>&1; then
+  if ! echo '#include <atomic>' | clang++-14 -x c++ -fsyntax-only - >/dev/null 2>&1; then
+    echo "ERROR: clang++-14 cannot find libstdc++ headers (e.g. <atomic>)." >&2
+    echo "       On Ubuntu 22.04 this usually means gcc-12 is installed but" >&2
+    echo "       libstdc++-12-dev is missing — clang-14 picks the gcc-12 toolchain" >&2
+    echo "       and fails to resolve standard C++ headers." >&2
+    echo "       Install with: sudo apt-get install -y libstdc++-12-dev" >&2
+    exit 1
+  fi
+fi
+
 # Filter the staged files passed by pre-commit to the same set CI lints:
 #   src/(agnocastlib|agnocast_components)/**/*.{cpp,hpp}, excluding /test/.
 agnocastlib_files=()
@@ -73,7 +90,36 @@ for pkg in agnocastlib agnocast_components; do
     continue
   fi
 
-  if ! "$RUN_CLANG_TIDY_BIN" -j "$JOBS" -p "$P_DIR" "${pkg_files[@]}"; then
+  # run-clang-tidy silently skips files absent from the compile DB, which
+  # would let the hook report "Passed" without actually analysing them.
+  # Partition staged files by DB membership and warn about the gap.
+  db="$P_DIR/compile_commands.json"
+  matched_files=()
+  missing_files=()
+  for f in "${pkg_files[@]}"; do
+    if grep -Fq "\"file\": \"$REPO_ROOT/$f\"" "$db"; then
+      matched_files+=("$f")
+    else
+      missing_files+=("$f")
+    fi
+  done
+
+  if [ ${#missing_files[@]} -gt 0 ]; then
+    if [ ${#matched_files[@]} -eq 0 ]; then
+      echo "WARN: $db has no entries for the staged files in '$pkg' — skipping clang-tidy." >&2
+    else
+      echo "WARN: $db is missing entries for some staged files in '$pkg' — those files will not be linted locally." >&2
+    fi
+    for f in "${missing_files[@]}"; do
+      echo "      missing: $f" >&2
+    done
+    echo "      $BUILD_HINT" >&2
+    echo "      CI will still run clang-tidy on this PR." >&2
+  fi
+
+  [ ${#matched_files[@]} -eq 0 ] && continue
+
+  if ! "$RUN_CLANG_TIDY_BIN" -j "$JOBS" -p "$P_DIR" "${matched_files[@]}"; then
     EXIT_CODE=1
   fi
 done

--- a/scripts/test/run_clang_tidy_precommit.bash
+++ b/scripts/test/run_clang_tidy_precommit.bash
@@ -11,6 +11,34 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# Packages linted by this hook. Keep in sync with:
+#   - the `files:` regex in .pre-commit-config.yaml
+#   - the changed-files regex in
+#     .github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+PKGS=(agnocastlib agnocast_components)
+
+# ---------------------------------------------------------------------------
+# Filter the staged files passed by pre-commit to the same set CI lints.
+# Done before the toolchain probes below — those spawn clang++-14 and add
+# noticeable latency, so a no-op invocation should bail early.
+# ---------------------------------------------------------------------------
+pairs=()
+for f in "$@"; do
+  for pkg in "${PKGS[@]}"; do
+    if [[ "$f" =~ ^src/$pkg/.*\.(cpp|hpp)$ ]] && [[ "$f" != *"/test/"* ]]; then
+      pairs+=("$pkg|$f")
+      break
+    fi
+  done
+done
+
+if [ ${#pairs[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Toolchain checks.
+# ---------------------------------------------------------------------------
 CLANG_TIDY_BIN="clang-tidy-14"
 RUN_CLANG_TIDY_BIN="run-clang-tidy-14"
 
@@ -22,7 +50,11 @@ if ! command -v "$CLANG_TIDY_BIN" >/dev/null 2>&1 || \
 fi
 
 # Sanity check: must be LLVM 14.x, matching CI.
-TIDY_VERSION="$("$CLANG_TIDY_BIN" --version | grep -oE 'version [0-9]+' | head -n1 | awk '{print $2}')"
+tidy_version_out="$("$CLANG_TIDY_BIN" --version)"
+TIDY_VERSION=""
+if [[ "$tidy_version_out" =~ version[[:space:]]+([0-9]+) ]]; then
+  TIDY_VERSION="${BASH_REMATCH[1]}"
+fi
 if [ "$TIDY_VERSION" != "14" ]; then
   echo "ERROR: $CLANG_TIDY_BIN reports major version '$TIDY_VERSION', expected 14." >&2
   exit 1
@@ -45,38 +77,50 @@ if command -v clang++-14 >/dev/null 2>&1; then
   fi
 fi
 
-# Filter the staged files passed by pre-commit to the same set CI lints:
-#   src/(agnocastlib|agnocast_components)/**/*.{cpp,hpp}, excluding /test/.
-agnocastlib_files=()
-agnocast_components_files=()
-for f in "$@"; do
-  if [[ "$f" =~ ^src/(agnocastlib|agnocast_components)/.*\.(cpp|hpp)$ ]] && \
-     [[ "$f" != *"/test/"* ]]; then
-    pkg="${f#src/}"; pkg="${pkg%%/*}"
-    case "$pkg" in
-      agnocastlib)         agnocastlib_files+=("$f") ;;
-      agnocast_components) agnocast_components_files+=("$f") ;;
-    esac
-  fi
-done
-
-if [ ${#agnocastlib_files[@]} -eq 0 ] && [ ${#agnocast_components_files[@]} -eq 0 ]; then
-  exit 0
-fi
-
-# clang-tidy needs a compilation database. colcon writes one per package
-# under build/<pkg>/compile_commands.json when built with
-# -DCMAKE_EXPORT_COMPILE_COMMANDS=1. With --merge-install some setups also
-# expose build/compile_commands.json. If neither exists the hook prints a
-# warning and skips — CI runs clang-tidy on the PR, so a stale local build
+# ---------------------------------------------------------------------------
+# Lint each package. clang-tidy needs a compilation database.
+# colcon writes one per package under build/<pkg>/compile_commands.json when
+# built with -DCMAKE_EXPORT_COMPILE_COMMANDS=1. With --merge-install some
+# setups also expose build/compile_commands.json. If neither exists the hook
+# warns and skips — CI runs clang-tidy on the PR, so a stale local build
 # should not block the commit.
+# ---------------------------------------------------------------------------
 BUILD_HINT="Build with: colcon build --packages-up-to agnocastlib agnocast_components --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1"
+
+# Partition the input files by membership in a compile DB. JSON-aware
+# (whitespace/formatting independent), canonicalises both the DB entries
+# and the input paths via realpath so that symlinked workspaces match.
+# Outputs one line per input file:
+#   "+ <relpath>" — present in DB, will be linted
+#   "- <relpath>" — absent  from DB, will be reported as a gap
+partition_files_against_db() {
+  python3 - "$@" <<'PY'
+import json, os, sys
+db_path, repo, *files = sys.argv[1:]
+with open(db_path) as fh:
+    entries = json.load(fh)
+in_db = set()
+for e in entries:
+    p = e.get("file")
+    if not p:
+        continue
+    if not os.path.isabs(p):
+        p = os.path.join(e.get("directory", ""), p)
+    in_db.add(os.path.realpath(p))
+for f in files:
+    abs_p = os.path.realpath(os.path.join(repo, f))
+    print(("+ " if abs_p in in_db else "- ") + f)
+PY
+}
 
 JOBS="$(nproc)"
 EXIT_CODE=0
-for pkg in agnocastlib agnocast_components; do
-  declare -n pkg_files="${pkg}_files"
-  [ ${#pkg_files[@]} -eq 0 ] && continue
+for pkg in "${PKGS[@]}"; do
+  files=()
+  for pair in "${pairs[@]}"; do
+    [ "${pair%%|*}" = "$pkg" ] && files+=("${pair#*|}")
+  done
+  [ ${#files[@]} -eq 0 ] && continue
 
   if [ -f "build/$pkg/compile_commands.json" ]; then
     P_DIR="build/$pkg"
@@ -90,19 +134,19 @@ for pkg in agnocastlib agnocast_components; do
     continue
   fi
 
+  db="$P_DIR/compile_commands.json"
+
   # run-clang-tidy silently skips files absent from the compile DB, which
   # would let the hook report "Passed" without actually analysing them.
   # Partition staged files by DB membership and warn about the gap.
-  db="$P_DIR/compile_commands.json"
   matched_files=()
   missing_files=()
-  for f in "${pkg_files[@]}"; do
-    if grep -Fq "\"file\": \"$REPO_ROOT/$f\"" "$db"; then
-      matched_files+=("$f")
-    else
-      missing_files+=("$f")
-    fi
-  done
+  while IFS= read -r line; do
+    case "$line" in
+      "+ "*) matched_files+=("${line#+ }") ;;
+      "- "*) missing_files+=("${line#- }") ;;
+    esac
+  done < <(partition_files_against_db "$db" "$REPO_ROOT" "${files[@]}")
 
   if [ ${#missing_files[@]} -gt 0 ]; then
     if [ ${#matched_files[@]} -eq 0 ]; then
@@ -119,7 +163,11 @@ for pkg in agnocastlib agnocast_components; do
 
   [ ${#matched_files[@]} -eq 0 ] && continue
 
-  if ! "$RUN_CLANG_TIDY_BIN" -j "$JOBS" -p "$P_DIR" "${matched_files[@]}"; then
+  # Pass -clang-tidy-binary explicitly so the wrapper does not fall back to
+  # an unsuffixed `clang-tidy` (which on multi-version systems may resolve
+  # to a different LLVM major version than the one we just validated).
+  if ! "$RUN_CLANG_TIDY_BIN" -j "$JOBS" -p "$P_DIR" \
+      -clang-tidy-binary "$CLANG_TIDY_BIN" "${matched_files[@]}"; then
     EXIT_CODE=1
   fi
 done


### PR DESCRIPTION
## Summary
- Pin clang-tidy to v14 in CI (`run-clang-tidy-14` instead of the runner-default `run-clang-tidy`) so the lint step can no longer drift with future GitHub runner image updates.
- Add a local pre-commit hook (`scripts/test/run_clang_tidy_precommit.bash`) that runs the same `run-clang-tidy-14` against the same file pattern as CI (`src/(agnocastlib|agnocast_components)/**/*.{cpp,hpp}`, excluding `/test/`).
- The hook verifies that `clang-tidy-14` is installed and refuses to run with a different major version, so contributors hit the same checks locally that CI will enforce.

## Background
A short-lived debug job confirmed the CI baseline:
- ubuntu-22.04 runner: `clang-tidy` (default) → LLVM 14.0.0 (`clang-tidy-14`: `1:14.0.0-1ubuntu1.1`)
- Local Ubuntu 22.04: `clang-tidy-14` 14.0.6

Both major versions are 14, but the unsuffixed `clang-tidy` symlink could change with runner image updates. Pinning to the version-suffixed binary avoids that.

## Test plan
- [x] Confirm CI clang-tidy version via temporary debug job (LLVM 14.0.0)
- [x] Replace `run-clang-tidy` with `run-clang-tidy-14` in workflow + explicit `apt-get install clang-tidy-14`
- [x] Add `scripts/test/run_clang_tidy_precommit.bash` and register in `.pre-commit-config.yaml`
- [x] Run the script locally on a real `.cpp` file → `clang-tidy-14` invoked correctly via per-package `compile_commands.json`
- [x] Remove debug job
- [ ] CI green on this PR