### PR TITLE
fix(sample_application): add agnocast_ prefix to sample app and thread_configurator

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -11,13 +11,13 @@ find_package(rclcpp REQUIRED)
 find_package(agnocast_cie_config_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-add_library(thread_configurator SHARED
+add_library(agnocast_thread_configurator SHARED
   src/util.cpp
   src/non_ros_thread_ipc.cpp
   src/thread_config.cpp
 )
-ament_target_dependencies(thread_configurator rclcpp agnocast_cie_config_msgs)
-target_link_libraries(thread_configurator yaml-cpp)
+ament_target_dependencies(agnocast_thread_configurator rclcpp agnocast_cie_config_msgs)
+target_link_libraries(agnocast_thread_configurator yaml-cpp)
 
 add_executable(
   thread_configurator_node
@@ -26,7 +26,7 @@ add_executable(
   src/prerun_node.cpp
 )
 ament_target_dependencies(thread_configurator_node rclcpp agnocast_cie_config_msgs)
-target_link_libraries(thread_configurator_node yaml-cpp thread_configurator)
+target_link_libraries(thread_configurator_node yaml-cpp agnocast_thread_configurator)
 
 target_include_directories(thread_configurator_node PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -38,18 +38,18 @@ add_executable(
   src/prerun_node.cpp
 )
 ament_target_dependencies(prerun_node rclcpp agnocast_cie_config_msgs)
-target_link_libraries(prerun_node yaml-cpp thread_configurator)
+target_link_libraries(prerun_node yaml-cpp agnocast_thread_configurator)
 
 target_include_directories(prerun_node PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_include_directories(thread_configurator PUBLIC
+target_include_directories(agnocast_thread_configurator PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 
-install(TARGETS thread_configurator
+install(TARGETS agnocast_thread_configurator
   EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -78,12 +78,12 @@ if(BUILD_TESTING)
   ament_add_gtest(test_${PROJECT_NAME}
     test/test_non_ros_thread_ipc.cpp
   )
-  target_link_libraries(test_${PROJECT_NAME} thread_configurator)
+  target_link_libraries(test_${PROJECT_NAME} agnocast_thread_configurator)
 
   ament_add_gtest(test_reapply_config
     test/test_reapply_config.cpp
   )
-  target_link_libraries(test_reapply_config thread_configurator yaml-cpp)
+  target_link_libraries(test_reapply_config agnocast_thread_configurator yaml-cpp)
   target_include_directories(test_reapply_config PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -14,112 +14,112 @@ find_package(agnocastlib REQUIRED)
 find_package(agnocast_components REQUIRED)
 find_package(agnocast_cie_thread_configurator REQUIRED)
 
-add_library(test_talker_component SHARED src/test_publisher.cpp)
-ament_target_dependencies(test_talker_component rclcpp rclcpp_components std_msgs agnocastlib)
-target_include_directories(test_talker_component PRIVATE
+add_library(agnocast_test_talker_component SHARED src/test_publisher.cpp)
+ament_target_dependencies(agnocast_test_talker_component rclcpp rclcpp_components std_msgs agnocastlib)
+target_include_directories(agnocast_test_talker_component PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 rclcpp_components_register_node(
-  test_talker_component
+  agnocast_test_talker_component
   PLUGIN "TestPublisher"
   EXECUTABLE test_talker
 )
 
-add_library(test_listener_component SHARED src/test_subscriber.cpp)
-ament_target_dependencies(test_listener_component rclcpp rclcpp_components std_msgs agnocastlib)
-target_include_directories(test_listener_component PRIVATE
+add_library(agnocast_test_listener_component SHARED src/test_subscriber.cpp)
+ament_target_dependencies(agnocast_test_listener_component rclcpp rclcpp_components std_msgs agnocastlib)
+target_include_directories(agnocast_test_listener_component PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 rclcpp_components_register_node(
-  test_listener_component
+  agnocast_test_listener_component
   PLUGIN "TestSubscriber"
   EXECUTABLE test_listener
 )
 
-add_library(test_taker_component SHARED src/test_take_subscriber.cpp)
-ament_target_dependencies(test_taker_component rclcpp rclcpp_components std_msgs agnocastlib)
-target_include_directories(test_taker_component PRIVATE
+add_library(agnocast_test_taker_component SHARED src/test_take_subscriber.cpp)
+ament_target_dependencies(agnocast_test_taker_component rclcpp rclcpp_components std_msgs agnocastlib)
+target_include_directories(agnocast_test_taker_component PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 rclcpp_components_register_node(
-  test_taker_component
+  agnocast_test_taker_component
   PLUGIN "TestTakeSubscriber"
   EXECUTABLE test_taker
 )
 
-add_library(test_ros2_listener_component SHARED src/test_ros2_subscriber.cpp)
-ament_target_dependencies(test_ros2_listener_component rclcpp rclcpp_components std_msgs)
+add_library(agnocast_test_ros2_listener_component SHARED src/test_ros2_subscriber.cpp)
+ament_target_dependencies(agnocast_test_ros2_listener_component rclcpp rclcpp_components std_msgs)
 rclcpp_components_register_node(
-  test_ros2_listener_component
+  agnocast_test_ros2_listener_component
   PLUGIN "TestROS2Subscriber"
   EXECUTABLE test_ros2_listener
 )
 
-add_library(test_ros2_talker_component SHARED src/test_ros2_publisher.cpp)
-ament_target_dependencies(test_ros2_talker_component rclcpp rclcpp_components std_msgs)
+add_library(agnocast_test_ros2_talker_component SHARED src/test_ros2_publisher.cpp)
+ament_target_dependencies(agnocast_test_ros2_talker_component rclcpp rclcpp_components std_msgs)
 rclcpp_components_register_node(
-  test_ros2_talker_component
+  agnocast_test_ros2_talker_component
   PLUGIN "TestROS2Publisher"
   EXECUTABLE test_ros2_talker
 )
 
-add_library(test_cie_publisher_component SHARED src/test_publisher_component.cpp)
-ament_target_dependencies(test_cie_publisher_component rclcpp rclcpp_components std_msgs agnocastlib agnocast_cie_thread_configurator)
+add_library(agnocast_test_cie_publisher_component SHARED src/test_publisher_component.cpp)
+ament_target_dependencies(agnocast_test_cie_publisher_component rclcpp rclcpp_components std_msgs agnocastlib agnocast_cie_thread_configurator)
 
-agnocast_components_register_node(test_cie_publisher_component
+agnocast_components_register_node(agnocast_test_cie_publisher_component
   PLUGIN "agnocast_e2e_test::TestPublisherComponent"
   EXECUTABLE test_cie_publisher
   EXECUTOR CallbackIsolatedAgnocastExecutor)
 
-add_library(test_cie_subscription_component SHARED src/test_subscription_component.cpp)
-ament_target_dependencies(test_cie_subscription_component rclcpp rclcpp_components std_msgs)
+add_library(agnocast_test_cie_subscription_component SHARED src/test_subscription_component.cpp)
+ament_target_dependencies(agnocast_test_cie_subscription_component rclcpp rclcpp_components std_msgs)
 
-agnocast_components_register_node(test_cie_subscription_component
+agnocast_components_register_node(agnocast_test_cie_subscription_component
   PLUGIN "agnocast_e2e_test::TestSubscriptionComponent"
   EXECUTABLE test_cie_subscriber
   EXECUTOR CallbackIsolatedAgnocastExecutor)
 
-ament_export_targets(export_test_talker_component)
-install(TARGETS test_talker_component
-        EXPORT export_test_talker_component
+ament_export_targets(export_agnocast_test_talker_component)
+install(TARGETS agnocast_test_talker_component
+        EXPORT export_agnocast_test_talker_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_test_listener_component)
-install(TARGETS test_listener_component
-        EXPORT export_test_listener_component
+ament_export_targets(export_agnocast_test_listener_component)
+install(TARGETS agnocast_test_listener_component
+        EXPORT export_agnocast_test_listener_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_test_taker_component)
-install(TARGETS test_taker_component
-        EXPORT export_test_taker_component
+ament_export_targets(export_agnocast_test_taker_component)
+install(TARGETS agnocast_test_taker_component
+        EXPORT export_agnocast_test_taker_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_test_ros2_listener_component)
-install(TARGETS test_ros2_listener_component
-        EXPORT export_test_ros2_listener_component
+ament_export_targets(export_agnocast_test_ros2_listener_component)
+install(TARGETS agnocast_test_ros2_listener_component
+        EXPORT export_agnocast_test_ros2_listener_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_test_ros2_talker_component)
-install(TARGETS test_ros2_talker_component
-        EXPORT export_test_ros2_talker_component
+ament_export_targets(export_agnocast_test_ros2_talker_component)
+install(TARGETS agnocast_test_ros2_talker_component
+        EXPORT export_agnocast_test_ros2_talker_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
 )
 
-install(TARGETS test_cie_publisher_component test_cie_subscription_component
+install(TARGETS agnocast_test_cie_publisher_component agnocast_test_cie_subscription_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin

--- a/src/agnocast_sample_application/CMakeLists.txt
+++ b/src/agnocast_sample_application/CMakeLists.txt
@@ -29,22 +29,22 @@ target_include_directories(cie_talker PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 
-add_library(cie_listener_component SHARED src/cie_subscriber.cpp)
-ament_target_dependencies(cie_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
-target_include_directories(cie_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
+add_library(agnocast_cie_listener_component SHARED src/cie_subscriber.cpp)
+ament_target_dependencies(agnocast_cie_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
+target_include_directories(agnocast_cie_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
 
 agnocast_components_register_node(
-  cie_listener_component
+  agnocast_cie_listener_component
   PLUGIN "CieSubscriber"
   EXECUTABLE cie_listener
 )
 
-add_library(no_rclcpp_listener_component SHARED src/no_rclcpp_subscriber.cpp)
-ament_target_dependencies(no_rclcpp_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
-target_include_directories(no_rclcpp_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
+add_library(agnocast_no_rclcpp_listener_component SHARED src/no_rclcpp_subscriber.cpp)
+ament_target_dependencies(agnocast_no_rclcpp_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
+target_include_directories(agnocast_no_rclcpp_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
 
 agnocast_components_register_node(
-  no_rclcpp_listener_component
+  agnocast_no_rclcpp_listener_component
   PLUGIN "NoRclcppSubscriber"
   EXECUTABLE no_rclcpp_listener
   EXECUTOR AgnocastOnlySingleThreadedExecutor
@@ -116,9 +116,9 @@ install(TARGETS agnocast_listener_component
         RUNTIME DESTINATION bin
 )
 
-ament_export_targets(export_cie_listener_component)
-install(TARGETS cie_listener_component
-        EXPORT export_cie_listener_component
+ament_export_targets(export_agnocast_cie_listener_component)
+install(TARGETS agnocast_cie_listener_component
+        EXPORT export_agnocast_cie_listener_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -133,9 +133,9 @@ install(TARGETS cie_talker
 install(TARGETS cie_tutorial_node
   DESTINATION lib/${PROJECT_NAME})
 
-ament_export_targets(export_no_rclcpp_listener_component)
-install(TARGETS no_rclcpp_listener_component
-        EXPORT export_no_rclcpp_listener_component
+ament_export_targets(export_agnocast_no_rclcpp_listener_component)
+install(TARGETS agnocast_no_rclcpp_listener_component
+        EXPORT export_agnocast_no_rclcpp_listener_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin

--- a/src/agnocast_sample_application/CMakeLists.txt
+++ b/src/agnocast_sample_application/CMakeLists.txt
@@ -98,19 +98,19 @@ target_include_directories(sim_time_timer PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 
-add_library(listener_component SHARED src/minimal_subscriber.cpp)
-ament_target_dependencies(listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
-target_include_directories(listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
+add_library(agnocast_listener_component SHARED src/minimal_subscriber.cpp)
+ament_target_dependencies(agnocast_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
+target_include_directories(agnocast_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
 
 agnocast_components_register_node(
-  listener_component
+  agnocast_listener_component
   PLUGIN "MinimalSubscriber"
   EXECUTABLE listener
 )
 
-ament_export_targets(export_listener_component)
-install(TARGETS listener_component
-        EXPORT export_listener_component
+ament_export_targets(export_agnocast_listener_component)
+install(TARGETS agnocast_listener_component
+        EXPORT export_agnocast_listener_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin


### PR DESCRIPTION
## Description
Rename shared library targets that get installed to `/opt/ros/jazzy/lib/` so they don't collide with stock ROS 2 Jazzy packages.

### Issue
Installing the `ros-jazzy-agnocast-sample-application` deb fails because `liblistener_component.so` is already shipped by `ros-jazzy-composition`:

  ```
  dpkg: error processing archive ros-jazzy-agnocast-sample-application_...deb (--unpack):
   trying to overwrite '/opt/ros/jazzy/lib/liblistener_component.so',
   which is also in package ros-jazzy-composition
  ```

  Shared libraries are installed flat under `/opt/ros/jazzy/lib/`, so two packages producing `lib<same-name>.so` conflict on deb install.

  ## Changes

  Added `agnocast_` prefix to CMake library targets installed via `LIBRARY DESTINATION lib`:

  **`agnocast_sample_application`**
  - `listener_component` → `agnocast_listener_component` (confirmed collision with `ros-jazzy-composition`)
  - `cie_listener_component` → `agnocast_cie_listener_component` (defensive)
  - `no_rclcpp_listener_component` → `agnocast_no_rclcpp_listener_component` (defensive)

  **`agnocast_cie_thread_configurator`**
  - `thread_configurator` → `agnocast_thread_configurator` (defensive; generic name)

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
