### PR TITLE
feat(cie_thread_configurator): add ~/reapply_config service for runtime YAML reload

### DIFF
--- a/src/agnocast_cie_config_msgs/CMakeLists.txt
+++ b/src/agnocast_cie_config_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CallbackGroupInfo.msg"
+  "srv/ReapplyConfig.srv"
 )
 
 ament_package()

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -1,0 +1,16 @@
+# Re-read the YAML at the configurator's 'config_file' parameter and apply
+# scheduling attributes. Added/removed entries are accepted: added entries
+# enter as applied=false (configured once their thread_id is announced),
+# removed entries drop out of in-memory state (kernel scheduling persists).
+# Only YAML parse / per-entry validation rejects the request; on rejection
+# no state is mutated. hardware_info / rt_throttling are NOT re-evaluated
+# on reapply; changes there require a process restart.
+---
+bool success                       # true iff parse + per-entry validation passed
+string error_message               # parse / validation failure reason (empty on success)
+string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"
+string[] applied_non_ros_threads   # syscalls succeeded; thread name
+string[] failed_callback_groups    # syscall failed (details in configurator log)
+string[] failed_non_ros_threads    # syscall failed (details in configurator log)
+string[] skipped_callback_groups   # thread_id not yet announced; will apply on next announcement
+string[] skipped_non_ros_threads

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -34,13 +34,10 @@ struct ThreadConfig
 extern const std::unordered_map<std::string, int> policy_to_sched_const;
 
 // Parse the given YAML document and populate the two output vectors.
-// Throws std::runtime_error on per-entry validation error (unknown policy,
-// missing SCHED_DEADLINE fields, etc.).
-//
-// Output ThreadConfigs have thread_id=-1 and applied=false.
-//
-// hardware_info / rt_throttling sections are NOT processed here; they are validated
-// at startup only by ThreadConfiguratorNode's constructor.
+// Throws std::runtime_error on per-entry validation error. Output ThreadConfigs
+// have thread_id=-1 and applied=false; callers that re-parse must carry
+// thread_id over from their existing index manually.
+// hardware_info / rt_throttling are validated only at startup, not here.
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,
   std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out);

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -6,9 +6,11 @@
 #include "yaml-cpp/yaml.h"
 
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
+#include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -16,18 +18,15 @@ class ThreadConfiguratorNode : public rclcpp::Node
 {
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
 
-  // Each ThreadConfig instance is touched by exactly one writer:
-  // - callback_group_configs_ entries: written from CallbackGroupInfo
-  //   subscription callbacks dispatched by the SingleThreadedExecutor
-  //   (one subscription on the main node and one per extra per-domain
-  //   node, all on the node's default callback group).
-  // - non_ros_thread_configs_ entries: written from the
-  //   NonRosThreadInfoListener's private reader thread.
-  // The two vectors are disjoint, so there is no shared mutable state
-  // between the executor thread and the listener thread.
-  // print_all_unapplied() reads applied flags only after main.cpp calls
-  // node->stop() (which joins the listener) and after executor->spin()
-  // returns, so no concurrent access is possible at read time.
+  // Concurrency:
+  // - callback_group_configs_ / id_to_callback_group_config_: written by the
+  //   subscription callbacks AND the reapply service handler, all on the same
+  //   SingleThreadedExecutor — no mutex needed.
+  // - non_ros_thread_configs_ / id_to_non_ros_thread_config_: written by both
+  //   the NonRosThreadInfoListener reader thread and the reapply handler;
+  //   all access must hold non_ros_state_mutex_.
+  // - print_all_unapplied(): called only after stop() + executor return, so
+  //   reads need no lock.
 
 public:
   explicit ThreadConfiguratorNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
@@ -46,11 +45,16 @@ private:
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
 
+  void on_reapply_config_request(
+    const std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Request> request,
+    std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Response> response);
+
   std::vector<rclcpp::Node::SharedPtr> nodes_for_each_domain_;
   std::vector<rclcpp::Subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr>
     subs_for_each_domain_;
   std::unique_ptr<agnocast_cie_thread_configurator::NonRosThreadInfoListener>
     non_ros_thread_listener_;
+  rclcpp::Service<agnocast_cie_config_msgs::srv::ReapplyConfig>::SharedPtr reapply_service_;
 
   std::vector<ThreadConfig> callback_group_configs_;
   // (domain_id, callback_group_id) -> ThreadConfig*
@@ -63,4 +67,8 @@ private:
   std::atomic<int> unapplied_num_{0};
   std::atomic<int> cgroup_num_{0};
   std::atomic<bool> configured_at_least_once_{false};
+
+  const std::string config_file_;
+  const size_t default_domain_id_;
+  std::mutex non_ros_state_mutex_;
 };

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_set>
+#include <utility>
 
 namespace agnocast_cie_thread_configurator
 {
@@ -91,6 +93,27 @@ void parse_yaml(
       cfg.deadline = nrt["deadline"].as<unsigned int>();
     } else {
       cfg.priority = nrt["priority"].as<int>();
+    }
+  }
+
+  // Reject duplicates: id_to_*_config_ would silently collapse them to the
+  // last-inserted entry, dropping earlier YAML lines without warning.
+  // The std::find_if rewrite cppcheck suggests would hide a side-effecting
+  // predicate inside the algorithm; a plain loop is clearer here.
+  std::unordered_set<std::string> seen_cb;
+  for (const auto & c : callback_groups_out) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen_cb.insert(std::to_string(c.domain_id) + ":" + c.thread_str).second) {
+      throw std::runtime_error(
+        "Duplicate callback_group entry: domain_id=" + std::to_string(c.domain_id) +
+        ", id=" + c.thread_str);
+    }
+  }
+  std::unordered_set<std::string> seen_nrt;
+  for (const auto & c : non_ros_threads_out) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen_nrt.insert(c.thread_str).second) {
+      throw std::runtime_error("Duplicate non_ros_thread entry: name=" + c.thread_str);
     }
   }
 }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -256,12 +256,9 @@ void ThreadConfiguratorNode::print_all_unapplied()
 
   RCLCPP_WARN(this->get_logger(), "Following non-ROS threads are not yet configured");
 
-  {
-    std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
-    for (auto & config : non_ros_thread_configs_) {
-      if (!config.applied) {
-        RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
-      }
+  for (auto & config : non_ros_thread_configs_) {
+    if (!config.applied) {
+      RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
     }
   }
 }
@@ -575,10 +572,8 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     }
     if (issue_syscalls(cfg)) {
       response->applied_callback_groups.push_back(std::move(key));
-      if (!cfg.applied) {
-        cfg.applied = true;
-        unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
-      }
+      cfg.applied = true;
+      unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
     } else {
       response->failed_callback_groups.push_back(std::move(key));
     }

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -7,6 +7,7 @@
 #include "yaml-cpp/yaml.h"
 
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
+#include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <error.h>
 #include <sys/resource.h>
@@ -23,30 +24,33 @@
 using agnocast_cie_thread_configurator::policy_to_sched_const;
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
-: Node("thread_configurator_node", options)
+: Node("thread_configurator_node", options),
+  config_file_([this]() {
+    rcl_interfaces::msg::ParameterDescriptor desc;
+    desc.read_only = true;
+    return this->declare_parameter<std::string>("config_file", "", desc);
+  }()),
+  default_domain_id_(agnocast_cie_thread_configurator::get_default_domain_id())
 {
-  const auto config_file = this->declare_parameter<std::string>("config_file", "");
-  if (config_file.empty()) {
+  if (config_file_.empty()) {
     throw std::runtime_error(
       "'config_file' parameter must be provided with a valid YAML file path.");
   }
 
   YAML::Node yaml;
   try {
-    yaml = YAML::LoadFile(config_file);
+    yaml = YAML::LoadFile(config_file_);
   } catch (const std::exception & e) {
-    throw std::runtime_error("Error reading the YAML file '" + config_file + "': " + e.what());
+    throw std::runtime_error("Error reading the YAML file '" + config_file_ + "': " + e.what());
   }
 
   validate_hardware_info(yaml);
   validate_rt_throttling(yaml);
 
-  RCLCPP_INFO(this->get_logger(), "Loaded config from: %s", config_file.c_str());
-
-  size_t default_domain_id = agnocast_cie_thread_configurator::get_default_domain_id();
+  RCLCPP_INFO(this->get_logger(), "Loaded config from: %s", config_file_.c_str());
 
   agnocast_cie_thread_configurator::parse_yaml(
-    yaml, default_domain_id, callback_group_configs_, non_ros_thread_configs_);
+    yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -70,19 +74,17 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
       },
       this->get_logger());
 
-  // Create subscription for default domain on this node. Uses the node's default
-  // callback group, mirroring the per-domain extra nodes below.
   subs_for_each_domain_.push_back(
     this->create_subscription<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
       "/agnocast_cie_thread_configurator/callback_group_info", cbg_qos,
-      [this,
-       default_domain_id](const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
+      [this, default_domain_id = default_domain_id_](
+        const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg) {
         this->callback_group_callback(default_domain_id, msg);
       }));
 
   // Create nodes and subscriptions for other domain IDs
   for (size_t domain_id : domain_ids) {
-    if (domain_id == default_domain_id) {
+    if (domain_id == default_domain_id_) {
       continue;
     }
 
@@ -98,6 +100,14 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
     RCLCPP_INFO(this->get_logger(), "Created subscription for domain ID: %zu", domain_id);
   }
+
+  reapply_service_ = this->create_service<agnocast_cie_config_msgs::srv::ReapplyConfig>(
+    "~/reapply_config",
+    [this](
+      const std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Request> request,
+      std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Response> response) {
+      this->on_reapply_config_request(request, response);
+    });
 }
 
 void ThreadConfiguratorNode::validate_rt_throttling(const YAML::Node & yaml)
@@ -246,9 +256,12 @@ void ThreadConfiguratorNode::print_all_unapplied()
 
   RCLCPP_WARN(this->get_logger(), "Following non-ROS threads are not yet configured");
 
-  for (auto & config : non_ros_thread_configs_) {
-    if (!config.applied) {
-      RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
+  {
+    std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
+    for (auto & config : non_ros_thread_configs_) {
+      if (!config.applied) {
+        RCLCPP_WARN(this->get_logger(), "  - %s", config.thread_str.c_str());
+      }
     }
   }
 }
@@ -443,6 +456,8 @@ void ThreadConfiguratorNode::callback_group_callback(
 void ThreadConfiguratorNode::non_ros_thread_callback(
   agnocast_cie_thread_configurator::NonRosThreadInfo info)
 {
+  std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
+
   auto it = id_to_non_ros_thread_config_.find(info.name);
   if (it == id_to_non_ros_thread_config_.end()) {
     RCLCPP_INFO(
@@ -484,5 +499,122 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
         RCLCPP_INFO(this->get_logger(), "Success: All of the configurations are applied.");
       }
     }
+  }
+}
+
+void ThreadConfiguratorNode::on_reapply_config_request(
+  const std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Request> /*request*/,
+  std::shared_ptr<agnocast_cie_config_msgs::srv::ReapplyConfig::Response> response)
+{
+  RCLCPP_INFO(this->get_logger(), "Reapplying configuration from: %s", config_file_.c_str());
+
+  YAML::Node yaml;
+  try {
+    yaml = YAML::LoadFile(config_file_);
+  } catch (const std::exception & e) {
+    response->success = false;
+    response->error_message = "YAML parse error for '" + config_file_ + "': " + e.what();
+    RCLCPP_ERROR(this->get_logger(), "Reapply rejected: %s", response->error_message.c_str());
+    return;
+  }
+
+  std::vector<ThreadConfig> new_cb;
+  std::vector<ThreadConfig> new_nrt;
+  try {
+    agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
+  } catch (const std::exception & e) {
+    response->success = false;
+    response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();
+    RCLCPP_ERROR(this->get_logger(), "Reapply rejected: %s", response->error_message.c_str());
+    return;
+  }
+
+  // Carry thread_id over from existing state. 'applied' is intentionally NOT
+  // carried: a syscall failure below must leave applied=false, not the stale
+  // 'true' that a verbatim carry-over would imply.
+  for (auto & cfg : new_cb) {
+    auto it = id_to_callback_group_config_.find(std::make_pair(cfg.domain_id, cfg.thread_str));
+    if (it != id_to_callback_group_config_.end()) {
+      cfg.thread_id = it->second->thread_id;
+    }
+  }
+
+  callback_group_configs_ = std::move(new_cb);
+  id_to_callback_group_config_.clear();
+  for (auto & cfg : callback_group_configs_) {
+    id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+  }
+
+  // One lock spans non-ROS carry-over + swap + unapplied_num_ recompute so the
+  // listener cannot write thread_id into the old vector between phases (the
+  // update would be dropped by move-assign) nor race the counter store.
+  {
+    std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
+    for (auto & cfg : new_nrt) {
+      auto it = id_to_non_ros_thread_config_.find(cfg.thread_str);
+      if (it != id_to_non_ros_thread_config_.end()) {
+        cfg.thread_id = it->second->thread_id;
+      }
+    }
+    non_ros_thread_configs_ = std::move(new_nrt);
+    id_to_non_ros_thread_config_.clear();
+    for (auto & cfg : non_ros_thread_configs_) {
+      id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
+    }
+
+    unapplied_num_.store(
+      static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()),
+      std::memory_order_release);
+  }
+
+  for (auto & cfg : callback_group_configs_) {
+    std::string key = std::to_string(cfg.domain_id) + ":" + cfg.thread_str;
+    if (cfg.thread_id == -1) {
+      response->skipped_callback_groups.push_back(std::move(key));
+      continue;
+    }
+    if (issue_syscalls(cfg)) {
+      response->applied_callback_groups.push_back(std::move(key));
+      if (!cfg.applied) {
+        cfg.applied = true;
+        unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
+      }
+    } else {
+      response->failed_callback_groups.push_back(std::move(key));
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(non_ros_state_mutex_);
+    for (auto & cfg : non_ros_thread_configs_) {
+      if (cfg.thread_id == -1) {
+        response->skipped_non_ros_threads.push_back(cfg.thread_str);
+        continue;
+      }
+      if (issue_syscalls(cfg)) {
+        response->applied_non_ros_threads.push_back(cfg.thread_str);
+        if (!cfg.applied) {
+          cfg.applied = true;
+          unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
+        }
+      } else {
+        response->failed_non_ros_threads.push_back(cfg.thread_str);
+      }
+    }
+  }
+
+  response->success = true;
+  RCLCPP_INFO(
+    this->get_logger(), "Reapply done: applied=%zu, failed=%zu, skipped=%zu",
+    response->applied_callback_groups.size() + response->applied_non_ros_threads.size(),
+    response->failed_callback_groups.size() + response->failed_non_ros_threads.size(),
+    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size());
+
+  // configured_at_least_once_ is one-shot, so the "all applied" log is not
+  // re-emitted on reapply; operators need a dedicated reapply-complete signal.
+  if (
+    response->failed_callback_groups.empty() && response->failed_non_ros_threads.empty() &&
+    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty()) {
+    RCLCPP_INFO(this->get_logger(), "Reapply: all entries successfully (re-)applied.");
   }
 }

--- a/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
@@ -202,3 +202,62 @@ non_ros_threads: []
   ASSERT_EQ(cb.size(), 1u);
   EXPECT_EQ(cb[0].thread_str, "beta");
 }
+
+TEST(ParseYaml, RejectsDuplicateCallbackGroupKey)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: cg
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - id: cg
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, AllowsSameIdInDifferentDomains)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: cg
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - id: cg
+    domain_id: 1
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 2u);
+}
+
+TEST(ParseYaml, RejectsDuplicateNonRosThreadName)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups: []
+non_ros_threads:
+  - name: t
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - name: t
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -135,6 +135,7 @@ if(BUILD_TESTING)
   add_launch_test(test/functional/test_agnocast_callback_isolated_executor_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_multi_domain_cie_talker_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_thread_configurator_reapply_launch.py TIMEOUT 120)
 endif()
 
 ament_package()

--- a/src/agnocast_e2e_test/package.xml
+++ b/src/agnocast_e2e_test/package.xml
@@ -28,6 +28,7 @@
   <depend>agnocast_components</depend>
   <depend>agnocast_cie_thread_configurator</depend>
 
+  <test_depend>agnocast_cie_config_msgs</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>

--- a/src/agnocast_e2e_test/src/test_publisher_component.cpp
+++ b/src/agnocast_e2e_test/src/test_publisher_component.cpp
@@ -4,6 +4,7 @@
 
 #include <std_msgs/msg/string.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -45,13 +46,21 @@ public:
 
   ~TestPublisherComponent()
   {
+    stop_non_ros_thread_.store(true);
     if (non_ros_thread_.joinable()) {
       non_ros_thread_.join();
     }
   }
 
 private:
-  void non_ros_thread_func() {}
+  // Kept alive so the configurator's reapply path has a live tid to operate
+  // on; an empty body would let the thread exit and syscalls would get ESRCH.
+  void non_ros_thread_func()
+  {
+    while (!stop_non_ros_thread_.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
 
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
@@ -60,6 +69,7 @@ private:
   int count_;
 
   std::thread non_ros_thread_;
+  std::atomic<bool> stop_non_ros_thread_{false};
 };
 
 }  // namespace agnocast_e2e_test

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -1,0 +1,360 @@
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import yaml
+from ament_index_python.packages import get_package_prefix
+
+import rclpy
+from agnocast_cie_config_msgs.srv import ReapplyConfig
+
+CONFIG_DIR = os.path.join(
+    tempfile.gettempdir(), 'agnocast_test_thread_configurator_reapply'
+)
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
+
+REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
+
+
+def _run_prerun():
+    """Run prerun_node alongside test_cie_publisher to generate config YAML."""
+    if os.path.exists(CONFIG_DIR):
+        shutil.rmtree(CONFIG_DIR)
+    os.makedirs(CONFIG_DIR)
+
+    tc_prefix = get_package_prefix('agnocast_cie_thread_configurator')
+    prerun_exe = os.path.join(
+        tc_prefix, 'lib', 'agnocast_cie_thread_configurator', 'prerun_node'
+    )
+
+    e2e_prefix = get_package_prefix('agnocast_e2e_test')
+    publisher_exe = os.path.join(
+        e2e_prefix, 'lib', 'agnocast_e2e_test', 'test_cie_publisher'
+    )
+
+    prerun_log = tempfile.NamedTemporaryFile(
+        mode='w', suffix='.log', delete=False
+    )
+    prerun_proc = subprocess.Popen(
+        [prerun_exe],
+        cwd=CONFIG_DIR,
+        stdout=prerun_log,
+        stderr=subprocess.STDOUT,
+    )
+    publisher_proc = subprocess.Popen(
+        [publisher_exe],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    time.sleep(5)
+
+    try:
+        publisher_proc.send_signal(signal.SIGINT)
+        publisher_proc.wait(timeout=10)
+        prerun_proc.send_signal(signal.SIGINT)
+        prerun_proc.wait(timeout=10)
+    finally:
+        for proc in [publisher_proc, prerun_proc]:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    prerun_log.close()
+    if not os.path.exists(CONFIG_FILE):
+        with open(prerun_log.name) as f:
+            prerun_output = f.read()
+        os.unlink(prerun_log.name)
+        raise RuntimeError(
+            f'prerun_node failed to generate {CONFIG_FILE}.\n'
+            f'Output:\n{prerun_output}'
+        )
+    os.unlink(prerun_log.name)
+
+
+def _read_config():
+    with open(CONFIG_FILE) as f:
+        return yaml.safe_load(f)
+
+
+def _write_config(cfg):
+    with open(CONFIG_FILE, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _call_reapply(timeout_sec=10.0):
+    """Call the reapply_config service synchronously and return the response."""
+    rclpy.init()
+    try:
+        node = rclpy.create_node('test_reapply_client')
+        client = node.create_client(ReapplyConfig, REAPPLY_SERVICE)
+        if not client.wait_for_service(timeout_sec=timeout_sec):
+            node.destroy_node()
+            raise RuntimeError(f'service {REAPPLY_SERVICE} not available')
+        future = client.call_async(ReapplyConfig.Request())
+        rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+        if not future.done():
+            node.destroy_node()
+            raise RuntimeError('reapply service call timed out')
+        response = future.result()
+        node.destroy_node()
+        return response
+    finally:
+        rclpy.shutdown()
+
+
+# Snapshot of the prerun-generated YAML, restored by setUp before each test.
+_ORIGINAL_CONFIG_BYTES = None
+
+
+def _snapshot_original_config():
+    global _ORIGINAL_CONFIG_BYTES
+    with open(CONFIG_FILE, 'rb') as f:
+        _ORIGINAL_CONFIG_BYTES = f.read()
+
+
+def _restore_original_config():
+    if _ORIGINAL_CONFIG_BYTES is None:
+        raise RuntimeError(
+            '_restore_original_config called before _snapshot_original_config'
+        )
+    with open(CONFIG_FILE, 'wb') as f:
+        f.write(_ORIGINAL_CONFIG_BYTES)
+
+
+def generate_test_description():
+    _run_prerun()
+    _snapshot_original_config()
+
+    thread_configurator = launch_ros.actions.Node(
+        package='agnocast_cie_thread_configurator',
+        executable='thread_configurator_node',
+        name='thread_configurator_node',
+        output='screen',
+        parameters=[{'config_file': CONFIG_FILE}],
+    )
+
+    test_app = launch_ros.actions.Node(
+        package='agnocast_e2e_test',
+        executable='test_cie_publisher',
+        output='screen',
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable(
+                'RCUTILS_LOGGING_BUFFERED_STREAM', '0'
+            ),
+
+            thread_configurator,
+
+            # Start the target app after DDS discovery has time to settle.
+            launch.actions.TimerAction(
+                period=2.0,
+                actions=[test_app],
+            ),
+
+            launch.actions.TimerAction(
+                period=8.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]),
+        {
+            'thread_configurator': thread_configurator,
+            'test_app': test_app,
+        },
+    )
+
+
+class TestThreadConfiguratorReapply(unittest.TestCase):
+    # Tests wait for 'Received CallbackGroupInfo' (not 'All applied') because
+    # the publisher's worker thread race with the configurator can leave the
+    # initial apply pass incomplete; receiving one CallbackGroupInfo is the
+    # precondition the reapply tests actually need.
+
+    def setUp(self):
+        _restore_original_config()
+
+    def test_configurator_receives_registration(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_after_priority_change(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        self.assertGreater(
+            len(cfg.get('callback_groups', [])), 0,
+            'prerun must produce at least one callback_group',
+        )
+        first = cfg['callback_groups'][0]
+        # SCHED_OTHER + positive nice value: lowering priority needs no
+        # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
+        first['policy'] = 'SCHED_OTHER'
+        first['priority'] = 10
+        first.setdefault('affinity', [])
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        # Equality (not >=) catches both the silent no-op case and any
+        # future bug that double-routes an entry into multiple arrays.
+        outcomes_total = (
+            len(response.applied_callback_groups)
+            + len(response.skipped_callback_groups)
+            + len(response.failed_callback_groups)
+        )
+        self.assertEqual(
+            outcomes_total,
+            len(cfg['callback_groups']),
+            'reapply must visit every callback_group entry exactly once',
+        )
+        self.assertGreaterEqual(
+            len(response.applied_callback_groups), 1,
+            'modified callback_group must appear in applied_callback_groups',
+        )
+
+        proc_output.assertWaitFor(
+            'Reapply done:',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_accepts_added_entry(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        added_entry = {
+            'id': 'fictitious_unannounced_cbg',
+            'domain_id': 0,
+            'policy': 'SCHED_OTHER',
+            'priority': 0,
+            'affinity': [],
+        }
+        cfg.setdefault('callback_groups', []).append(added_entry)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        added_key = f"{added_entry['domain_id']}:{added_entry['id']}"
+        self.assertIn(added_key, list(response.skipped_callback_groups))
+
+    # 'zz_' prefix forces alphabetical-last execution: removing the cb-group
+    # clears in-memory state and there is no re-announcement mechanism, so
+    # this test would poison every test that runs after it.
+    def test_zz_reapply_accepts_removed_entry(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        self.assertGreater(
+            len(cfg.get('callback_groups', [])), 0,
+            'prerun must produce at least one callback_group',
+        )
+        removed = cfg['callback_groups'].pop(0)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        removed_key = f"{removed.get('domain_id', 0)}:{removed['id']}"
+        for arr in (
+            response.applied_callback_groups,
+            response.skipped_callback_groups,
+            response.failed_callback_groups,
+        ):
+            self.assertNotIn(removed_key, list(arr))
+
+    def test_reapply_non_ros_thread_priority_change(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received NonRosThreadInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        nrts = cfg.get('non_ros_threads', []) or []
+        target = next(
+            (e for e in nrts if e.get('name') == 'test_non_ros_worker'), None
+        )
+        if target is None:
+            self.skipTest(
+                'prerun did not produce test_non_ros_worker non_ros_thread entry'
+            )
+        target['policy'] = 'SCHED_OTHER'
+        target['priority'] = 10
+        target.setdefault('affinity', [])
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        self.assertIn(
+            'test_non_ros_worker', list(response.applied_non_ros_threads),
+            'modified non_ros_thread must appear in applied_non_ros_threads',
+        )
+
+    def test_reapply_rejects_invalid_policy(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        if len(cfg.get('callback_groups', [])) == 0:
+            self.skipTest('no callback_groups produced by prerun')
+        cfg['callback_groups'][0]['policy'] = 'NOT_A_POLICY'
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertFalse(response.success)
+        self.assertIn('Unknown scheduling policy', response.error_message)
+
+
+@launch_testing.post_shutdown_test()
+class TestThreadConfiguratorReapplyShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, -signal.SIGINT]
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(CONFIG_DIR):
+            shutil.rmtree(CONFIG_DIR)

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -229,8 +229,9 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             len(cfg['callback_groups']),
             'reapply must visit every callback_group entry exactly once',
         )
-        self.assertGreaterEqual(
-            len(response.applied_callback_groups), 1,
+        first_key = f"{first['domain_id']}:{first['id']}"
+        self.assertIn(
+            first_key, list(response.applied_callback_groups),
             'modified callback_group must appear in applied_callback_groups',
         )
 


### PR DESCRIPTION
## Description

Adds a `~/reapply_config` ROS service to `ThreadConfiguratorNode` so operators can edit the configurator's YAML and reapply scheduling attributes to running threads without restarting the configurator or any target application. Typical tuning loop becomes `vim config.yaml && ros2 service call .../reapply_config`.

**Behavior** (validate-then-apply):

1. Parse the read-only `config_file` parameter.
2. Per-entry validation via `parse_yaml`. Per-entry errors abort with `success=false` and no state mutation. `parse_yaml` also rejects duplicate keys, since the configurator's id maps would otherwise silently collapse duplicates to the last-inserted entry.
3. Carry over `thread_id` from the existing in-memory state into the new vectors by direct lookup in `id_to_*_config_`. `applied` is intentionally NOT carried over — every entry restarts as `applied=false` and is promoted to `true` by the syscall loop only when the new config has actually landed, so the response's `failed_*` array stays consistent with the in-memory state.
4. Swap the in-memory vectors and rebuild the id maps. Added entries (key in new but not in old) enter as `thread_id=-1` / `applied=false`; removed entries (key in old but not in new) drop out and the configurator no longer manages them (their kernel-level scheduling persists).
5. Apply syscalls. Per-entry results land in `applied_*` / `failed_*` / `skipped_*`. `skipped_*` means the thread has not yet announced itself; the new params will take effect on the next announcement. When all entries succeed cleanly the handler logs `Reapply: all entries successfully (re-)applied` so operators have a per-call health signal (`configured_at_least_once_` is one-shot for the process lifetime and is not re-emitted).

**Concurrency:** `non_ros_state_mutex_` protects `non_ros_thread_configs_` against the AUDS-driven listener thread. The non-ROS carry-over, swap, and `unapplied_num_` recompute share one critical section so the listener cannot squeeze a `thread_id` update into the OLD vector between phases. Callback-group state needs no lock — both subscriptions and the reapply handler run on the same `SingleThreadedExecutor`.

**Out of scope:** re-validating `hardware_info` / `rt_throttling` (changes there require a process restart, documented in the `.srv`), cleaning up orphaned `/sys/fs/cgroup/cpuset/<id>` directories.

**Tests:** unit tests cover duplicate-key rejection and same-id-different-domain acceptance. Launch tests cover priority change, added entry, removed entry, invalid policy, and the non-ROS-thread reapply path (separate from the callback-group path because of the mutex). The destructive removal test is named with a `zz_` prefix so it runs last alphabetically — removing a callback group clears the configurator's in-memory state and there is no re-announcement mechanism, so any test that runs after it would see a stale `thread_id=-1`. `test_publisher_component`'s non-ROS worker is now kept alive for the node lifetime so the reapply path has a live tid to operate on; an empty body would let the thread exit and the syscall would get ESRCH.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] \`bash scripts/test/e2e_test_1to1.bash\` (required)
- [ ] \`bash scripts/test/e2e_test_2to2.bash\` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] \`bash scripts/test/run_requires_kernel_module_tests.bash\` (required)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- \`need-major-update\`: User API breaking changes
- \`need-minor-update\`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- \`need-patch-update\`: Bug fixes and other changes

**Important notes:**

- If you need \`need-major-update\` or \`need-minor-update\`, please include this in the PR title as well.
  - Example: \`fix(foo)[needs major version update]: bar\` or \`feat(baz)[needs minor version update]: qux\`
- After receiving approval from reviewers, add the \`run-build-test\` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.