### PR TITLE
fix(agnocastlib): add warning for reliability, `qos_depth==0`, and `avoid_ros_namespace_connventions`

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -114,7 +114,7 @@ class BasicPublisher
             rclcpp::detail::PublisherQosParametersTraits{})
         : qos;
 
-    validate_qos(actual_qos);
+    validate_publisher_qos(actual_qos);
 
     id_ =
       initialize_publisher(topic_name_, node->get_fully_qualified_name(), actual_qos, is_bridge);

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -133,7 +133,7 @@ class BasicSubscription : public SubscriptionBase
             rclcpp::detail::SubscriptionQosParametersTraits{})
         : qos;
 
-    validate_qos(actual_qos);
+    validate_subscription_qos(actual_qos);
 
     union ioctl_add_subscriber_args add_subscriber_args = initialize(
       actual_qos, false, options.ignore_local_publications, is_bridge,
@@ -242,7 +242,7 @@ private:
             rclcpp::detail::SubscriptionQosParametersTraits{})
         : qos;
 
-    validate_qos(actual_qos);
+    validate_subscription_qos(actual_qos);
 
     union ioctl_add_subscriber_args add_subscriber_args = initialize(
       actual_qos, true, options.ignore_local_publications, false, node->get_fully_qualified_name());

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -14,7 +14,10 @@ extern rclcpp::Logger logger;
 extern int agnocast_fd;
 extern bool is_bridge_process;
 
-inline void validate_qos(const rclcpp::QoS & qos)
+namespace detail
+{
+
+inline void validate_qos_common(const rclcpp::QoS & qos)
 {
   if (qos.history() == rclcpp::HistoryPolicy::KeepAll) {
     RCLCPP_ERROR(logger, "Agnocast does not support KeepAll history policy. Use KeepLast instead.");
@@ -42,6 +45,35 @@ inline void validate_qos(const rclcpp::QoS & qos)
       logger,
       "Agnocast does not support liveliness_lease_duration QoS policy. It will be ignored.");
   }
+
+  if (qos.depth() == 0) {
+    RCLCPP_WARN(logger, "Agnocast does not support QoS depth=0. No messages will be delivered.");
+  }
+
+  if (rmw_qos.avoid_ros_namespace_conventions) {
+    RCLCPP_WARN(
+      logger,
+      "Agnocast does not honor avoid_ros_namespace_conventions QoS policy. It will be ignored.");
+  }
+}
+
+}  // namespace detail
+
+inline void validate_publisher_qos(const rclcpp::QoS & qos)
+{
+  detail::validate_qos_common(qos);
+
+  if (qos.reliability() == rclcpp::ReliabilityPolicy::BestEffort) {
+    RCLCPP_WARN(
+      logger,
+      "Agnocast publishers do not honor the BestEffort reliability QoS policy. "
+      "Messages are delivered through shared memory regardless of this setting.");
+  }
+}
+
+inline void validate_subscription_qos(const rclcpp::QoS & qos)
+{
+  detail::validate_qos_common(qos);
 }
 
 void validate_ld_preload();

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -14,7 +14,7 @@ std::string captured_log;
 int captured_warn_count = 0;
 
 void capture_log_handler(
-  const rcutils_log_location_t * /*location*/, int severity, const char * /*name*/,
+  const rcutils_log_location_t * /*location*/, int severity, const char * name,
   rcutils_time_point_value_t /*timestamp*/, const char * format, va_list * args)
 {
   char buf[1024];
@@ -22,6 +22,10 @@ void capture_log_handler(
   va_copy(args_copy, *args);
   vsnprintf(buf, sizeof(buf), format, args_copy);
   va_end(args_copy);
+  const bool from_agnocast = name != nullptr && std::string(name) == "Agnocast";
+  if (!from_agnocast) {
+    return;
+  }
   captured_log += buf;
   captured_log += "\n";
   if (severity == RCUTILS_LOG_SEVERITY_WARN) {

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -1,6 +1,51 @@
 #include "agnocast/agnocast_utils.hpp"
 
 #include <gtest/gtest.h>
+#include <rcutils/logging.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+namespace
+{
+
+std::string captured_log;
+int captured_warn_count = 0;
+
+void capture_log_handler(
+  const rcutils_log_location_t * /*location*/, int severity, const char * /*name*/,
+  rcutils_time_point_value_t /*timestamp*/, const char * format, va_list * args)
+{
+  char buf[1024];
+  va_list args_copy;
+  va_copy(args_copy, *args);
+  vsnprintf(buf, sizeof(buf), format, args_copy);
+  va_end(args_copy);
+  captured_log += buf;
+  captured_log += "\n";
+  if (severity == RCUTILS_LOG_SEVERITY_WARN) {
+    ++captured_warn_count;
+  }
+}
+
+class LogCapture
+{
+public:
+  LogCapture()
+  {
+    captured_log.clear();
+    captured_warn_count = 0;
+    previous_ = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(capture_log_handler);
+  }
+  ~LogCapture() { rcutils_logging_set_output_handler(previous_); }
+
+private:
+  rcutils_logging_output_handler_t previous_;
+};
+
+}  // namespace
 
 TEST(AgnocastUtilsTest, create_mq_name_normal)
 {
@@ -63,4 +108,149 @@ TEST(AgnocastUtilsTest, validate_ld_preload_only_libagnocast_heaphook)
   setenv("LD_PRELOAD", "libagnocast_heaphook.so", 1);
   EXPECT_NO_THROW(agnocast::validate_ld_preload());
   unsetenv("LD_PRELOAD");
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_default_no_warning)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(10));
+  EXPECT_EQ(captured_warn_count, 0) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_default_no_warning)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(10));
+  EXPECT_EQ(captured_warn_count, 0) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_keep_all_exits)
+{
+  EXPECT_EXIT(
+    agnocast::validate_publisher_qos(rclcpp::QoS(rclcpp::KeepAll())),
+    ::testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_keep_all_exits)
+{
+  EXPECT_EXIT(
+    agnocast::validate_subscription_qos(rclcpp::QoS(rclcpp::KeepAll())),
+    ::testing::ExitedWithCode(EXIT_FAILURE), "");
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_depth_zero_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(0));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("depth=0"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_depth_zero_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(0));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("depth=0"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_best_effort_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(10).best_effort());
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("BestEffort"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_best_effort_silent)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(10).best_effort());
+  EXPECT_EQ(captured_warn_count, 0) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_avoid_ros_namespace_conventions_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(10).avoid_ros_namespace_conventions(true));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("avoid_ros_namespace_conventions"), std::string::npos)
+    << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_avoid_ros_namespace_conventions_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(10).avoid_ros_namespace_conventions(true));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("avoid_ros_namespace_conventions"), std::string::npos)
+    << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_deadline_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(10).deadline(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("deadline"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_deadline_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(10).deadline(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("deadline"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_lifespan_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(rclcpp::QoS(10).lifespan(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("lifespan"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_lifespan_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(rclcpp::QoS(10).lifespan(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("lifespan"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_liveliness_manual_by_topic_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(
+    rclcpp::QoS(10).liveliness(rclcpp::LivelinessPolicy::ManualByTopic));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("ManualByTopic"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_liveliness_manual_by_topic_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(
+    rclcpp::QoS(10).liveliness(rclcpp::LivelinessPolicy::ManualByTopic));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("ManualByTopic"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_publisher_qos_liveliness_lease_duration_warns)
+{
+  LogCapture capture;
+  agnocast::validate_publisher_qos(
+    rclcpp::QoS(10).liveliness_lease_duration(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("liveliness_lease_duration"), std::string::npos) << captured_log;
+}
+
+TEST(AgnocastUtilsTest, validate_subscription_qos_liveliness_lease_duration_warns)
+{
+  LogCapture capture;
+  agnocast::validate_subscription_qos(
+    rclcpp::QoS(10).liveliness_lease_duration(rclcpp::Duration(1, 0)));
+  EXPECT_EQ(captured_warn_count, 1);
+  EXPECT_NE(captured_log.find("liveliness_lease_duration"), std::string::npos) << captured_log;
 }


### PR DESCRIPTION
## Description
Split `validate_qos` into `validate_publisher_qos` / `validate_subscription_qos`, sharing `detail::validate_qos_common`. Publisher- and subscription-specific checks no longer get cross-applied.
  - Warn when `qos.depth() == 0` (no messages will be delivered through Agnocast).
  - Warn when `avoid_ros_namespace_conventions` is set (Agnocast does not honor it).
  - Warn when a publisher uses `BestEffort` reliability (Agnocast publishers always deliver via shared memory, so the policy is effectively ignored).
  - Add unit tests in `test_agnocast_utils.cpp` covering KeepAll exit, depth=0, BestEffort, avoid_ros_namespace_conventions, and the existing deadline/lifespan/liveliness warning paths for both publisher and subscription. 

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
