### PR TITLE
refactor(cie_thread_configurator): extract ThreadConfig and YAML parser into thread_config.hpp/cpp

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -14,8 +14,10 @@ find_package(yaml-cpp REQUIRED)
 add_library(thread_configurator SHARED
   src/util.cpp
   src/non_ros_thread_ipc.cpp
+  src/thread_config.cpp
 )
 ament_target_dependencies(thread_configurator rclcpp agnocast_cie_config_msgs)
+target_link_libraries(thread_configurator yaml-cpp)
 
 add_executable(
   thread_configurator_node

--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -79,6 +79,14 @@ if(BUILD_TESTING)
     test/test_non_ros_thread_ipc.cpp
   )
   target_link_libraries(test_${PROJECT_NAME} thread_configurator)
+
+  ament_add_gtest(test_reapply_config
+    test/test_reapply_config.cpp
+  )
+  target_link_libraries(test_reapply_config thread_configurator yaml-cpp)
+  target_include_directories(test_reapply_config PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
 endif()
 
 ament_package()

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "yaml-cpp/yaml.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// A single thread's scheduling configuration as parsed from the YAML and
+// observed at runtime. Owned by ThreadConfiguratorNode in two vectors.
+struct ThreadConfig
+{
+  std::string thread_str;  // callback_group_id or thread_name
+  size_t domain_id = 0;
+  int64_t thread_id = -1;  // -1 until announced by the target application
+  std::vector<int> affinity;
+  std::string policy;
+  int priority = 0;
+
+  // SCHED_DEADLINE only
+  unsigned int runtime = 0;
+  unsigned int period = 0;
+  unsigned int deadline = 0;
+
+  bool applied = false;  // true once issue_syscalls() has succeeded
+};
+
+// Mapping from the policy string in the YAML to the kernel SCHED_* constant.
+// Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
+extern const std::unordered_map<std::string, int> policy_to_sched_const;
+
+// Parse the given YAML document and populate the two output vectors.
+// Throws std::runtime_error on per-entry validation error (unknown policy,
+// missing SCHED_DEADLINE fields, etc.).
+//
+// Output ThreadConfigs have thread_id=-1 and applied=false.
+//
+// hardware_info / rt_throttling sections are NOT processed here; they are validated
+// at startup only by ThreadConfiguratorNode's constructor.
+void parse_yaml(
+  const YAML::Node & yaml, size_t default_domain_id,
+  std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out);
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "agnocast_cie_thread_configurator/non_ros_thread_ipc.hpp"
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -13,6 +14,8 @@
 
 class ThreadConfiguratorNode : public rclcpp::Node
 {
+  using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
+
   // Each ThreadConfig instance is touched by exactly one writer:
   // - callback_group_configs_ entries: written from CallbackGroupInfo
   //   subscription callbacks dispatched by the SingleThreadedExecutor
@@ -25,22 +28,6 @@ class ThreadConfiguratorNode : public rclcpp::Node
   // print_all_unapplied() reads applied flags only after main.cpp calls
   // node->stop() (which joins the listener) and after executor->spin()
   // returns, so no concurrent access is possible at read time.
-  struct ThreadConfig
-  {
-    std::string thread_str;  // callback_group_id or thread_name
-    size_t domain_id = 0;
-    int64_t thread_id = -1;
-    std::vector<int> affinity;
-    std::string policy;
-    int priority = 0;
-
-    // For SCHED_DEADLINE
-    unsigned int runtime = 0;
-    unsigned int period = 0;
-    unsigned int deadline = 0;
-
-    bool applied = false;
-  };
 
 public:
   explicit ThreadConfiguratorNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -1,0 +1,98 @@
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
+
+#include <linux/sched.h>
+#include <sched.h>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace agnocast_cie_thread_configurator
+{
+
+const std::unordered_map<std::string, int> policy_to_sched_const = {
+  {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
+  {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
+};
+
+namespace
+{
+// Backward compatibility: strip trailing "@Waitable" suffixes from a callback-group id.
+std::string remove_trailing_waitable(std::string s)
+{
+  static constexpr std::string_view suffix = "@Waitable";
+  const std::size_t suffix_size = suffix.size();
+  std::size_t s_size = s.size();
+  while (s_size >= suffix_size &&
+         std::char_traits<char>::compare(
+           s.data() + (s_size - suffix_size), suffix.data(), suffix_size) == 0) {
+    s_size -= suffix_size;
+  }
+  s.resize(s_size);
+  return s;
+}
+}  // namespace
+
+void parse_yaml(
+  const YAML::Node & yaml, size_t default_domain_id,
+  std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out)
+{
+  YAML::Node callback_groups = yaml["callback_groups"];
+  YAML::Node non_ros_threads = yaml["non_ros_threads"];
+
+  callback_groups_out.clear();
+  non_ros_threads_out.clear();
+  callback_groups_out.resize(callback_groups.size());
+  non_ros_threads_out.resize(non_ros_threads.size());
+
+  for (size_t i = 0; i < callback_groups.size(); ++i) {
+    const auto & cg = callback_groups[i];
+    auto & cfg = callback_groups_out[i];
+
+    cfg.thread_str = remove_trailing_waitable(cg["id"].as<std::string>());
+    cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
+    for (auto & cpu : cg["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    cfg.policy = cg["policy"].as<std::string>();
+
+    if (policy_to_sched_const.count(cfg.policy) == 0) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + cfg.policy + "' for id=" + cfg.thread_str +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
+    }
+
+    if (cfg.policy == "SCHED_DEADLINE") {
+      cfg.runtime = cg["runtime"].as<unsigned int>();
+      cfg.period = cg["period"].as<unsigned int>();
+      cfg.deadline = cg["deadline"].as<unsigned int>();
+    } else {
+      cfg.priority = cg["priority"].as<int>();
+    }
+  }
+
+  for (size_t i = 0; i < non_ros_threads.size(); ++i) {
+    const auto & nrt = non_ros_threads[i];
+    auto & cfg = non_ros_threads_out[i];
+
+    cfg.thread_str = nrt["name"].as<std::string>();
+    for (auto & cpu : nrt["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    cfg.policy = nrt["policy"].as<std::string>();
+
+    if (policy_to_sched_const.count(cfg.policy) == 0) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + cfg.policy + "' for name=" + cfg.thread_str +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
+    }
+
+    if (cfg.policy == "SCHED_DEADLINE") {
+      cfg.runtime = nrt["runtime"].as<unsigned int>();
+      cfg.period = nrt["period"].as<unsigned int>();
+      cfg.deadline = nrt["deadline"].as<unsigned int>();
+    } else {
+      cfg.priority = nrt["priority"].as<int>();
+    }
+  }
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -16,16 +17,9 @@
 #include <fstream>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
-namespace
-{
-const std::unordered_map<std::string, int> policy_to_sched_const = {
-  {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
-  {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
-};
-}  // namespace
+using agnocast_cie_thread_configurator::policy_to_sched_const;
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options)
@@ -48,98 +42,22 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   RCLCPP_INFO(this->get_logger(), "Loaded config from: %s", config_file.c_str());
 
-  YAML::Node callback_groups = yaml["callback_groups"];
-  YAML::Node non_ros_threads = yaml["non_ros_threads"];
-
-  unapplied_num_.store(static_cast<int>(callback_groups.size() + non_ros_threads.size()));
-  callback_group_configs_.resize(callback_groups.size());
-  non_ros_thread_configs_.resize(non_ros_threads.size());
-
   size_t default_domain_id = agnocast_cie_thread_configurator::get_default_domain_id();
 
-  // For backward compatibility: remove trailing "Waitable@"s
-  auto remove_trailing_waitable = [](std::string s) {
-    static constexpr std::string_view suffix = "@Waitable";
-    const std::size_t suffix_size = suffix.size();
-    std::size_t s_size = s.size();
+  agnocast_cie_thread_configurator::parse_yaml(
+    yaml, default_domain_id, callback_group_configs_, non_ros_thread_configs_);
 
-    while (s_size >= suffix_size &&
-           std::char_traits<char>::compare(
-             s.data() + (s_size - suffix_size), suffix.data(), suffix_size) == 0) {
-      s_size -= suffix_size;
-    }
-    s.resize(s_size);
-
-    return s;
-  };
+  unapplied_num_.store(
+    static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
 
   std::set<size_t> domain_ids;
-  for (size_t i = 0; i < callback_groups.size(); i++) {
-    const auto & callback_group = callback_groups[i];
-    auto & config = callback_group_configs_[i];
-
-    config.thread_str = remove_trailing_waitable(callback_group["id"].as<std::string>());
-
-    // Get domain_id from config, default to default_domain_id for backward compatibility
-    if (callback_group["domain_id"]) {
-      config.domain_id = callback_group["domain_id"].as<size_t>();
-    } else {
-      config.domain_id = default_domain_id;
-    }
-    domain_ids.insert(config.domain_id);
-
-    for (auto & cpu : callback_group["affinity"]) {
-      config.affinity.push_back(cpu.as<int>());
-    }
-    config.policy = callback_group["policy"].as<std::string>();
-
-    if (policy_to_sched_const.count(config.policy) == 0) {
-      throw std::runtime_error(
-        "Unknown scheduling policy '" + config.policy + "' for id=" + config.thread_str +
-        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
-        "SCHED_DEADLINE");
-    }
-
-    if (config.policy == "SCHED_DEADLINE") {
-      config.runtime = callback_group["runtime"].as<unsigned int>();
-      config.period = callback_group["period"].as<unsigned int>();
-      config.deadline = callback_group["deadline"].as<unsigned int>();
-    } else {
-      config.priority = callback_group["priority"].as<int>();
-    }
-
-    auto key = std::make_pair(config.domain_id, config.thread_str);
-    id_to_callback_group_config_[key] = &config;
+  for (auto & cfg : callback_group_configs_) {
+    domain_ids.insert(cfg.domain_id);
+    auto key = std::make_pair(cfg.domain_id, cfg.thread_str);
+    id_to_callback_group_config_[key] = &cfg;
   }
-
-  // Load non-ROS thread configurations
-  for (size_t i = 0; i < non_ros_threads.size(); i++) {
-    const auto & non_ros_thread = non_ros_threads[i];
-    auto & config = non_ros_thread_configs_[i];
-
-    config.thread_str = non_ros_thread["name"].as<std::string>();
-
-    for (auto & cpu : non_ros_thread["affinity"]) {
-      config.affinity.push_back(cpu.as<int>());
-    }
-    config.policy = non_ros_thread["policy"].as<std::string>();
-
-    if (policy_to_sched_const.count(config.policy) == 0) {
-      throw std::runtime_error(
-        "Unknown scheduling policy '" + config.policy + "' for name=" + config.thread_str +
-        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
-        "SCHED_DEADLINE");
-    }
-
-    if (config.policy == "SCHED_DEADLINE") {
-      config.runtime = non_ros_thread["runtime"].as<unsigned int>();
-      config.period = non_ros_thread["period"].as<unsigned int>();
-      config.deadline = non_ros_thread["deadline"].as<unsigned int>();
-    } else {
-      config.priority = non_ros_thread["priority"].as<int>();
-    }
-
-    id_to_non_ros_thread_config_[config.thread_str] = &config;
+  for (auto & cfg : non_ros_thread_configs_) {
+    id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
   }
 
   auto cbg_qos = rclcpp::QoS(rclcpp::KeepAll()).reliable().transient_local();

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 

--- a/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
 #include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
 
 #include <stdexcept>
 #include <string>
@@ -114,6 +115,25 @@ non_ros_threads:
     policy: NOT_A_POLICY
     priority: 0
     affinity: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsSchedDeadlineMissingRuntimeField)
+{
+  // SCHED_DEADLINE requires runtime/period/deadline. parse_yaml calls
+  // .as<unsigned int>() on a missing node, which makes yaml-cpp throw
+  // YAML::TypedBadConversion (a subclass of YAML::Exception, which is
+  // a subclass of std::runtime_error). The test catches the most general
+  // shape so it does not couple to the precise yaml-cpp exception type.
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: dl_cbg
+    domain_id: 0
+    policy: SCHED_DEADLINE
+    affinity: []
+non_ros_threads: []
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
   EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);

--- a/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_reapply_config.cpp
@@ -1,0 +1,184 @@
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace acie = agnocast_cie_thread_configurator;
+
+namespace
+{
+constexpr size_t kTestDefaultDomain = 7;
+
+YAML::Node yaml_from_str(const char * s)
+{
+  return YAML::Load(s);
+}
+}  // namespace
+
+// ---------- parse_yaml ----------
+
+TEST(ParseYaml, ParsesEmptyConfig)
+{
+  auto y = yaml_from_str("callback_groups: []\nnon_ros_threads: []\n");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  EXPECT_TRUE(cb.empty());
+  EXPECT_TRUE(nrt.empty());
+}
+
+TEST(ParseYaml, ParsesCallbackGroupSchedFifo)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 3
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: [0, 1]
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].thread_str, "my_cbg");
+  EXPECT_EQ(cb[0].domain_id, 3u);
+  EXPECT_EQ(cb[0].policy, "SCHED_FIFO");
+  EXPECT_EQ(cb[0].priority, 50);
+  EXPECT_EQ(cb[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_EQ(cb[0].thread_id, -1);
+  EXPECT_FALSE(cb[0].applied);
+}
+
+TEST(ParseYaml, FallsBackToDefaultDomainId)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].domain_id, kTestDefaultDomain);
+}
+
+TEST(ParseYaml, ParsesSchedDeadline)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: dl_cbg
+    domain_id: 0
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: 5000000
+    deadline: 5000000
+    affinity: [2]
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].policy, "SCHED_DEADLINE");
+  EXPECT_EQ(cb[0].runtime, 1000000u);
+  EXPECT_EQ(cb[0].period, 5000000u);
+  EXPECT_EQ(cb[0].deadline, 5000000u);
+}
+
+TEST(ParseYaml, RejectsUnknownPolicyOnCallbackGroup)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: bad
+    domain_id: 0
+    policy: SCHED_BOGUS
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsUnknownPolicyOnNonRosThread)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups: []
+non_ros_threads:
+  - name: bad_worker
+    policy: NOT_A_POLICY
+    priority: 0
+    affinity: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, ParsesNonRosThread)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups: []
+non_ros_threads:
+  - name: worker
+    policy: SCHED_RR
+    priority: 30
+    affinity: [3]
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(nrt.size(), 1u);
+  EXPECT_EQ(nrt[0].thread_str, "worker");
+  EXPECT_EQ(nrt[0].policy, "SCHED_RR");
+  EXPECT_EQ(nrt[0].priority, 30);
+}
+
+TEST(ParseYaml, StripsTrailingWaitableSuffix)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg@Waitable@Waitable
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].thread_str, "my_cbg");
+}
+
+TEST(ParseYaml, ClearsOutputVectorsOnReparse)
+{
+  auto y1 = yaml_from_str(R"YAML(
+callback_groups:
+  - id: alpha
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  acie::parse_yaml(y1, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+
+  auto y2 = yaml_from_str(R"YAML(
+callback_groups:
+  - id: beta
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  acie::parse_yaml(y2, kTestDefaultDomain, cb, nrt);
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].thread_str, "beta");
+}


### PR DESCRIPTION
## Description

Behavior-preserving refactor of `ThreadConfiguratorNode`'s YAML parsing path. The constructor's inline YAML parse loops are extracted into a free function `parse_yaml(...)` declared in a new shared header `thread_config.hpp`, and the `ThreadConfig` struct is moved out of `ThreadConfiguratorNode`'s private section into the same header so it can be reused.

This split is preparation for #1303 (the upcoming `~/reapply_config` service): the reapply handler needs to re-validate a fresh YAML against the same per-entry rules as the constructor (unknown policy, missing SCHED_DEADLINE fields, etc.). Pulling the parser out now lets that PR focus on the service handler logic, and lets reviewers look at the parser API in isolation here.

**What changed:**

- New header `agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp`:
  - `ThreadConfig` struct (moved out of `ThreadConfiguratorNode`'s private section, now in `agnocast_cie_thread_configurator` namespace)
  - `extern const std::unordered_map<std::string, int> policy_to_sched_const`
  - `parse_yaml(...)` declaration
- New source `thread_config.cpp`:
  - `parse_yaml` definition (logic identical to the old inline code)
  - `policy_to_sched_const` definition (was previously a file-local `static` in `thread_configurator_node.cpp`)
  - Anonymous-namespace `remove_trailing_waitable` helper (was a constructor-local lambda)
- `thread_configurator_node.hpp` no longer defines `ThreadConfig`; uses `using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;` so the rest of the class is unchanged. Adds `<set>` include explicitly (was previously transitively available).
- `thread_configurator_node.cpp` constructor calls `parse_yaml(...)` instead of doing the parse inline; brings the now-extern `policy_to_sched_const` into scope with a `using` declaration.
- `CMakeLists.txt`:
  - Adds `src/thread_config.cpp` to the `thread_configurator` library
  - Links `yaml-cpp` to the `thread_configurator` library (previously yaml-cpp was only linked to the executable)
  - Adds a new `test_reapply_config` gtest target
- New unit test `test/test_reapply_config.cpp` (10 cases): exercises `parse_yaml` directly without spinning rclcpp or making syscalls. Covers empty config, callback groups with SCHED_FIFO and SCHED_DEADLINE, non-ROS threads, default-domain fallback, `@Waitable` suffix stripping, unknown-policy rejection, and missing SCHED_DEADLINE field rejection.

**Behavior preservation:** The existing `test_thread_configurator_restart_launch.py` continues to pass. The constructor produces the same `callback_group_configs_` / `non_ros_thread_configs_` and id-maps as before. `unapplied_num_` is now computed from the populated vector sizes after parsing instead of from raw YAML node sizes — equivalent post-parse, slightly cleaner.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] \`bash scripts/test/e2e_test_1to1.bash\` (required)
- [ ] \`bash scripts/test/e2e_test_2to2.bash\` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] \`bash scripts/test/run_requires_kernel_module_tests.bash\` (required)
- [x] sample application

## Notes for reviewers

The new test file is named `test_reapply_config.cpp` because it lays the groundwork for #1303's reapply tests — currently it only covers `parse_yaml`, but additional cases for the reapply helpers will land in that PR.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- \`need-major-update\`: User API breaking changes
- \`need-minor-update\`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- \`need-patch-update\`: Bug fixes and other changes

**Important notes:**

- If you need \`need-major-update\` or \`need-minor-update\`, please include this in the PR title as well.
  - Example: \`fix(foo)[needs major version update]: bar\` or \`feat(baz)[needs minor version update]: qux\`
- After receiving approval from reviewers, add the \`run-build-test\` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.