### PR TITLE
fix: set use_sim_time=false for cie node

### DIFF
--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -92,6 +92,8 @@ create_rclcpp_client_publisher()
   options.start_parameter_event_publisher(false);
   options.enable_rosout(false);
   options.use_clock_thread(false);
+  // Force use_sim_time=false to prevent NodeTimeSource from creating a /clock subscription.
+  options.parameter_overrides({rclcpp::Parameter("use_sim_time", false)});
   auto node = std::make_shared<rclcpp::Node>(
     "client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator", options);
   auto publisher = node->create_publisher<agnocast_cie_config_msgs::msg::CallbackGroupInfo>(
@@ -111,6 +113,8 @@ create_agnocast_client_publisher()
   options.start_parameter_event_publisher(false);
   options.enable_rosout(false);
   options.use_clock_thread(false);
+  // Force use_sim_time=false to prevent NodeTimeSource from creating a /clock subscription.
+  options.parameter_overrides({rclcpp::Parameter("use_sim_time", false)});
   auto node = std::make_shared<agnocast::Node>(
     "agnocast_client_node_" + std::to_string(getpid()), "/agnocast_cie_thread_configurator",
     options);


### PR DESCRIPTION
## Description
Disable `use_sim_time` on CIE client nodes to avoid an unnecessary `/clock` subscription

The internal per-client nodes in `cie_client_utils.cpp` don't need simulated time. With `use_sim_time=true`, NodeTimeSource creates a needless `/clock` subscription on them. Forcing `use_sim_time=false` via `parameter_overrides` prevents that subscription from being created.

## Related links

## How was this PR tested?

- [x] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
