### PR TITLE
fix(kmod): add explanatory comments to memory barrier calls

### DIFF
--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -24,6 +24,8 @@ static struct file_operations fops = {
 static int exit_worker_thread(void * data)
 {
   while (!kthread_should_stop()) {
+    // Pairs with smp_store_release() in agnocast_enqueue_exit_pid(); ensures all
+    // queue writes from the enqueuer are visible before we read the queue.
     wait_event_interruptible(worker_wait, smp_load_acquire(&has_new_pid) || kthread_should_stop());
 
     if (kthread_should_stop()) break;
@@ -42,6 +44,8 @@ static int exit_worker_thread(void * data)
         got_pid = true;
       }
 
+      // Release ensures the queue-drain reads complete before has_new_pid is cleared,
+      // preventing the enqueuer from seeing a stale 0 after re-checking the queue.
       if (queue_head == queue_tail) smp_store_release(&has_new_pid, 0);
 
       spin_unlock_irqrestore(&pid_queue_lock, flags);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -229,6 +229,8 @@ void agnocast_enqueue_exit_pid(const pid_t pid)
   if (next != queue_head) {  // queue is not full
     exit_pid_queue[queue_tail] = pid;
     queue_tail = next;
+    // Pairs with smp_load_acquire() in the worker thread; ensures the queue write
+    // is visible before the worker observes has_new_pid == 1.
     smp_store_release(&has_new_pid, 1);
     need_wakeup = true;
   }


### PR DESCRIPTION
## Description

smp_store_release/smp_load_acquire pairs require comments explaining the synchronization intent per checkpatch MEMORY_BARRIER guidance.

Resolves part of #1253: MEMORY_BARRIER (3): Memory barriers without explanatory comments


## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
