### PR TITLE
refactor(bridge-plugins): consolidate .so and enable unity/lld build

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
@@ -38,11 +38,10 @@ private:
   std::unordered_map<std::string, void *> loaded_libraries_;
 
   static std::string convert_type_to_snake_case(const std::string & message_type);
-  static std::vector<std::string> generate_library_paths(
-    const std::string & snake_type, bool is_service);
+  static std::vector<std::string> generate_library_paths();
   void * load_library_from_paths(const std::vector<std::string> & paths);
   void * get_bridge_factory_symbol(
-    const std::string & type_name, const std::string & symbol_name, bool is_service);
+    const std::string & type_name, const std::string & symbol_name_prefix, bool is_service);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -71,12 +71,10 @@ std::string PerformanceBridgeLoader::convert_type_to_snake_case(const std::strin
   return result;
 }
 
-std::vector<std::string> PerformanceBridgeLoader::generate_library_paths(
-  const std::string & snake_type, bool is_service)
+std::vector<std::string> PerformanceBridgeLoader::generate_library_paths()
 {
   std::vector<std::string> paths;
-  const std::string lib_name =
-    (is_service ? "libservice_bridge_plugin_" : "libpubsub_bridge_plugin_") + snake_type + ".so";
+  const std::string lib_name = "libagnocast_bridge_plugins.so";
 
   // 1. Check environment variable AGNOCAST_BRIDGE_PLUGINS_PATH (colon-separated)
   const char * env_path = std::getenv("AGNOCAST_BRIDGE_PLUGINS_PATH");
@@ -140,16 +138,18 @@ void * PerformanceBridgeLoader::load_library_from_paths(const std::vector<std::s
 }
 
 void * PerformanceBridgeLoader::get_bridge_factory_symbol(
-  const std::string & type_name, const std::string & symbol_name, bool is_service)
+  const std::string & type_name, const std::string & symbol_name_prefix, bool is_service)
 {
   const char * type_label = is_service ? "service" : "message";
   std::string snake_type = convert_type_to_snake_case(type_name);
-  std::vector<std::string> lib_paths = generate_library_paths(snake_type, is_service);
+  std::vector<std::string> lib_paths = generate_library_paths();
 
   void * handle = load_library_from_paths(lib_paths);
   if (handle == nullptr) {
     return nullptr;
   }
+
+  const std::string symbol_name = symbol_name_prefix + "_" + snake_type;
 
   dlerror();
   void * symbol = dlsym(handle, symbol_name.c_str());

--- a/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
+++ b/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(agnocast_bridge_plugins)
 
+set(CMAKE_UNITY_BUILD ON)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -11,6 +13,13 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
+
+  find_program(LLD_LINKER lld)
+  if(LLD_LINKER)
+    add_link_options("-fuse-ld=lld")
+  else()
+    message(WARNING "lld not found. Link times may be longer. To use lld, install it and make sure it's in your PATH.")
+  endif()
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -20,57 +29,34 @@ find_package(agnocastlib REQUIRED)
 find_package(@(pkg) REQUIRED)
 @[end for]
 
+add_library(${PROJECT_NAME} SHARED
 @[for msg_type in message_types]
-@{
-safe_name = msg_type.replace('/', '_')
-pkg = msg_type.split('/')[0]
-}
-# Plugin for @(msg_type)
-add_library(pubsub_bridge_plugin_@(safe_name) SHARED src/pubsub_bridge_plugin_@(safe_name).cpp)
-target_link_libraries(pubsub_bridge_plugin_@(safe_name) agnocastlib::agnocast)
-ament_target_dependencies(pubsub_bridge_plugin_@(safe_name) rclcpp @(pkg))
-
-install(TARGETS pubsub_bridge_plugin_@(safe_name)
-  DESTINATION lib/${PROJECT_NAME})
-
+  src/pubsub_bridge_plugin_@(msg_type.replace('/', '_')).cpp
 @[end for]
-
 @[for srv_type in service_types]
-@{
-safe_name = srv_type.replace('/', '_')
-pkg = srv_type.split('/')[0]
-}
-# Plugin for @(srv_type)
-add_library(service_bridge_plugin_@(safe_name) SHARED src/service_bridge_plugin_@(safe_name).cpp)
-target_link_libraries(service_bridge_plugin_@(safe_name) agnocastlib::agnocast)
-ament_target_dependencies(service_bridge_plugin_@(safe_name) rclcpp @(pkg))
-
-install(TARGETS service_bridge_plugin_@(safe_name)
-  DESTINATION lib/${PROJECT_NAME})
-
+  src/service_bridge_plugin_@(srv_type.replace('/', '_')).cpp
 @[end for]
+)
+
+target_link_libraries(${PROJECT_NAME} agnocastlib::agnocast)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+@[for pkg in package_names]
+  @(pkg)
+@[end for]
+)
+
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
 
 # Use precompiled headers to speed up build (requires CMake >= 3.16)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
-@{
-all_targets = (
-  ['pubsub_bridge_plugin_' + t.replace('/', '_') for t in message_types] +
-  ['service_bridge_plugin_' + t.replace('/', '_') for t in service_types]
-)
-first_target = all_targets[0]
-rest_targets = all_targets[1:]
-}
-  set_target_properties(@(first_target) PROPERTIES DEFINE_SYMBOL "AGNOCAST_BRIDGE_PLUGIN_EXPORTS")
-  target_precompile_headers(@(first_target) PRIVATE
+  set_target_properties(${PROJECT_NAME} PROPERTIES DEFINE_SYMBOL "AGNOCAST_BRIDGE_PLUGIN_EXPORTS")
+  target_precompile_headers(${PROJECT_NAME} PRIVATE
     <agnocast/agnocast.hpp>
     <rclcpp/rclcpp.hpp>
     <utility>)
-
-@[for target in rest_targets]
-  set_target_properties(@(target) PROPERTIES DEFINE_SYMBOL "AGNOCAST_BRIDGE_PLUGIN_EXPORTS")
-  target_precompile_headers(@(target) REUSE_FROM @(first_target))
-
-@[end for]
 endif()
 
 ament_package()

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -9,7 +9,7 @@
 
 #include "@(header_path)"
 
-extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge(
+extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge_@(snake_type_name)(
   rclcpp::Node::SharedPtr node,
   const std::string & topic_name,
   const rclcpp::QoS & sub_qos)
@@ -42,7 +42,7 @@ extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge(
   return {ros_sub, ros_cb_group};
 }
 
-extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge(
+extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge_@(snake_type_name)(
   rclcpp::Node::SharedPtr node,
   const std::string & topic_name,
   const rclcpp::QoS & sub_qos)

--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -9,7 +9,7 @@
 
 #include "@(header_path)"
 
-extern "C" PerformanceServiceBridgeResult create_r2a_service_bridge(
+extern "C" PerformanceServiceBridgeResult create_r2a_service_bridge_@(snake_type_name)(
   rclcpp::Node::SharedPtr node,
   const std::string & service_name,
   const rclcpp::QoS & qos /*QoS for the target Agnocast service*/)

--- a/src/ros2agnocast/ros2agnocast/verb/generate_bridge_plugins.py
+++ b/src/ros2agnocast/ros2agnocast/verb/generate_bridge_plugins.py
@@ -164,6 +164,7 @@ class GenerateBridgePluginsVerb(VerbExtension):
                 'msg_type': typ,
                 'cpp_type': cpp_type,
                 'header_path': header_path,
+                'snake_type_name': flat_type,
             }
             template_file = templates_pkg.joinpath('pubsub_bridge_plugin.cpp.em')
         else:
@@ -171,6 +172,7 @@ class GenerateBridgePluginsVerb(VerbExtension):
                 'srv_type': typ,
                 'cpp_type': cpp_type,
                 'header_path': header_path,
+                'snake_type_name': flat_type,
             }
             template_file = templates_pkg.joinpath('service_bridge_plugin.cpp.em')
 


### PR DESCRIPTION
## Description

### Summary

This PR consolidates multiple `.so` libraries (previously generated for each message type by `ros2 agnocast generate-bridge-plugins`) into a single shared library: `libagnocast_bridge_plugins.so`.

> [!NOTE]
> Please review #1330 before checking this PR.

**Key Changes:**
- [x] Consolidate multiple .so files into a single .so file. 
- [x] Enable UNITY_BUILD.
- [x] Use ld.lld instead of ld (if available).

### Details

#### Linker Update (Prioritizing `lld`)
* **Problem:** Because `.so` files are now consolidated, using the default `ld` linker (which does not support multi-threading) might increase link time.
* **Solution:** This PR configures the build system to **prefer `lld` over `ld`** if it is installed in the environment to speed up the linking process.
* **Fallback:** If `lld` is not available, it automatically falls back to the default linker.

#### `.so` File Structure
* **Before:** The `ros2 agnocast generate-bridge-plugins` command generated `libagnocast_bridge_plugins_<msg_name>.so` for each message type. Functions (e.g., `create_r2a_pubsub_bridge`) were defined inside each corresponding `.so` file.
* **After:** A single, all-inclusive `libagnocast_bridge_plugins.so` is generated. To prevent conflicts, the message name is now added as a suffix to the function names.

#### Enabling UNITY_BUILD
* **Background:** It is safe to use here because there are no name conflicts for macros or static variables.
* **Effect:** It reduces duplicated build processes, leading to faster build times.

#### Build Time Performance
This change slightly reduces the build time. 

In my environment, the build time decreased from **~2 minutes to ~1.5 minutes**.
* **CPU:** Intel Core Ultra 9 285K
* **Memory:** 32GiB
* **Workspace:** underlay + agnocast overlay

## Related links

* #1330
* #1332 

## How was this PR tested?

- [ ] Autoware (required)
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) with `-b performance` option (#1332)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (heaphook/kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`
- After receiving approval from reviewers, add the `run-build-test` label. The PR can only be merged after the build tests pass.

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
