### PR TITLE
chore(.github): install from apt

### DIFF
--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -17,6 +17,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
+      # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
       - name: Install dependencies, colcon and cppcheck
         run: |
           sudo mkdir -p /usr/share/keyrings
@@ -28,11 +29,6 @@ jobs:
             git \
             python3-colcon-common-extensions \
             cppcheck
-
-      # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
-      - name: Install Cppcheck
-        run: sudo apt-get install -y cppcheck
-
 
       - name: Fetch the base branch with enough history for a common merge-base commit
         run: git fetch origin ${{ github.base_ref }}

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -29,7 +29,7 @@ jobs:
           sudo apt update
           sudo apt install -y python3-colcon-common-extensions
 
-      # cppcheck from apt(on ubuntu-22.04) does not yet support --check-level args, but apt(on ubuntu-24.04) does.
+      # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
       - name: Install Cppcheck
         run: |
           sudo apt-get update

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
           curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt update
-          sudo apt install -y python3-colcon-common-extensions
+          sudo apt-get update
+          sudo apt-get install -y python3-colcon-common-extensions
 
       # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
       - name: Install Cppcheck

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -17,17 +17,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
-      - name: Update apt
-        run: sudo apt-get update
-
-      - name: Install dependencies
-        run: sudo apt-get install -y git
-
-      - name: Install colcon
+      - name: Install dependencies, colcon and cppcheck
         run: |
-          sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
-          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt-get install -y python3-colcon-common-extensions
+          sudo mkdir -p /usr/share/keyrings
+          curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | gpg --dearmor | sudo tee /usr/share/keyrings/ros-archive-keyring.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://repo.ros2.org/ubuntu/main $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2-latest.list > /dev/null
+
+          sudo apt-get update
+          sudo apt-get install -y \
+            git \
+            python3-colcon-common-extensions \
+            cppcheck
 
       # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
       - name: Install Cppcheck

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cppcheck-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set PR fetch depth
@@ -27,12 +27,14 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
           curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
           sudo apt update
-          sudo apt install python3-colcon-common-extensions
+          sudo apt install -y python3-colcon-common-extensions
 
-      # cppcheck from apt does not yet support --check-level args, and thus install from snap
-      - name: Install Cppcheck from snap
+      # cppcheck from apt(on ubuntu-22.04) does not yet support --check-level args, but apt(on ubuntu-24.04) does.
+      - name: Install Cppcheck
         run: |
-          sudo snap install cppcheck
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
 
       - name: Fetch the base branch with enough history for a common merge-base commit
         run: git fetch origin ${{ github.base_ref }}

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -17,23 +17,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
+      - name: Update apt
+        run: sudo apt-get update
+
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git
+        run: sudo apt-get install -y git
 
       - name: Install colcon
         run: |
           sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
           curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt-get update
           sudo apt-get install -y python3-colcon-common-extensions
 
       # Cppcheck from apt on Ubuntu 22.04 does not support --check-level, but the apt version on Ubuntu 24.04 does.
       - name: Install Cppcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cppcheck
+        run: sudo apt-get install -y cppcheck
 
 
       - name: Fetch the base branch with enough history for a common merge-base commit


### PR DESCRIPTION
## Description
The `sudo snap install cppcheck` command is failing, causing GitHub Actions to crash. The reason for using snap was that the version of Cppcheck available via apt on Ubuntu 22.04 did not support the `--check-level `option. However, with the new support for Ubuntu 24.04, the apt version now supports this option. Therefore, I am migrating from snap to apt.

(In addition, Migrated from apt-key (deprecated) to signed-by with GPG keyrings for modern APT repository management.)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
