### PR TITLE
fix(kmod): remove redundant zero-initialisation of globals

### DIFF
--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -18,7 +18,7 @@ uint32_t queue_tail;
 
 struct task_struct * worker_task;
 DECLARE_WAIT_QUEUE_HEAD(worker_wait);
-int has_new_pid = false;
+int has_new_pid;
 
 struct tracepoint * tp_sched_process_exit;
 

--- a/agnocast_kmod/agnocast_memory_allocator.c
+++ b/agnocast_kmod/agnocast_memory_allocator.c
@@ -33,7 +33,7 @@ int mempool_size_gb = DEFAULT_MEMPOOL_SIZE_GB;
 module_param(mempool_size_gb, int, 0444);
 MODULE_PARM_DESC(mempool_size_gb, "Default mempool size in GB (default: 16)");
 
-uint64_t mempool_size_bytes = 0;
+uint64_t mempool_size_bytes;
 
 int init_memory_allocator(void)
 {


### PR DESCRIPTION
## Description

Global variables are zero-initialised by the C standard, so explicit = 0 / = false initialisers are unnecessary.

Resolves part of #1253 : GLOBAL_INITIALISERS (2): Remove redundant = 0 / = false for globals.

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
