### PR TITLE
fix(agnocastlib): pass `use_clock_thread` to Node constructor

### DIFF
--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -28,7 +28,7 @@ Node::Node(
     node_base_, options.parameter_overrides(), local_args_.get())),
   node_clock_(std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME)),
   node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(
-    node_clock_, this, rclcpp::ClockQoS(), options.use_clock_thread())),
+    node_clock_, this, options.clock_qos(), options.use_clock_thread())),
   node_logging_(std::make_shared<node_interfaces::NodeLogging>(logger_))
 {
   if (options.start_parameter_services()) {

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -27,7 +27,8 @@ Node::Node(
   node_parameters_(std::make_shared<node_interfaces::NodeParameters>(
     node_base_, options.parameter_overrides(), local_args_.get())),
   node_clock_(std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME)),
-  node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(node_clock_, this)),
+  node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(
+    node_clock_, this, rclcpp::ClockQoS(), options.use_clock_thread())),
   node_logging_(std::make_shared<node_interfaces::NodeLogging>(logger_))
 {
   if (options.start_parameter_services()) {

--- a/src/agnocastlib/test/integration/test_agnocast_node.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_node.cpp
@@ -1,8 +1,11 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "rclcpp/callback_group.hpp"
+#include "rclcpp/parameter.hpp"
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <memory>
 
 class AgnocastNodeConstructionTest : public ::testing::Test
@@ -31,4 +34,42 @@ TEST_F(AgnocastNodeConstructionTest, construct_with_parameter_services_disabled)
 TEST_F(AgnocastNodeConstructionTest, construct_with_default_options)
 {
   EXPECT_NO_THROW({ auto node = std::make_shared<agnocast::Node>("test_node_default"); });
+}
+
+namespace
+{
+std::size_t count_callback_groups(const std::shared_ptr<agnocast::Node> & node)
+{
+  std::size_t count = 0;
+  node->for_each_callback_group([&count](const rclcpp::CallbackGroup::SharedPtr &) { ++count; });
+  return count;
+}
+}  // namespace
+
+// agnocast::Node must forward `options.use_clock_thread()` to NodeTimeSource, which creates
+// a dedicated clock callback group only when it is true. These tests pin that by counting
+// callback groups. `use_sim_time` is enabled to trigger the clock subscription setup.
+
+TEST_F(AgnocastNodeConstructionTest, clock_thread_disabled_skips_clock_callback_group)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("use_sim_time", true)});
+  options.use_clock_thread(false);
+
+  auto node = std::make_shared<agnocast::Node>("test_node_clock_thread_off", options);
+
+  // Only the default callback group exists; no dedicated clock callback group is created.
+  EXPECT_EQ(count_callback_groups(node), 1u);
+}
+
+TEST_F(AgnocastNodeConstructionTest, clock_thread_enabled_creates_clock_callback_group)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("use_sim_time", true)});
+  options.use_clock_thread(true);
+
+  auto node = std::make_shared<agnocast::Node>("test_node_clock_thread_on", options);
+
+  // The default callback group plus the dedicated clock callback group.
+  EXPECT_EQ(count_callback_groups(node), 2u);
 }


### PR DESCRIPTION
## Description
Propagate the `use_clock_thread` node option to `NodeTimeSource`.

## Related links

## How was this PR tested?

- [x] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
