### PR TITLE
refactor(timer): refactor timer unit tests

### DIFF
--- a/src/agnocastlib/test/unit/test_agnocast_timer.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer.cpp
@@ -1,7 +1,7 @@
-// White-box regression tests coupled to the current TimerInfo / JumpHandler
-// design — rewrite or delete on internal refactor, not a stability contract.
-// The user-facing timer contract lives in test/integration/test_agnocast_create_timer.cpp.
+// White-box tests for the timer subsystem internals — rewrite or delete on internal
+// refactor. The public-API spec lives in test_agnocast_timer_api.cpp.
 
+#include "agnocast/agnocast.hpp"
 #include "agnocast/agnocast_timer_info.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
@@ -669,4 +669,63 @@ TEST_F(TestRegisterTimerInfo, attaches_jump_handler_only_for_ros_time)
     ASSERT_NE(info, nullptr);
     EXPECT_NE(info->jump_handler, nullptr);
   }
+}
+
+// =============================================================================
+// create_timer (free function) — wrapper over register_timer_info; tested here
+// because the default-callback-group fallback is observable only via the
+// internal registry (no public API exposes the callback group).
+// =============================================================================
+
+TEST_F(TestRegisterTimerInfo, create_timer_uses_default_callback_group_when_nullptr)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+  auto expected_group = default_callback_group();
+
+  // Act — pass nullptr explicitly; create_timer must fall back to the node's default.
+  auto timer = agnocast::create_timer(node_.get(), clock, period, []() {}, nullptr);
+
+  // Assert — locate the registered TimerInfo by timer instance and verify the group.
+  ASSERT_NE(timer, nullptr);
+  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+  bool found = false;
+  for (const auto & [id, info] : agnocast::id2_timer_info) {
+    if (info->callback_group == expected_group && info->timer.lock() == timer) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "create_timer with nullptr group must use the node's default";
+}
+
+// =============================================================================
+// allocate_timer_id — overflow guard against the reserved epoll-flag bits region
+// =============================================================================
+
+TEST(AllocateTimerIdTest, throws_when_id_reaches_reserved_range)
+{
+  // Arrange — pin next_timer_id at the boundary so the next allocation overflows.
+  const uint32_t original = agnocast::next_timer_id.load();
+  agnocast::next_timer_id.store(agnocast::MAX_TIMER_ID);
+
+  // Act & Assert
+  EXPECT_THROW(agnocast::allocate_timer_id(), std::runtime_error);
+
+  // Cleanup
+  agnocast::next_timer_id.store(original);
+}
+
+TEST(AllocateTimerIdTest, succeeds_at_the_highest_valid_id)
+{
+  // Arrange — last allocatable ID is MAX_TIMER_ID - 1.
+  const uint32_t original = agnocast::next_timer_id.load();
+  agnocast::next_timer_id.store(agnocast::MAX_TIMER_ID - 1);
+
+  // Act & Assert
+  EXPECT_EQ(agnocast::allocate_timer_id(), agnocast::MAX_TIMER_ID - 1);
+
+  // Cleanup
+  agnocast::next_timer_id.store(original);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -33,11 +33,14 @@ protected:
 
 TEST_F(CreateTimerFreeFunctionTest, create_timer_returns_timer_with_specified_clock)
 {
+  // Arrange
   auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
   const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
 
+  // Act
   auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
 
+  // Assert
   ASSERT_NE(timer, nullptr);
   EXPECT_EQ(timer->get_clock()->get_clock_type(), RCL_STEADY_TIME);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -67,8 +67,7 @@ TEST_F(CreateTimerFreeFunctionTest, callback_with_timer_base_argument_receives_s
   const auto period = rclcpp::Duration(std::chrono::milliseconds(10));
   agnocast::TimerBase * captured = nullptr;
   auto timer = agnocast::create_timer(
-    node.get(), clock, period,
-    [&captured](agnocast::TimerBase & self) { captured = &self; });
+    node.get(), clock, period, [&captured](agnocast::TimerBase & self) { captured = &self; });
 
   // Act
   timer->execute_callback();
@@ -233,4 +232,3 @@ TEST_F(CreateTimerFreeFunctionTest, reset_re_anchors_next_call_when_time_has_adv
   EXPECT_EQ(tut_before_reset, std::chrono::nanoseconds(kPeriodNs - kHalfPeriodNs));
   EXPECT_EQ(tut_after_reset, std::chrono::nanoseconds(kPeriodNs));
 }
-

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -57,6 +57,49 @@ TEST_F(CreateTimerFreeFunctionTest, callback_is_invoked)
   EXPECT_TRUE(called);
 }
 
+TEST_F(CreateTimerFreeFunctionTest, callback_with_timer_base_argument_receives_self)
+{
+  // Arrange
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(10));
+  agnocast::TimerBase * captured = nullptr;
+  auto timer = agnocast::create_timer(
+    node.get(), clock, period,
+    [&captured](agnocast::TimerBase & self) { captured = &self; });
+
+  // Act
+  timer->execute_callback();
+
+  // Assert
+  EXPECT_EQ(captured, timer.get());
+}
+
+TEST_F(CreateTimerFreeFunctionTest, is_steady_reflects_clock_type)
+{
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+
+  // STEADY_TIME
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+    auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+    EXPECT_TRUE(timer->is_steady());
+  }
+
+  // ROS_TIME
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+    EXPECT_FALSE(timer->is_steady());
+  }
+
+  // SYSTEM_TIME
+  {
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+    auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+    EXPECT_FALSE(timer->is_steady());
+  }
+}
+
 // =========================================
 // cancel and reset and time_until_trigger function tests
 // =========================================
@@ -154,5 +197,37 @@ TEST_F(CreateTimerFreeFunctionTest, time_until_trigger_cancel_and_reset_ros_time
   EXPECT_EQ(tut_after_reset, std::chrono::nanoseconds(kPeriodNs));
   EXPECT_EQ(tut_after_wait, std::chrono::nanoseconds(kPeriodNs - kAdvanceNs));
   EXPECT_FALSE(called);
+}
+
+TEST_F(CreateTimerFreeFunctionTest, reset_re_anchors_next_call_when_time_has_advanced)
+{
+  // Arrange
+  constexpr int64_t kT0Ns = 1'000'000'000;
+  constexpr int64_t kPeriodNs = 100'000'000;
+  constexpr int64_t kHalfPeriodNs = 50'000'000;
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * rcl_clock = clock->get_clock_handle();
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, kT0Ns), RCL_RET_OK);
+  }
+  const auto period = rclcpp::Duration(std::chrono::nanoseconds(kPeriodNs));
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+
+  // Act
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, kT0Ns + kHalfPeriodNs), RCL_RET_OK);
+  }
+  const auto tut_before_reset = timer->time_until_trigger();
+  const bool was_canceled_before_reset = timer->is_canceled();
+  timer->reset();
+  const auto tut_after_reset = timer->time_until_trigger();
+
+  // Assert
+  EXPECT_FALSE(was_canceled_before_reset);
+  EXPECT_EQ(tut_before_reset, std::chrono::nanoseconds(kPeriodNs - kHalfPeriodNs));
+  EXPECT_EQ(tut_after_reset, std::chrono::nanoseconds(kPeriodNs));
 }
 

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -1,5 +1,7 @@
+// Spec tests for the public Agnocast timer API. White-box tests (internal-state
+// peeks, direct calls to internal helpers) live in test_agnocast_timer.cpp.
+
 #include "agnocast/agnocast.hpp"
-#include "agnocast/agnocast_timer_info.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include <gtest/gtest.h>
@@ -9,8 +11,6 @@
 #include <memory>
 #include <mutex>
 #include <thread>
-
-using namespace agnocast;
 
 // =========================================
 // create_timer free function tests
@@ -31,65 +31,15 @@ protected:
   std::shared_ptr<agnocast::Node> node;
 };
 
-TEST_F(CreateTimerFreeFunctionTest, creates_timer_and_registers_info)
+TEST_F(CreateTimerFreeFunctionTest, create_timer_returns_timer_with_specified_clock)
 {
-  // Arrange
   auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
   const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
 
-  // Act
   auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
 
-  // Assert
   ASSERT_NE(timer, nullptr);
   EXPECT_EQ(timer->get_clock()->get_clock_type(), RCL_STEADY_TIME);
-}
-
-TEST_F(CreateTimerFreeFunctionTest, uses_default_callback_group_when_nullptr)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
-  auto expected_group = node->get_node_base_interface()->get_default_callback_group();
-
-  // Act
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, nullptr);
-
-  // Assert: verify the timer was registered with the default callback group
-  ASSERT_NE(timer, nullptr);
-  // Check via id2_timer_info that the callback group matches the default
-  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
-  bool found = false;
-  for (const auto & [id, info] : agnocast::id2_timer_info) {
-    if (info->callback_group == expected_group && info->timer.lock() == timer) {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Timer should be registered with the default callback group";
-}
-
-TEST_F(CreateTimerFreeFunctionTest, uses_explicit_callback_group)
-{
-  // Arrange
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(50));
-  auto group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
-  // Act
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {}, group);
-
-  // Assert
-  ASSERT_NE(timer, nullptr);
-  std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
-  bool found = false;
-  for (const auto & [id, info] : agnocast::id2_timer_info) {
-    if (info->callback_group == group && info->timer.lock() == timer) {
-      found = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found) << "Timer should be registered with the explicit callback group";
 }
 
 TEST_F(CreateTimerFreeFunctionTest, callback_is_invoked)
@@ -206,32 +156,3 @@ TEST_F(CreateTimerFreeFunctionTest, time_until_trigger_cancel_and_reset_ros_time
   EXPECT_FALSE(called);
 }
 
-// =========================================
-// ID overflow tests
-// =========================================
-
-TEST(AllocateTimerIdTest, throws_when_id_has_reserved_epoll_flag_bits)
-{
-  // Arrange: Set next_timer_id to MAX_TIMER_ID so the next allocation overflows the boundary.
-  const uint32_t original = next_timer_id.load();
-  next_timer_id.store(MAX_TIMER_ID);
-
-  // Act & Assert
-  EXPECT_THROW(allocate_timer_id(), std::runtime_error);
-
-  // Cleanup
-  next_timer_id.store(original);
-}
-
-TEST(AllocateTimerIdTest, succeeds_just_below_reserved_range)
-{
-  // Arrange: Set next_timer_id to the maximum valid value.
-  const uint32_t original = next_timer_id.load();
-  next_timer_id.store(MAX_TIMER_ID - 1);
-
-  // Act & Assert
-  EXPECT_EQ(allocate_timer_id(), MAX_TIMER_ID - 1);
-
-  // Cleanup
-  next_timer_id.store(original);
-}


### PR DESCRIPTION
## Description
Separate the API spec tests from the white-box internal tests in the timer test files.

  - **Moved API → white-box**:
    - `uses_default_callback_group_when_nullptr`
    - `AllocateTimerIdTest.*`
  - **Dropped** `uses_explicit_callback_group` — already covered by `populates_timer_info_from_arguments_and_clock`.
  - **Renamed** `creates_timer_and_registers_info` → `create_timer_returns_timer_with_specified_clock` (the old name overclaimed coverage).
  - **Added (spec)**:
    - `callback_with_timer_base_argument_receives_self` — `void(TimerBase&)` callback signature
    - `is_steady_reflects_clock_type` — STEADY/ROS/SYSTEM
    - `reset_re_anchors_next_call_when_time_has_advanced` — distinguishes `reset()` from a no-op (the existing cancel→reset path cannot)



## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers
The combined diff is noisy — please review commit-by-commit:

  1. [0fb44f9](https://github.com/autowarefoundation/agnocast/pull/1329/commits/0fb44f99a6858668a1927d12fd8a7ef01450bef1) — relocate existing tests across files (mechanical: rename + fixture/namespace
  adjustments, no semantic change).
  2. [243ae9b](https://github.com/autowarefoundation/agnocast/pull/1329/commits/243ae9b28ed8630cf63336a009b88e7a81c6ad65) — add the three new spec tests.


## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
