### PR TITLE
refactor(ros2agnocast): drop misleading bridge-label call for service entries

### DIFF
--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -341,14 +341,14 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 print(f"    {service.name}: {', '.join(service.types)}")
 
             for service_name in agnocast_servers:
-                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics)}")
+                print(f"    {service_name}: <UNKNOWN> (Agnocast enabled)")
 
             print("  Service Clients:")
             for client in service_clients:
                 print(f"    {client.name}: {', '.join(client.types)}")
 
             for service_name in agnocast_clients:
-                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics)}")
+                print(f"    {service_name}: <UNKNOWN> (Agnocast enabled)")
 
             # ======== Action ========
             print("  Action Servers:")


### PR DESCRIPTION
## Description
Replace `get_agnocast_label(service_name, ...)` calls with the constant `(Agnocast enabled)` when printing Agnocast service servers and clients.
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  ## Why
  `get_agnocast_label` reasons over ROS2 pub/sub topic lists to decide whether to append a `bridged` suffix. Service request/response endpoints are never visible to the ROS2 topic graph, so the function always fell through to the default `(Agnocast enabled)` label for them. Inlining the constant removes a confusing call that depended on this implicit early-return behavior.                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                         
  No user-visible output change.


## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
