### PR TITLE
fix(bridge): suppress bridge plugin compilation warning

### DIFF
--- a/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
+++ b/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
@@ -17,7 +17,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # GCC 12/13 emits false-positive -Warray-bounds / -Wstringop-overflow
   # inside std::vector<bool> when ROS message types (e.g. test_msgs) are
   # instantiated under optimization.
-  # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109945
+  # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110498
   if(CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(-Wno-array-bounds -Wno-stringop-overflow)
   endif()

--- a/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
+++ b/src/ros2agnocast/ros2agnocast/templates/CMakeLists.txt.em
@@ -14,6 +14,14 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 
+  # GCC 12/13 emits false-positive -Warray-bounds / -Wstringop-overflow
+  # inside std::vector<bool> when ROS message types (e.g. test_msgs) are
+  # instantiated under optimization.
+  # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109945
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wno-array-bounds -Wno-stringop-overflow)
+  endif()
+
   find_program(LLD_LINKER lld)
   if(LLD_LINKER)
     add_link_options("-fuse-ld=lld")


### PR DESCRIPTION
## Description
On Ubuntu 24.04 (GCC 13), building the generated `agnocast_bridge_plugins` package fails with GCC false-positive `-Warray-bounds` / `-Wstringop-overflow` warnings raised inside `std::vector<bool>` when ROS message types are instantiated under optimization (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110498).

This adds `-Wno-array-bounds -Wno-stringop-overflow` (GCC only) to the generated `CMakeLists.txt.em` template to suppress them.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) (performance mode)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) (performance mode)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
