### PR TITLE
fix(cie): disable unnecessary options for cie client node

### DIFF
--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -88,6 +88,9 @@ create_rclcpp_client_publisher()
   // Disable global arguments so that global "__node" remapping cannot override this name
   // and cause duplicate node names for these per-client nodes.
   options.use_global_arguments(false);
+  options.start_parameter_services(false);
+  options.start_parameter_event_publisher(false);
+  options.enable_rosout(false);
   auto node = std::make_shared<rclcpp::Node>(
     "client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator", options);
   auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
@@ -103,6 +106,9 @@ create_agnocast_client_publisher()
   // Disable global arguments so that global "__node" remapping cannot override this name
   // and cause duplicate node names for these per-client nodes.
   options.use_global_arguments(false);
+  options.start_parameter_services(false);
+  options.start_parameter_event_publisher(false);
+  options.enable_rosout(false);
   auto node = std::make_shared<agnocast::Node>(
     "agnocast_client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator",
     options);

--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -91,6 +91,7 @@ create_rclcpp_client_publisher()
   options.start_parameter_services(false);
   options.start_parameter_event_publisher(false);
   options.enable_rosout(false);
+  options.use_clock_thread(false);
   auto node = std::make_shared<rclcpp::Node>(
     "client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator", options);
   auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
@@ -109,6 +110,7 @@ create_agnocast_client_publisher()
   options.start_parameter_services(false);
   options.start_parameter_event_publisher(false);
   options.enable_rosout(false);
+  options.use_clock_thread(false);
   auto node = std::make_shared<agnocast::Node>(
     "agnocast_client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator",
     options);


### PR DESCRIPTION
## Description
Disable `start_parameter_services` / `start_parameter_event_publisher` / `enable_rosout` on the per-process CIE helper nodes (`create_rclcpp_client_publisher` / `create_agnocast_client_publisher`). These helpers only host a single `CallbackGroupInfo` publisher, so the auto-created parameter services / event publisher / rosout publisher are pure startup overhead with no functional value.

For `agnocast::Node` the impact is more than cosmetic: each auto-created parameter service becomes an `agnocast::Service`, which the bridge proxies (Service + Client per op × 6 = 12 extra child threads per helper) and floods `/agnocast_cie_thread_configurator/callback_group_info` with proxy entries. This also caused `agnocast_e2e_test` tests `TestComponentContainerCIE` / `TestCallbackIsolatedExecutor` to fail with `AssertionError: 4 != 2 : Expected exactly 2 'Received CallbackGroupInfo:' messages`.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
