### PR TITLE
fix(kmod): mark file_operations struct as const

### DIFF
--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -16,7 +16,7 @@ static char * agnocast_devnode(struct device * dev, umode_t * mode)
   return NULL;
 }
 
-static struct file_operations fops = {
+static const struct file_operations fops = {
   .owner = THIS_MODULE,
   .unlocked_ioctl = agnocast_ioctl,
 };


### PR DESCRIPTION
## Description

struct file_operations is never modified after initialisation; adding const lets the compiler place it in read-only memory.

Resolves part of #1253 : CONST_STRUCT (1): struct file_operations should be const.

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
