### PR TITLE
fix(kmod): place constants on right side of comparisons

### DIFF
--- a/agnocast_kmod/agnocast_init.c
+++ b/agnocast_kmod/agnocast_init.c
@@ -4,7 +4,7 @@
 // =========================================
 // Initialize and cleanup
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if KERNEL_VERSION(6, 2, 0) <= LINUX_VERSION_CODE
 static char * agnocast_devnode(const struct device * dev, umode_t * mode)
 #else
 static char * agnocast_devnode(struct device * dev, umode_t * mode)
@@ -76,7 +76,7 @@ int agnocast_init_device(void)
     return major;
   }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
   agnocast_class = class_create("agnocast_class");
 #else
   agnocast_class = class_create(THIS_MODULE, "agnocast_class");

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -863,7 +863,7 @@ static int receive_msg_core(
   for (; node; node = rb_next(node)) {
     struct entry_node * en = container_of(node, struct entry_node, node);
 
-    if (MAX_RECEIVE_NUM == ioctl_ret->ret_entry_num) {
+    if (ioctl_ret->ret_entry_num == MAX_RECEIVE_NUM) {
       ioctl_ret->ret_call_again = true;
       break;
     }


### PR DESCRIPTION
## Description

Fixes CONSTANT_COMPARISON checkpatch warnings: swap LINUX_VERSION_CODE and MAX_RECEIVE_NUM from left to right side of their comparison operators.

Resolves part of #1253 : CONSTANT_COMPARISON (3): Yoda-style comparisons (0 == x → x == 0).

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
