### PR TITLE
fix(kmod): use kvcalloc instead of kvzalloc with multiply

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1551,7 +1551,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
 
   struct topic_info_ret * topic_info_mem = NULL;
   if (subscriber_num > 0) {
-    topic_info_mem = kvzalloc(sizeof(struct topic_info_ret) * subscriber_num, GFP_KERNEL);
+    topic_info_mem = kvcalloc(subscriber_num, sizeof(struct topic_info_ret), GFP_KERNEL);
     if (!topic_info_mem) {
       ret = -ENOMEM;
       goto unlock;
@@ -1637,7 +1637,7 @@ int agnocast_ioctl_get_topic_publisher_info(
 
   struct topic_info_ret * topic_info_mem = NULL;
   if (publisher_num > 0) {
-    topic_info_mem = kvzalloc(sizeof(struct topic_info_ret) * publisher_num, GFP_KERNEL);
+    topic_info_mem = kvcalloc(publisher_num, sizeof(struct topic_info_ret), GFP_KERNEL);
     if (!topic_info_mem) {
       ret = -ENOMEM;
       goto unlock;


### PR DESCRIPTION
## Description

use kvcalloc instead of kvzalloc with multiply.

kvcalloc(n, size, flags) is safer than kvzalloc(n * size, flags) because it checks for multiplication overflow internally.

Resolves part of #1253 : ALLOC_WITH_MULTIPLY (2): Use kvcalloc instead of kvzalloc with multiply.

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
