### PR TITLE
chore: fix pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## How was this PR tested?
 
-- [ ] Autoware (required)
+- [ ] Autoware
 - [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
 - [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
 - [ ] kunit tests (required when modifying the kernel module)
@@ -18,13 +18,12 @@
 Please add **exactly one** of the following labels to this PR:
 
 - `need-major-update`: User API breaking changes
-- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
+- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
 - `need-patch-update`: Bug fixes and other changes
 
 **Important notes:**
 
 - If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
   - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
-- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for your interest in contributing to Agnocast!
 Every pull request **must** have exactly one of the following labels:
 
 - **`need-major-update`**: User API breaking changes - requires MAJOR version update
-- **`need-minor-update`**: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility) - requires MINOR version update
+- **`need-minor-update`**: Internal API breaking changes (kmod/agnocastlib compatibility) - requires MINOR version update
 - **`need-patch-update`**: Bug fixes and other changes - requires PATCH version update
 
 **Important notes:**
@@ -18,7 +18,6 @@ Every pull request **must** have exactly one of the following labels:
 - **PR Title Convention**: If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
   - Example: `fix(foo)[needs major version update]: bar`
   - Example: `feat(baz)[needs minor version update]: qux`
-- **Build Test Requirement**: After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.
 
 ## Versioning Rules
 
@@ -40,7 +39,6 @@ Increment when you make **breaking changes to internal APIs or component compati
 
 This includes changes that affect compatibility between:
 
-- heaphook
 - kmod
 - agnocastlib
 
@@ -48,7 +46,7 @@ Examples:
 
 - Removing or renaming ioctl commands
 - Modifying data structures used in ioctl interfaces
-- Changing shared data structures between heaphook/kmod/agnocastlib
+- Changing shared data structures between kmod/agnocastlib
 - Breaking changes to internal APIs not exposed to end users
 
 ### PATCH version (`need-patch-update`)
@@ -67,7 +65,7 @@ Examples:
 
 Before submitting a PR, please ensure the following tests pass:
 
-- [ ] Autoware (required)
+- [ ] Autoware
 - [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
 - [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
 - [ ] kunit tests (required when modifying the kernel module)


### PR DESCRIPTION
## Description
This branch updates `.github/pull_request_template.md` and keeps `CONTRIBUTING.md` consistent with it:

  - Autoware testing is no longer marked as required. Both the template checklist and the "Testing Requirements" section now list Autoware without (required). Review might ask to check the behavior with Autoware as needed.
  - need-minor-update scope narrowed to kmod/agnocastlib. heaphook is dropped from the internal-compatibility list (label description, the MINOR-version compatibility list, and its examples). This is just a fix, not the policy change.
  - Removed the run-build-test label instruction. The note telling contributors to add the run-build-test label after approval is dropped from both files; adding that label is basically handled by reviewers/code owners, and doesn't have to be explicitly written in pull_request_template.

## Related links

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
