### PR TITLE
feat(agnocastlib): support dynamic `add_callback_group` / `remove_callback_group` calls

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
@@ -1,7 +1,10 @@
 #pragma once
 #include "agnocast/agnocast_executor.hpp"
 #include "agnocast/agnocast_public_api.hpp"
+#include "agnocast/cie_client_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include <mutex>
 
 namespace agnocast
 {
@@ -54,6 +57,13 @@ class CallbackIsolatedAgnocastExecutor : public rclcpp::Executor
   // owner has not yet released its SharedPtr, and its `associated_with_executor` flag is false).
   std::set<rclcpp::CallbackGroup::WeakPtr, std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
     stopped_groups_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
+
+  // Lazy-initialized publisher used by child threads to report (tid, callback_group_id) to the
+  // CIE thread configurator. Shared between spin()'s auto-discovery path and
+  // attach_callback_group()'s explicit attach path.
+  std::once_flag client_publisher_once_;
+  rclcpp::Publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr client_publisher_;
+  std::mutex client_publisher_mutex_;
 
   std::vector<rclcpp::CallbackGroup::WeakPtr> get_manually_added_callback_groups_internal() const
     RCPPUTILS_TSA_REQUIRES(mutex_);
@@ -142,6 +152,18 @@ public:
   /// @param notify If true, wake the executor so it picks up the change immediately.
   AGNOCAST_PUBLIC
   void remove_node(rclcpp::Node::SharedPtr node_ptr, bool notify = true) override;
+
+private:
+  // Spawn a child executor for `group` on `node` and start its dedicated thread. Caller must hold
+  // `child_resources_mutex_`. Used by both spin()'s auto-discovery path and
+  // attach_callback_group()'s explicit attach path.
+  void spawn_child_executor_locked(
+    const rclcpp::CallbackGroup::SharedPtr & group,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node)
+    RCPPUTILS_TSA_REQUIRES(child_resources_mutex_);
+
+  // Lazy-initialize client_publisher_ on first use. Safe to call concurrently or repeatedly.
+  void ensure_client_publisher();
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
@@ -49,12 +49,9 @@ class CallbackIsolatedAgnocastExecutor : public rclcpp::Executor
   // Child threads created during spin()
   std::vector<std::thread> child_threads_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
 
-  // Callback groups that were explicitly stopped via stop_callback_group(). The monitor loop in
-  // spin() must not re-spawn child executors for these groups, even if they are still discoverable
-  // via the node's callback group list. Without this set, a TOCTOU race between
-  // stop_callback_group() and the monitor loop can cause a stopped group to be re-spawned while
-  // another callback group teardown is still in progress (the stopped group is alive because its
-  // owner has not yet released its SharedPtr, and its `associated_with_executor` flag is false).
+  // Sentinel for groups stopped via stop_callback_group(): suppresses respawn by the monitor
+  // loop while the group is still owned by its caller (associated_with_executor flag is cleared
+  // on stop, but the group may outlive that and look like an orphan to the monitor loop).
   std::set<rclcpp::CallbackGroup::WeakPtr, std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
     stopped_groups_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
 

--- a/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
@@ -46,6 +46,15 @@ class CallbackIsolatedAgnocastExecutor : public rclcpp::Executor
   // Child threads created during spin()
   std::vector<std::thread> child_threads_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
 
+  // Callback groups that were explicitly stopped via stop_callback_group(). The monitor loop in
+  // spin() must not re-spawn child executors for these groups, even if they are still discoverable
+  // via the node's callback group list. Without this set, a TOCTOU race between
+  // stop_callback_group() and the monitor loop can cause a stopped group to be re-spawned while
+  // another callback group teardown is still in progress (the stopped group is alive because its
+  // owner has not yet released its SharedPtr, and its `associated_with_executor` flag is false).
+  std::set<rclcpp::CallbackGroup::WeakPtr, std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
+    stopped_groups_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
+
   std::vector<rclcpp::CallbackGroup::WeakPtr> get_manually_added_callback_groups_internal() const
     RCPPUTILS_TSA_REQUIRES(mutex_);
 

--- a/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_isolated_executor.hpp
@@ -58,9 +58,6 @@ class CallbackIsolatedAgnocastExecutor : public rclcpp::Executor
   std::set<rclcpp::CallbackGroup::WeakPtr, std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
     stopped_groups_ RCPPUTILS_TSA_GUARDED_BY(child_resources_mutex_);
 
-  // Lazy-initialized publisher used by child threads to report (tid, callback_group_id) to the
-  // CIE thread configurator. Shared between spin()'s auto-discovery path and
-  // attach_callback_group()'s explicit attach path.
   std::once_flag client_publisher_once_;
   rclcpp::Publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>::SharedPtr client_publisher_;
   std::mutex client_publisher_mutex_;
@@ -154,15 +151,11 @@ public:
   void remove_node(rclcpp::Node::SharedPtr node_ptr, bool notify = true) override;
 
 private:
-  // Spawn a child executor for `group` on `node` and start its dedicated thread. Caller must hold
-  // `child_resources_mutex_`. Used by both spin()'s auto-discovery path and
-  // attach_callback_group()'s explicit attach path.
   void spawn_child_executor_locked(
     const rclcpp::CallbackGroup::SharedPtr & group,
     const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node)
     RCPPUTILS_TSA_REQUIRES(child_resources_mutex_);
 
-  // Lazy-initialize client_publisher_ on first use. Safe to call concurrently or repeatedly.
   void ensure_client_publisher();
 };
 

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -132,10 +132,8 @@ public:
     agnocast_pub_ = std::make_shared<AgnoPub>(
       parent_node.get(), topic_name, rclcpp::QoS(DEFAULT_QOS_DEPTH).transient_local(), agno_opts,
       true);
-    // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
-    // this group to the executor explicitly, and stops it explicitly during teardown. This avoids
-    // the TOCTOU window where, after stop_callback_group(), the monitor loop could re-spawn a child
-    // executor for a still-alive group whose `associated_with_executor` flag has been cleared.
+    // Bridge groups are attached/detached explicitly by the bridge manager. Opt out of monitor
+    // loop auto-discovery to avoid re-spawn races with stop_callback_group().
     ros_cb_group_ = parent_node->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive,
       /*automatically_add_to_executor_with_node=*/false);
@@ -185,7 +183,6 @@ public:
     // ROS subscribers without connectivity issues.
     ros_pub_ = parent_node->create_publisher<MessageT>(
       topic_name, rclcpp::QoS(DEFAULT_QOS_DEPTH).reliable().transient_local());
-    // See RosToAgnocastBridge for why we opt out of auto-discovery.
     agno_cb_group_ = parent_node->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive,
       /*automatically_add_to_executor_with_node=*/false);

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -132,8 +132,13 @@ public:
     agnocast_pub_ = std::make_shared<AgnoPub>(
       parent_node.get(), topic_name, rclcpp::QoS(DEFAULT_QOS_DEPTH).transient_local(), agno_opts,
       true);
-    ros_cb_group_ =
-      parent_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
+    // this group to the executor explicitly, and stops it explicitly during teardown. This avoids
+    // the TOCTOU window where, after stop_callback_group(), the monitor loop could re-spawn a child
+    // executor for a still-alive group whose `associated_with_executor` flag has been cleared.
+    ros_cb_group_ = parent_node->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive,
+      /*automatically_add_to_executor_with_node=*/false);
 
     rclcpp::SubscriptionOptions ros_opts;
     ros_opts.ignore_local_publications = true;
@@ -180,8 +185,10 @@ public:
     // ROS subscribers without connectivity issues.
     ros_pub_ = parent_node->create_publisher<MessageT>(
       topic_name, rclcpp::QoS(DEFAULT_QOS_DEPTH).reliable().transient_local());
-    agno_cb_group_ =
-      parent_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    // See RosToAgnocastBridge for why we opt out of auto-discovery.
+    agno_cb_group_ = parent_node->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive,
+      /*automatically_add_to_executor_with_node=*/false);
 
     agnocast::SubscriptionOptions agno_opts;
     agno_opts.ignore_local_publications = true;

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -64,44 +64,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
     }
   }  // guard mutex_
 
-  std::mutex client_publisher_mutex;
-  auto client_publisher = agnocast::create_rclcpp_client_publisher();
-
-  // Note: spawn_child_executor must be called while holding child_resources_mutex_.
-  auto spawn_child_executor =
-    [this, &client_publisher, &client_publisher_mutex](
-      const rclcpp::CallbackGroup::SharedPtr & group,
-      const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node) {
-      std::shared_ptr<rclcpp::Executor> executor;
-      auto agnocast_topics = agnocast::get_agnocast_topics_by_group(group);
-      auto callback_group_id = agnocast::create_callback_group_id(group, node, agnocast_topics);
-
-      if (agnocast_topics.empty()) {
-        executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-        std::static_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(executor)
-          ->add_callback_group(group, node);
-      } else {
-        executor = std::make_shared<SingleThreadedAgnocastExecutor>(
-          rclcpp::ExecutorOptions{}, next_exec_timeout_ms_);
-        std::static_pointer_cast<SingleThreadedAgnocastExecutor>(executor)
-          ->dedicate_to_callback_group(group, node);
-      }
-
-      child_callback_groups_.push_back(group);
-      weak_child_executors_.push_back(executor);
-
-      child_threads_.emplace_back([executor, callback_group_id = std::move(callback_group_id),
-                                   &client_publisher, &client_publisher_mutex]() {
-        auto tid = static_cast<pid_t>(syscall(SYS_gettid));
-
-        {
-          std::lock_guard<std::mutex> lock{client_publisher_mutex};
-          agnocast::publish_callback_group_info(client_publisher, tid, callback_group_id);
-        }
-
-        executor->spin();
-      });
-    };
+  ensure_client_publisher();
 
   {
     std::lock_guard<std::mutex> guard{child_resources_mutex_};
@@ -109,7 +72,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
       return;
     }
     for (auto & [group, node] : groups_and_nodes) {
-      spawn_child_executor(group, node);
+      spawn_child_executor_locked(group, node);
     }
   }  // guard child_resources_mutex_
 
@@ -170,7 +133,7 @@ void CallbackIsolatedAgnocastExecutor::spin()
       if (stopped_groups_.find(group) != stopped_groups_.end()) {
         continue;
       }
-      spawn_child_executor(group, node);
+      spawn_child_executor_locked(group, node);
     }
   }
 
@@ -204,23 +167,44 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
 {
   (void)notify;
 
+  if (!group_ptr || !node_ptr) {
+    RCLCPP_ERROR(logger, "add_callback_group: group or node is null");
+    return;
+  }
+
   std::weak_ptr<rclcpp::CallbackGroup> weak_group_ptr = group_ptr;
   std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface> weak_node_ptr = node_ptr;
 
-  std::lock_guard<std::mutex> guard{mutex_};
-
-  // Confirm that group_ptr does not refer to any of the callback groups held by nodes in
-  // weak_nodes_.
-  for (const auto & weak_node : weak_nodes_) {
-    auto n = weak_node.lock();
-
-    if (!n) {
-      continue;
+  // Reject the case where the same group would be both auto-discovered (via add_node) and
+  // manually added: that yields two child executors for one group. A group with
+  // `automatically_add_to_executor_with_node = false` on an already-added node is fine: it stays
+  // hidden from the monitor loop and only this manual path attaches it.
+  {
+    std::lock_guard<std::mutex> guard{mutex_};
+    if (group_ptr->automatically_add_to_executor_with_node()) {
+      for (const auto & weak_node : weak_nodes_) {
+        auto n = weak_node.lock();
+        if (!n) {
+          continue;
+        }
+        if (n->callback_group_in_node(group_ptr)) {
+          RCLCPP_ERROR(
+            logger,
+            "add_callback_group: group is auto-add and its owning node is already added; this "
+            "would double-attach. Create the group with automatically_add_to_executor_with_node = "
+            "false to manage it manually. Node: %s",
+            n->get_fully_qualified_name());
+          if (agnocast_fd != -1) {
+            close(agnocast_fd);
+          }
+          exit(EXIT_FAILURE);
+        }
+      }
     }
 
-    if (n->callback_group_in_node(group_ptr)) {
-      RCLCPP_ERROR(
-        logger, "Callback group already exists in node: %s", n->get_fully_qualified_name());
+    auto insert_info = weak_groups_to_nodes_.insert(std::make_pair(weak_group_ptr, weak_node_ptr));
+    if (!insert_info.second) {
+      RCLCPP_ERROR(logger, "Callback group already exists in the executor");
       if (agnocast_fd != -1) {
         close(agnocast_fd);
       }
@@ -228,15 +212,24 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
     }
   }
 
-  auto insert_info = weak_groups_to_nodes_.insert(std::make_pair(weak_group_ptr, weak_node_ptr));
-
-  if (!insert_info.second) {
-    RCLCPP_ERROR(logger, "Callback group already exists in the executor");
-    if (agnocast_fd != -1) {
-      close(agnocast_fd);
-    }
-    exit(EXIT_FAILURE);
+  // Eagerly spawn the child executor when spinning so the group starts dispatching callbacks
+  // immediately instead of waiting for the next spin() startup. When not spinning yet, spin()'s
+  // initial setup will spawn it from weak_groups_to_nodes_.
+  if (!spinning.load()) {
+    return;
   }
+
+  ensure_client_publisher();
+  std::lock_guard<std::mutex> guard{child_resources_mutex_};
+  for (const auto & weak_grp : child_callback_groups_) {
+    if (weak_grp.lock() == group_ptr) {
+      // Already spawned (e.g., spin()'s initial setup raced ahead). Nothing to do.
+      return;
+    }
+  }
+  // If the group was previously stopped, allow re-attach by clearing its sentinel entry.
+  stopped_groups_.erase(group_ptr);
+  spawn_child_executor_locked(group_ptr, node_ptr);
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr>
@@ -312,19 +305,23 @@ void CallbackIsolatedAgnocastExecutor::remove_callback_group(
 {
   (void)notify;
 
-  std::lock_guard<std::mutex> guard{mutex_};
-
-  auto it = weak_groups_to_nodes_.find(group_ptr);
-
-  if (it != weak_groups_to_nodes_.end()) {
-    weak_groups_to_nodes_.erase(it);
-  } else {
-    RCLCPP_ERROR(logger, "Callback group not found in the executor");
-    if (agnocast_fd != -1) {
-      close(agnocast_fd);
+  {
+    std::lock_guard<std::mutex> guard{mutex_};
+    auto it = weak_groups_to_nodes_.find(group_ptr);
+    if (it != weak_groups_to_nodes_.end()) {
+      weak_groups_to_nodes_.erase(it);
+    } else {
+      RCLCPP_ERROR(logger, "Callback group not found in the executor");
+      if (agnocast_fd != -1) {
+        close(agnocast_fd);
+      }
+      exit(EXIT_FAILURE);
     }
-    exit(EXIT_FAILURE);
   }
+
+  // Tear down the child executor (cancel + join its thread) if one was spawned for this group.
+  // No-op if spin() never spawned it (e.g., remove_callback_group called before any spin()).
+  stop_callback_group(group_ptr);
 }
 
 void CallbackIsolatedAgnocastExecutor::add_node(
@@ -458,6 +455,46 @@ void CallbackIsolatedAgnocastExecutor::stop_callback_group(
       thread_to_join.join();
     }
   }
+}
+
+void CallbackIsolatedAgnocastExecutor::ensure_client_publisher()
+{
+  std::call_once(client_publisher_once_, [this]() {
+    client_publisher_ = agnocast::create_rclcpp_client_publisher();
+  });
+}
+
+void CallbackIsolatedAgnocastExecutor::spawn_child_executor_locked(
+  const rclcpp::CallbackGroup::SharedPtr & group,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr & node)
+{
+  std::shared_ptr<rclcpp::Executor> executor;
+  auto agnocast_topics = agnocast::get_agnocast_topics_by_group(group);
+  auto callback_group_id = agnocast::create_callback_group_id(group, node, agnocast_topics);
+
+  if (agnocast_topics.empty()) {
+    executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    std::static_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(executor)
+      ->add_callback_group(group, node);
+  } else {
+    executor = std::make_shared<SingleThreadedAgnocastExecutor>(
+      rclcpp::ExecutorOptions{}, next_exec_timeout_ms_);
+    std::static_pointer_cast<SingleThreadedAgnocastExecutor>(executor)
+      ->dedicate_to_callback_group(group, node);
+  }
+
+  child_callback_groups_.push_back(group);
+  weak_child_executors_.push_back(executor);
+
+  child_threads_.emplace_back(
+    [this, executor, callback_group_id = std::move(callback_group_id)]() {
+      auto tid = static_cast<pid_t>(syscall(SYS_gettid));
+      {
+        std::lock_guard<std::mutex> lock{client_publisher_mutex_};
+        agnocast::publish_callback_group_info(client_publisher_, tid, callback_group_id);
+      }
+      executor->spin();
+    });
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -167,20 +167,14 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
 {
   (void)notify;
 
-  if (!group_ptr || !node_ptr) {
-    RCLCPP_ERROR(logger, "add_callback_group: group or node is null");
-    return;
-  }
-
   std::weak_ptr<rclcpp::CallbackGroup> weak_group_ptr = group_ptr;
   std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface> weak_node_ptr = node_ptr;
 
-  // Reject the case where the same group would be both auto-discovered (via add_node) and
-  // manually added: that yields two child executors for one group. A group with
-  // `automatically_add_to_executor_with_node = false` on an already-added node is fine: it stays
-  // hidden from the monitor loop and only this manual path attaches it.
   {
     std::lock_guard<std::mutex> guard{mutex_};
+
+    // Auto-add groups on already-added nodes are picked up by the monitor loop, so manually
+    // adding them here would double-attach. Auto-add=false groups have no such conflict.
     if (group_ptr->automatically_add_to_executor_with_node()) {
       for (const auto & weak_node : weak_nodes_) {
         auto n = weak_node.lock();
@@ -190,9 +184,8 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
         if (n->callback_group_in_node(group_ptr)) {
           RCLCPP_ERROR(
             logger,
-            "add_callback_group: group is auto-add and its owning node is already added; this "
-            "would double-attach. Create the group with automatically_add_to_executor_with_node = "
-            "false to manage it manually. Node: %s",
+            "Callback group is auto-add and already discoverable via an added node: %s. Create "
+            "the group with automatically_add_to_executor_with_node=false to add it manually.",
             n->get_fully_qualified_name());
           if (agnocast_fd != -1) {
             close(agnocast_fd);
@@ -212,9 +205,8 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
     }
   }
 
-  // Eagerly spawn the child executor when spinning so the group starts dispatching callbacks
-  // immediately instead of waiting for the next spin() startup. When not spinning yet, spin()'s
-  // initial setup will spawn it from weak_groups_to_nodes_.
+  // Spawn now if spin() is already running; otherwise spin()'s initial setup will spawn from
+  // weak_groups_to_nodes_.
   if (!spinning.load()) {
     return;
   }
@@ -223,11 +215,10 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
   std::lock_guard<std::mutex> guard{child_resources_mutex_};
   for (const auto & weak_grp : child_callback_groups_) {
     if (weak_grp.lock() == group_ptr) {
-      // Already spawned (e.g., spin()'s initial setup raced ahead). Nothing to do.
+      // spin() initial setup raced ahead and already spawned this group.
       return;
     }
   }
-  // If the group was previously stopped, allow re-attach by clearing its sentinel entry.
   stopped_groups_.erase(group_ptr);
   spawn_child_executor_locked(group_ptr, node_ptr);
 }
@@ -319,8 +310,6 @@ void CallbackIsolatedAgnocastExecutor::remove_callback_group(
     }
   }
 
-  // Tear down the child executor (cancel + join its thread) if one was spawned for this group.
-  // No-op if spin() never spawned it (e.g., remove_callback_group called before any spin()).
   stop_callback_group(group_ptr);
 }
 

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -468,22 +468,21 @@ void CallbackIsolatedAgnocastExecutor::spawn_child_executor_locked(
   } else {
     executor = std::make_shared<SingleThreadedAgnocastExecutor>(
       rclcpp::ExecutorOptions{}, next_exec_timeout_ms_);
-    std::static_pointer_cast<SingleThreadedAgnocastExecutor>(executor)
-      ->dedicate_to_callback_group(group, node);
+    std::static_pointer_cast<SingleThreadedAgnocastExecutor>(executor)->dedicate_to_callback_group(
+      group, node);
   }
 
   child_callback_groups_.push_back(group);
   weak_child_executors_.push_back(executor);
 
-  child_threads_.emplace_back(
-    [this, executor, callback_group_id = std::move(callback_group_id)]() {
-      auto tid = static_cast<pid_t>(syscall(SYS_gettid));
-      {
-        std::lock_guard<std::mutex> lock{client_publisher_mutex_};
-        agnocast::publish_callback_group_info(client_publisher_, tid, callback_group_id);
-      }
-      executor->spin();
-    });
+  child_threads_.emplace_back([this, executor, callback_group_id = std::move(callback_group_id)]() {
+    auto tid = static_cast<pid_t>(syscall(SYS_gettid));
+    {
+      std::lock_guard<std::mutex> lock{client_publisher_mutex_};
+      agnocast::publish_callback_group_info(client_publisher_, tid, callback_group_id);
+    }
+    executor->spin();
+  });
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -152,8 +152,22 @@ void CallbackIsolatedAgnocastExecutor::spin()
     if (!spinning.load() || !rclcpp::ok()) {
       break;
     }
+    // Prune stopped_groups_ entries whose target callback group has died, to keep the set bounded.
+    for (auto it = stopped_groups_.begin(); it != stopped_groups_.end();) {
+      if (it->expired()) {
+        it = stopped_groups_.erase(it);
+      } else {
+        ++it;
+      }
+    }
     for (auto & [group, node] : new_groups) {
       if (group->get_associated_with_executor_atomic().load()) {
+        continue;
+      }
+      // Skip groups that were explicitly stopped via stop_callback_group(). They may still be
+      // discoverable via the node (if their owner has not yet released the SharedPtr), but must
+      // not be re-spawned.
+      if (stopped_groups_.find(group) != stopped_groups_.end()) {
         continue;
       }
       spawn_child_executor(group, node);
@@ -429,6 +443,9 @@ void CallbackIsolatedAgnocastExecutor::stop_callback_group(
         break;
       }
     }
+    // Record the group as stopped so the monitor loop in spin() does not re-spawn a child executor
+    // for it, even if the group is still reachable via the owning node.
+    stopped_groups_.insert(group_ptr);
   }
 
   if (found && thread_to_join.joinable()) {

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -337,9 +337,6 @@ void PerformanceBridgeManager::create_pubsub_bridge_if_needed(
     }
 
     if (result.entity_handle) {
-      // Plugin-created groups have auto-add disabled, so the executor's monitor loop never sees
-      // them. Attach explicitly via the rclcpp-standard add_callback_group API; teardown happens
-      // via stop_callback_group() (or remove_callback_group()).
       if (result.callback_group) {
         executor_->add_callback_group(
           result.callback_group, container_node_->get_node_base_interface());
@@ -407,9 +404,6 @@ void PerformanceBridgeManager::create_service_bridge_if_needed(
     PerformanceServiceBridgeResult result =
       loader_.create_r2a_service_bridge(container_node_, service_name, service_type, service_qos);
     if (result.entity_handle) {
-      // Plugin-created groups have auto-add disabled, so the executor's monitor loop never sees
-      // them. Attach explicitly via the rclcpp-standard add_callback_group API; teardown happens
-      // via stop_callback_group() (or remove_callback_group()).
       if (result.ros_srv_cb_group) {
         executor_->add_callback_group(
           result.ros_srv_cb_group, container_node_->get_node_base_interface());

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -337,6 +337,14 @@ void PerformanceBridgeManager::create_pubsub_bridge_if_needed(
     }
 
     if (result.entity_handle) {
+      // Plugin-created groups have auto-add disabled, so the executor's monitor loop never sees
+      // them. Attach explicitly via the rclcpp-standard add_callback_group API; teardown happens
+      // via stop_callback_group() (or remove_callback_group()).
+      if (result.callback_group) {
+        executor_->add_callback_group(
+          result.callback_group, container_node_->get_node_base_interface());
+      }
+
       if (is_r2a) {
         if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
           RCLCPP_ERROR(
@@ -399,6 +407,17 @@ void PerformanceBridgeManager::create_service_bridge_if_needed(
     PerformanceServiceBridgeResult result =
       loader_.create_r2a_service_bridge(container_node_, service_name, service_type, service_qos);
     if (result.entity_handle) {
+      // Plugin-created groups have auto-add disabled, so the executor's monitor loop never sees
+      // them. Attach explicitly via the rclcpp-standard add_callback_group API; teardown happens
+      // via stop_callback_group() (or remove_callback_group()).
+      if (result.ros_srv_cb_group) {
+        executor_->add_callback_group(
+          result.ros_srv_cb_group, container_node_->get_node_base_interface());
+      }
+      if (result.agno_client_cb_group) {
+        executor_->add_callback_group(
+          result.agno_client_cb_group, container_node_->get_node_base_interface());
+      }
       active_r2a_service_bridges_[service_name] = std::move(result);
     }
   } catch (const std::exception & e) {

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -244,9 +244,6 @@ bool StandardBridgeManager::activate_bridge(const DirectedBridgeRef bridge_ref)
       return false;
     }
 
-    // Bridges create callback groups with auto-add disabled, so the executor's monitor loop never
-    // sees them. Attach the group explicitly here via the rclcpp-standard add_callback_group API;
-    // teardown happens via stop_callback_group() (or remove_callback_group()).
     if (auto cb_group = bridge->get_callback_group()) {
       executor_->add_callback_group(cb_group, container_node_->get_node_base_interface());
     }

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -244,6 +244,13 @@ bool StandardBridgeManager::activate_bridge(const DirectedBridgeRef bridge_ref)
       return false;
     }
 
+    // Bridges create callback groups with auto-add disabled, so the executor's monitor loop never
+    // sees them. Attach the group explicitly here via the rclcpp-standard add_callback_group API;
+    // teardown happens via stop_callback_group() (or remove_callback_group()).
+    if (auto cb_group = bridge->get_callback_group()) {
+      executor_->add_callback_group(cb_group, container_node_->get_node_base_interface());
+    }
+
     if (is_r2a) {
       if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
         RCLCPP_ERROR(

--- a/src/agnocastlib/test/unit/test_agnocast_executors.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_executors.cpp
@@ -348,8 +348,8 @@ TEST_F(CallbackIsolatedAgnocastExecutorTest, remove_callback_group_stops_dispatc
     rclcpp::CallbackGroupType::MutuallyExclusive,
     /*automatically_add_to_executor_with_node=*/false);
   std::atomic_int callback_count{0};
-  auto timer = node->create_wall_timer(
-    std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
+  auto timer =
+    node->create_wall_timer(std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
 
   executor->add_callback_group(group, node->get_node_base_interface());
 
@@ -418,8 +418,8 @@ TEST_F(CallbackIsolatedAgnocastExecutorTest, re_add_after_remove_succeeds)
     rclcpp::CallbackGroupType::MutuallyExclusive,
     /*automatically_add_to_executor_with_node=*/false);
   std::atomic_int callback_count{0};
-  auto timer = node->create_wall_timer(
-    std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
+  auto timer =
+    node->create_wall_timer(std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
 
   std::thread spin_thread([this]() { executor->spin(); });
 

--- a/src/agnocastlib/test/unit/test_agnocast_executors.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_executors.cpp
@@ -300,3 +300,148 @@ TEST_F(CallbackIsolatedAgnocastExecutorTest, cancel_from_child_callback_does_not
 
   EXPECT_TRUE(spin_finished);
 }
+
+// Regression test: add_callback_group called while spin() is already running must immediately
+// spawn a child executor, so callbacks start dispatching without waiting for spin to restart.
+// Uses automatically_add_to_executor_with_node=false so the monitor loop cannot pick up the
+// group: the eager-spawn path is the only way callbacks can fire here.
+TEST_F(CallbackIsolatedAgnocastExecutorTest, add_callback_group_during_spin_dispatches_callbacks)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  executor->add_node(node);
+
+  std::thread spin_thread([this]() { executor->spin(); });
+
+  // Let spin() reach its monitor loop before we attach a new group.
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+  auto group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
+  std::atomic_bool callback_called{false};
+  auto timer = node->create_wall_timer(
+    std::chrono::milliseconds(10), [&]() { callback_called = true; }, group);
+
+  executor->add_callback_group(group, node->get_node_base_interface());
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (!callback_called) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+      << "Callback never fired after add_callback_group during spin";
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  executor->cancel();
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// Regression test: remove_callback_group must tear down the child executor and prevent further
+// dispatch for the group, even when the group's owning node remains in the executor.
+TEST_F(CallbackIsolatedAgnocastExecutorTest, remove_callback_group_stops_dispatch)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  executor->add_node(node);
+
+  auto group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
+  std::atomic_int callback_count{0};
+  auto timer = node->create_wall_timer(
+    std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
+
+  executor->add_callback_group(group, node->get_node_base_interface());
+
+  std::thread spin_thread([this]() { executor->spin(); });
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (callback_count.load() == 0) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline) << "Callback never fired";
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  executor->remove_callback_group(group);
+
+  int count_at_remove = callback_count.load();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_EQ(callback_count.load(), count_at_remove)
+    << "Callbacks must not fire after remove_callback_group";
+
+  executor->cancel();
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}
+
+// Regression test: a group with automatically_add_to_executor_with_node=false on an already-added
+// node must be allowed by add_callback_group. The strict sanity check applies only to auto-add=true
+// groups (which would conflict with the monitor loop).
+TEST_F(CallbackIsolatedAgnocastExecutorTest, add_callback_group_auto_add_false_on_added_node)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  executor->add_node(node);
+
+  auto group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
+
+  EXPECT_NO_FATAL_FAILURE(executor->add_callback_group(group, node->get_node_base_interface()));
+  EXPECT_EQ(executor->get_manually_added_callback_groups().size(), 1u);
+
+  executor->remove_callback_group(group);
+  EXPECT_EQ(executor->get_manually_added_callback_groups().size(), 0u);
+}
+
+// Regression test: an auto-add=true group whose owning node is already added must still abort,
+// because it would double-attach (once via the monitor loop, once via add_callback_group).
+TEST_F(CallbackIsolatedAgnocastExecutorTest, add_callback_group_auto_add_true_on_added_node_exits)
+{
+  EXPECT_EXIT(
+    {
+      auto node = std::make_shared<rclcpp::Node>("test_node");
+      executor->add_node(node);
+      auto group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      executor->add_callback_group(group, node->get_node_base_interface());
+    },
+    ::testing::ExitedWithCode(EXIT_FAILURE), "auto-add and already discoverable");
+}
+
+// Regression test: after remove_callback_group, the same group can be added again. The
+// stopped_groups_ sentinel that suppresses monitor-loop respawn must not block explicit re-attach.
+TEST_F(CallbackIsolatedAgnocastExecutorTest, re_add_after_remove_succeeds)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  executor->add_node(node);
+
+  auto group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
+  std::atomic_int callback_count{0};
+  auto timer = node->create_wall_timer(
+    std::chrono::milliseconds(10), [&]() { callback_count++; }, group);
+
+  std::thread spin_thread([this]() { executor->spin(); });
+
+  auto wait_for_more_than = [&](int from) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (callback_count.load() <= from) {
+      ASSERT_LT(std::chrono::steady_clock::now(), deadline);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  };
+
+  executor->add_callback_group(group, node->get_node_base_interface());
+  wait_for_more_than(0);
+
+  executor->remove_callback_group(group);
+  int count_after_remove = callback_count.load();
+
+  executor->add_callback_group(group, node->get_node_base_interface());
+  wait_for_more_than(count_after_remove);
+
+  executor->cancel();
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+}

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -23,7 +23,11 @@ extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge(
     agnocast::PublisherOptions{},
     true);
 
-  auto ros_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
+  // and stops this group explicitly via attach_callback_group / stop_callback_group.
+  auto ros_cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
 
   rclcpp::SubscriptionOptions ros_opts;
   ros_opts.ignore_local_publications = true;
@@ -50,7 +54,10 @@ extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge(
   auto ros_pub = node->create_publisher<@(cpp_type)>(
     topic_name, rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).reliable().transient_local());
 
-  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // See create_r2a_pubsub_bridge above for the rationale.
+  auto cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    /*automatically_add_to_executor_with_node=*/false);
 
   auto agno_callback = [ros_pub](const agnocast::ipc_shared_ptr<@(cpp_type)> msg) {
     auto loaned_msg = ros_pub->borrow_loaned_message();

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -23,8 +23,8 @@ extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge(
     agnocast::PublisherOptions{},
     true);
 
-  // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
-  // and stops this group explicitly via attach_callback_group / stop_callback_group.
+  // The bridge manager attaches/detaches this group explicitly; opt out of monitor-loop
+  // auto-discovery to avoid re-spawn races with stop_callback_group().
   auto ros_cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive,
     /*automatically_add_to_executor_with_node=*/false);
@@ -54,7 +54,6 @@ extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge(
   auto ros_pub = node->create_publisher<@(cpp_type)>(
     topic_name, rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).reliable().transient_local());
 
-  // See create_r2a_pubsub_bridge above for the rationale.
   auto cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive,
     /*automatically_add_to_executor_with_node=*/false);

--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -16,10 +16,14 @@ extern "C" PerformanceServiceBridgeResult create_r2a_service_bridge(
 {
   using ServiceT = @(cpp_type);
 
-  auto srv_cb_group =
-    node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-  auto client_cb_group =
-    node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
+  // and stops these groups explicitly via attach_callback_group / stop_callback_group.
+  auto srv_cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::Reentrant,
+    /*automatically_add_to_executor_with_node=*/false);
+  auto client_cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::Reentrant,
+    /*automatically_add_to_executor_with_node=*/false);
 
   auto agno_client = agnocast::create_client<ServiceT>(
     node.get(), service_name, qos, client_cb_group);

--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -16,8 +16,8 @@ extern "C" PerformanceServiceBridgeResult create_r2a_service_bridge(
 {
   using ServiceT = @(cpp_type);
 
-  // Opt out of automatic discovery by the executor's monitor loop. The bridge manager attaches
-  // and stops these groups explicitly via attach_callback_group / stop_callback_group.
+  // The bridge manager attaches/detaches these groups explicitly; opt out of monitor-loop
+  // auto-discovery to avoid re-spawn races with stop_callback_group().
   auto srv_cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::Reentrant,
     /*automatically_add_to_executor_with_node=*/false);


### PR DESCRIPTION
## Description
Support dynamic `add_callback_group` / `remove_callback_group` calls.

  - `add_callback_group` immediately spawns a child executor when `spin()` is running. The "group's owning node is already added" abort is relaxed to apply only to `auto-add=true` groups (which would genuinely double-attach).                                                                                                                                                                                                        
  - `remove_callback_group` tears down the child executor and joins its thread, mirroring `add_callback_group`.
  - Spawn logic is extracted from `spin()`'s local lambda into a private member, with `client_publisher_` lazily initialized as a member so both paths share one implementation.                                                                                                                                                                                                                                                         
  - Bridge callback groups (pub/sub bridges and service bridge plugin templates) are created with `automatically_add_to_executor_with_node = false`, and bridge managers attach them explicitly. The monitor loop never sees them, so the TOCTOU window doesn't exist for bridges.

## Related links
[Issue when server bridge is removed.
](https://github.com/autowarefoundation/agnocast/pull/1289#discussion_r3200715390)

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
