### PR TITLE
fix(service): move warning from Constructor to user API function

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -207,7 +207,7 @@ typename Client<ServiceT>::SharedPtr create_client(
     node->get_logger(),
     "Agnocast service/client is not officially supported yet and the API may change in the "
     "future: %s",
-    service_name.c_str());
+    node->get_node_services_interface()->resolve_service_name(service_name).c_str());
   return std::make_shared<Client<ServiceT>>(node, service_name, qos, group);
 }
 
@@ -231,7 +231,7 @@ typename Service<ServiceT>::SharedPtr create_service(
     node->get_logger(),
     "Agnocast service/client is not officially supported yet and the API may change in the "
     "future: %s",
-    service_name.c_str());
+    node->get_node_services_interface()->resolve_service_name(service_name).c_str());
   return std::make_shared<Service<ServiceT>>(
     node, service_name, std::forward<Func>(callback), qos, group);
 }

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -203,6 +203,11 @@ typename Client<ServiceT>::SharedPtr create_client(
   rclcpp::Node * node, const std::string & service_name,
   const rclcpp::QoS & qos = rclcpp::ServicesQoS(), rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
+  RCLCPP_WARN(
+    node->get_logger(),
+    "Agnocast service/client is not officially supported yet and the API may change in the "
+    "future: %s",
+    service_name.c_str());
   return std::make_shared<Client<ServiceT>>(node, service_name, qos, group);
 }
 
@@ -222,6 +227,11 @@ typename Service<ServiceT>::SharedPtr create_service(
   rclcpp::Node * node, const std::string & service_name, Func && callback,
   const rclcpp::QoS & qos = rclcpp::ServicesQoS(), rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
+  RCLCPP_WARN(
+    node->get_logger(),
+    "Agnocast service/client is not officially supported yet and the API may change in the "
+    "future: %s",
+    service_name.c_str());
   return std::make_shared<Service<ServiceT>>(
     node, service_name, std::forward<Func>(callback), qos, group);
 }

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -128,12 +128,6 @@ public:
       std::is_same_v<NodeT, rclcpp::Node> || std::is_same_v<NodeT, agnocast::Node>,
       "NodeT must be either rclcpp::Node or agnocast::Node");
 
-    RCLCPP_WARN(
-      logger_,
-      "Agnocast service/client is not officially supported yet and the API may change in the "
-      "future: %s",
-      service_name_.c_str());
-
     // TransientLocal durability is not allowed for services.
     const rclcpp::QoS qos = rclcpp::QoS(qos_arg).durability_volatile();
 

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -72,12 +72,6 @@ public:
       "Callback must be callable with ipc_shared_ptr<ServiceT::Request> and "
       "ipc_shared_ptr<ServiceT::Response> (const&, &&, or by-value)");
 
-    RCLCPP_WARN(
-      node->get_logger(),
-      "Agnocast service/client is not officially supported yet and the API may change in the "
-      "future: %s",
-      service_name_.c_str());
-
     auto subscriber_callback = [this, callback = std::forward<Func>(callback)](
                                  ipc_shared_ptr<RequestT> && request) {
       typename ServiceResponsePublisher::SharedPtr publisher;

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -596,7 +596,7 @@ public:
       get_logger(),
       "Agnocast service/client is not officially supported yet and the API may change in the "
       "future: %s",
-      service_name.c_str());
+      get_node_services_interface()->resolve_service_name(service_name).c_str());
     return std::make_shared<Client<ServiceT>>(this, service_name, qos, group);
   }
 
@@ -619,7 +619,7 @@ public:
       get_logger(),
       "Agnocast service/client is not officially supported yet and the API may change in the "
       "future: %s",
-      service_name.c_str());
+      get_node_services_interface()->resolve_service_name(service_name).c_str());
     return std::make_shared<Service<ServiceT>>(
       this, service_name, std::forward<Func>(callback), qos, group);
   }

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -592,6 +592,11 @@ public:
     const std::string & service_name, const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
+    RCLCPP_WARN(
+      get_logger(),
+      "Agnocast service/client is not officially supported yet and the API may change in the "
+      "future: %s",
+      service_name.c_str());
     return std::make_shared<Client<ServiceT>>(this, service_name, qos, group);
   }
 
@@ -610,6 +615,11 @@ public:
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
+    RCLCPP_WARN(
+      get_logger(),
+      "Agnocast service/client is not officially supported yet and the API may change in the "
+      "future: %s",
+      service_name.c_str());
     return std::make_shared<Service<ServiceT>>(
       this, service_name, std::forward<Func>(callback), qos, group);
   }


### PR DESCRIPTION
## Description
`agnocast::ParameterService` internally creates 6 Service instances, so every `agnocast::Node` startup prints the `"service/client is not officially supported yet" ` warning 6 times — noise users can't suppress.

### Change
Move the warning from the BasicService / Client constructors into the public `create_service` / `create_client` factories (both free functions and Node methods). `ParameterService` constructs Service directly via `std::make_shared`, so it no longer triggers the warning. User-facing usage is unchanged.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
