### PR TITLE
fix(agnocastlib): fix infinite recursion (segfault) when calling dlopen() in performance bridge process

### DIFF
--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -9,6 +9,14 @@
 namespace agnocast
 {
 
+// Keep the initial-exec TLS model here: it avoids the following infinite recursion that causes a
+// SIGSEGV:
+// 1. heaphook malloc() is called.
+// 2. agnocast_get_borrowed_publisher_num() is called and accesses a thread_local variable.
+// 3. __tls_get_addr() is called to resolve the address.
+// 4. _dl_resize_dtv() is called to resize the DTV region. This occurs when new .so libraries are
+//    loaded via dlopen() and the number of managed TLS variables increases.
+// 5. _dl_resize_dtv() calls malloc(), which loops back to step 1.
 __attribute__((tls_model("initial-exec"))) thread_local uint32_t borrowed_publisher_num = 0;
 
 extern "C" uint32_t agnocast_get_borrowed_publisher_num()

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -9,7 +9,7 @@
 namespace agnocast
 {
 
-thread_local uint32_t borrowed_publisher_num = 0;
+__attribute__((tls_model("initial-exec"))) thread_local uint32_t borrowed_publisher_num = 0;
 
 extern "C" uint32_t agnocast_get_borrowed_publisher_num()
 {


### PR DESCRIPTION
## Description

### Bug Description
The bridge process was crashing (segfault) shortly after being created.
We found that an infinite recursion was happening inside the `malloc` hook during a `dlopen()` call, causing a stack overflow.

### Root Cause
1. When a new shared library is loaded via `dlopen()`, the Thread Local Storage (TLS) management table (called DTV) needs to be expanded.
2. To expand the DTV, the dynamic linker (`ld.so`) calls `malloc`.
3. This triggers our custom `malloc` hook (`libagnocast_heaphook.so`).
4. Inside our hook, we access a TLS variable (e.g., via `agnocast_get_borrowed_publisher_num()`).
5. Accessing this dynamic TLS variable forces the system to call `__tls_get_addr()`, which notices the DTV is too small and calls `malloc` again to resize it.
6. This results in an endless loop: `malloc` -> `hook` -> `TLS access` -> `_dl_resize_dtv` -> `malloc`.

### Fix
Applied the `initial-exec` TLS model to the TLS variable used inside the hook.

```cpp
__attribute__((tls_model("initial-exec"))) thread_local uint32_t borrowed_publisher_num = 0;
```
initial-exec model: We strictly used the initial-exec TLS model for the variable. This ensures that the variable is accessed using a static offset (preventing __tls_get_addr() from being called), which safely breaks the infinite loop.

## Related links

glibc also adopts the `"initial-exec"` model for arena:
https://elixir.bootlin.com/glibc/glibc-2.39/source/malloc/arena.c#L88 

## How was this PR tested?

- [x] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

I did not include a reproduction test case because this bug is highly dependent on the GLIBC version and the specific runtime environment, making it difficult to reliably reproduce.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
