### PR TITLE
test(timer): add unit tests for timer internals

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -134,6 +134,8 @@ if(BUILD_TESTING)
     test/unit/test_agnocast_utils.cpp
     test/unit/test_agnocast_subscription.cpp
     test/unit/test_agnocast_signal_handler.cpp
+    test/unit/test_agnocast_timer.cpp
+    test/unit/test_agnocast_timer_api.cpp
     test/unit/test_mocked_agnocast.cpp
     test/unit/test_agnocast_executors.cpp
     test/unit/test_agnocast_epoll_event.cpp

--- a/src/agnocastlib/test/unit/test_agnocast_timer.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer.cpp
@@ -1,0 +1,622 @@
+// White-box regression tests coupled to the current TimerInfo / JumpHandler
+// design — rewrite or delete on internal refactor, not a stability contract.
+// The user-facing timer contract lives in test/integration/test_agnocast_create_timer.cpp.
+
+#include "agnocast/agnocast_timer_info.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+
+#include <gtest/gtest.h>
+#include <poll.h>
+#include <rcl/time.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+
+using namespace std::chrono_literals;
+
+// Forward declarations for internal helpers (defined in agnocast_timer_info.cpp
+// but not exposed via the public header; declared here so tests can call them
+// directly).
+namespace agnocast
+{
+void handle_pre_time_jump(TimerInfo & timer_info);
+void handle_post_time_jump(TimerInfo & timer_info, const rcl_time_jump_t & jump);
+}  // namespace agnocast
+
+class TestTimer : public ::testing::Test
+{
+protected:
+  void TearDown() override
+  {
+    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+    agnocast::id2_timer_info.clear();
+  }
+
+  static constexpr int64_t kPeriodNs = 100'000'000;  // 100ms
+
+  // Creates a Clock (RCL_ROS_TIME) with ROS time override enabled and set to `time_ns`.
+  rclcpp::Clock::SharedPtr make_ros_clock_at(int64_t time_ns) const
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    rcl_clock_t * rcl_clock = clock->get_clock_handle();
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    EXPECT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    EXPECT_EQ(rcl_set_ros_time_override(rcl_clock, time_ns), RCL_RET_OK);
+    return clock;
+  }
+
+  // Builds a TimerInfo with the minimum fields required by the time-jump handlers.
+  std::shared_ptr<agnocast::TimerInfo> make_timer_info(
+    rclcpp::Clock::SharedPtr clock, int64_t now_ns, int64_t period_ns = kPeriodNs) const
+  {
+    auto info = std::make_shared<agnocast::TimerInfo>();
+    info->timer_id = 1;
+    info->period = std::chrono::nanoseconds{period_ns};
+    info->clock = std::move(clock);
+    info->last_call_time_ns.store(now_ns, std::memory_order_relaxed);
+    info->next_call_time_ns.store(now_ns + period_ns, std::memory_order_relaxed);
+    info->time_credit.store(0, std::memory_order_relaxed);
+    return info;
+  }
+
+  // Reads up to one u64 event from `fd`. Returns true if an event was consumed.
+  // poll() guards against blocking when the fd was not opened with EFD_NONBLOCK.
+  static bool consume_eventfd(int fd)
+  {
+    pollfd pfd{fd, POLLIN, 0};
+    if (poll(&pfd, 1, /*timeout_ms=*/0) <= 0) {
+      return false;
+    }
+    uint64_t value = 0;
+    const ssize_t ret = read(fd, &value, sizeof(value));
+    return ret == sizeof(value) && value > 0;
+  }
+};
+
+// handle_pre_time_jump — saves remaining period as time_credit before a jump
+// =============================================================================
+
+TEST_F(TestTimer, handle_pre_time_jump_saves_remaining_period_as_time_credit)
+{
+  // Arrange
+  const int64_t now_ns = 500'000'000;  // 0.5s on the new epoch
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  // Pin next_call so the credit is deterministic: now + 30ms.
+  const int64_t next_call_ns = now_ns + 30'000'000;
+  info->next_call_time_ns.store(next_call_ns, std::memory_order_relaxed);
+
+  // Act
+  agnocast::handle_pre_time_jump(*info);
+
+  // Assert
+  EXPECT_EQ(info->time_credit.load(std::memory_order_relaxed), next_call_ns - now_ns);
+}
+
+TEST_F(TestTimer, handle_pre_time_jump_is_noop_when_clock_uninitialized)
+{
+  // Arrange — ROS clock at t=0 (uninitialized).
+  auto clock = make_ros_clock_at(0);
+  auto info = make_timer_info(clock, /*now_ns=*/0);
+  // Had the function not bailed out, it would have stored
+  // (next_call_time_ns - now_ns) into time_credit. Pick a sentinel that
+  // differs from that value so a false positive cannot hide a regression.
+  const int64_t would_be_credit = info->next_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t sentinel = would_be_credit + 1;
+  info->time_credit.store(sentinel, std::memory_order_relaxed);
+
+  // Act
+  agnocast::handle_pre_time_jump(*info);
+
+  // Assert — time_credit is preserved (function did not perform its store).
+  EXPECT_EQ(info->time_credit.load(std::memory_order_relaxed), sentinel);
+}
+
+TEST_F(TestTimer, handle_pre_time_jump_swallows_exception_from_clock_now)
+{
+  // Arrange — RCL_CLOCK_UNINITIALIZED has no get_now hook, so clock->now()
+  // throws rclcpp::exceptions::RCLError (a std::exception).
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_CLOCK_UNINITIALIZED);
+  auto info = make_timer_info(clock, /*now_ns=*/0);
+  const int64_t would_be_credit = info->next_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t sentinel = would_be_credit + 1;
+  info->time_credit.store(sentinel, std::memory_order_relaxed);
+
+  // Act / Assert — exception must not escape.
+  EXPECT_NO_THROW(agnocast::handle_pre_time_jump(*info));
+  EXPECT_EQ(info->time_credit.load(std::memory_order_relaxed), sentinel);
+}
+
+// handle_post_time_jump (RCL_ROS_TIME_ACTIVATED) — closes timer_fd and applies time_credit
+// =============================================================================
+
+TEST_F(TestTimer, handle_post_time_jump_ros_time_activation_closes_timer_fd)
+{
+  // Arrange
+  auto clock = make_ros_clock_at(1'000'000'000);  // 1s
+  auto info = make_timer_info(clock, /*now_ns=*/1'000'000'000);
+  // Open a real eventfd as a stand-in for timerfd so we can observe the close.
+  info->timer_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_ACTIVATED;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_EQ(info->timer_fd, -1);
+}
+
+TEST_F(TestTimer, handle_post_time_jump_ros_time_activation_consumes_and_applies_time_credit)
+{
+  // Arrange — 30ms of credit was saved in the pre-jump callback.
+  const int64_t now_ns = 2'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  const int64_t credit = 30'000'000;
+  info->time_credit.store(credit, std::memory_order_relaxed);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_ACTIVATED;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert — credit is consumed (set to 0) and applied to the call-time anchors.
+  EXPECT_EQ(info->time_credit.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), now_ns - credit);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns - credit + kPeriodNs);
+}
+
+TEST_F(TestTimer, handle_post_time_jump_ros_time_activation_leaves_anchors_when_no_credit)
+{
+  // Arrange — credit is zero (pre-jump never ran or stored 0).
+  const int64_t now_ns = 2'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  const int64_t snapshot_last = info->last_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_ACTIVATED;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), snapshot_last);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
+}
+
+TEST_F(TestTimer, handle_post_time_jump_ros_time_activation_skips_credit_when_clock_uninitialized)
+{
+  // Arrange — clock at 0 (uninitialized) with credit pre-saved.
+  auto clock = make_ros_clock_at(0);
+  auto info = make_timer_info(clock, /*now_ns=*/0);
+  info->timer_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+  const int64_t credit = 30'000'000;
+  info->time_credit.store(credit, std::memory_order_relaxed);
+  const int64_t snapshot_last = info->last_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_ACTIVATED;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert — timer_fd is closed but credit is preserved and anchors are untouched.
+  EXPECT_EQ(info->timer_fd, -1);
+  EXPECT_EQ(info->time_credit.load(std::memory_order_relaxed), credit);
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), snapshot_last);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
+}
+
+// handle_post_time_jump (RCL_ROS_TIME_DEACTIVATED) — currently a no-op (warns only)
+// =============================================================================
+
+TEST_F(TestTimer, handle_post_time_jump_ros_time_deactivation_does_not_mutate_state)
+{
+  // Arrange
+  const int64_t now_ns = 3'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  info->timer_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+  const int fd_before = info->timer_fd;
+  const int64_t snapshot_last = info->last_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_DEACTIVATED;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_EQ(info->timer_fd, fd_before);
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), snapshot_last);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
+
+  close(info->timer_fd);
+  info->timer_fd = -1;
+}
+
+// handle_post_time_jump (forward jump) — writes clock_eventfd when timer is ready
+// =============================================================================
+
+TEST_F(TestTimer, handle_post_time_jump_forward_jump_writes_clock_eventfd_when_ready)
+{
+  // Arrange — now has advanced past next_call_time, so the timer is ready.
+  const int64_t now_ns = 1'200'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/now_ns - 200'000'000);
+  info->next_call_time_ns.store(now_ns - 100'000'000, std::memory_order_relaxed);
+  info->clock_eventfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->clock_eventfd, 0);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_TRUE(consume_eventfd(info->clock_eventfd));
+}
+
+TEST_F(TestTimer, handle_post_time_jump_forward_jump_does_not_write_when_not_ready)
+{
+  // Arrange — next_call_time is still in the future after the jump.
+  const int64_t now_ns = 1'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  info->next_call_time_ns.store(now_ns + 100'000'000, std::memory_order_relaxed);
+  info->clock_eventfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->clock_eventfd, 0);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_FALSE(consume_eventfd(info->clock_eventfd));
+}
+
+// handle_post_time_jump (backward jump) — resets anchors when now < last_call_time
+// =============================================================================
+
+TEST_F(TestTimer, handle_post_time_jump_backward_jump_resets_anchors_when_past_last_call)
+{
+  // Arrange — now is earlier than the recorded last_call_time.
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = 200'000'000;  // 800ms backwards
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns + kPeriodNs);
+}
+
+TEST_F(TestTimer, handle_post_time_jump_leaves_anchors_when_jump_falls_within_one_period)
+{
+  // Arrange — now is between last_call and next_call: neither branch fires.
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = 1'050'000'000;  // 50ms after last_call
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  info->next_call_time_ns.store(now_ns + 50'000'000, std::memory_order_relaxed);
+  info->clock_eventfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  ASSERT_GE(info->clock_eventfd, 0);
+  rcl_time_jump_t jump = {};
+  jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
+
+  // Act
+  agnocast::handle_post_time_jump(*info, jump);
+
+  // Assert
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), last_call_ns);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns + 50'000'000);
+  EXPECT_FALSE(consume_eventfd(info->clock_eventfd));
+}
+
+// =============================================================================
+// handle_timer_event — periodic dispatch with missed-cycle catch-up
+// =============================================================================
+
+TEST_F(TestTimer, handle_timer_event_is_noop_when_timer_weakptr_is_expired)
+{
+  // Arrange — info->timer is left as default-constructed (empty weak_ptr).
+  const int64_t now_ns = 1'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns);
+  const int64_t snapshot_last = info->last_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+
+  // Act
+  agnocast::handle_timer_event(*info);
+
+  // Assert
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), snapshot_last);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
+}
+
+TEST_F(TestTimer, handle_timer_event_advances_next_call_by_one_period_and_invokes_callback)
+{
+  // Arrange — timer last fired one period ago and is scheduled to fire at now.
+  // The candidate (stored + period) lands in the future, so catch-up is not entered.
+  const int64_t now_ns = 1'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, now_ns - kPeriodNs);
+  int call_count = 0;
+  std::function<void()> cb = [&call_count]() { ++call_count; };
+  auto timer = std::make_shared<agnocast::GenericTimer<std::function<void()>>>(
+    /*timer_id=*/0u, std::chrono::nanoseconds{kPeriodNs}, clock, std::move(cb));
+  info->timer = timer;
+
+  // Act
+  agnocast::handle_timer_event(*info);
+
+  // Assert
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns + kPeriodNs);
+  EXPECT_EQ(call_count, 1);
+}
+
+TEST_F(TestTimer, handle_timer_event_just_past_two_period_boundary_advances_extra_period)
+{
+  // Arrange — simulate "executor is 2 periods + 1ns late": catch-up must advance
+  // next_call by 3 periods (1ns past the boundary triggers an extra period).
+  const int64_t stored_next = 1'000'000'000;
+  const int64_t now_ns = stored_next + 2 * kPeriodNs + 1;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, stored_next - kPeriodNs);
+  std::function<void()> cb = []() {};
+  auto timer = std::make_shared<agnocast::GenericTimer<std::function<void()>>>(
+    0u, std::chrono::nanoseconds{kPeriodNs}, clock, std::move(cb));
+  info->timer = timer;
+
+  // Act
+  agnocast::handle_timer_event(*info);
+
+  // Assert
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), stored_next + 3 * kPeriodNs);
+}
+
+TEST_F(TestTimer, handle_timer_event_catches_up_many_periods_at_once)
+{
+  // Arrange — simulate "executor is 5 periods late". Catch-up must advance by 5
+  // periods AND callback must fire exactly once (drop-missed semantics, not burst).
+  const int64_t stored_next = 1'000'000'000;
+  const int64_t now_ns = stored_next + 5 * kPeriodNs;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, stored_next - kPeriodNs);
+  int call_count = 0;
+  std::function<void()> cb = [&call_count]() { ++call_count; };
+  auto timer = std::make_shared<agnocast::GenericTimer<std::function<void()>>>(
+    0u, std::chrono::nanoseconds{kPeriodNs}, clock, std::move(cb));
+  info->timer = timer;
+
+  // Act
+  agnocast::handle_timer_event(*info);
+
+  // Assert — exactly 5 periods advance, ending at now (no overshoot).
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  EXPECT_EQ(call_count, 1) << "drop-missed: must fire once even when many periods late";
+}
+
+TEST_F(TestTimer, handle_timer_event_with_zero_period_sets_next_call_to_now)
+{
+  // Arrange — period=0 timer with stored next_call far in the past. Callback must
+  // fire exactly once (no infinite-loop in the period=0 catch-up branch).
+  const int64_t stored_next = 100;
+  const int64_t now_ns = 1'000'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, stored_next, /*period_ns=*/0);
+  int call_count = 0;
+  std::function<void()> cb = [&call_count]() { ++call_count; };
+  auto timer = std::make_shared<agnocast::GenericTimer<std::function<void()>>>(
+    0u, std::chrono::nanoseconds{0}, clock, std::move(cb));
+  info->timer = timer;
+
+  // Act
+  agnocast::handle_timer_event(*info);
+
+  // Assert
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  EXPECT_EQ(call_count, 1) << "period=0 must fire exactly once per call, not loop";
+}
+
+// =============================================================================
+// register_timer_info — initializes TimerInfo and inserts into the registry
+// =============================================================================
+
+class TestRegisterTimerInfo : public ::testing::Test
+{
+protected:
+  void TearDown() override
+  {
+    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+    agnocast::id2_timer_info.clear();
+  }
+
+  rclcpp::CallbackGroup::SharedPtr default_callback_group()
+  {
+    if (!node_) {
+      rclcpp::NodeOptions options;
+      options.start_parameter_services(false);
+      node_ = std::make_shared<agnocast::Node>("test_register_timer_info", options);
+    }
+    return node_->get_node_base_interface()->get_default_callback_group();
+  }
+
+  std::shared_ptr<agnocast::TimerBase> make_generic_timer(
+    uint32_t timer_id, std::chrono::nanoseconds period, rclcpp::Clock::SharedPtr clock)
+  {
+    return std::make_shared<agnocast::GenericTimer<std::function<void()>>>(
+      timer_id, period, std::move(clock), std::function<void()>{[]() {}});
+  }
+
+  std::shared_ptr<agnocast::TimerInfo> find_registered(uint32_t timer_id) const
+  {
+    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+    auto it = agnocast::id2_timer_info.find(timer_id);
+    return it != agnocast::id2_timer_info.end() ? it->second : nullptr;
+  }
+
+  static constexpr int64_t kPeriodNs = 50'000'000;  // 50ms
+
+  std::shared_ptr<agnocast::Node> node_;
+};
+
+TEST_F(TestRegisterTimerInfo, steady_time_clock_creates_timer_fd_only)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = std::chrono::nanoseconds{kPeriodNs};
+  const uint32_t timer_id = 1;
+  auto timer = make_generic_timer(timer_id, period, clock);
+
+  // Act
+  agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+  // Assert
+  auto info = find_registered(timer_id);
+  ASSERT_NE(info, nullptr);
+  EXPECT_GE(info->timer_fd, 0);
+  EXPECT_EQ(info->clock_eventfd, -1);
+}
+
+TEST_F(TestRegisterTimerInfo, ros_time_clock_inactive_creates_both_timer_fd_and_clock_eventfd)
+{
+  // Arrange — RCL_ROS_TIME clock without override enabled (sim time inactive).
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  ASSERT_FALSE(clock->ros_time_is_active());
+  const auto period = std::chrono::nanoseconds{kPeriodNs};
+  const uint32_t timer_id = 2;
+  auto timer = make_generic_timer(timer_id, period, clock);
+
+  // Act
+  agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+  // Assert
+  auto info = find_registered(timer_id);
+  ASSERT_NE(info, nullptr);
+  EXPECT_GE(info->timer_fd, 0);
+  EXPECT_GE(info->clock_eventfd, 0);
+}
+
+TEST_F(TestRegisterTimerInfo, ros_time_clock_active_skips_timer_fd)
+{
+  // Arrange — RCL_ROS_TIME clock with override enabled (sim time active).
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * rcl_clock = clock->get_clock_handle();
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, 1'000'000'000LL), RCL_RET_OK);
+  }
+  ASSERT_TRUE(clock->ros_time_is_active());
+  const auto period = std::chrono::nanoseconds{kPeriodNs};
+  const uint32_t timer_id = 3;
+  auto timer = make_generic_timer(timer_id, period, clock);
+
+  // Act
+  agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+  // Assert
+  auto info = find_registered(timer_id);
+  ASSERT_NE(info, nullptr);
+  EXPECT_EQ(info->timer_fd, -1);
+  EXPECT_GE(info->clock_eventfd, 0);
+}
+
+TEST_F(TestRegisterTimerInfo, populates_timer_info_from_arguments_and_clock)
+{
+  // Arrange — pin ROS time so the anchor values can be asserted exactly.
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * rcl_clock = clock->get_clock_handle();
+  const int64_t now_ns = 5'000'000'000LL;
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, now_ns), RCL_RET_OK);
+  }
+  const auto period = std::chrono::nanoseconds{kPeriodNs};
+  const uint32_t timer_id = 42;
+  auto timer = make_generic_timer(timer_id, period, clock);
+  auto cb_group = default_callback_group();
+
+  // Act
+  agnocast::register_timer_info(timer_id, timer, period, cb_group, clock);
+
+  // Assert
+  auto info = find_registered(timer_id);
+  ASSERT_NE(info, nullptr);
+  // Argument forwarding: each argument is stored verbatim.
+  EXPECT_EQ(info->timer_id, timer_id);
+  EXPECT_EQ(info->timer.lock(), timer);
+  EXPECT_EQ(info->period, period);
+  EXPECT_EQ(info->callback_group, cb_group);
+  // Call-time anchors initialized from clock->now().
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns + kPeriodNs);
+}
+
+TEST_F(TestRegisterTimerInfo, sets_epoll_update_flags_per_created_fds)
+{
+  // Arrange — STEADY_TIME so only timer_fd is created (no clock_eventfd).
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = std::chrono::nanoseconds{kPeriodNs};
+  const uint32_t timer_id = 5;
+  auto timer = make_generic_timer(timer_id, period, clock);
+
+  // Act
+  agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+  // Assert
+  auto info = find_registered(timer_id);
+  ASSERT_NE(info, nullptr);
+  EXPECT_TRUE(info->need_epoll_update);
+  EXPECT_TRUE(info->timer_fd_need_update);
+  EXPECT_FALSE(info->clock_eventfd_need_update);
+}
+
+TEST_F(TestRegisterTimerInfo, attaches_jump_handler_only_for_ros_time)
+{
+  // STEADY_TIME — no jump handler.
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+    const auto period = std::chrono::nanoseconds{kPeriodNs};
+    const uint32_t timer_id = 6;
+    auto timer = make_generic_timer(timer_id, period, clock);
+
+    agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+    auto info = find_registered(timer_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->jump_handler, nullptr);
+  }
+
+  // ROS_TIME — jump handler installed (drives handle_pre/post_time_jump).
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    const auto period = std::chrono::nanoseconds{kPeriodNs};
+    const uint32_t timer_id = 7;
+    auto timer = make_generic_timer(timer_id, period, clock);
+
+    agnocast::register_timer_info(timer_id, timer, period, default_callback_group(), clock);
+
+    auto info = find_registered(timer_id);
+    ASSERT_NE(info, nullptr);
+    EXPECT_NE(info->jump_handler, nullptr);
+  }
+}

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -1,0 +1,136 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_timer_info.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+
+using namespace agnocast;
+
+// =========================================
+// create_timer free function tests
+// =========================================
+
+class CreateTimerFreeFunctionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::NodeOptions options;
+    options.start_parameter_services(false);
+    node = std::make_shared<agnocast::Node>("test_timer_node", options);
+  }
+
+  void TearDown() override { node.reset(); }
+
+  std::shared_ptr<agnocast::Node> node;
+};
+
+TEST_F(CreateTimerFreeFunctionTest, creates_timer_and_registers_info)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+
+  // Act
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+
+  // Assert
+  ASSERT_NE(timer, nullptr);
+  EXPECT_EQ(timer->get_clock()->get_clock_type(), RCL_STEADY_TIME);
+}
+
+TEST_F(CreateTimerFreeFunctionTest, uses_default_callback_group_when_nullptr)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+  auto expected_group = node->get_node_base_interface()->get_default_callback_group();
+
+  // Act
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, nullptr);
+
+  // Assert: verify the timer was registered with the default callback group
+  ASSERT_NE(timer, nullptr);
+  // Check via id2_timer_info that the callback group matches the default
+  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+  bool found = false;
+  for (const auto & [id, info] : agnocast::id2_timer_info) {
+    if (info->callback_group == expected_group && info->timer.lock() == timer) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Timer should be registered with the default callback group";
+}
+
+TEST_F(CreateTimerFreeFunctionTest, uses_explicit_callback_group)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(50));
+  auto group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  // Act
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, group);
+
+  // Assert
+  ASSERT_NE(timer, nullptr);
+  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+  bool found = false;
+  for (const auto & [id, info] : agnocast::id2_timer_info) {
+    if (info->callback_group == group && info->timer.lock() == timer) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Timer should be registered with the explicit callback group";
+}
+
+TEST_F(CreateTimerFreeFunctionTest, callback_is_invoked)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(10));
+  bool called = false;
+  auto timer = agnocast::create_timer(node.get(), clock, period, [&called]() { called = true; });
+
+  // Act
+  timer->execute_callback();
+
+  // Assert
+  EXPECT_TRUE(called);
+}
+
+// =========================================
+// ID overflow tests
+// =========================================
+
+TEST(AllocateTimerIdTest, throws_when_id_has_reserved_epoll_flag_bits)
+{
+  // Arrange: Set next_timer_id to MAX_TIMER_ID so the next allocation overflows the boundary.
+  const uint32_t original = next_timer_id.load();
+  next_timer_id.store(MAX_TIMER_ID);
+
+  // Act & Assert
+  EXPECT_THROW(allocate_timer_id(), std::runtime_error);
+
+  // Cleanup
+  next_timer_id.store(original);
+}
+
+TEST(AllocateTimerIdTest, succeeds_just_below_reserved_range)
+{
+  // Arrange: Set next_timer_id to the maximum valid value.
+  const uint32_t original = next_timer_id.load();
+  next_timer_id.store(MAX_TIMER_ID - 1);
+
+  // Act & Assert
+  EXPECT_EQ(allocate_timer_id(), MAX_TIMER_ID - 1);
+
+  // Cleanup
+  next_timer_id.store(original);
+}

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -3,7 +3,6 @@
 #include "agnocast/agnocast_epoll.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
-#include "agnocast/agnocast_timer_info.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "std_msgs/msg/int32.hpp"
@@ -623,101 +622,6 @@ TEST_F(AgnocastCallbackInfoTest, get_erased_callback_const_ptr)
 }
 
 // =========================================
-// create_timer free function tests
-// =========================================
-
-class CreateTimerFreeFunctionTest : public ::testing::Test
-{
-protected:
-  void SetUp() override
-  {
-    rclcpp::NodeOptions options;
-    options.start_parameter_services(false);
-    node = std::make_shared<agnocast::Node>("test_timer_node", options);
-  }
-
-  void TearDown() override { node.reset(); }
-
-  std::shared_ptr<agnocast::Node> node;
-};
-
-TEST_F(CreateTimerFreeFunctionTest, creates_timer_and_registers_info)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
-
-  // Act
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
-
-  // Assert
-  ASSERT_NE(timer, nullptr);
-  EXPECT_EQ(timer->get_clock()->get_clock_type(), RCL_STEADY_TIME);
-}
-
-TEST_F(CreateTimerFreeFunctionTest, uses_default_callback_group_when_nullptr)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
-  auto expected_group = node->get_node_base_interface()->get_default_callback_group();
-
-  // Act
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, nullptr);
-
-  // Assert: verify the timer was registered with the default callback group
-  ASSERT_NE(timer, nullptr);
-  // Check via id2_timer_info that the callback group matches the default
-  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
-  bool found = false;
-  for (const auto & [id, info] : agnocast::id2_timer_info) {
-    if (info->callback_group == expected_group && info->timer.lock() == timer) {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Timer should be registered with the default callback group";
-}
-
-TEST_F(CreateTimerFreeFunctionTest, uses_explicit_callback_group)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(50));
-  auto group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
-  // Act
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, group);
-
-  // Assert
-  ASSERT_NE(timer, nullptr);
-  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
-  bool found = false;
-  for (const auto & [id, info] : agnocast::id2_timer_info) {
-    if (info->callback_group == group && info->timer.lock() == timer) {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Timer should be registered with the explicit callback group";
-}
-
-TEST_F(CreateTimerFreeFunctionTest, callback_is_invoked)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(10));
-  bool called = false;
-  auto timer = agnocast::create_timer(node.get(), clock, period, [&called]() { called = true; });
-
-  // Act
-  timer->execute_callback();
-
-  // Assert
-  EXPECT_TRUE(called);
-}
-
-// =========================================
 // ID overflow tests
 // =========================================
 
@@ -746,32 +650,6 @@ TEST(AllocateCallbackInfoIdTest, succeeds_just_below_reserved_range)
 
   // Cleanup
   next_callback_info_id.store(original);
-}
-
-TEST(AllocateTimerIdTest, throws_when_id_has_reserved_epoll_flag_bits)
-{
-  // Arrange: Set next_timer_id to MAX_TIMER_ID so the next allocation overflows the boundary.
-  const uint32_t original = next_timer_id.load();
-  next_timer_id.store(MAX_TIMER_ID);
-
-  // Act & Assert
-  EXPECT_THROW(allocate_timer_id(), std::runtime_error);
-
-  // Cleanup
-  next_timer_id.store(original);
-}
-
-TEST(AllocateTimerIdTest, succeeds_just_below_reserved_range)
-{
-  // Arrange: Set next_timer_id to the maximum valid value.
-  const uint32_t original = next_timer_id.load();
-  next_timer_id.store(MAX_TIMER_ID - 1);
-
-  // Act & Assert
-  EXPECT_EQ(allocate_timer_id(), MAX_TIMER_ID - 1);
-
-  // Cleanup
-  next_timer_id.store(original);
 }
 
 TEST_F(AgnocastSmartPointerTest, converting_copy_constructor)


### PR DESCRIPTION
## Description
Add white-box regression tests for `agnocastlib`'s timer internals.

Tests are grouped and follow the Arrange / Act / Assert pattern:
  - **Pre-jump callback** (`handle_pre_time_jump`): saves remaining period as time credit; no-op when clock is uninitialized.
  - **Post-jump — ROS time activation**: closes `timer_fd`; consumes and applies time credit to call-time anchors.
  - **Post-jump — ROS time deactivation**: leaves state untouched (currently unsupported).
  - **Post-jump — forward jump**: writes `clock_eventfd` only when the timer is ready.
  - **Post-jump — backward jump**: resets call-time anchors only when "now" precedes `last_call_time`.
  - **Periodic dispatch** (`handle_timer_event`): advances `next_call_time` by one period when on time, catches up the right number of periods on missed cycles (off-by-one boundaries pinned), sets `next_call` to `now` for zero-period timers, and is a no-op when the timer's `weak_ptr` has expired.                                                                                                                              
  - **Timer registration** (`register_timer_info`): allocates `timer_fd` and/or `clock_eventfd` per clock type and sim-time state, registers the entry in the global map, initializes the call-time anchors to `now` / `now + period`, and attaches a jump handler only for ROS-time clocks.

Also, moved the timer related API tests to `test_agnocast_timer_api.cpp` from `test_mocked_agnocast.cpp`. Will implement specification tests for those APIs in a follow-up PR.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers
Integration test is implemented in a separate PR.
https://github.com/autowarefoundation/agnocast/pull/1104

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
