### PR TITLE
fix(kmod): remove needless null checks before kfree calls

### DIFF
--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -65,9 +65,7 @@ static void remove_all_bridge_info(void)
   hash_for_each_safe(bridge_htable, bkt, tmp, br_info, node)
   {
     hash_del(&br_info->node);
-    if (br_info->topic_name) {
-      kfree(br_info->topic_name);
-    }
+    kfree(br_info->topic_name);
     kfree(br_info);
   }
 }

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -303,9 +303,7 @@ void agnocast_process_exit_cleanup(const pid_t pid)
       agnocast_get_size_pub_info_htable(wrapper) == 0 &&
       agnocast_get_size_sub_info_htable(wrapper) == 0) {
       hash_del(&wrapper->node);
-      if (wrapper->key) {
-        kfree(wrapper->key);
-      }
+      kfree(wrapper->key);
       kfree(wrapper);
     }
   }
@@ -315,9 +313,7 @@ void agnocast_process_exit_cleanup(const pid_t pid)
   {
     if (br_info->pid == pid) {
       hash_del(&br_info->node);
-      if (br_info->topic_name) {
-        kfree(br_info->topic_name);
-      }
+      kfree(br_info->topic_name);
       kfree(br_info);
     }
   }


### PR DESCRIPTION
## Description

kfree(NULL) is safe, so guarding it with if (p) is unnecessary.

Resolves part of #1253 : NEEDLESS_IF (3): if (p) kfree(p) — kfree(NULL) is safe

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
