### PR TITLE
feat(timer): support `set_period` API

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_timer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer.hpp
@@ -45,6 +45,17 @@ public:
 
   void set_timer_info(std::weak_ptr<TimerInfo> timer_info) { timer_info_ = timer_info; }
 
+  /** @brief Update the timer's period.
+   *
+   * Aligned with `rcl_timer_exchange_period`: the already-scheduled next firing keeps its
+   * time; only subsequent firings adopt the new period. Throws on an invalidated timer
+   * (rcl's equivalent is `RCL_RET_TIMER_INVALID`).
+   *
+   * @param period New firing period.
+   * @throw std::runtime_error If the underlying TimerInfo has been unregistered. */
+  AGNOCAST_PUBLIC
+  void set_period(std::chrono::nanoseconds period);
+
   /** @brief Return whether this timer uses a steady clock.
    *  @return True if the clock is steady. */
   AGNOCAST_PUBLIC

--- a/src/agnocastlib/include/agnocast/agnocast_timer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer.hpp
@@ -53,7 +53,6 @@ public:
    *
    * @param period New firing period.
    * @throw std::runtime_error If the underlying TimerInfo has been unregistered. */
-  AGNOCAST_PUBLIC
   void set_period(std::chrono::nanoseconds period);
 
   /** @brief Return whether this timer uses a steady clock.

--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -48,7 +48,7 @@ struct TimerInfo
   std::atomic<int64_t> last_call_time_ns;
   std::atomic<int64_t> next_call_time_ns;
   std::atomic<int64_t> time_credit{0};  // Credit for time elapsed before ROS time is activated
-  std::chrono::nanoseconds period;
+  std::atomic<int64_t> period_ns;
   bool need_epoll_update = true;
 
   rclcpp::Clock::SharedPtr clock;

--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -30,6 +30,9 @@ struct TimerInfo
 
   void reset();
 
+  // Implementation of TimerBase::set_period; see that for semantics.
+  void set_period(std::chrono::nanoseconds new_period);
+
   // Mutex to protect timer_fd access.
   // - shared_lock: for reading timer_fd (read(), epoll_ctl()).
   // - unique_lock: for writing timer_fd (close()).

--- a/src/agnocastlib/src/agnocast_timer.cpp
+++ b/src/agnocastlib/src/agnocast_timer.cpp
@@ -36,4 +36,14 @@ std::chrono::nanoseconds TimerBase::time_until_trigger()
   const int64_t next_ns = timer_info->next_call_time_ns.load();
   return std::chrono::nanoseconds(next_ns - now_ns);
 }
+
+void TimerBase::set_period(std::chrono::nanoseconds period)
+{
+  auto timer_info = timer_info_.lock();
+  if (!timer_info) {
+    throw std::runtime_error("set_period called on an invalidated timer (timer_info expired)");
+  }
+  timer_info->set_period(period);
+}
+
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -12,6 +12,7 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <stdexcept>
@@ -160,27 +161,32 @@ TimerInfo::~TimerInfo()
   }
 }
 
+static struct timespec ns_to_armed_timespec(int64_t ns)
+{
+  // {0, 0} disarms the timerfd; use 1ns instead to keep it armed.
+  if (ns == 0) {
+    return {0, 1};
+  }
+  return {ns / NANOSECONDS_PER_SECOND, ns % NANOSECONDS_PER_SECOND};
+}
+
+// Wraps timerfd_settime; throws std::runtime_error on failure.
+static void set_timer_fd(int timer_fd, uint32_t timer_id, const struct itimerspec & spec)
+{
+  if (timerfd_settime(timer_fd, 0, &spec, nullptr) == -1) {
+    throw std::runtime_error(
+      "timerfd_settime failed for timer_id=" + std::to_string(timer_id) + ": " +
+      std::strerror(errno));
+  }
+}
+
+// Arms the timerfd to fire after `period` from now and then every `period`.
 static void arm_timer_fd(int timer_fd, uint32_t timer_id, std::chrono::nanoseconds period)
 {
   struct itimerspec spec = {};
-  const auto period_count = period.count();
-  if (period_count == 0) {
-    // Workaround: timerfd_settime() disarms the timer when both it_value and it_interval
-    // are zero. Use 1ns to keep the timer armed and achieve "always ready" semantics.
-    spec.it_interval.tv_sec = 0;
-    spec.it_interval.tv_nsec = 1;
-  } else {
-    spec.it_interval.tv_sec = period_count / NANOSECONDS_PER_SECOND;
-    spec.it_interval.tv_nsec = period_count % NANOSECONDS_PER_SECOND;
-  }
+  spec.it_interval = ns_to_armed_timespec(period.count());
   spec.it_value = spec.it_interval;
-
-  if (timerfd_settime(timer_fd, 0, &spec, nullptr) == -1) {
-    const int saved_errno = errno;
-    throw std::runtime_error(
-      "timerfd_settime failed for timer_id=" + std::to_string(timer_id) +
-      ", period=" + std::to_string(period_count) + "ns: " + std::strerror(saved_errno));
-  }
+  set_timer_fd(timer_fd, timer_id, spec);
 }
 
 void TimerInfo::reset()
@@ -325,6 +331,28 @@ void unregister_timer_info(uint32_t timer_id)
 {
   std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
   id2_timer_info.erase(timer_id);
+}
+
+void TimerInfo::set_period(std::chrono::nanoseconds new_period)
+{
+  // rcl_timer_exchange_period semantics.
+  period = new_period;
+
+  std::shared_lock fd_lock(fd_mutex);
+  if (timer_fd == -1) {
+    return;
+  }
+
+  // it_value preserves the existing next firing; it_interval applies the new period to
+  // subsequent firings.
+  const int64_t now_ns = clock->now().nanoseconds();
+  const int64_t next_call_ns = next_call_time_ns.load(std::memory_order_relaxed);
+  const int64_t remaining_ns = std::max<int64_t>(next_call_ns - now_ns, 0);
+
+  struct itimerspec spec = {};
+  spec.it_value = ns_to_armed_timespec(remaining_ns);
+  spec.it_interval = ns_to_armed_timespec(new_period.count());
+  set_timer_fd(timer_fd, timer_id, spec);
 }
 
 void TimerEventHandler::prepare_epoll(

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -174,9 +174,10 @@ static struct timespec ns_to_armed_timespec(int64_t ns)
 static void set_timer_fd(int timer_fd, uint32_t timer_id, const struct itimerspec & spec)
 {
   if (timerfd_settime(timer_fd, 0, &spec, nullptr) == -1) {
+    const int saved_errno = errno;
     throw std::runtime_error(
       "timerfd_settime failed for timer_id=" + std::to_string(timer_id) + ": " +
-      std::strerror(errno));
+      std::strerror(saved_errno));
   }
 }
 

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -65,7 +65,7 @@ void handle_post_time_jump(TimerInfo & timer_info, const rcl_time_jump_t & jump)
 
   const int64_t last_call_ns = timer_info.last_call_time_ns.load(std::memory_order_relaxed);
   const int64_t next_call_ns = timer_info.next_call_time_ns.load(std::memory_order_relaxed);
-  const int64_t period_ns = timer_info.period.count();
+  const int64_t period_ns = timer_info.period_ns.load(std::memory_order_relaxed);
 
   if (jump.clock_change == RCL_ROS_TIME_ACTIVATED) {
     // ROS time activated: close timerfd (simulation time will use clock_eventfd)
@@ -192,12 +192,13 @@ static void arm_timer_fd(int timer_fd, uint32_t timer_id, std::chrono::nanosecon
 void TimerInfo::reset()
 {
   const int64_t now_ns = clock->now().nanoseconds();
-  next_call_time_ns.store(now_ns + period.count(), std::memory_order_relaxed);
+  const int64_t cur_period_ns = period_ns.load(std::memory_order_relaxed);
+  next_call_time_ns.store(now_ns + cur_period_ns, std::memory_order_relaxed);
 
   std::shared_lock fd_lock(fd_mutex);
 
   if (timer_fd != -1) {
-    arm_timer_fd(timer_fd, timer_id, period);
+    arm_timer_fd(timer_fd, timer_id, std::chrono::nanoseconds{cur_period_ns});
   }
 }
 
@@ -246,7 +247,7 @@ void register_timer_info(
   timer_info->timer = timer;
   timer_info->last_call_time_ns.store(now_ns, std::memory_order_relaxed);
   timer_info->next_call_time_ns.store(now_ns + period.count(), std::memory_order_relaxed);
-  timer_info->period = period;
+  timer_info->period_ns.store(period.count(), std::memory_order_relaxed);
   timer_info->callback_group = callback_group;
   timer_info->need_epoll_update = true;
   timer_info->clock = clock;
@@ -305,7 +306,7 @@ void handle_timer_event(TimerInfo & timer_info)
 
   timer_info.last_call_time_ns.store(now_ns, std::memory_order_relaxed);
 
-  const int64_t period_ns = timer_info.period.count();
+  const int64_t period_ns = timer_info.period_ns.load(std::memory_order_relaxed);
   int64_t next_call_time_ns =
     timer_info.next_call_time_ns.load(std::memory_order_relaxed) + period_ns;
 
@@ -336,7 +337,7 @@ void unregister_timer_info(uint32_t timer_id)
 void TimerInfo::set_period(std::chrono::nanoseconds new_period)
 {
   // rcl_timer_exchange_period semantics.
-  period = new_period;
+  period_ns.store(new_period.count(), std::memory_order_relaxed);
 
   std::shared_lock fd_lock(fd_mutex);
   if (timer_fd == -1) {

--- a/src/agnocastlib/test/unit/test_agnocast_timer.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer.cpp
@@ -9,6 +9,7 @@
 #include <poll.h>
 #include <rcl/time.h>
 #include <sys/eventfd.h>
+#include <sys/timerfd.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -483,6 +484,124 @@ TEST_F(TestTimer, handle_timer_event_with_zero_period_sets_next_call_to_now)
   // Assert
   EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns);
   EXPECT_EQ(call_count, 1) << "period=0 must fire exactly once per call, not loop";
+}
+
+// =============================================================================
+// TimerInfo::set_period — semantics defined in TimerBase::set_period docstring.
+// =============================================================================
+
+TEST_F(TestTimer, set_period_updates_period_only_without_modifying_call_time_anchors)
+{
+  // Arrange — last_call != now catches an anchor-to-now regression (set_period must not
+  // behave like reset).
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = 1'200'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+  const std::chrono::nanoseconds new_period{500'000'000};
+
+  // Act
+  info->set_period(new_period);
+
+  // Assert — period swapped; call-time anchors untouched.
+  EXPECT_EQ(info->period, new_period);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
+  EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), last_call_ns);
+}
+
+TEST_F(TestTimer, set_period_arms_timer_fd_to_fire_at_existing_next_call_then_every_new_period)
+{
+  // Arrange — pin now 30ms before next_call so remaining = 30ms. Expect it_value=remaining
+  // (preserves the existing firing time) and it_interval=new_period (subsequent firings).
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = last_call_ns + 70'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  const int64_t expected_remaining_ns =
+    info->next_call_time_ns.load(std::memory_order_relaxed) - now_ns;
+  ASSERT_EQ(expected_remaining_ns, 30'000'000);
+  info->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+  const std::chrono::nanoseconds new_period{250'000'000};
+
+  // Act
+  info->set_period(new_period);
+
+  // Assert
+  struct itimerspec spec = {};
+  ASSERT_EQ(timerfd_gettime(info->timer_fd, &spec), 0);
+  // it_value: kernel reports remaining time. Slack because nanoseconds elapse between
+  // set_period and timerfd_gettime.
+  const int64_t got_value_ns = spec.it_value.tv_sec * 1'000'000'000LL + spec.it_value.tv_nsec;
+  EXPECT_GT(got_value_ns, 0);
+  EXPECT_LE(got_value_ns, expected_remaining_ns);
+  const int64_t got_interval_ns =
+    spec.it_interval.tv_sec * 1'000'000'000LL + spec.it_interval.tv_nsec;
+  EXPECT_EQ(got_interval_ns, new_period.count());
+}
+
+TEST_F(TestTimer, set_period_arms_timer_fd_to_fire_immediately_when_already_overdue)
+{
+  // Arrange — now > next_call → remaining is negative. set_period must clamp it_value to
+  // 1ns (0 disarms the timerfd; negative is rejected with EINVAL). The 1ns expiry fires
+  // essentially immediately; verify by polling the timerfd for readability rather than
+  // by reading it_value (which the kernel auto-overwrites with the next interval).
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = last_call_ns + 500'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  ASSERT_LT(info->next_call_time_ns.load(std::memory_order_relaxed), now_ns);
+  info->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+
+  // Act
+  info->set_period(std::chrono::nanoseconds{250'000'000});
+
+  // Assert
+  pollfd pfd{info->timer_fd, POLLIN, 0};
+  ASSERT_GT(poll(&pfd, 1, /*timeout_ms=*/100), 0) << "timerfd should be readable within 100ms";
+  EXPECT_TRUE(pfd.revents & POLLIN);
+  uint64_t expirations = 0;
+  ASSERT_EQ(
+    read(info->timer_fd, &expirations, sizeof(expirations)),
+    static_cast<ssize_t>(sizeof(expirations)));
+  EXPECT_GE(expirations, 1u);
+}
+
+TEST_F(TestTimer, set_period_with_zero_period_arms_timer_fd_with_one_nanosecond_interval)
+{
+  // Arrange — same 1ns interval workaround as arm_timer_fd: zero would disarm the timerfd.
+  const int64_t last_call_ns = 1'000'000'000;
+  const int64_t now_ns = last_call_ns + 30'000'000;
+  auto clock = make_ros_clock_at(now_ns);
+  auto info = make_timer_info(clock, /*now_ns=*/last_call_ns);
+  info->timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+  ASSERT_GE(info->timer_fd, 0);
+
+  // Act
+  info->set_period(std::chrono::nanoseconds{0});
+
+  // Assert
+  struct itimerspec spec = {};
+  ASSERT_EQ(timerfd_gettime(info->timer_fd, &spec), 0);
+  EXPECT_EQ(spec.it_interval.tv_sec, 0);
+  EXPECT_EQ(spec.it_interval.tv_nsec, 1);
+}
+
+TEST_F(TestTimer, set_period_skips_timer_fd_re_arm_when_fd_is_minus_one)
+{
+  // Arrange — sim-time path: no timerfd. period is updated; next_call is preserved.
+  auto clock = make_ros_clock_at(1'200'000'000);
+  auto info = make_timer_info(clock, /*now_ns=*/1'000'000'000);
+  ASSERT_EQ(info->timer_fd, -1);
+  const int64_t snapshot_next = info->next_call_time_ns.load(std::memory_order_relaxed);
+  const std::chrono::nanoseconds new_period{250'000'000};
+
+  // Act / Assert
+  EXPECT_NO_THROW(info->set_period(new_period));
+  EXPECT_EQ(info->period, new_period);
+  EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
 }
 
 // =============================================================================

--- a/src/agnocastlib/test/unit/test_agnocast_timer.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer.cpp
@@ -56,7 +56,7 @@ protected:
   {
     auto info = std::make_shared<agnocast::TimerInfo>();
     info->timer_id = 1;
-    info->period = std::chrono::nanoseconds{period_ns};
+    info->period_ns.store(period_ns, std::memory_order_relaxed);
     info->clock = std::move(clock);
     info->last_call_time_ns.store(now_ns, std::memory_order_relaxed);
     info->next_call_time_ns.store(now_ns + period_ns, std::memory_order_relaxed);
@@ -505,7 +505,7 @@ TEST_F(TestTimer, set_period_updates_period_only_without_modifying_call_time_anc
   info->set_period(new_period);
 
   // Assert — period swapped; call-time anchors untouched.
-  EXPECT_EQ(info->period, new_period);
+  EXPECT_EQ(info->period_ns.load(std::memory_order_relaxed), new_period.count());
   EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
   EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), last_call_ns);
 }
@@ -600,7 +600,7 @@ TEST_F(TestTimer, set_period_skips_timer_fd_re_arm_when_fd_is_minus_one)
 
   // Act / Assert
   EXPECT_NO_THROW(info->set_period(new_period));
-  EXPECT_EQ(info->period, new_period);
+  EXPECT_EQ(info->period_ns.load(std::memory_order_relaxed), new_period.count());
   EXPECT_EQ(info->next_call_time_ns.load(std::memory_order_relaxed), snapshot_next);
 }
 
@@ -733,7 +733,7 @@ TEST_F(TestRegisterTimerInfo, populates_timer_info_from_arguments_and_clock)
   // Argument forwarding: each argument is stored verbatim.
   EXPECT_EQ(info->timer_id, timer_id);
   EXPECT_EQ(info->timer.lock(), timer);
-  EXPECT_EQ(info->period, period);
+  EXPECT_EQ(info->period_ns.load(std::memory_order_relaxed), period.count());
   EXPECT_EQ(info->callback_group, cb_group);
   // Call-time anchors initialized from clock->now().
   EXPECT_EQ(info->last_call_time_ns.load(std::memory_order_relaxed), now_ns);

--- a/src/agnocastlib/test/unit/test_agnocast_timer.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer.cpp
@@ -589,6 +589,25 @@ TEST_F(TestTimer, set_period_with_zero_period_arms_timer_fd_with_one_nanosecond_
   EXPECT_EQ(spec.it_interval.tv_nsec, 1);
 }
 
+TEST_F(TestTimer, set_period_throws_when_underlying_timer_info_is_invalid)
+{
+  // Arrange — rcl's RCL_RET_TIMER_INVALID equivalent: the weak_ptr to TimerInfo fails to
+  // lock. Reproduced here by force-erasing the global registry to drop the only strong ref.
+  rclcpp::NodeOptions options;
+  options.start_parameter_services(false);
+  auto node = std::make_shared<agnocast::Node>("test_timer_set_period_invalid", options);
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+  {
+    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+    agnocast::id2_timer_info.clear();
+  }
+
+  // Act / Assert
+  EXPECT_THROW(timer->set_period(std::chrono::nanoseconds{50'000'000}), std::runtime_error);
+}
+
 TEST_F(TestTimer, set_period_skips_timer_fd_re_arm_when_fd_is_minus_one)
 {
   // Arrange — sim-time path: no timerfd. period is updated; next_call is preserved.

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -316,6 +316,5 @@ TEST_F(CreateTimerFreeFunctionTest, set_period_throws_when_underlying_timer_info
   }
 
   // Act / Assert
-  EXPECT_THROW(
-    timer->set_period(std::chrono::nanoseconds{50'000'000}), std::runtime_error);
+  EXPECT_THROW(timer->set_period(std::chrono::nanoseconds{50'000'000}), std::runtime_error);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -302,19 +302,3 @@ TEST_F(CreateTimerFreeFunctionTest, set_period_preserves_canceled_state)
   // Assert
   EXPECT_TRUE(timer->is_canceled());
 }
-
-TEST_F(CreateTimerFreeFunctionTest, set_period_throws_when_underlying_timer_info_is_invalid)
-{
-  // Arrange — rcl's RCL_RET_TIMER_INVALID equivalent: the weak_ptr to TimerInfo fails to
-  // lock. Reproduced here by force-erasing the global registry to drop the only strong ref.
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
-  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
-  {
-    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
-    agnocast::id2_timer_info.clear();
-  }
-
-  // Act / Assert
-  EXPECT_THROW(timer->set_period(std::chrono::nanoseconds{50'000'000}), std::runtime_error);
-}

--- a/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_timer_api.cpp
@@ -232,3 +232,90 @@ TEST_F(CreateTimerFreeFunctionTest, reset_re_anchors_next_call_when_time_has_adv
   EXPECT_EQ(tut_before_reset, std::chrono::nanoseconds(kPeriodNs - kHalfPeriodNs));
   EXPECT_EQ(tut_after_reset, std::chrono::nanoseconds(kPeriodNs));
 }
+
+// =========================================
+// set_period function tests
+// =========================================
+
+TEST_F(CreateTimerFreeFunctionTest, set_period_does_not_change_immediate_time_until_trigger)
+{
+  // Arrange — pin ROS time so before/after time_until_trigger comparisons are exact.
+  constexpr int64_t kT0Ns = 1'000'000'000;
+  constexpr int64_t kPeriodNs = 100'000'000;
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * rcl_clock = clock->get_clock_handle();
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, kT0Ns), RCL_RET_OK);
+  }
+  const auto period = rclcpp::Duration(std::chrono::nanoseconds(kPeriodNs));
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+
+  // Act — swap to a deliberately different period.
+  const auto tut_before = timer->time_until_trigger();
+  timer->set_period(std::chrono::nanoseconds{kPeriodNs * 5});
+  const auto tut_after = timer->time_until_trigger();
+
+  // Assert — the already-scheduled next firing must keep its time across the period swap.
+  EXPECT_EQ(tut_before, std::chrono::nanoseconds(kPeriodNs));
+  EXPECT_EQ(tut_after, tut_before);
+}
+
+TEST_F(CreateTimerFreeFunctionTest, set_period_takes_effect_on_subsequent_reset)
+{
+  // Arrange
+  constexpr int64_t kT0Ns = 1'000'000'000;
+  constexpr int64_t kInitialPeriodNs = 100'000'000;
+  constexpr int64_t kNewPeriodNs = 50'000'000;
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * rcl_clock = clock->get_clock_handle();
+  {
+    std::lock_guard<std::mutex> lock(clock->get_clock_mutex());
+    ASSERT_EQ(rcl_enable_ros_time_override(rcl_clock), RCL_RET_OK);
+    ASSERT_EQ(rcl_set_ros_time_override(rcl_clock, kT0Ns), RCL_RET_OK);
+  }
+  auto timer = agnocast::create_timer(
+    node.get(), clock, rclcpp::Duration(std::chrono::nanoseconds(kInitialPeriodNs)), []() {});
+
+  // Act — reset() anchors next_call at now + period using the latest period value.
+  timer->set_period(std::chrono::nanoseconds{kNewPeriodNs});
+  timer->reset();
+
+  // Assert
+  EXPECT_EQ(timer->time_until_trigger(), std::chrono::nanoseconds(kNewPeriodNs));
+}
+
+TEST_F(CreateTimerFreeFunctionTest, set_period_preserves_canceled_state)
+{
+  // Arrange — set_period and cancel are orthogonal; calling set_period on a canceled
+  // timer must not implicitly un-cancel it.
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+  timer->cancel();
+  ASSERT_TRUE(timer->is_canceled());
+
+  // Act
+  timer->set_period(std::chrono::nanoseconds{50'000'000});
+
+  // Assert
+  EXPECT_TRUE(timer->is_canceled());
+}
+
+TEST_F(CreateTimerFreeFunctionTest, set_period_throws_when_underlying_timer_info_is_invalid)
+{
+  // Arrange — rcl's RCL_RET_TIMER_INVALID equivalent: the weak_ptr to TimerInfo fails to
+  // lock. Reproduced here by force-erasing the global registry to drop the only strong ref.
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
+  const auto period = rclcpp::Duration(std::chrono::milliseconds(100));
+  auto timer = agnocast::create_timer(node.get(), clock, period, []() {});
+  {
+    std::lock_guard<std::mutex> lock(agnocast::id2_timer_info_mtx);
+    agnocast::id2_timer_info.clear();
+  }
+
+  // Act / Assert
+  EXPECT_THROW(
+    timer->set_period(std::chrono::nanoseconds{50'000'000}), std::runtime_error);
+}


### PR DESCRIPTION
## Description
Add `agnocast::TimerBase::set_period`, aligned with `rcl_timer_exchange_period`: swap the period, leave `next_call_time` alone, re-arm the timerfd so the existing next firing is preserved and subsequent firings use the new period.

## Related links

## How was this PR tested?

- [x] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
