### PR TITLE
fix: e2e stress workaround

### DIFF
--- a/scripts/test/e2e_test_stress.bash
+++ b/scripts/test/e2e_test_stress.bash
@@ -19,15 +19,7 @@ for ((i = 0; i < NUM_PERCENTAGES; i++)); do
 done
 TIMEOUT=680s # based on the measurement time of e2e tests
 
-# Workaround for launch_testing timeout configuration
-# This is because it is hard coded in https://github.com/ros2/launch/blob/f31c1ff13fcbed3653d1a0e26438cb739e96d751/launch_testing/launch_testing/test_runner.py#L184.
-SED_TARGET_FILE=$(dirname "$(python3 -c 'import launch_testing; print(launch_testing.__file__)')")/test_runner.py
-sudo cp $SED_TARGET_FILE $SED_TARGET_FILE.bak
-TIMEOUT_WITH_BUFFER=$((TIMEOUT_EACH_TEST_CASE_S + 10))
-sudo sed -i '/if not self._processes_launched.wait/s/\(timeout=\)[0-9]\+/\1'"$TIMEOUT_WITH_BUFFER"'/' "$SED_TARGET_FILE"
-
 cleanup() {
-    sudo cp $SED_TARGET_FILE.bak $SED_TARGET_FILE
     echo "Stopping stress-ng..."
     pkill -P $$ # Kill all child processes
     exit 1

--- a/src/agnocast_e2e_test/test/test_1to1.py
+++ b/src/agnocast_e2e_test/test/test_1to1.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 
 import launch_testing
@@ -63,7 +64,9 @@ def calc_action_delays(config: dict) -> tuple:
     unit_delay = 1.0
     pub_delay = 0.0 if config['launch_pub_before_sub'] else unit_delay
     sub_delay = 0.01 * EXPECT_INIT_PUB_NUM + unit_delay if config['launch_pub_before_sub'] else 0.0
-    ready_delay = float(TIMEOUT) if TIMEOUT else pub_delay + sub_delay + 10.0
+    # ReadyToTest must fire within launch_testing's ~15s limit; the stress
+    # soak is done in Test1To1.setUpClass.
+    ready_delay = pub_delay + sub_delay + 10.0
     return pub_delay, sub_delay, ready_delay
 
 
@@ -257,6 +260,12 @@ def generate_test_description():
 
 
 class Test1To1(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Stress soak: forever=True nodes keep running while we sleep here.
+        if TIMEOUT:
+            time.sleep(float(TIMEOUT))
 
     def test_pub(self, proc_output, test_pub):
         output_text = "".join(

--- a/src/agnocast_e2e_test/test/test_1to1.py
+++ b/src/agnocast_e2e_test/test/test_1to1.py
@@ -26,7 +26,7 @@ EXPECT_ROS2_SUB_NUM: int
 
 BRIDGE_OFF = check_bridge_mode()
 TOPIC_NAME = os.environ.get('E2E_TOPIC_NAME', '/test_topic')
-TIMEOUT = os.environ.get('STRESS_TEST_TIMEOUT')
+TIMEOUT = float(os.environ.get('STRESS_TEST_TIMEOUT', 0.0))
 FOREVER = True if (os.environ.get('STRESS_TEST_TIMEOUT')) else False
 
 
@@ -67,6 +67,10 @@ def calc_action_delays(config: dict) -> tuple:
     # ReadyToTest must fire within launch_testing's ~15s limit; the stress
     # soak is done in Test1To1.setUpClass.
     ready_delay = pub_delay + sub_delay + 10.0
+    assert ready_delay < 15.0, (
+        f'ready_delay={ready_delay:.2f}s exceeds launch_testing\'s ~15s cap; '
+        f'reduce pub_qos_depth or the soak buffer'
+    )
     return pub_delay, sub_delay, ready_delay
 
 
@@ -264,8 +268,8 @@ class Test1To1(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Stress soak: forever=True nodes keep running while we sleep here.
-        if TIMEOUT:
-            time.sleep(float(TIMEOUT))
+        if FOREVER:
+            time.sleep(TIMEOUT)
 
     def test_pub(self, proc_output, test_pub):
         output_text = "".join(

--- a/src/agnocast_e2e_test/test/test_2to2.py
+++ b/src/agnocast_e2e_test/test/test_2to2.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 
 import launch_testing
@@ -18,6 +19,9 @@ QOS_DEPTH = 10
 PUB_NUM = int(QOS_DEPTH / 2)
 TIMEOUT = float(os.environ.get('STRESS_TEST_TIMEOUT', 8.0))
 FOREVER = True if (os.environ.get('STRESS_TEST_TIMEOUT')) else False
+# ReadyToTest must fire within launch_testing's ~15s limit; the stress soak
+# is done in Test2To2.setUpClass.
+READY_TO_TEST_DELAY = 8.0
 
 BRIDGE_MODE = os.environ.get('AGNOCAST_BRIDGE_MODE', 'off').lower()
 IS_STANDARD_BRIDGE = (BRIDGE_MODE == '1' or BRIDGE_MODE == 'standard')
@@ -136,7 +140,7 @@ def generate_test_description():
             [
                 SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '0'),
                 *containers,
-                TimerAction(period=TIMEOUT, actions=[launch_testing.actions.ReadyToTest()])
+                TimerAction(period=READY_TO_TEST_DELAY, actions=[launch_testing.actions.ReadyToTest()])
             ]
         ), testing_processes
     )
@@ -145,6 +149,12 @@ def generate_test_description():
 class Test2To2(unittest.TestCase):
     pub_i_ = 0
     sub_i_ = 0
+
+    @classmethod
+    def setUpClass(cls):
+        # Stress soak: forever=True nodes keep running while we sleep here.
+        if FOREVER:
+            time.sleep(TIMEOUT)
 
     def common_assert(self, proc_output, container_proc, nodes):
         if not nodes:


### PR DESCRIPTION
## Description
 Fix e2e stress tests for Ubuntu 24.04 / Jazzy
  
The old design delayed `ReadyToTest` by the full soak duration, but launch_testing hard-codes a ~15s limit for reaching `ReadyToTest` and aborts otherwise. The previous workaround sed-patched the installed `launch_testing` source at runtime, which is fragile and broke on Jazzy.

Instead:
  - `ReadyToTest` now fires promptly, within the limit.
  - The soak is moved to `setUpClass` (test phase, no limit); `forever=True` nodes keep running during it.
  - Removed the sed workaround from `e2e_test_stress.bash`.



## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
