### PR TITLE
fix(AgnocastOnlyExecutor): add `cancel_requested_` to separate the state

### DIFF
--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -80,7 +80,9 @@ public:
   AGNOCAST_PUBLIC
   virtual void spin() = 0;
 
-  /// Request the executor to stop spinning. Causes the current or next spin() call to return.
+  /// Request the executor to stop spinning. Causes the current spin() call to return.
+  /// One-shot: once called, the executor is permanently stopped -- every subsequent spin()
+  /// returns immediately. Create a new instance to spin again.
   AGNOCAST_PUBLIC
   virtual void cancel();
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -24,13 +24,23 @@ using WeakCallbackGroupsToNodesMap = std::map<
 struct AgnocastExecutable;
 class Node;
 
-/** @brief Base class for Stage 2 executors that handle only Agnocast callbacks (no RMW). Used with
- * agnocast::Node. */
+/**
+ * @brief Base class for Stage 2 executors that handle only Agnocast callbacks (no RMW). Used with
+ * agnocast::Node.
+ *
+ * One-shot: once cancel() is called, spin() will not run again on the same instance -- create a
+ * new executor instead. All current uses (clock executor, CIE child executors) are recreated.
+ * TODO: to support re-spin, replace the spinning_ / cancel_requested_ flags with one atomic state
+ * enum (Idle / Spinning / Cancelled) so spin() can re-arm to Idle on exit.
+ */
 AGNOCAST_PUBLIC
 class AgnocastOnlyExecutor
 {
 protected:
   std::atomic_bool spinning_;
+  // Sticky cancel flag: set by cancel(), never cleared, so a cancel() before spin() is not lost
+  // when spin() does spinning_.exchange(true). Never cleared -> the executor is one-shot.
+  std::atomic_bool cancel_requested_{false};
   std::unique_ptr<EpollManager> epoll_manager_;
   int shutdown_event_fd_;
   pid_t my_pid_;
@@ -66,6 +76,7 @@ public:
   virtual ~AgnocastOnlyExecutor();
 
   /// Block the calling thread and process Agnocast callbacks in a loop until cancel() is called.
+  /// One-shot: if cancel() was already called, spin() returns at once (see class comment).
   AGNOCAST_PUBLIC
   virtual void spin() = 0;
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_only_executor.hpp
@@ -37,7 +37,7 @@ AGNOCAST_PUBLIC
 class AgnocastOnlyExecutor
 {
 protected:
-  std::atomic_bool spinning_;
+  std::atomic_bool spinning_{false};
   // Sticky cancel flag: set by cancel(), never cleared, so a cancel() before spin() is not lost
   // when spin() does spinning_.exchange(true). Never cleared -> the executor is one-shot.
   std::atomic_bool cancel_requested_{false};

--- a/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
@@ -127,12 +127,13 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
     {
       std::unique_lock<std::mutex> lock(callback_group_created_cv_mutex_);
       callback_group_created_cv_.wait_for(lock, std::chrono::milliseconds(CV_TIMEOUT_MS), [this] {
-        return callback_group_created_ || !spinning_.load() || !agnocast::ok();
+        return callback_group_created_ || !spinning_.load() || cancel_requested_.load() ||
+               !agnocast::ok();
       });
       callback_group_created_ = false;
     }
 
-    if (!spinning_.load() || !agnocast::ok()) {
+    if (!spinning_.load() || cancel_requested_.load() || !agnocast::ok()) {
       break;
     }
 
@@ -164,7 +165,7 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
     }
 
     std::lock_guard<std::mutex> guard{child_resources_mutex_};
-    if (!spinning_.load() || !agnocast::ok()) {
+    if (!spinning_.load() || cancel_requested_.load() || !agnocast::ok()) {
       break;
     }
     for (auto & [group, node] : new_groups) {

--- a/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_callback_isolated_executor.cpp
@@ -39,6 +39,10 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
 
   RCPPUTILS_SCOPE_EXIT(this->spinning_.store(false););
 
+  if (cancel_requested_.load()) {
+    return;
+  }
+
   std::vector<std::pair<
     rclcpp::CallbackGroup::SharedPtr, rclcpp::node_interfaces::NodeBaseInterface::SharedPtr>>
     groups_and_nodes;
@@ -110,7 +114,7 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
 
   {
     std::lock_guard<std::mutex> guard{child_resources_mutex_};
-    if (!spinning_.load()) {
+    if (!spinning_.load() || cancel_requested_.load()) {
       return;
     }
     for (auto & [group, node] : groups_and_nodes) {
@@ -119,7 +123,7 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
   }  // guard child_resources_mutex_
 
   // Monitoring loop: wait for notification when new callback groups are created
-  while (agnocast::ok() && spinning_.load()) {
+  while (agnocast::ok() && spinning_.load() && !cancel_requested_.load()) {
     {
       std::unique_lock<std::mutex> lock(callback_group_created_cv_mutex_);
       callback_group_created_cv_.wait_for(lock, std::chrono::milliseconds(CV_TIMEOUT_MS), [this] {
@@ -196,6 +200,7 @@ void AgnocastOnlyCallbackIsolatedExecutor::spin()
 
 void AgnocastOnlyCallbackIsolatedExecutor::cancel()
 {
+  cancel_requested_.store(true);
   {
     std::lock_guard<std::mutex> lock(callback_group_created_cv_mutex_);
     spinning_.store(false);

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -143,6 +143,7 @@ void AgnocastOnlyExecutor::execute_agnocast_executable(AgnocastExecutable & agno
 
 void AgnocastOnlyExecutor::cancel()
 {
+  cancel_requested_.store(true);
   spinning_.store(false);
   uint64_t val = 1;
   if (write(shutdown_event_fd_, &val, sizeof(val)) == -1) {

--- a/src/agnocastlib/src/node/agnocast_only_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_executor.cpp
@@ -18,8 +18,7 @@ namespace agnocast
 {
 
 AgnocastOnlyExecutor::AgnocastOnlyExecutor()
-: spinning_(false),
-  shutdown_event_fd_(eventfd(0, EFD_NONBLOCK)),
+: shutdown_event_fd_(eventfd(0, EFD_NONBLOCK)),
   my_pid_(getpid()),
   epoll_update_tracker_(EpollUpdateDispatcher::get_instance().register_tracker())
 {

--- a/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_multi_threaded_executor.cpp
@@ -30,6 +30,10 @@ void AgnocastOnlyMultiThreadedExecutor::spin()
 
   RCPPUTILS_SCOPE_EXIT(this->spinning_.store(false););
 
+  if (cancel_requested_.load()) {
+    return;
+  }
+
   std::vector<std::thread> threads;
 
   for (size_t i = 0; i < number_of_threads_ - 1; i++) {
@@ -46,7 +50,7 @@ void AgnocastOnlyMultiThreadedExecutor::spin()
 
 void AgnocastOnlyMultiThreadedExecutor::agnocast_spin()
 {
-  while (spinning_.load() && agnocast::ok()) {
+  while (spinning_.load() && !cancel_requested_.load() && agnocast::ok()) {
     if (epoll_update_tracker_.take_update_request()) {
       add_callback_groups_from_nodes_associated_to_executor();
       epoll_manager_->prepare_epoll([this](const rclcpp::CallbackGroup::SharedPtr & group) {
@@ -56,7 +60,7 @@ void AgnocastOnlyMultiThreadedExecutor::agnocast_spin()
 
     agnocast::AgnocastExecutable agnocast_executable;
 
-    if (!spinning_.load() || !agnocast::ok()) {
+    if (!spinning_.load() || cancel_requested_.load() || !agnocast::ok()) {
       return;
     }
 

--- a/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
+++ b/src/agnocastlib/src/node/agnocast_only_single_threaded_executor.cpp
@@ -31,7 +31,7 @@ void AgnocastOnlySingleThreadedExecutor::spin()
 
   RCPPUTILS_SCOPE_EXIT(this->spinning_.store(false););
 
-  while (spinning_.load() && agnocast::ok()) {
+  while (spinning_.load() && !cancel_requested_.load() && agnocast::ok()) {
     if (epoll_update_tracker_.take_update_request()) {
       add_callback_groups_from_nodes_associated_to_executor();
       epoll_manager_->prepare_epoll([this](const rclcpp::CallbackGroup::SharedPtr & group) {

--- a/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_init_ok_shutdown.cpp
@@ -65,6 +65,33 @@ void expect_cancel_stops_spin_without_shutdown(const std::string & executor_name
   agnocast::shutdown();
 }
 
+// Verifies that a cancel() issued *before* spin() ever starts still makes spin() return.
+template <typename ExecutorT>
+void expect_spin_returns_when_cancelled_before_spin(const std::string & executor_name)
+{
+  agnocast::init(0, nullptr);
+  auto executor = std::make_shared<ExecutorT>();
+
+  // cancel() happens before spin() is ever called.
+  executor->cancel();
+
+  std::atomic_bool spin_exited{false};
+  std::thread spin_thread([&]() {
+    executor->spin();
+    spin_exited.store(true);
+  });
+
+  wait_until_or_fail(
+    [&]() { return spin_exited.load(); }, 2s,
+    executor_name + " spin() did not return after a cancel() that preceded it.");
+
+  if (spin_thread.joinable()) {
+    spin_thread.join();
+  }
+
+  agnocast::shutdown();
+}
+
 }  // namespace
 
 class InitOkShutdownTest : public ::testing::Test
@@ -182,6 +209,24 @@ TEST_F(InitOkShutdownTest, CancelStopsAgnocastOnlyMultiThreadedExecutorSpinWitho
 TEST_F(InitOkShutdownTest, CancelStopsAgnocastOnlyCallbackIsolatedExecutorSpinWithoutShutdown)
 {
   expect_cancel_stops_spin_without_shutdown<agnocast::AgnocastOnlyCallbackIsolatedExecutor>(
+    "AgnocastOnlyCallbackIsolatedExecutor");
+}
+
+TEST_F(InitOkShutdownTest, CancelBeforeSpinStopsAgnocastOnlySingleThreadedExecutorSpin)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlySingleThreadedExecutor>(
+    "AgnocastOnlySingleThreadedExecutor");
+}
+
+TEST_F(InitOkShutdownTest, CancelBeforeSpinStopsAgnocastOnlyMultiThreadedExecutorSpin)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyMultiThreadedExecutor>(
+    "AgnocastOnlyMultiThreadedExecutor");
+}
+
+TEST_F(InitOkShutdownTest, CancelBeforeSpinStopsAgnocastOnlyCallbackIsolatedExecutorSpin)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyCallbackIsolatedExecutor>(
     "AgnocastOnlyCallbackIsolatedExecutor");
 }
 

--- a/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
@@ -2,6 +2,8 @@
 #include <agnocast/node/agnocast_context.hpp>
 #include <agnocast/node/agnocast_only_callback_isolated_executor.hpp>
 #include <agnocast/node/agnocast_only_executor.hpp>
+#include <agnocast/node/agnocast_only_multi_threaded_executor.hpp>
+#include <agnocast/node/agnocast_only_single_threaded_executor.hpp>
 
 #include <agnocast_cie_config_msgs/msg/callback_group_info.hpp>
 
@@ -159,4 +161,42 @@ TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, cancel_via_base_class_pointer_u
 
   // Assert
   EXPECT_TRUE(spin_exited) << "spin() did not unblock after cancel() via base class pointer";
+}
+
+// Verifies that a cancel() issued before spin() starts still makes spin() return.
+template <typename ExecutorT>
+void expect_spin_returns_when_cancelled_before_spin()
+{
+  ExecutorT executor;
+  executor.cancel();  // cancel() happens before spin() ever starts
+
+  std::atomic_bool spin_returned{false};
+  std::thread spin_thread([&executor, &spin_returned]() {
+    executor.spin();
+    spin_returned = true;
+  });
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (!spin_returned) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+      << "spin() did not return after a cancel() that preceded it (cancel-before-spin race)";
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  spin_thread.join();
+  EXPECT_TRUE(spin_returned);
+}
+
+TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, single_threaded_cancel_before_spin_returns)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlySingleThreadedExecutor>();
+}
+
+TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, multi_threaded_cancel_before_spin_returns)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyMultiThreadedExecutor>();
+}
+
+TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, callback_isolated_cancel_before_spin_returns)
+{
+  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyCallbackIsolatedExecutor>();
 }

--- a/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_only_callback_isolated_executor.cpp
@@ -2,8 +2,6 @@
 #include <agnocast/node/agnocast_context.hpp>
 #include <agnocast/node/agnocast_only_callback_isolated_executor.hpp>
 #include <agnocast/node/agnocast_only_executor.hpp>
-#include <agnocast/node/agnocast_only_multi_threaded_executor.hpp>
-#include <agnocast/node/agnocast_only_single_threaded_executor.hpp>
 
 #include <agnocast_cie_config_msgs/msg/callback_group_info.hpp>
 
@@ -161,42 +159,4 @@ TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, cancel_via_base_class_pointer_u
 
   // Assert
   EXPECT_TRUE(spin_exited) << "spin() did not unblock after cancel() via base class pointer";
-}
-
-// Verifies that a cancel() issued before spin() starts still makes spin() return.
-template <typename ExecutorT>
-void expect_spin_returns_when_cancelled_before_spin()
-{
-  ExecutorT executor;
-  executor.cancel();  // cancel() happens before spin() ever starts
-
-  std::atomic_bool spin_returned{false};
-  std::thread spin_thread([&executor, &spin_returned]() {
-    executor.spin();
-    spin_returned = true;
-  });
-
-  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-  while (!spin_returned) {
-    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
-      << "spin() did not return after a cancel() that preceded it (cancel-before-spin race)";
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-  spin_thread.join();
-  EXPECT_TRUE(spin_returned);
-}
-
-TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, single_threaded_cancel_before_spin_returns)
-{
-  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlySingleThreadedExecutor>();
-}
-
-TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, multi_threaded_cancel_before_spin_returns)
-{
-  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyMultiThreadedExecutor>();
-}
-
-TEST_F(AgnocastOnlyCallbackIsolatedExecutorTest, callback_isolated_cancel_before_spin_returns)
-{
-  expect_spin_returns_when_cancelled_before_spin<agnocast::AgnocastOnlyCallbackIsolatedExecutor>();
 }


### PR DESCRIPTION
## Description
Add a `cancel_requested_` flag to `AgnocastOnlyExecutor` so cancellation is not lost when it races with `spin()`:

  - `cancel()` sets `cancel_requested_ = true` (in addition to `spinning_`). It is sticky — never cleared — so the executor is one-shot: a cancelled instance must not be re-spun.
  - Every `spin()` checks it, so a cancel is honored regardless of whether it arrived before or after `spin()` started:
    - single-threaded: added to the `while` loop condition
    - multi-threaded: early-return before spawning workers; added to the worker loop condition
    - callback-isolated: early-return before setup; added to the spawn guard and the monitoring loop condition

With this, `cancel()` is order-independent and `join()` always returns.

A cleaner design would replace the `spinning_` / `cancel_requested_` flag pair with a single atomic state enum (`Idle` / `Spinning` / `Cancelled`), which would also allow re-spinning the same instance. Since a release is imminent, this PR keeps the change minimal and stays with the flag-based fix; the one-shot limitation and the enum-based alternative are recorded as a TODO comment in the header.

### Problem occurs before this fix
  `AgnocastOnlyExecutor` used a single `spinning_` atomic to carry two opposite intents: `spin()` sets it `true` to start, `cancel()` sets it `false` to stop.

  `spin()` begins with `spinning_.exchange(true)`, which unconditionally overwrites whatever `cancel()` wrote, and `cancel()` leaves no other record that a stop was requested. So when `cancel()` runs *before* `spin()` starts, the cancellation is silently lost and `spin()` enters its loop and never exits.

This is hit in practice by short-lived nodes (e.g. the throwaway publisher node in `create_agnocast_client_publisher()`): the clock executor thread is spawned but, before it is scheduled into `spin()`, the node is already being torn down and calls `cancel()` + `join()`. The spawned thread then enters `spin()`, ignores the lost cancel, and loops forever — `join()` blocks permanently and the process hangs.

Spawning a thread and immediately cancelling it is a legitimate sequence; a cancellation API must tolerate `cancel()` arriving before `spin()`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
