### PR TITLE
feat(agnocastlib): cross-NS bridge MQ infrastructure + tmpfs type-registry writer

### DIFF
--- a/scripts/test/e2e_test_cross_ns_cli.bash
+++ b/scripts/test/e2e_test_cross_ns_cli.bash
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# E2E regression smoke test for the ros2agnocast CLI verbs after they
+# learned to subscribe to /_agnocast_discovery and merge cross-NS /
+# cross-ECU state.
+#
+# This script does not actually create multiple IPC namespaces (that
+# requires sudo unshare); instead it runs the daemon and the CLI in the
+# same namespace and checks that:
+#
+#   * Each verb accepts `--gossip-timeout`.
+#   * Each verb finishes without raising when the daemon is publishing.
+#   * `topic list_agnocast` surfaces an Agnocast topic via gossip even
+#     when the caller's own ioctl path is the only source (single-NS
+#     baseline; cross-NS visibility is exercised by manual unshare-based
+#     tests).
+#
+# Requires:
+#   * agnocast kernel module loaded
+#   * workspace built (bash scripts/dev/build_all.bash)
+#
+# Usage:
+#   bash scripts/test/e2e_test_cross_ns_cli.bash
+#
+# Exit codes:
+#   0 - all checks passed
+#   1 - prerequisite failure
+#   2 - assertion failure
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+GOSSIP_TIMEOUT=${GOSSIP_TIMEOUT:-1.0}
+DAEMON_WARMUP_SEC=${DAEMON_WARMUP_SEC:-2}
+TALKER_WARMUP_SEC=${TALKER_WARMUP_SEC:-3}
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+if ! grep -q "^agnocast " /proc/modules; then
+    red "ERROR: agnocast kmod not loaded."
+    echo "  -> sudo insmod $ROOT_DIR/agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+if [ ! -f "$ROOT_DIR/install/setup.bash" ]; then
+    red "ERROR: workspace not built ($ROOT_DIR/install/setup.bash missing)."
+    echo "  -> bash $ROOT_DIR/scripts/dev/build_all.bash" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$ROOT_DIR/install/setup.bash"
+set -u
+green "✓ kmod loaded and workspace sourced"
+
+LOG_DIR=$(mktemp -d)
+cleanup() {
+    pkill -P $$ 2>/dev/null || true
+    sleep 1
+    rm -rf "$LOG_DIR"
+}
+trap cleanup EXIT
+
+yellow "Starting agnocast_discovery_agent and talker..."
+ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+sleep "$DAEMON_WARMUP_SEC"
+ros2 launch agnocast_sample_application talker.launch.xml > "$LOG_DIR/talker.log" 2>&1 &
+sleep "$TALKER_WARMUP_SEC"
+
+if ! grep -q "discovery_agent up" "$LOG_DIR/agent.log"; then
+    red "ERROR: daemon did not start within ${DAEMON_WARMUP_SEC}s."
+    cat "$LOG_DIR/agent.log" >&2
+    exit 2
+fi
+green "✓ daemon + talker running"
+
+fail() {
+    red "ERROR: $1"
+    [ -n "${2:-}" ] && { echo "----- output -----" >&2; printf '%s\n' "$2" >&2; }
+    echo "----- agent log -----" >&2; cat "$LOG_DIR/agent.log" >&2
+    echo "----- talker log -----" >&2; cat "$LOG_DIR/talker.log" >&2
+    exit 2
+}
+
+# ----- topic list_agnocast -----
+out=$(ros2 topic list_agnocast --gossip-timeout "$GOSSIP_TIMEOUT" 2>&1) \
+    || fail "topic list_agnocast exited non-zero" "$out"
+grep -q -- "/my_topic" <<<"$out" \
+    || fail "topic list_agnocast did not include /my_topic" "$out"
+grep -- "/my_topic" <<<"$out" | grep -q "Agnocast enabled" \
+    || fail "/my_topic present but missing '(Agnocast enabled)' annotation" "$out"
+green "✓ topic list_agnocast"
+
+# ----- node list_agnocast -----
+out=$(ros2 node list_agnocast --gossip-timeout "$GOSSIP_TIMEOUT" 2>&1) \
+    || fail "node list_agnocast exited non-zero" "$out"
+grep -q -- "/talker_node" <<<"$out" \
+    || fail "node list_agnocast did not include /talker_node" "$out"
+green "✓ node list_agnocast"
+
+# ----- topic info_agnocast -----
+out=$(ros2 topic info_agnocast /my_topic --gossip-timeout "$GOSSIP_TIMEOUT" 2>&1) \
+    || fail "topic info_agnocast exited non-zero" "$out"
+grep -qE "Agnocast Publisher count:\s*1" <<<"$out" \
+    || fail "topic info_agnocast did not report 1 Agnocast publisher" "$out"
+green "✓ topic info_agnocast"
+
+# ----- node info_agnocast -----
+out=$(ros2 node info_agnocast /talker_node --gossip-timeout "$GOSSIP_TIMEOUT" 2>&1) \
+    || fail "node info_agnocast exited non-zero" "$out"
+grep -q -- "/my_topic" <<<"$out" \
+    || fail "node info_agnocast /talker_node did not list /my_topic" "$out"
+green "✓ node info_agnocast"
+
+green ""
+green "===== ALL CHECKS PASSED ====="

--- a/scripts/test/e2e_test_discovery_agent.bash
+++ b/scripts/test/e2e_test_discovery_agent.bash
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# E2E regression smoke test for ros2agnocast_discovery_agent.
+#
+# Starts one discovery agent in the current IPC namespace, lets it run for a
+# couple of polling cycles, and verifies that an AgnocastDaemonState message
+# appears on /_agnocast_discovery with the expected fields populated. This
+# does not require any Agnocast pub / sub to be running -- the message is
+# expected to carry an empty `topics` list in that case.
+#
+# Requires:
+#   * agnocast kernel module loaded (sudo insmod agnocast_kmod/agnocast.ko)
+#   * workspace built (bash scripts/dev/build_all.bash)
+#
+# Usage:
+#   bash scripts/test/e2e_test_discovery_agent.bash
+#
+# Exit codes:
+#   0 - all checks passed
+#   1 - prerequisite failure (kmod / workspace)
+#   2 - assertion failure (msg fields didn't match expectation)
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+ECHO_TIMEOUT_SEC=${ECHO_TIMEOUT_SEC:-5}
+DAEMON_WARMUP_SEC=${DAEMON_WARMUP_SEC:-2}
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+# ----- prerequisites -----
+if ! grep -q "^agnocast " /proc/modules; then
+    red "ERROR: agnocast kmod not loaded."
+    echo "  -> sudo insmod $ROOT_DIR/agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+if [ ! -f "$ROOT_DIR/install/setup.bash" ]; then
+    red "ERROR: workspace not built ($ROOT_DIR/install/setup.bash missing)."
+    echo "  -> bash $ROOT_DIR/scripts/dev/build_all.bash" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$ROOT_DIR/install/setup.bash"
+set -u
+green "✓ kmod loaded and workspace sourced"
+
+# ----- start daemon -----
+LOG_DIR=$(mktemp -d)
+cleanup() {
+    pkill -P $$ 2>/dev/null || true
+    sleep 1
+    rm -rf "$LOG_DIR"
+}
+trap cleanup EXIT
+
+yellow "Starting agnocast_discovery_agent..."
+ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+sleep "$DAEMON_WARMUP_SEC"
+
+if ! grep -q "discovery_agent up" "$LOG_DIR/agent.log"; then
+    red "ERROR: daemon did not log startup within ${DAEMON_WARMUP_SEC}s."
+    echo "----- agent log -----" >&2
+    cat "$LOG_DIR/agent.log" >&2
+    exit 2
+fi
+green "✓ daemon started"
+
+# ----- assert msg shape -----
+fail() {
+    red "ERROR: $1"
+    [ -n "${2:-}" ] && { echo "----- output -----" >&2; printf '%s\n' "$2" >&2; }
+    echo "----- agent log -----" >&2
+    cat "$LOG_DIR/agent.log" >&2
+    exit 2
+}
+
+msg=$(timeout "$ECHO_TIMEOUT_SEC" ros2 topic echo --once /_agnocast_discovery 2>&1) \
+    || fail "ros2 topic echo on /_agnocast_discovery timed out or failed" "$msg"
+
+grep -q '^schema_version: 1$'                  <<<"$msg" || fail "schema_version != 1" "$msg"
+grep -q '^host_uuid: [0-9a-f-]\+$'             <<<"$msg" || fail "host_uuid missing or malformed" "$msg"
+grep -q '^host_hostname: '                     <<<"$msg" || fail "host_hostname missing" "$msg"
+grep -q '^ipc_ns_inode: [0-9]\+$'              <<<"$msg" || fail "ipc_ns_inode missing or non-numeric" "$msg"
+grep -q '^timestamp:'                          <<<"$msg" || fail "timestamp missing" "$msg"
+grep -q '^topics:'                             <<<"$msg" || fail "topics field missing" "$msg"
+green "✓ AgnocastDaemonState shape OK (schema_version, host_uuid, host_hostname, ipc_ns_inode, timestamp, topics)"
+
+# ----- QoS sanity (Reliable + TransientLocal + Liveliness Automatic) -----
+qos=$(timeout "$ECHO_TIMEOUT_SEC" ros2 topic info /_agnocast_discovery --verbose 2>&1) \
+    || fail "ros2 topic info on /_agnocast_discovery failed" "$qos"
+grep -q "Reliability: RELIABLE"          <<<"$qos" || fail "QoS reliability != RELIABLE" "$qos"
+grep -q "Durability: TRANSIENT_LOCAL"    <<<"$qos" || fail "QoS durability != TRANSIENT_LOCAL" "$qos"
+grep -q "Liveliness: AUTOMATIC"          <<<"$qos" || fail "QoS liveliness != AUTOMATIC" "$qos"
+green "✓ QoS profile: RELIABLE + TRANSIENT_LOCAL + Liveliness AUTOMATIC"
+
+green ""
+green "===== ALL CHECKS PASSED ====="

--- a/scripts/test/e2e_test_discovery_agent.bash
+++ b/scripts/test/e2e_test_discovery_agent.bash
@@ -79,13 +79,16 @@ fail() {
 msg=$(timeout "$ECHO_TIMEOUT_SEC" ros2 topic echo --once /_agnocast_discovery 2>&1) \
     || fail "ros2 topic echo on /_agnocast_discovery timed out or failed" "$msg"
 
-grep -q '^schema_version: 1$'                  <<<"$msg" || fail "schema_version != 1" "$msg"
-grep -q '^host_uuid: [0-9a-f-]\+$'             <<<"$msg" || fail "host_uuid missing or malformed" "$msg"
-grep -q '^host_hostname: '                     <<<"$msg" || fail "host_hostname missing" "$msg"
-grep -q '^ipc_ns_inode: [0-9]\+$'              <<<"$msg" || fail "ipc_ns_inode missing or non-numeric" "$msg"
-grep -q '^timestamp:'                          <<<"$msg" || fail "timestamp missing" "$msg"
-grep -q '^topics:'                             <<<"$msg" || fail "topics field missing" "$msg"
-green "✓ AgnocastDaemonState shape OK (schema_version, host_uuid, host_hostname, ipc_ns_inode, timestamp, topics)"
+grep -q '^schema_version: 1$'                       <<<"$msg" || fail "schema_version != 1" "$msg"
+grep -q '^agnocast_version: \(.*\)$'                <<<"$msg" || fail "agnocast_version missing" "$msg"
+# Assert agnocast_version is non-empty so a misconfigured importlib.metadata
+# lookup is caught (would silently fall back to '' otherwise).
+grep -q '^agnocast_version: ..*$'                   <<<"$msg" || fail "agnocast_version is empty" "$msg"
+grep -q '^host_uuid: [0-9a-f-]\+$'                  <<<"$msg" || fail "host_uuid missing or malformed" "$msg"
+grep -q '^host_hostname: '                          <<<"$msg" || fail "host_hostname missing" "$msg"
+grep -q '^ipc_ns_inode: [0-9]\+$'                   <<<"$msg" || fail "ipc_ns_inode missing or non-numeric" "$msg"
+grep -q '^topics:'                                  <<<"$msg" || fail "topics field missing" "$msg"
+green "✓ AgnocastDaemonState shape OK (schema_version, agnocast_version, host_uuid, host_hostname, ipc_ns_inode, topics)"
 
 # ----- QoS sanity (Reliable + TransientLocal + Liveliness Automatic) -----
 qos=$(timeout "$ECHO_TIMEOUT_SEC" ros2 topic info /_agnocast_discovery --verbose 2>&1) \
@@ -94,6 +97,20 @@ grep -q "Reliability: RELIABLE"          <<<"$qos" || fail "QoS reliability != R
 grep -q "Durability: TRANSIENT_LOCAL"    <<<"$qos" || fail "QoS durability != TRANSIENT_LOCAL" "$qos"
 grep -q "Liveliness: AUTOMATIC"          <<<"$qos" || fail "QoS liveliness != AUTOMATIC" "$qos"
 green "✓ QoS profile: RELIABLE + TRANSIENT_LOCAL + Liveliness AUTOMATIC"
+
+# ----- pop a talker in the same IPC NS and assert its endpoint shows up -----
+yellow "Starting agnocast_sample_application talker (discovery_agent=false to avoid a 2nd agent)..."
+ros2 launch agnocast_sample_application talker.launch.xml discovery_agent:=false \
+    > "$LOG_DIR/talker.log" 2>&1 &
+# Give the talker time to call its Publisher<T> ctor and the daemon time to
+# observe it on its next 1 Hz tick.
+sleep 3
+msg_with_topic=$(timeout "$ECHO_TIMEOUT_SEC" ros2 topic echo --once /_agnocast_discovery 2>&1) \
+    || fail "ros2 topic echo (with talker running) timed out" "$msg_with_topic"
+
+grep -q 'topic_name: /my_topic'      <<<"$msg_with_topic" || fail "talker's /my_topic not seen in snapshot" "$msg_with_topic"
+grep -q 'node_name: /talker_node'    <<<"$msg_with_topic" || fail "talker_node not seen in snapshot" "$msg_with_topic"
+green "✓ talker's /my_topic + /talker_node appear in the snapshot"
 
 green ""
 green "===== ALL CHECKS PASSED ====="

--- a/src/agnocast_sample_application/launch/listener.launch.xml
+++ b/src/agnocast_sample_application/launch/listener.launch.xml
@@ -1,4 +1,14 @@
 <launch>
+    <!--
+      `discovery_agent` arg controls whether the per-IPC-namespace Agnocast
+      discovery agent is spawned alongside the listener. Exactly one daemon
+      should run per IPC namespace; set this to false when including this
+      launch from another launch that already spawns the daemon.
+    -->
+    <arg name="discovery_agent" default="true"/>
+    <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
+             if="$(var discovery_agent)"/>
+
     <node_container pkg="agnocast_components" exec="agnocast_component_container" name="listener_container" namespace="" output="screen">
       <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
 

--- a/src/agnocast_sample_application/launch/listener.launch.xml
+++ b/src/agnocast_sample_application/launch/listener.launch.xml
@@ -5,7 +5,7 @@
       should run per IPC namespace; set this to false when including this
       launch from another launch that already spawns the daemon.
     -->
-    <arg name="discovery_agent" default="true"/>
+    <arg name="discovery_agent" default="false"/>
     <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
              if="$(var discovery_agent)"/>
 

--- a/src/agnocast_sample_application/launch/talker.launch.xml
+++ b/src/agnocast_sample_application/launch/talker.launch.xml
@@ -1,4 +1,14 @@
 <launch>
+    <!--
+      `discovery_agent` arg controls whether the per-IPC-namespace Agnocast
+      discovery agent is spawned alongside the talker. Exactly one daemon
+      should run per IPC namespace; set this to false when including this
+      launch from another launch that already spawns the daemon.
+    -->
+    <arg name="discovery_agent" default="true"/>
+    <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
+             if="$(var discovery_agent)"/>
+
     <node pkg="agnocast_sample_application" exec="talker" name="talker_node" output="screen">
         <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
     </node>

--- a/src/agnocast_sample_application/launch/talker.launch.xml
+++ b/src/agnocast_sample_application/launch/talker.launch.xml
@@ -5,7 +5,7 @@
       should run per IPC namespace; set this to false when including this
       launch from another launch that already spawns the daemon.
     -->
-    <arg name="discovery_agent" default="true"/>
+    <arg name="discovery_agent" default="false"/>
     <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
              if="$(var discovery_agent)"/>
 

--- a/src/agnocast_sample_application/package.xml
+++ b/src/agnocast_sample_application/package.xml
@@ -27,6 +27,8 @@
   <depend>agnocast_sample_interfaces</depend>
   <depend>agnocastlib</depend>
 
+  <exec_depend>ros2agnocast_discovery_agent</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -131,6 +131,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(std_msgs REQUIRED)
+  find_package(rcl_interfaces REQUIRED)
 
   # Unit tests
   ament_add_gmock(test_unit_${PROJECT_NAME}
@@ -148,10 +149,12 @@ if(BUILD_TESTING)
     test/unit/test_node_base.cpp
     test/unit/test_cie_client_utils.cpp
     test/unit/test_agnocast_context.cpp
-    test/unit/test_diagnostic_updater.cpp)
+    test/unit/test_diagnostic_updater.cpp
+    test/unit/test_bridge_factory_registry.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
-  ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater)
+  ament_target_dependencies(test_unit_${PROJECT_NAME}
+    std_msgs diagnostic_msgs diagnostic_updater rcl_interfaces)
   set_tests_properties(test_unit_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(agnocast SHARED
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
   src/cie_client_utils.cpp
+  src/internal/type_registry_writer.cpp
   src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp
   src/bridge/standard/agnocast_standard_bridge_ipc_event_loop.cpp src/bridge/standard/agnocast_standard_bridge_loader.cpp src/bridge/standard/agnocast_standard_bridge_manager.cpp src/bridge/agnocast_bridge_utils.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -150,7 +151,8 @@ if(BUILD_TESTING)
     test/unit/test_cie_client_utils.cpp
     test/unit/test_agnocast_context.cpp
     test/unit/test_diagnostic_updater.cpp
-    test/unit/test_bridge_factory_registry.cpp)
+    test/unit/test_bridge_factory_registry.cpp
+    test/unit/test_type_registry_writer.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME}

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -89,10 +89,32 @@ struct MqMsgPerformanceBridge
   bool is_service;
 };
 
+// Daemon-originated bridge request (F1). Sent by the per-IPC daemon to a
+// bridge_manager in the same IPC namespace. The msg is type-name based so the
+// daemon can fill it without process-specific factory pointers (Standard mode
+// resolves via process-local bridge factory registry; Performance mode resolves
+// via the existing plugin loader).
+struct MqMsgDaemonBridge
+{
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
+  BridgeDirection direction;
+};
+
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
+constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 16;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
+constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;
+
+// MQ name conventions for daemon-originated bridge requests.
+// - Standard mode: `/agnocast_daemon_bridge@<pid>` (one MQ per user process; the
+//   daemon picks the target pid based on gossip data).
+// - Performance mode: `/agnocast_daemon_bridge_perf` (one MQ per IPC namespace).
+inline constexpr const char * DAEMON_BRIDGE_MQ_PREFIX = "/agnocast_daemon_bridge";
+inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME =
+  "/agnocast_daemon_bridge_perf";
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -94,11 +94,19 @@ struct MqMsgPerformanceBridge
 // daemon can fill it without process-specific factory pointers (Standard mode
 // resolves via process-local bridge factory registry; Performance mode resolves
 // via the existing plugin loader).
+//
+// QoS is supplied explicitly because the receiving bridge_manager cannot
+// always resolve it locally (the kernel exposes subscriber QoS by id but not
+// publisher QoS without an id). The daemon already knows the QoS of every
+// local endpoint via the same procfs read used to build the gossip payload.
 struct MqMsgDaemonBridge
 {
   char topic_name[TOPIC_NAME_BUFFER_SIZE];
   char type_name[MESSAGE_TYPE_BUFFER_SIZE];
   BridgeDirection direction;
+  uint32_t qos_depth;
+  bool qos_is_transient_local;
+  bool qos_is_reliable;
 };
 
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -89,7 +89,7 @@ struct MqMsgPerformanceBridge
   bool is_service;
 };
 
-// Daemon-originated bridge request (F1). Sent by the per-IPC daemon to a
+// Daemon-originated bridge request. Sent by the per-IPC daemon to a
 // bridge_manager in the same IPC namespace. The msg is type-name based so the
 // daemon can fill it without process-specific factory pointers (Standard mode
 // resolves via process-local bridge factory registry; Performance mode resolves

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -122,7 +122,6 @@ constexpr mode_t BRIDGE_MQ_PERMS = 0600;
 //   daemon picks the target pid based on gossip data).
 // - Performance mode: `/agnocast_daemon_bridge_perf` (one MQ per IPC namespace).
 inline constexpr const char * DAEMON_BRIDGE_MQ_PREFIX = "/agnocast_daemon_bridge";
-inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME =
-  "/agnocast_daemon_bridge_perf";
+inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME = "/agnocast_daemon_bridge_perf";
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -109,40 +109,27 @@ struct MqMsgDaemonBridge
   bool qos_is_reliable;
 };
 
-// Sent from the user process to its Standard-mode bridge_manager whenever a
-// new `Publisher<T>` or `Subscription<T>` is constructed. The bridge_manager
-// is a child process forked from this same user process by
-// `agnocast::init()` — but the fork happens *before* user code creates
-// the Publisher / Subscription, so the bridge_manager's
-// `BridgeFactoryRegistry` is empty by default and a daemon-originated
-// `MqMsgDaemonBridge` for type `T` is silently skipped with the WARN
-// `no factory registered in this process`.
+// User process → Standard-mode bridge_manager pre-registration of the
+// factory pair backing each `register_bridge_factory<T>()` call. The
+// bridge_manager is forked from the user process by `agnocast::init()`
+// *before* Publisher / Subscription ctors run, so it inherits an empty
+// BridgeFactoryRegistry and needs to be told about every type the parent
+// later registers. We don't send raw function pointers because
+// composable_node libraries (e.g. `libagnocast_listener_component.so`)
+// are typically dlopen()'d in the parent *after* the fork, so the
+// addresses live in pages the bridge_manager has never mapped; we send
+// (shared_lib_path, fn_offset_*) so the bridge_manager can dlopen the
+// same library and reconstruct the address as `base + offset`. Same
+// shape as the existing intra-NS MqMsgBridge / BridgeFactoryInfo path.
 //
-// We can't just send raw function pointers because composable_node
-// libraries (e.g. listener_component.so) are dlopen()'d in the user
-// process *after* fork: the resulting template instantiations live in
-// pages that exist only in the parent's address space, and the
-// bridge_manager would segfault on call. Instead we send (shared_lib_path,
-// fn_offset_*) tuples — the bridge_manager dlopens the same library and
-// reconstructs the address as `base + offset`. This mirrors the existing
-// intra-NS MqMsgBridge / BridgeFactoryInfo pattern.
-//
-// TODO: Replace with a `need-minor-update` kmod-based design when the
-// agnocastlib ↔ kmod ABI is bumped — the kmod can expose the message type
-// alongside the existing topic / node info and the bridge_manager can
-// pre-populate its registry directly from the kmod, removing the need for
-// this user → bridge_manager MQ entirely.
+// TODO: When the next `need-minor-update` release bumps the
+// agnocastlib ↔ kmod ABI, carry the message type through the kmod
+// alongside topic / node info; the bridge_manager can then pre-populate
+// its registry directly from the kmod and this MQ can go away.
 struct MqMsgFactoryRegister
 {
   char type_name[MESSAGE_TYPE_BUFFER_SIZE];
-  // Path to the shared library (or main executable) hosting the template
-  // instantiations of `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`.
-  // Obtained on the user side via `dladdr`.
   char shared_lib_path[SHARED_LIB_PATH_BUFFER_SIZE];
-  // Offsets from the library's load base address. The bridge_manager
-  // dlopen()s the library, reads its base via `dlinfo(RTLD_DI_LINKMAP)`,
-  // and computes `base + offset` to get the function address valid in
-  // *its own* address space.
   uintptr_t fn_offset_a2r;
   uintptr_t fn_offset_r2a;
 };

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -111,7 +111,13 @@ struct MqMsgDaemonBridge
 
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
-constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 16;
+// Kept at or below the kernel default `/proc/sys/fs/mqueue/msg_max = 10`,
+// otherwise mq_open() returns EINVAL on hosts that have not raised the
+// limit (which would require CAP_SYS_RESOURCE). 8 is enough headroom for
+// the daemon's burst write pattern: even at Autoware-scale (~100
+// processes), a single per-NS daemon tick can only enqueue a handful of
+// bridge requests before the bridge_manager drains them.
+constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 8;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
 constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -109,6 +109,36 @@ struct MqMsgDaemonBridge
   bool qos_is_reliable;
 };
 
+// Sent from the user process to its Standard-mode bridge_manager whenever a
+// new `Publisher<T>` or `Subscription<T>` is constructed. The bridge_manager
+// is a child process forked from this same user process by
+// `agnocast::init()`, so it shares the user's address-space layout (the
+// shared library hosting the factory templates is mapped at the same
+// addresses on both sides). Function pointers obtained in the user process
+// are therefore valid to call from the bridge_manager process.
+//
+// Without this pre-registration, the bridge_manager's
+// `BridgeFactoryRegistry` is empty (the registration `register_bridge_factory<T>()`
+// happens *after* the fork) and a daemon-originated `MqMsgDaemonBridge`
+// arriving for type `T` is silently skipped with the WARN
+// `no factory registered in this process`.
+//
+// TODO: Replace with a `need-minor-update` kmod-based design when the
+// agnocastlib ↔ kmod ABI is bumped — the kmod can expose the message type
+// alongside the existing topic / node info and the bridge_manager can
+// pre-populate its registry directly from the kmod, removing the need for
+// this user → bridge_manager MQ entirely.
+struct MqMsgFactoryRegister
+{
+  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
+  // Pointers to `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`
+  // template instantiations. Stored as uintptr_t for portability; recast
+  // to the appropriate function pointer type in the bridge_manager
+  // handler.
+  uintptr_t fn_a2r;
+  uintptr_t fn_r2a;
+};
+
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
 // Kept at or below the kernel default `/proc/sys/fs/mqueue/msg_max = 10`,
@@ -121,6 +151,11 @@ constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 8;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
 constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
+// Same kernel-default ceiling reasoning as DAEMON_BRIDGE_MQ_MAX_MESSAGES.
+// One write per `Publisher<T>` / `Subscription<T>` construction; bursts at
+// node startup are bounded by the number of pub/sub endpoints in the node.
+constexpr int64_t FACTORY_REGISTER_MQ_MAX_MESSAGES = 8;
+constexpr int64_t FACTORY_REGISTER_MQ_MESSAGE_SIZE = sizeof(MqMsgFactoryRegister);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;
 
 // MQ name conventions for daemon-originated bridge requests.
@@ -129,5 +164,11 @@ constexpr mode_t BRIDGE_MQ_PERMS = 0600;
 // - Performance mode: `/agnocast_daemon_bridge_perf` (one MQ per IPC namespace).
 inline constexpr const char * DAEMON_BRIDGE_MQ_PREFIX = "/agnocast_daemon_bridge";
 inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME = "/agnocast_daemon_bridge_perf";
+
+// MQ name for the user → bridge_manager factory pre-registration channel.
+// One MQ per Standard-mode bridge_manager (= per user process).
+// TODO: Replace with kmod-side type info when MqMsgFactoryRegister itself
+// becomes unnecessary (see comment on the struct above).
+inline constexpr const char * FACTORY_REGISTER_MQ_PREFIX = "/agnocast_factory_register";
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -112,16 +112,20 @@ struct MqMsgDaemonBridge
 // Sent from the user process to its Standard-mode bridge_manager whenever a
 // new `Publisher<T>` or `Subscription<T>` is constructed. The bridge_manager
 // is a child process forked from this same user process by
-// `agnocast::init()`, so it shares the user's address-space layout (the
-// shared library hosting the factory templates is mapped at the same
-// addresses on both sides). Function pointers obtained in the user process
-// are therefore valid to call from the bridge_manager process.
-//
-// Without this pre-registration, the bridge_manager's
-// `BridgeFactoryRegistry` is empty (the registration `register_bridge_factory<T>()`
-// happens *after* the fork) and a daemon-originated `MqMsgDaemonBridge`
-// arriving for type `T` is silently skipped with the WARN
+// `agnocast::init()` — but the fork happens *before* user code creates
+// the Publisher / Subscription, so the bridge_manager's
+// `BridgeFactoryRegistry` is empty by default and a daemon-originated
+// `MqMsgDaemonBridge` for type `T` is silently skipped with the WARN
 // `no factory registered in this process`.
+//
+// We can't just send raw function pointers because composable_node
+// libraries (e.g. listener_component.so) are dlopen()'d in the user
+// process *after* fork: the resulting template instantiations live in
+// pages that exist only in the parent's address space, and the
+// bridge_manager would segfault on call. Instead we send (shared_lib_path,
+// fn_offset_*) tuples — the bridge_manager dlopens the same library and
+// reconstructs the address as `base + offset`. This mirrors the existing
+// intra-NS MqMsgBridge / BridgeFactoryInfo pattern.
 //
 // TODO: Replace with a `need-minor-update` kmod-based design when the
 // agnocastlib ↔ kmod ABI is bumped — the kmod can expose the message type
@@ -131,12 +135,16 @@ struct MqMsgDaemonBridge
 struct MqMsgFactoryRegister
 {
   char type_name[MESSAGE_TYPE_BUFFER_SIZE];
-  // Pointers to `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`
-  // template instantiations. Stored as uintptr_t for portability; recast
-  // to the appropriate function pointer type in the bridge_manager
-  // handler.
-  uintptr_t fn_a2r;
-  uintptr_t fn_r2a;
+  // Path to the shared library (or main executable) hosting the template
+  // instantiations of `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`.
+  // Obtained on the user side via `dladdr`.
+  char shared_lib_path[SHARED_LIB_PATH_BUFFER_SIZE];
+  // Offsets from the library's load base address. The bridge_manager
+  // dlopen()s the library, reads its base via `dlinfo(RTLD_DI_LINKMAP)`,
+  // and computes `base + offset` to get the function address valid in
+  // *its own* address space.
+  uintptr_t fn_offset_a2r;
+  uintptr_t fn_offset_r2a;
 };
 
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -12,6 +12,17 @@ inline pid_t standard_bridge_manager_pid = 0;
 inline constexpr pid_t PERFORMANCE_BRIDGE_VIRTUAL_PID = -1;
 
 inline constexpr size_t SHARED_LIB_PATH_BUFFER_SIZE = 4096;  // Linux PATH_MAX is 4096
+// MqMsgFactoryRegister sits on a per-bridge_manager auxiliary MQ, so its
+// kernel accounting is multiplied by the number of Standard-mode
+// bridge_managers in the IPC namespace (each user process forks one). A full
+// PATH_MAX buffer there blows past `RLIMIT_MSGQUEUE` (default 819200 bytes
+// per real UID) once a handful of bridge_managers are live in parallel —
+// e.g. running `e2e_test_1to1.bash -p 32` exhausts the limit. Real Autoware
+// `.so` paths (`/opt/ros/.../lib*.so`, `/home/<user>/autoware/install/.../lib*.so`)
+// are well under this; values that exceed it fail the
+// `register_bridge_factory<T>()` notification with a one-shot WARN and the
+// cross-IPC-NS bridge for that type stays disabled until the path shortens.
+inline constexpr size_t FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE = 512;
 inline constexpr size_t SYMBOL_NAME_BUFFER_SIZE = 256;
 inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
 inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
@@ -129,27 +140,32 @@ struct MqMsgDaemonBridge
 struct MqMsgFactoryRegister
 {
   char type_name[MESSAGE_TYPE_BUFFER_SIZE];
-  char shared_lib_path[SHARED_LIB_PATH_BUFFER_SIZE];
+  char shared_lib_path[FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE];
   uintptr_t fn_offset_a2r;
   uintptr_t fn_offset_r2a;
 };
 
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
-// Kept at or below the kernel default `/proc/sys/fs/mqueue/msg_max = 10`,
-// otherwise mq_open() returns EINVAL on hosts that have not raised the
-// limit (which would require CAP_SYS_RESOURCE). 8 is enough headroom for
-// the daemon's burst write pattern: even at Autoware-scale (~100
-// processes), a single per-NS daemon tick can only enqueue a handful of
-// bridge requests before the bridge_manager drains them.
-constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 8;
+// The two aux MQs below are per-Standard-bridge_manager, so their kernel
+// accounting (which has a ~3.3 KB floor per MQ on Linux regardless of
+// max_messages × msg_size, plus max_messages × msg_size on top) is
+// multiplied by the number of bridge_managers in the IPC namespace. Each
+// extra message slot costs another msg_size against `RLIMIT_MSGQUEUE`
+// (default 819200 bytes per real UID). Kept at 2 — matching the primary
+// `BRIDGE_MQ_MAX_MESSAGES` — to stay near the per-MQ overhead floor: a
+// single per-Pub/Sub register request and the daemon's one-per-bridge
+// dispatch both fit comfortably, and `notify_bridge_manager_of_factory` /
+// `send_mq_message` retry on EAGAIN so transient fullness is handled.
+constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
 constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
-// Same kernel-default ceiling reasoning as DAEMON_BRIDGE_MQ_MAX_MESSAGES.
-// One write per `Publisher<T>` / `Subscription<T>` construction; bursts at
-// node startup are bounded by the number of pub/sub endpoints in the node.
-constexpr int64_t FACTORY_REGISTER_MQ_MAX_MESSAGES = 8;
+// Same `RLIMIT_MSGQUEUE` reasoning as DAEMON_BRIDGE_MQ_MAX_MESSAGES. One
+// write per `Publisher<T>` / `Subscription<T>` construction; node-startup
+// bursts are bounded by the number of pub/sub endpoints and absorbed by
+// the EAGAIN retry on the user side.
+constexpr int64_t FACTORY_REGISTER_MQ_MAX_MESSAGES = 2;
 constexpr int64_t FACTORY_REGISTER_MQ_MESSAGE_SIZE = sizeof(MqMsgFactoryRegister);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;
 

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -12,16 +12,11 @@ inline pid_t standard_bridge_manager_pid = 0;
 inline constexpr pid_t PERFORMANCE_BRIDGE_VIRTUAL_PID = -1;
 
 inline constexpr size_t SHARED_LIB_PATH_BUFFER_SIZE = 4096;  // Linux PATH_MAX is 4096
-// MqMsgFactoryRegister sits on a per-bridge_manager auxiliary MQ, so its
-// kernel accounting is multiplied by the number of Standard-mode
-// bridge_managers in the IPC namespace (each user process forks one). A full
-// PATH_MAX buffer there blows past `RLIMIT_MSGQUEUE` (default 819200 bytes
-// per real UID) once a handful of bridge_managers are live in parallel —
-// e.g. running `e2e_test_1to1.bash -p 32` exhausts the limit. Real Autoware
-// `.so` paths (`/opt/ros/.../lib*.so`, `/home/<user>/autoware/install/.../lib*.so`)
-// are well under this; values that exceed it fail the
-// `register_bridge_factory<T>()` notification with a one-shot WARN and the
-// cross-IPC-NS bridge for that type stays disabled until the path shortens.
+// Per-bridge_manager MQ accounting scales with bridge_manager count, so a
+// full `PATH_MAX` buffer here exhausts `RLIMIT_MSGQUEUE` (default 819200
+// bytes per real UID) under modest parallelism. 512 covers typical Linux
+// `.so` paths; longer paths produce a one-shot WARN and the cross-IPC-NS
+// bridge for that type stays disabled until the path can fit.
 inline constexpr size_t FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE = 512;
 inline constexpr size_t SYMBOL_NAME_BUFFER_SIZE = 256;
 inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
@@ -147,24 +142,17 @@ struct MqMsgFactoryRegister
 
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
-// The two aux MQs below are per-Standard-bridge_manager, so their kernel
-// accounting (which has a ~3.3 KB floor per MQ on Linux regardless of
-// max_messages × msg_size, plus max_messages × msg_size on top) is
-// multiplied by the number of bridge_managers in the IPC namespace. Each
-// extra message slot costs another msg_size against `RLIMIT_MSGQUEUE`
-// (default 819200 bytes per real UID). Kept at 2 — matching the primary
-// `BRIDGE_MQ_MAX_MESSAGES` — to stay near the per-MQ overhead floor: a
-// single per-Pub/Sub register request and the daemon's one-per-bridge
-// dispatch both fit comfortably, and `notify_bridge_manager_of_factory` /
-// `send_mq_message` retry on EAGAIN so transient fullness is handled.
+// The two aux MQs below are per-Standard-bridge_manager. Linux POSIX MQ
+// accounting has a ~3.3 KB floor per MQ plus `max_messages * msg_size`,
+// multiplied by the number of bridge_managers in the IPC namespace —
+// keeping `max_messages` at 2 (matching `BRIDGE_MQ_MAX_MESSAGES`) keeps
+// each aux MQ near the floor. Senders retry on EAGAIN
+// (`notify_bridge_manager_of_factory` / `send_mq_message`), so transient
+// fullness is harmless.
 constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
 constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
-// Same `RLIMIT_MSGQUEUE` reasoning as DAEMON_BRIDGE_MQ_MAX_MESSAGES. One
-// write per `Publisher<T>` / `Subscription<T>` construction; node-startup
-// bursts are bounded by the number of pub/sub endpoints and absorbed by
-// the EAGAIN retry on the user side.
 constexpr int64_t FACTORY_REGISTER_MQ_MAX_MESSAGES = 2;
 constexpr int64_t FACTORY_REGISTER_MQ_MESSAGE_SIZE = sizeof(MqMsgFactoryRegister);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -3,6 +3,7 @@
 #include "agnocast/agnocast_ioctl.hpp"
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_public_api.hpp"
+#include "agnocast/internal/bridge_factory_registry.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
@@ -120,6 +121,10 @@ class BasicPublisher
       initialize_publisher(topic_name_, node->get_fully_qualified_name(), actual_qos, is_bridge);
     generate_gid();
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    // Register the bridge factory pair for MessageT so daemon-originated bridge
+    // requests (MqMsgDaemonBridge, F1) can be resolved within this process by
+    // type name alone. No-op for non-message types (gated via SFINAE).
+    internal::register_bridge_factory<MessageT>();
 
     return actual_qos;
   }

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -132,7 +132,8 @@ class BasicPublisher
     // types pulled in by BasicService<ServiceT> have no rosidl message name.
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       internal::TypeRegistryWriter::instance().register_type(
-        topic_name_, rosidl_generator_traits::name<MessageT>(), "pub", node_name);
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "pub", node_name,
+        standard_bridge_manager_pid);
     }
 
     return actual_qos;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -123,7 +123,7 @@ class BasicPublisher
     generate_gid();
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
     // Register the bridge factory pair for MessageT so daemon-originated bridge
-    // requests (MqMsgDaemonBridge, F1) can be resolved within this process by
+    // requests (MqMsgDaemonBridge) can be resolved within this process by
     // type name alone. No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
     // Announce (topic, type, role, node) to the per-IPC-namespace

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -3,10 +3,10 @@
 #include "agnocast/agnocast_ioctl.hpp"
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_public_api.hpp"
-#include "agnocast/internal/bridge_factory_registry.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/internal/bridge_factory_registry.hpp"
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -7,6 +7,7 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/internal/bridge_factory_registry.hpp"
+#include "agnocast/internal/type_registry_writer.hpp"
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -117,14 +118,22 @@ class BasicPublisher
 
     validate_publisher_qos(actual_qos);
 
-    id_ =
-      initialize_publisher(topic_name_, node->get_fully_qualified_name(), actual_qos, is_bridge);
+    const std::string node_name = node->get_fully_qualified_name();
+    id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge);
     generate_gid();
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
     // Register the bridge factory pair for MessageT so daemon-originated bridge
     // requests (MqMsgDaemonBridge, F1) can be resolved within this process by
     // type name alone. No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
+    // Announce (topic, type, role, node) to the per-IPC-namespace
+    // discovery agent via the tmpfs registry so it can fill in type_name +
+    // pid on the gossip publication. Gated to message types only — service
+    // types pulled in by BasicService<ServiceT> have no rosidl message name.
+    if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
+      internal::TypeRegistryWriter::instance().register_type(
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "pub", node_name);
+    }
 
     return actual_qos;
   }

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -153,7 +153,8 @@ class BasicSubscription : public SubscriptionBase
     // BasicService<ServiceT> have no rosidl message name.
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       internal::TypeRegistryWriter::instance().register_type(
-        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name);
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name,
+        standard_bridge_manager_pid);
     }
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
@@ -274,7 +275,8 @@ private:
     // BasicService<ServiceT> have no rosidl message name.
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       internal::TypeRegistryWriter::instance().register_type(
-        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name);
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name,
+        standard_bridge_manager_pid);
     }
 
     return actual_qos;

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -8,6 +8,7 @@
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/internal/bridge_factory_registry.hpp"
+#include "agnocast/internal/type_registry_writer.hpp"
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -137,9 +138,9 @@ class BasicSubscription : public SubscriptionBase
 
     validate_subscription_qos(actual_qos);
 
-    union ioctl_add_subscriber_args add_subscriber_args = initialize(
-      actual_qos, false, options.ignore_local_publications, is_bridge,
-      node->get_fully_qualified_name());
+    const std::string node_name = node->get_fully_qualified_name();
+    union ioctl_add_subscriber_args add_subscriber_args =
+      initialize(actual_qos, false, options.ignore_local_publications, is_bridge, node_name);
 
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
@@ -147,6 +148,13 @@ class BasicSubscription : public SubscriptionBase
     // requests can be resolved within this process by type name alone (F1).
     // No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
+    // Announce (topic, type, role, node) to the per-IPC-namespace discovery
+    // agent. Gated to message types — service types pulled in by
+    // BasicService<ServiceT> have no rosidl message name.
+    if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
+      internal::TypeRegistryWriter::instance().register_type(
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name);
+    }
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
@@ -251,8 +259,9 @@ private:
 
     validate_subscription_qos(actual_qos);
 
-    union ioctl_add_subscriber_args add_subscriber_args = initialize(
-      actual_qos, true, options.ignore_local_publications, false, node->get_fully_qualified_name());
+    const std::string node_name = node->get_fully_qualified_name();
+    union ioctl_add_subscriber_args add_subscriber_args =
+      initialize(actual_qos, true, options.ignore_local_publications, false, node_name);
 
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
@@ -260,6 +269,13 @@ private:
     // requests can be resolved within this process by type name alone (F1).
     // No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
+    // Announce (topic, type, role, node) to the per-IPC-namespace discovery
+    // agent. Gated to message types — service types pulled in by
+    // BasicService<ServiceT> have no rosidl message name.
+    if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
+      internal::TypeRegistryWriter::instance().register_type(
+        topic_name_, rosidl_generator_traits::name<MessageT>(), "sub", node_name);
+    }
 
     return actual_qos;
   }

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -7,6 +7,7 @@
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/internal/bridge_factory_registry.hpp"
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -142,6 +143,10 @@ class BasicSubscription : public SubscriptionBase
 
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    // Register bridge factory pair for MessageT so daemon-originated bridge
+    // requests can be resolved within this process by type name alone (F1).
+    // No-op for non-message types (gated via SFINAE).
+    internal::register_bridge_factory<MessageT>();
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
@@ -251,6 +256,10 @@ private:
 
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    // Register bridge factory pair for MessageT so daemon-originated bridge
+    // requests can be resolved within this process by type name alone (F1).
+    // No-op for non-message types (gated via SFINAE).
+    internal::register_bridge_factory<MessageT>();
 
     return actual_qos;
   }

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -145,7 +145,7 @@ class BasicSubscription : public SubscriptionBase
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
     // Register bridge factory pair for MessageT so daemon-originated bridge
-    // requests can be resolved within this process by type name alone (F1).
+    // requests can be resolved within this process by type name alone.
     // No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
     // Announce (topic, type, role, node) to the per-IPC-namespace discovery
@@ -266,7 +266,7 @@ private:
     id_ = add_subscriber_args.ret_id;
     BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
     // Register bridge factory pair for MessageT so daemon-originated bridge
-    // requests can be resolved within this process by type name alone (F1).
+    // requests can be resolved within this process by type name alone.
     // No-op for non-message types (gated via SFINAE).
     internal::register_bridge_factory<MessageT>();
     // Announce (topic, type, role, node) to the per-IPC-namespace discovery

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -86,6 +86,16 @@ std::string create_mq_name_for_bridge(const pid_t pid);
 // (one MQ per IPC namespace, optionally suffixed with the domain id to mirror
 // the existing Performance bridge MQ naming).
 std::string create_mq_name_for_daemon_bridge(const pid_t pid);
+// MQ used by user processes to pre-register bridge factory function pointers
+// in the bridge_manager forked from them (Standard mode only). One MQ per
+// user process, named with the bridge_manager's pid. See
+// `MqMsgFactoryRegister` for the protocol and the rationale.
+//
+// TODO: Replace with a `need-minor-update` kmod path that exposes the
+// message type alongside the existing topic / node info — that would let
+// the bridge_manager pre-populate its registry directly from the kmod and
+// retire this MQ entirely.
+std::string create_mq_name_for_factory_register(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -80,6 +80,12 @@ void validate_ld_preload();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);
+// MQ used by the per-IPC daemon (F1) to ask a bridge_manager to instantiate a
+// bridge. Standard mode: `/agnocast_daemon_bridge@<pid>` (one MQ per user
+// process). Performance mode: `/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]`
+// (one MQ per IPC namespace, optionally suffixed with the domain id to mirror
+// the existing Performance bridge MQ naming).
+std::string create_mq_name_for_daemon_bridge(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
 std::string create_service_request_topic_name(const std::string & service_name);
 std::string create_service_response_topic_name(

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -87,6 +87,10 @@ std::string create_mq_name_for_bridge(const pid_t pid);
 // the existing Performance bridge MQ naming).
 std::string create_mq_name_for_daemon_bridge(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
+// Return the inode number of the calling process's IPC namespace
+// (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the
+// per-namespace key for the tmpfs directory `/run/agnocast/<ipc_ns_inode>/`.
+uint64_t get_self_ipc_ns_inode();
 std::string create_service_request_topic_name(const std::string & service_name);
 std::string create_service_response_topic_name(
   const std::string & service_name, const std::string & client_node_name);

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -80,7 +80,7 @@ void validate_ld_preload();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);
-// MQ used by the per-IPC daemon (F1) to ask a bridge_manager to instantiate a
+// MQ used by the per-IPC daemon to ask a bridge_manager to instantiate a
 // bridge. Standard mode: `/agnocast_daemon_bridge@<pid>` (one MQ per user
 // process). Performance mode: `/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]`
 // (one MQ per IPC namespace, optionally suffixed with the domain id to mirror

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -99,7 +99,8 @@ std::string create_mq_name_for_factory_register(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the
-// per-namespace key for the tmpfs directory `/run/agnocast/<ipc_ns_inode>/`.
+// per-namespace key for the tmpfs directory
+// `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/`.
 uint64_t get_self_ipc_ns_inode();
 std::string create_service_request_topic_name(const std::string & service_name);
 std::string create_service_response_topic_name(

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -49,11 +49,15 @@ public:
   void set_signal_handler(SignalCallback cb);
 
   // Register a secondary MQ on this event loop (e.g. the daemon-originated
-  // bridge request MQ). The MQ is created with `O_CREAT | O_RDONLY |
-  // O_NONBLOCK | O_CLOEXEC` and `BRIDGE_MQ_PERMS`. Must be called before
-  // `spin_once`. Throws on failure.
-  void register_aux_mq(const std::string & name, long max_messages, long msg_size);
-  void set_aux_mq_handler(EventCallback cb);
+  // bridge request MQ, or the user-process factory pre-registration MQ).
+  // The MQ is created with `O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC`
+  // and `BRIDGE_MQ_PERMS`. Must be called before `spin_once`. May be
+  // called more than once to register multiple aux MQs (e.g. one for
+  // daemon-originated bridge requests and one for user-process factory
+  // pre-registration). Each registration takes its own handler so the
+  // dispatch is keyed by fd inside the event loop. Throws on failure.
+  void register_aux_mq(
+    const std::string & name, long max_messages, long msg_size, EventCallback cb);
 
   const std::string & get_mq_name() const { return mq_name_; }
 
@@ -70,11 +74,17 @@ private:
 
   long mq_msg_size_;
 
-  mqd_t aux_mq_fd_ = (mqd_t)-1;
-  std::string aux_mq_name_;
+  // One entry per `register_aux_mq()` call. Indexed by fd in `spin_once`'s
+  // event dispatch loop.
+  struct AuxMq
+  {
+    mqd_t fd = (mqd_t)-1;
+    std::string name;
+    EventCallback cb;
+  };
+  std::vector<AuxMq> aux_mqs_;
 
   EventCallback mq_cb_;
-  EventCallback aux_mq_cb_;
   SignalCallback signal_cb_;
 
   void setup_mq();
@@ -132,10 +142,6 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
       if (mq_cb_) {
         mq_cb_(fd);
       }
-    } else if (fd == aux_mq_fd_ && aux_mq_fd_ != (mqd_t)-1) {
-      if (aux_mq_cb_) {
-        aux_mq_cb_(fd);
-      }
     } else if (fd == signal_fd_) {
       struct signalfd_siginfo fdsi
       {
@@ -143,6 +149,13 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
       ssize_t s = read(signal_fd_, &fdsi, sizeof(struct signalfd_siginfo));
       if (s == sizeof(struct signalfd_siginfo)) {
         handle_signal();
+      }
+    } else {
+      for (auto & aux : aux_mqs_) {
+        if (fd == aux.fd && aux.cb) {
+          aux.cb(fd);
+          break;
+        }
       }
     }
   }
@@ -161,23 +174,14 @@ inline void IpcEventLoopBase::set_mq_handler(EventCallback cb)
   mq_cb_ = std::move(cb);
 }
 
-inline void IpcEventLoopBase::set_aux_mq_handler(EventCallback cb)
-{
-  aux_mq_cb_ = std::move(cb);
-}
-
 inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
 {
   signal_cb_ = std::move(cb);
 }
 
 inline void IpcEventLoopBase::register_aux_mq(
-  const std::string & name, long max_messages, long msg_size)
+  const std::string & name, long max_messages, long msg_size, EventCallback cb)
 {
-  if (aux_mq_fd_ != (mqd_t)-1) {
-    throw std::runtime_error("register_aux_mq called twice");
-  }
-
   struct mq_attr attr = {};
   attr.mq_maxmsg = max_messages;
   attr.mq_msgsize = msg_size;
@@ -188,22 +192,19 @@ inline void IpcEventLoopBase::register_aux_mq(
     throw std::system_error(errno, std::generic_category(), "aux MQ open failed: " + name);
   }
 
-  aux_mq_fd_ = fd;
-  aux_mq_name_ = name;
-
   try {
-    add_fd_to_epoll(aux_mq_fd_, "AuxMQ");
+    add_fd_to_epoll(fd, "AuxMQ");
   } catch (...) {
-    if (mq_close(aux_mq_fd_) == -1) {
+    if (mq_close(fd) == -1) {
       RCLCPP_WARN(logger_, "Failed to close aux mq_fd: %s", strerror(errno));
     }
-    if (mq_unlink(aux_mq_name_.c_str()) == -1 && errno != ENOENT) {
+    if (mq_unlink(name.c_str()) == -1 && errno != ENOENT) {
       RCLCPP_WARN(logger_, "Failed to unlink aux mq: %s", strerror(errno));
     }
-    aux_mq_fd_ = (mqd_t)-1;
-    aux_mq_name_.clear();
     throw;
   }
+
+  aux_mqs_.push_back(AuxMq{fd, name, std::move(cb)});
 }
 
 inline void IpcEventLoopBase::setup_mq()
@@ -325,20 +326,21 @@ inline void IpcEventLoopBase::cleanup_resources()
     }
   }
 
-  if (aux_mq_fd_ != (mqd_t)-1) {
-    if (mq_close(aux_mq_fd_) == -1) {
-      RCLCPP_WARN_STREAM(
-        logger_,
-        "Failed to close aux mq_fd for mq_name='" << aux_mq_name_ << "': " << strerror(errno));
-    }
-    aux_mq_fd_ = (mqd_t)-1;
-
-    if (mq_unlink(aux_mq_name_.c_str()) == -1 && errno != ENOENT) {
-      RCLCPP_WARN_STREAM(
-        logger_,
-        "Failed to unlink aux mq for mq_name='" << aux_mq_name_ << "': " << strerror(errno));
+  for (auto & aux : aux_mqs_) {
+    if (aux.fd != (mqd_t)-1) {
+      if (mq_close(aux.fd) == -1) {
+        RCLCPP_WARN_STREAM(
+          logger_,
+          "Failed to close aux mq_fd for mq_name='" << aux.name << "': " << strerror(errno));
+      }
+      if (mq_unlink(aux.name.c_str()) == -1 && errno != ENOENT) {
+        RCLCPP_WARN_STREAM(
+          logger_,
+          "Failed to unlink aux mq for mq_name='" << aux.name << "': " << strerror(errno));
+      }
     }
   }
+  aux_mqs_.clear();
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -48,6 +48,13 @@ public:
   void set_mq_handler(EventCallback cb);
   void set_signal_handler(SignalCallback cb);
 
+  // Register a secondary MQ on this event loop (e.g. the daemon-originated
+  // bridge request MQ in F1). The MQ is created with `O_CREAT | O_RDONLY |
+  // O_NONBLOCK | O_CLOEXEC` and `BRIDGE_MQ_PERMS`. Must be called before
+  // `spin_once`. Throws on failure.
+  void register_aux_mq(const std::string & name, long max_messages, long msg_size);
+  void set_aux_mq_handler(EventCallback cb);
+
   const std::string & get_mq_name() const { return mq_name_; }
 
 protected:
@@ -63,7 +70,11 @@ private:
 
   long mq_msg_size_;
 
+  mqd_t aux_mq_fd_ = (mqd_t)-1;
+  std::string aux_mq_name_;
+
   EventCallback mq_cb_;
+  EventCallback aux_mq_cb_;
   SignalCallback signal_cb_;
 
   void setup_mq();
@@ -121,6 +132,10 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
       if (mq_cb_) {
         mq_cb_(fd);
       }
+    } else if (fd == aux_mq_fd_ && aux_mq_fd_ != (mqd_t)-1) {
+      if (aux_mq_cb_) {
+        aux_mq_cb_(fd);
+      }
     } else if (fd == signal_fd_) {
       struct signalfd_siginfo fdsi
       {
@@ -146,9 +161,49 @@ inline void IpcEventLoopBase::set_mq_handler(EventCallback cb)
   mq_cb_ = std::move(cb);
 }
 
+inline void IpcEventLoopBase::set_aux_mq_handler(EventCallback cb)
+{
+  aux_mq_cb_ = std::move(cb);
+}
+
 inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
 {
   signal_cb_ = std::move(cb);
+}
+
+inline void IpcEventLoopBase::register_aux_mq(
+  const std::string & name, long max_messages, long msg_size)
+{
+  if (aux_mq_fd_ != (mqd_t)-1) {
+    throw std::runtime_error("register_aux_mq called twice");
+  }
+
+  struct mq_attr attr = {};
+  attr.mq_maxmsg = max_messages;
+  attr.mq_msgsize = msg_size;
+
+  mqd_t fd =
+    mq_open(name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
+  if (fd == -1) {
+    throw std::system_error(errno, std::generic_category(), "aux MQ open failed: " + name);
+  }
+
+  aux_mq_fd_ = fd;
+  aux_mq_name_ = name;
+
+  try {
+    add_fd_to_epoll(aux_mq_fd_, "AuxMQ");
+  } catch (...) {
+    if (mq_close(aux_mq_fd_) == -1) {
+      RCLCPP_WARN(logger_, "Failed to close aux mq_fd: %s", strerror(errno));
+    }
+    if (mq_unlink(aux_mq_name_.c_str()) == -1 && errno != ENOENT) {
+      RCLCPP_WARN(logger_, "Failed to unlink aux mq: %s", strerror(errno));
+    }
+    aux_mq_fd_ = (mqd_t)-1;
+    aux_mq_name_.clear();
+    throw;
+  }
 }
 
 inline void IpcEventLoopBase::setup_mq()
@@ -267,6 +322,21 @@ inline void IpcEventLoopBase::cleanup_resources()
     if (mq_unlink(mq_name_.c_str()) == -1 && errno != ENOENT) {
       RCLCPP_WARN_STREAM(
         logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
+    }
+  }
+
+  if (aux_mq_fd_ != (mqd_t)-1) {
+    if (mq_close(aux_mq_fd_) == -1) {
+      RCLCPP_WARN_STREAM(
+        logger_,
+        "Failed to close aux mq_fd for mq_name='" << aux_mq_name_ << "': " << strerror(errno));
+    }
+    aux_mq_fd_ = (mqd_t)-1;
+
+    if (mq_unlink(aux_mq_name_.c_str()) == -1 && errno != ENOENT) {
+      RCLCPP_WARN_STREAM(
+        logger_,
+        "Failed to unlink aux mq for mq_name='" << aux_mq_name_ << "': " << strerror(errno));
     }
   }
 }

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -49,7 +49,7 @@ public:
   void set_signal_handler(SignalCallback cb);
 
   // Register a secondary MQ on this event loop (e.g. the daemon-originated
-  // bridge request MQ in F1). The MQ is created with `O_CREAT | O_RDONLY |
+  // bridge request MQ). The MQ is created with `O_CREAT | O_RDONLY |
   // O_NONBLOCK | O_CLOEXEC` and `BRIDGE_MQ_PERMS`. Must be called before
   // `spin_once`. Throws on failure.
   void register_aux_mq(const std::string & name, long max_messages, long msg_size);

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <csignal>
@@ -151,11 +152,10 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
         handle_signal();
       }
     } else {
-      for (auto & aux : aux_mqs_) {
-        if (fd == aux.fd && aux.cb) {
-          aux.cb(fd);
-          break;
-        }
+      auto it = std::find_if(
+        aux_mqs_.begin(), aux_mqs_.end(), [fd](const AuxMq & aux) { return fd == aux.fd; });
+      if (it != aux_mqs_.end() && it->cb) {
+        it->cb(fd);
       }
     }
   }
@@ -335,8 +335,7 @@ inline void IpcEventLoopBase::cleanup_resources()
       }
       if (mq_unlink(aux.name.c_str()) == -1 && errno != ENOENT) {
         RCLCPP_WARN_STREAM(
-          logger_,
-          "Failed to unlink aux mq for mq_name='" << aux.name << "': " << strerror(errno));
+          logger_, "Failed to unlink aux mq for mq_name='" << aux.name << "': " << strerror(errno));
       }
     }
   }

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -58,7 +58,10 @@ private:
   void start_ros_execution();
 
   void on_mq_request(int fd);
+  void on_daemon_mq_request(int fd);
   void on_signal();
+
+  void create_daemon_pubsub_bridge_if_needed(const MqMsgDaemonBridge & req);
 
   void check_and_create_pubsub_bridges();
   void check_and_remove_pubsub_bridges();

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp
@@ -45,6 +45,9 @@ public:
     const std::string & service_name, BridgeDirection direction,
     const BridgeFactorySpec & factory_spec, const rclcpp::QoS & qos);
 
+  // Public for the bridge_manager's MqMsgFactoryRegister bounds check.
+  static bool is_address_in_library_code_segment(void * handle, uintptr_t addr);
+
 private:
   rclcpp::Node::SharedPtr container_node_;
   rclcpp::Logger logger_;
@@ -60,7 +63,6 @@ private:
   std::pair<uintptr_t, std::shared_ptr<void>> resolve_factory_function(
     const std::string & name, BridgeDirection direction, const BridgeFactorySpec & factory_spec,
     bool is_service);
-  static bool is_address_in_library_code_segment(void * handle, uintptr_t addr);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
@@ -99,9 +99,11 @@ private:
   void start_ros_execution();
 
   void on_mq_request(mqd_t fd);
+  void on_daemon_mq_request(mqd_t fd);
   void on_signal();
 
   void register_pubsub_request(const MqMsgBridge & req);
+  void create_daemon_pubsub_bridge_if_needed(const MqMsgDaemonBridge & req);
 
   static BridgeKernelResult try_add_pubsub_bridge_to_kernel(
     const std::string & topic_name, bool is_r2a);

--- a/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp
@@ -100,6 +100,11 @@ private:
 
   void on_mq_request(mqd_t fd);
   void on_daemon_mq_request(mqd_t fd);
+  // Drains the user → bridge_manager factory pre-registration MQ and
+  // populates this process's BridgeFactoryRegistry. See the comment on
+  // `MqMsgFactoryRegister` for the rationale and the planned kmod-based
+  // replacement.
+  void on_factory_register_request(mqd_t fd);
   void on_signal();
 
   void register_pubsub_request(const MqMsgBridge & req);

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -30,16 +30,16 @@
 
 #pragma once
 
+#include <rclcpp/node.hpp>
+#include <rclcpp/qos.hpp>
+#include <rosidl_runtime_cpp/traits.hpp>
+
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
-
-#include <rclcpp/node.hpp>
-#include <rclcpp/qos.hpp>
-#include <rosidl_runtime_cpp/traits.hpp>
 
 namespace agnocast
 {
@@ -108,12 +108,12 @@ void register_bridge_factory()
   if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
     const std::string type_name = rosidl_generator_traits::name<MessageT>();
     BridgeFactoryEntry entry{
-      [](rclcpp::Node::SharedPtr node, const std::string & topic_name,
-         const rclcpp::QoS & qos) -> std::shared_ptr<PubsubBridgeBase> {
+      [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
+        -> std::shared_ptr<PubsubBridgeBase> {
         return start_a2r_pubsub_node<MessageT>(node, topic_name, qos);
       },
-      [](rclcpp::Node::SharedPtr node, const std::string & topic_name,
-         const rclcpp::QoS & qos) -> std::shared_ptr<PubsubBridgeBase> {
+      [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
+        -> std::shared_ptr<PubsubBridgeBase> {
         return start_r2a_pubsub_node<MessageT>(node, topic_name, qos);
       },
     };

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -111,24 +111,10 @@ private:
   std::unordered_map<std::string, BridgeFactoryEntry> map_;
 };
 
-// Mirrors a successful local `register_bridge_factory<T>()` to the
-// Standard-mode bridge_manager via a small POSIX MQ write.
-//
-// We can't send raw function pointers because the function may live in a
-// shared library dlopen()'d *after* the bridge_manager was forked
-// (composable_node case). Instead we resolve the function via `dladdr`
-// to (shared_lib_path, offset-from-base) and let the bridge_manager
-// dlopen the same library and reconstruct the address. This mirrors the
-// existing intra-NS MqMsgBridge / BridgeFactoryInfo flow.
-//
-// Best-effort: any failure (dladdr / mq_open / mq_send) is logged once and
-// the user process continues. The daemon path will silently no-op for
-// this type until a working pre-registration lands.
-//
-// TODO: Replace with a `need-minor-update` kmod path that exposes the
-// message type alongside the existing topic / node info so the
-// bridge_manager can pre-populate its registry directly from the kmod and
-// retire this MQ entirely.
+// Sender side of MqMsgFactoryRegister (see the struct's doc comment in
+// agnocast_mq.hpp for the why). Best-effort: any failure is logged once
+// and the caller continues — cross-IPC-NS bridge generation just stays
+// disabled for this type until something fixes the underlying error.
 template <typename MessageT>
 inline void notify_bridge_manager_of_factory(const std::string & type_name)
 {

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -1,0 +1,125 @@
+// Copyright 2025
+// SPDX-License-Identifier: Apache-2.0
+//
+// Process-local table mapping a ROS 2 message type name to the bridge
+// factory function pair (`start_a2r_pubsub_node<T>` /
+// `start_r2a_pubsub_node<T>`).
+//
+// `Publisher<T>` / `Subscription<T>` constructors register the entry for
+// their `T` exactly once. The Standard bridge_manager (which runs inside
+// the same user process) looks the entry up when it receives a
+// daemon-originated `MqMsgDaemonBridge` and instantiates the bridge node
+// without needing the factory information to travel over the MQ.
+//
+// Implementation notes:
+//
+// * This header avoids including `agnocast/bridge/agnocast_bridge_node.hpp`
+//   because that header pulls in `agnocast_publisher.hpp` /
+//   `agnocast_subscription.hpp` and the publisher / subscription headers
+//   include this header. The factory templates are forward-declared here
+//   and resolved at instantiation time when the user's translation unit
+//   has already pulled in the bridge factory definitions through the
+//   public `agnocast.hpp` umbrella.
+//
+// * `register_bridge_factory<T>()` is gated on
+//   `rosidl_generator_traits::is_message<T>::value` so that it is a no-op
+//   when instantiated for service types (which `BasicService<ServiceT>`
+//   does internally). Without this gate the bridge factory lambdas would
+//   force-instantiate `start_a2r_pubsub_node<ServiceT>` and trip a
+//   static_assert in `rclcpp::Publisher`.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/qos.hpp>
+#include <rosidl_runtime_cpp/traits.hpp>
+
+namespace agnocast
+{
+
+// Forward declarations from agnocast/bridge/agnocast_bridge_node.hpp.
+class PubsubBridgeBase;
+
+template <typename MessageT>
+std::shared_ptr<PubsubBridgeBase> start_a2r_pubsub_node(
+  rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos);
+
+template <typename MessageT>
+std::shared_ptr<PubsubBridgeBase> start_r2a_pubsub_node(
+  rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos);
+
+namespace internal
+{
+
+using BridgeFactoryFn = std::function<std::shared_ptr<PubsubBridgeBase>(
+  rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &)>;
+
+struct BridgeFactoryEntry
+{
+  BridgeFactoryFn a2r;
+  BridgeFactoryFn r2a;
+};
+
+class BridgeFactoryRegistry
+{
+public:
+  static BridgeFactoryRegistry & instance()
+  {
+    static BridgeFactoryRegistry registry;
+    return registry;
+  }
+
+  void register_entry(const std::string & type_name, BridgeFactoryEntry entry)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_[type_name] = std::move(entry);
+  }
+
+  bool lookup(const std::string & type_name, BridgeFactoryEntry & out) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = map_.find(type_name);
+    if (it == map_.end()) {
+      return false;
+    }
+    out = it->second;
+    return true;
+  }
+
+private:
+  BridgeFactoryRegistry() = default;
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, BridgeFactoryEntry> map_;
+};
+
+// Called from `Publisher<T>` / `Subscription<T>` constructors. Idempotent.
+// No-op when instantiated for non-message types (e.g. service types pulled in
+// by `BasicService<ServiceT>`'s internal subscription / publisher).
+template <typename MessageT>
+void register_bridge_factory()
+{
+  if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
+    const std::string type_name = rosidl_generator_traits::name<MessageT>();
+    BridgeFactoryEntry entry{
+      [](rclcpp::Node::SharedPtr node, const std::string & topic_name,
+         const rclcpp::QoS & qos) -> std::shared_ptr<PubsubBridgeBase> {
+        return start_a2r_pubsub_node<MessageT>(node, topic_name, qos);
+      },
+      [](rclcpp::Node::SharedPtr node, const std::string & topic_name,
+         const rclcpp::QoS & qos) -> std::shared_ptr<PubsubBridgeBase> {
+        return start_r2a_pubsub_node<MessageT>(node, topic_name, qos);
+      },
+    };
+    BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
+  }
+}
+
+}  // namespace internal
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -30,10 +30,21 @@
 
 #pragma once
 
+#include "agnocast/agnocast_mq.hpp"
+#include "agnocast/agnocast_utils.hpp"
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/qos.hpp>
 #include <rosidl_runtime_cpp/traits.hpp>
 
+#include <fcntl.h>
+#include <mqueue.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -99,6 +110,69 @@ private:
   std::unordered_map<std::string, BridgeFactoryEntry> map_;
 };
 
+// Mirrors a successful local `register_bridge_factory<T>()` to the
+// Standard-mode bridge_manager via a tiny POSIX MQ write. The bridge_manager
+// is a fork() child of this user process, so the addresses of
+// `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>` are valid in its
+// address space (same shared library at same offsets). The bridge_manager
+// stores those raw function pointers in its own BridgeFactoryRegistry and
+// uses them to honour daemon-originated `MqMsgDaemonBridge` requests.
+// Best-effort: any MQ failure is logged once and the user process continues
+// (the daemon path will silently no-op for this type until a working
+// bridge_manager picks the registration up).
+//
+// TODO: Replace with a `need-minor-update` kmod path that exposes the
+// message type alongside the existing topic / node info so the
+// bridge_manager can pre-populate its registry directly from the kmod and
+// retire this MQ entirely.
+template <typename MessageT>
+inline void notify_bridge_manager_of_factory(const std::string & type_name)
+{
+  if (standard_bridge_manager_pid <= 0) {
+    // Either bridge_manager has not been spawned yet (early static init?)
+    // or this process is running in Performance mode where the
+    // bridge_manager is a different process model.
+    return;
+  }
+
+  const std::string mq_name = create_mq_name_for_factory_register(standard_bridge_manager_pid);
+
+  struct mq_attr attr = {};
+  attr.mq_maxmsg = FACTORY_REGISTER_MQ_MAX_MESSAGES;
+  attr.mq_msgsize = FACTORY_REGISTER_MQ_MESSAGE_SIZE;
+
+  // O_CREAT so that the user process can race the bridge_manager — whichever
+  // side opens first creates the MQ. The kernel returns the existing MQ on
+  // subsequent calls.
+  mqd_t fd = mq_open(
+    mq_name.c_str(), O_WRONLY | O_CREAT | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
+  if (fd == (mqd_t)-1) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "Failed to open factory register MQ '%s': %s. Cross-IPC-NS bridges for "
+      "this process will not be auto-generated until this succeeds.",
+      mq_name.c_str(), std::strerror(errno));
+    return;
+  }
+
+  MqMsgFactoryRegister msg{};
+  std::strncpy(msg.type_name, type_name.c_str(), sizeof(msg.type_name) - 1);
+  msg.fn_a2r = reinterpret_cast<uintptr_t>(&start_a2r_pubsub_node<MessageT>);
+  msg.fn_r2a = reinterpret_cast<uintptr_t>(&start_r2a_pubsub_node<MessageT>);
+
+  if (mq_send(fd, reinterpret_cast<const char *>(&msg), sizeof(msg), 0) == -1) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "Failed to send factory register msg for type '%s' on MQ '%s': %s.",
+      type_name.c_str(), mq_name.c_str(), std::strerror(errno));
+  }
+  if (mq_close(fd) == -1) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"), "Failed to close factory register MQ '%s': %s.",
+      mq_name.c_str(), std::strerror(errno));
+  }
+}
+
 // Called from `Publisher<T>` / `Subscription<T>` constructors. Idempotent.
 // No-op when instantiated for non-message types (e.g. service types pulled in
 // by `BasicService<ServiceT>`'s internal subscription / publisher).
@@ -118,6 +192,7 @@ void register_bridge_factory()
       },
     };
     BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
+    notify_bridge_manager_of_factory<MessageT>(type_name);
   }
 }
 

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -39,6 +39,7 @@
 #include <rclcpp/qos.hpp>
 #include <rosidl_runtime_cpp/traits.hpp>
 
+#include <dlfcn.h>
 #include <fcntl.h>
 #include <mqueue.h>
 
@@ -111,15 +112,18 @@ private:
 };
 
 // Mirrors a successful local `register_bridge_factory<T>()` to the
-// Standard-mode bridge_manager via a tiny POSIX MQ write. The bridge_manager
-// is a fork() child of this user process, so the addresses of
-// `start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>` are valid in its
-// address space (same shared library at same offsets). The bridge_manager
-// stores those raw function pointers in its own BridgeFactoryRegistry and
-// uses them to honour daemon-originated `MqMsgDaemonBridge` requests.
-// Best-effort: any MQ failure is logged once and the user process continues
-// (the daemon path will silently no-op for this type until a working
-// bridge_manager picks the registration up).
+// Standard-mode bridge_manager via a small POSIX MQ write.
+//
+// We can't send raw function pointers because the function may live in a
+// shared library dlopen()'d *after* the bridge_manager was forked
+// (composable_node case). Instead we resolve the function via `dladdr`
+// to (shared_lib_path, offset-from-base) and let the bridge_manager
+// dlopen the same library and reconstruct the address. This mirrors the
+// existing intra-NS MqMsgBridge / BridgeFactoryInfo flow.
+//
+// Best-effort: any failure (dladdr / mq_open / mq_send) is logged once and
+// the user process continues. The daemon path will silently no-op for
+// this type until a working pre-registration lands.
 //
 // TODO: Replace with a `need-minor-update` kmod path that exposes the
 // message type alongside the existing topic / node info so the
@@ -132,6 +136,44 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
     // Either bridge_manager has not been spawned yet (early static init?)
     // or this process is running in Performance mode where the
     // bridge_manager is a different process model.
+    return;
+  }
+
+  // Resolve the function templates to (lib_path, offset-from-base) so the
+  // bridge_manager can reconstruct the address in its own process. dladdr
+  // on a template instantiation returns the .so (or main executable) that
+  // owns the instantiation.
+  auto fn_a2r_addr = reinterpret_cast<uintptr_t>(&start_a2r_pubsub_node<MessageT>);
+  auto fn_r2a_addr = reinterpret_cast<uintptr_t>(&start_r2a_pubsub_node<MessageT>);
+  Dl_info info_a2r{};
+  Dl_info info_r2a{};
+  if (
+    dladdr(reinterpret_cast<void *>(fn_a2r_addr), &info_a2r) == 0 ||
+    info_a2r.dli_fname == nullptr || info_a2r.dli_fbase == nullptr) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "dladdr failed for start_a2r_pubsub_node<%s>; skipping factory pre-register.",
+      type_name.c_str());
+    return;
+  }
+  if (
+    dladdr(reinterpret_cast<void *>(fn_r2a_addr), &info_r2a) == 0 ||
+    info_r2a.dli_fname == nullptr || info_r2a.dli_fbase == nullptr) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "dladdr failed for start_r2a_pubsub_node<%s>; skipping factory pre-register.",
+      type_name.c_str());
+    return;
+  }
+  // The two factories should come from the same translation unit / library
+  // (they're both template instantiations in the same scope). If they
+  // disagree something pathological is going on.
+  if (std::strcmp(info_a2r.dli_fname, info_r2a.dli_fname) != 0) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "start_a2r and start_r2a for type '%s' resolved to different libraries (%s vs %s);"
+      " skipping factory pre-register.",
+      type_name.c_str(), info_a2r.dli_fname, info_r2a.dli_fname);
     return;
   }
 
@@ -157,8 +199,9 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
 
   MqMsgFactoryRegister msg{};
   std::strncpy(msg.type_name, type_name.c_str(), sizeof(msg.type_name) - 1);
-  msg.fn_a2r = reinterpret_cast<uintptr_t>(&start_a2r_pubsub_node<MessageT>);
-  msg.fn_r2a = reinterpret_cast<uintptr_t>(&start_r2a_pubsub_node<MessageT>);
+  std::strncpy(msg.shared_lib_path, info_a2r.dli_fname, sizeof(msg.shared_lib_path) - 1);
+  msg.fn_offset_a2r = fn_a2r_addr - reinterpret_cast<uintptr_t>(info_a2r.dli_fbase);
+  msg.fn_offset_r2a = fn_r2a_addr - reinterpret_cast<uintptr_t>(info_r2a.dli_fbase);
 
   if (mq_send(fd, reinterpret_cast<const char *>(&msg), sizeof(msg), 0) == -1) {
     RCLCPP_WARN_ONCE(

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -42,6 +42,7 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <mqueue.h>
+#include <unistd.h>
 
 #include <cerrno>
 #include <cstdint>
@@ -183,17 +184,55 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
     return;
   }
 
+  // Detect overruns of the small shared_lib_path buffer before sending so
+  // the bridge_manager doesn't try to dlopen a truncated path. The buffer is
+  // sized for typical Linux .so paths (see comment on
+  // FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE). If your library lives
+  // somewhere deeper, the cross-IPC-NS bridge for this type stays disabled
+  // until the path can fit.
+  const std::size_t lib_path_len = std::strlen(info_a2r.dli_fname);
+  if (lib_path_len >= sizeof(MqMsgFactoryRegister{}.shared_lib_path)) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("agnocast"),
+      "Shared library path for type '%s' is %zu bytes, exceeds the %zu-byte buffer "
+      "in MqMsgFactoryRegister; skipping factory pre-register.",
+      type_name.c_str(), lib_path_len, sizeof(MqMsgFactoryRegister{}.shared_lib_path));
+    if (mq_close(fd) == -1) {
+      RCLCPP_WARN_ONCE(
+        rclcpp::get_logger("agnocast"), "Failed to close factory register MQ '%s': %s.",
+        mq_name.c_str(), std::strerror(errno));
+    }
+    return;
+  }
+
   MqMsgFactoryRegister msg{};
   std::strncpy(msg.type_name, type_name.c_str(), sizeof(msg.type_name) - 1);
   std::strncpy(msg.shared_lib_path, info_a2r.dli_fname, sizeof(msg.shared_lib_path) - 1);
   msg.fn_offset_a2r = fn_a2r_addr - reinterpret_cast<uintptr_t>(info_a2r.dli_fbase);
   msg.fn_offset_r2a = fn_r2a_addr - reinterpret_cast<uintptr_t>(info_r2a.dli_fbase);
 
-  if (mq_send(fd, reinterpret_cast<const char *>(&msg), sizeof(msg), 0) == -1) {
+  // Retry on EAGAIN: the small max_messages (2) tightens RLIMIT_MSGQUEUE
+  // pressure but means a burst of `register_bridge_factory<T>()` calls can
+  // transiently fill the queue before the bridge_manager drains it. Same
+  // retry shape as `send_mq_message` in agnocast_bridge_node.hpp.
+  constexpr int FACTORY_REGISTER_SEND_MAX_RETRIES = 100;
+  constexpr useconds_t FACTORY_REGISTER_SEND_RETRY_INTERVAL_US = 100000;  // 100 ms
+  int send_result = -1;
+  int last_errno = 0;
+  for (int retry = 0; retry <= FACTORY_REGISTER_SEND_MAX_RETRIES; ++retry) {
+    send_result = mq_send(fd, reinterpret_cast<const char *>(&msg), sizeof(msg), 0);
+    if (send_result == 0) break;
+    last_errno = errno;
+    if (last_errno != EAGAIN) break;
+    if (retry < FACTORY_REGISTER_SEND_MAX_RETRIES) {
+      usleep(FACTORY_REGISTER_SEND_RETRY_INTERVAL_US);
+    }
+  }
+  if (send_result < 0) {
     RCLCPP_WARN_ONCE(
       rclcpp::get_logger("agnocast"),
       "Failed to send factory register msg for type '%s' on MQ '%s': %s.", type_name.c_str(),
-      mq_name.c_str(), std::strerror(errno));
+      mq_name.c_str(), std::strerror(last_errno));
   }
   if (mq_close(fd) == -1) {
     RCLCPP_WARN_ONCE(

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -172,8 +172,8 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
   // O_CREAT so that the user process can race the bridge_manager — whichever
   // side opens first creates the MQ. The kernel returns the existing MQ on
   // subsequent calls.
-  mqd_t fd = mq_open(
-    mq_name.c_str(), O_WRONLY | O_CREAT | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
+  mqd_t fd =
+    mq_open(mq_name.c_str(), O_WRONLY | O_CREAT | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
   if (fd == (mqd_t)-1) {
     RCLCPP_WARN_ONCE(
       rclcpp::get_logger("agnocast"),
@@ -192,8 +192,8 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
   if (mq_send(fd, reinterpret_cast<const char *>(&msg), sizeof(msg), 0) == -1) {
     RCLCPP_WARN_ONCE(
       rclcpp::get_logger("agnocast"),
-      "Failed to send factory register msg for type '%s' on MQ '%s': %s.",
-      type_name.c_str(), mq_name.c_str(), std::strerror(errno));
+      "Failed to send factory register msg for type '%s' on MQ '%s': %s.", type_name.c_str(),
+      mq_name.c_str(), std::strerror(errno));
   }
   if (mq_close(fd) == -1) {
     RCLCPP_WARN_ONCE(

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -243,19 +243,26 @@ template <typename MessageT>
 void register_bridge_factory()
 {
   if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
-    const std::string type_name = rosidl_generator_traits::name<MessageT>();
-    BridgeFactoryEntry entry{
-      [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
-        -> std::shared_ptr<PubsubBridgeBase> {
-        return start_a2r_pubsub_node<MessageT>(node, topic_name, qos);
-      },
-      [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
-        -> std::shared_ptr<PubsubBridgeBase> {
-        return start_r2a_pubsub_node<MessageT>(node, topic_name, qos);
-      },
-    };
-    BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
-    notify_bridge_manager_of_factory<MessageT>(type_name);
+    // Once per `MessageT` per process. Every `Publisher<T>` / `Subscription<T>`
+    // ctor calls this, but repeating the MqMsgFactoryRegister send risks
+    // stalling on its EAGAIN retry and leaking dlopen handles on the
+    // bridge_manager (which intentionally never dlcloses).
+    static std::once_flag once;
+    std::call_once(once, []() {
+      const std::string type_name = rosidl_generator_traits::name<MessageT>();
+      BridgeFactoryEntry entry{
+        [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
+          -> std::shared_ptr<PubsubBridgeBase> {
+          return start_a2r_pubsub_node<MessageT>(node, topic_name, qos);
+        },
+        [](rclcpp::Node::SharedPtr node, const std::string & topic_name, const rclcpp::QoS & qos)
+          -> std::shared_ptr<PubsubBridgeBase> {
+          return start_r2a_pubsub_node<MessageT>(node, topic_name, qos);
+        },
+      };
+      BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
+      notify_bridge_manager_of_factory<MessageT>(type_name);
+    });
   }
 }
 

--- a/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
+++ b/src/agnocastlib/include/agnocast/internal/bridge_factory_registry.hpp
@@ -184,12 +184,9 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
     return;
   }
 
-  // Detect overruns of the small shared_lib_path buffer before sending so
-  // the bridge_manager doesn't try to dlopen a truncated path. The buffer is
-  // sized for typical Linux .so paths (see comment on
-  // FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE). If your library lives
-  // somewhere deeper, the cross-IPC-NS bridge for this type stays disabled
-  // until the path can fit.
+  // Catch path truncation up-front rather than letting bridge_manager dlopen
+  // a truncated string. See FACTORY_REGISTER_SHARED_LIB_PATH_BUFFER_SIZE
+  // for the trade-off.
   const std::size_t lib_path_len = std::strlen(info_a2r.dli_fname);
   if (lib_path_len >= sizeof(MqMsgFactoryRegister{}.shared_lib_path)) {
     RCLCPP_WARN_ONCE(
@@ -211,10 +208,8 @@ inline void notify_bridge_manager_of_factory(const std::string & type_name)
   msg.fn_offset_a2r = fn_a2r_addr - reinterpret_cast<uintptr_t>(info_a2r.dli_fbase);
   msg.fn_offset_r2a = fn_r2a_addr - reinterpret_cast<uintptr_t>(info_r2a.dli_fbase);
 
-  // Retry on EAGAIN: the small max_messages (2) tightens RLIMIT_MSGQUEUE
-  // pressure but means a burst of `register_bridge_factory<T>()` calls can
-  // transiently fill the queue before the bridge_manager drains it. Same
-  // retry shape as `send_mq_message` in agnocast_bridge_node.hpp.
+  // EAGAIN retry: `max_messages=2` (RLIMIT_MSGQUEUE budget) can transiently
+  // fill under bursts; same retry shape as `send_mq_message`.
   constexpr int FACTORY_REGISTER_SEND_MAX_RETRIES = 100;
   constexpr useconds_t FACTORY_REGISTER_SEND_RETRY_INTERVAL_US = 100000;  // 100 ms
   int send_result = -1;

--- a/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
+++ b/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
@@ -4,7 +4,7 @@
 // Per-process file writer that announces every `Publisher<T>` and
 // `Subscription<T>` registration to the per-IPC-namespace
 // `ros2agnocast_discovery_agent` via a tmpfs file under
-// `/run/agnocast/<ipc_ns_inode>/<pid>.txt`.
+// `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/<pid>.txt`.
 //
 // Each line is tab-separated and `\n`-terminated:
 //

--- a/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
+++ b/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
@@ -39,14 +39,19 @@ class TypeRegistryWriter
 public:
   static TypeRegistryWriter & instance();
 
-  // Append one `<topic>\t<type>\t<role>\t<node_name>\n` line to the
-  // per-pid file. `role` must be either `"pub"` or `"sub"`. Idempotent
-  // from the caller's view: the daemon dedupes identical triples on
-  // ingest. Errors are logged once and then silently swallowed so a
-  // missing `/run/agnocast` directory does not break user processes.
+  // Append one `<topic>\t<type>\t<role>\t<node_name>\t<bridge_manager_pid>\n`
+  // line to the per-pid file. `role` must be either `"pub"` or `"sub"`.
+  // `bridge_manager_pid` is the pid the daemon should target when sending
+  // a `MqMsgDaemonBridge` for this endpoint; in Standard mode that is the
+  // bridge_manager forked from this user process (= `agnocast::standard_bridge_manager_pid`),
+  // and in Performance mode it is 0 (the daemon then falls back to the
+  // per-NS Performance MQ). Idempotent from the caller's view: the daemon
+  // dedupes identical triples on ingest. Errors are logged once and then
+  // silently swallowed so a missing `/dev/shm/agnocast_type_registry`
+  // directory does not break user processes.
   void register_type(
     const std::string & topic_name, const std::string & type_name, const std::string & role,
-    const std::string & node_name);
+    const std::string & node_name, pid_t bridge_manager_pid);
 
   // Test seam: override the tmpfs base directory (default `/run/agnocast`).
   // Must be called before the first `register_type`.

--- a/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
+++ b/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
@@ -1,0 +1,75 @@
+// Copyright 2025
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-process file writer that announces every `Publisher<T>` and
+// `Subscription<T>` registration to the per-IPC-namespace
+// `ros2agnocast_discovery_agent` via a tmpfs file under
+// `/run/agnocast/<ipc_ns_inode>/<pid>.txt`.
+//
+// Each line is tab-separated and `\n`-terminated:
+//
+//   <topic_name>\t<type_name>\t<role>\t<node_name>\n
+//
+// `role` is `"pub"` or `"sub"`. The daemon scans the directory once per
+// tick and joins the discovered `(topic, role, node_name)` triples with
+// the kmod's per-IPC-NS endpoint list (which lacks both type and pid) to
+// populate `AgnocastTopic.type_name` and `AgnocastEndpoint.pid` on the
+// gossip publication. The pid lives in the filename; everything else
+// lives in the line content.
+//
+// The writer is a per-process singleton. The first `register_type` call
+// lazily creates the namespace directory and opens the per-pid file in
+// `O_APPEND` mode. Subsequent calls share the same descriptor.
+//
+// On normal process exit, an `atexit` handler unlinks the file as a
+// best-effort cleanup. On SIGKILL or crash, the daemon's
+// `cleanup_dead_pids()` (which checks `/proc/<pid>` existence) removes
+// the stale file on its next tick.
+
+#pragma once
+
+#include <mutex>
+#include <string>
+
+namespace agnocast::internal
+{
+
+class TypeRegistryWriter
+{
+public:
+  static TypeRegistryWriter & instance();
+
+  // Append one `<topic>\t<type>\t<role>\t<node_name>\n` line to the
+  // per-pid file. `role` must be either `"pub"` or `"sub"`. Idempotent
+  // from the caller's view: the daemon dedupes identical triples on
+  // ingest. Errors are logged once and then silently swallowed so a
+  // missing `/run/agnocast` directory does not break user processes.
+  void register_type(
+    const std::string & topic_name, const std::string & type_name, const std::string & role,
+    const std::string & node_name);
+
+  // Test seam: override the tmpfs base directory (default `/run/agnocast`).
+  // Must be called before the first `register_type`.
+  static void set_base_dir_for_test(const std::string & dir);
+
+  // Test seam: return the on-disk path this writer will use, given the
+  // current base dir and the caller's IPC namespace / pid.
+  std::string current_path_for_test() const;
+
+  // Test seam: close the cached fd and forget the path so the next
+  // `register_type()` call re-opens against the (possibly new) base dir.
+  void reset_for_test();
+
+private:
+  TypeRegistryWriter() = default;
+
+  void ensure_open_locked();
+  static void on_process_exit();
+
+  std::mutex mutex_;
+  int fd_ = -1;
+  bool open_failed_warned_ = false;
+  std::string path_;  // populated on first successful open
+};
+
+}  // namespace agnocast::internal

--- a/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
+++ b/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
@@ -31,6 +31,8 @@
 
 #pragma once
 
+#include <sys/types.h>  // pid_t
+
 #include <mutex>
 #include <string>
 

--- a/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
+++ b/src/agnocastlib/include/agnocast/internal/type_registry_writer.hpp
@@ -4,18 +4,21 @@
 // Per-process file writer that announces every `Publisher<T>` and
 // `Subscription<T>` registration to the per-IPC-namespace
 // `ros2agnocast_discovery_agent` via a tmpfs file under
-// `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/<pid>.txt`.
+// `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/<pid>.txt`.
 //
 // Each line is tab-separated and `\n`-terminated:
 //
-//   <topic_name>\t<type_name>\t<role>\t<node_name>\n
+//   <topic_name>\t<type_name>\t<role>\t<node_name>\t<bridge_manager_pid>\n
 //
-// `role` is `"pub"` or `"sub"`. The daemon scans the directory once per
-// tick and joins the discovered `(topic, role, node_name)` triples with
-// the kmod's per-IPC-NS endpoint list (which lacks both type and pid) to
-// populate `AgnocastTopic.type_name` and `AgnocastEndpoint.pid` on the
-// gossip publication. The pid lives in the filename; everything else
-// lives in the line content.
+// `role` is `"pub"` or `"sub"`. The 5th field carries the Standard-mode
+// bridge_manager pid the daemon should target when dispatching a
+// `MqMsgDaemonBridge` for this endpoint (0 in Performance mode). The
+// daemon scans the directory once per tick and joins the discovered
+// `(topic, role, node_name)` triples with the kmod's per-IPC-NS endpoint
+// list (which lacks both type and pid) to populate
+// `AgnocastTopic.type_name` and `AgnocastEndpoint.pid` on the gossip
+// publication. The user-process pid lives in the filename; everything
+// else lives in the line content.
 //
 // The writer is a per-process singleton. The first `register_type` call
 // lazily creates the namespace directory and opens the per-pid file in
@@ -53,8 +56,9 @@ public:
     const std::string & topic_name, const std::string & type_name, const std::string & role,
     const std::string & node_name, pid_t bridge_manager_pid);
 
-  // Test seam: override the tmpfs base directory (default `/run/agnocast`).
-  // Must be called before the first `register_type`.
+  // Test seam: override the tmpfs base directory (default
+  // `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry`). Must be
+  // called before the first `register_type`.
   static void set_base_dir_for_test(const std::string & dir);
 
   // Test seam: return the on-disk path this writer will use, given the

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -50,6 +50,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -6,16 +6,21 @@
 #include "agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp"
 #include "agnocast/bridge/standard/agnocast_standard_bridge_manager.hpp"
 
+#include <dirent.h>
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <mutex>
 #include <span>
+#include <string>
 #include <vector>
 
 extern "C" {
@@ -180,6 +185,53 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge(BridgeMode brid
     mempool_ptr,
     add_process_args.ret_shm_size,
   };
+}
+
+// On startup, sweep /dev/mqueue/ for agnocast-owned POSIX MQs whose `@<pid>`
+// suffix references a pid that no longer exists. This self-heals leaks from
+// previous runs where a bridge_manager exited abnormally (SIGKILL, crash) and
+// the previous `poll_for_unlink` daemon also exited before it could process
+// the kmod's do_exit hook for that pid. Without this sweep, leaked MQs
+// accumulate against `RLIMIT_MSGQUEUE` (per real UID) across repeated launch
+// cycles until `mq_open` returns EMFILE.
+//
+// Idempotent and bounded (`/dev/mqueue/` is small). Pid reuse race is benign:
+// if a leaked MQ's pid happens to be alive again (= a different process), we
+// skip it and the leak persists at most until the next sweep.
+static void sweep_orphan_agnocast_mqs()
+{
+  DIR * d = opendir("/dev/mqueue");
+  if (d == nullptr) {
+    return;
+  }
+  struct dirent * e = nullptr;
+  while ((e = readdir(d)) != nullptr) {
+    if (e->d_name[0] == '.') {
+      continue;
+    }
+    const char * at = std::strrchr(e->d_name, '@');
+    if (at == nullptr) {
+      continue;
+    }
+    const bool is_agnocast_pid_mq = std::strncmp(e->d_name, "agnocast_bridge_manager", 23) == 0 ||
+                                    std::strncmp(e->d_name, "agnocast_daemon_bridge", 22) == 0 ||
+                                    std::strncmp(e->d_name, "agnocast_factory_register", 25) == 0;
+    if (!is_agnocast_pid_mq) {
+      continue;
+    }
+    const pid_t pid = static_cast<pid_t>(std::atoi(at + 1));
+    if (pid <= 0) {
+      continue;
+    }
+    char proc_path[64];
+    std::snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid);
+    if (access(proc_path, F_OK) == 0) {
+      continue;  // owner still alive
+    }
+    const std::string mq_name = std::string("/") + e->d_name;
+    mq_unlink(mq_name.c_str());
+  }
+  closedir(d);
 }
 
 void poll_for_unlink()
@@ -486,6 +538,18 @@ struct initialize_agnocast_result initialize_agnocast(
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+
+  // Self-heal POSIX MQs left behind by previous runs where a bridge_manager
+  // exited abnormally (SIGKILL, crash) before its destructor could `mq_unlink`
+  // its own MQs. Without this, leaked MQs accumulate against
+  // `RLIMIT_MSGQUEUE` (per real UID) across repeated launch cycles until
+  // `mq_open` returns EMFILE. Done here (every Agnocast process init) rather
+  // than in `poll_for_unlink` only, because the unlink-daemon fork is gated
+  // on the kmod's `ret_unlink_daemon_exist` and the second+ Agnocast process
+  // in the same IPC NS would otherwise never get a chance to sweep.
+  // Idempotent and bounded (`/dev/mqueue/` is small). Pid reuse race is
+  // benign: live owners are skipped.
+  sweep_orphan_agnocast_mqs();
 
   union ioctl_add_process_args add_process_args = {};
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -201,7 +201,7 @@ static void sweep_orphan_agnocast_mqs()
   if (d == nullptr) {
     return;
   }
-  struct dirent * e = nullptr;
+  const struct dirent * e = nullptr;
   while ((e = readdir(d)) != nullptr) {
     if (e->d_name[0] == '.') {
       continue;

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -211,6 +211,20 @@ void poll_for_unlink()
         const std::string mq_name = create_mq_name_for_bridge(get_exit_process_args.ret_pid);
         mq_unlink(mq_name.c_str());
 
+        // The daemon-originated bridge MQ and the factory pre-register MQ are
+        // aux MQs owned by the Standard-mode bridge_manager. Its destructor
+        // unlinks them on graceful shutdown; here we also unlink them when the
+        // process exits abnormally (SIGKILL, crash) so leaked MQs do not
+        // accumulate against RLIMIT_MSGQUEUE. ENOENT is expected when the
+        // process was not a bridge_manager or already cleaned up.
+        const std::string daemon_bridge_mq_name =
+          create_mq_name_for_daemon_bridge(get_exit_process_args.ret_pid);
+        mq_unlink(daemon_bridge_mq_name.c_str());
+
+        const std::string factory_register_mq_name =
+          create_mq_name_for_factory_register(get_exit_process_args.ret_pid);
+        mq_unlink(factory_register_mq_name.c_str());
+
         // Unlink subscription MQs that the exited process owned
         for (uint32_t i = 0; i < get_exit_process_args.ret_subscription_mq_info_num; i++) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -187,17 +187,14 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge(BridgeMode brid
   };
 }
 
-// On startup, sweep /dev/mqueue/ for agnocast-owned POSIX MQs whose `@<pid>`
-// suffix references a pid that no longer exists. This self-heals leaks from
-// previous runs where a bridge_manager exited abnormally (SIGKILL, crash) and
-// the previous `poll_for_unlink` daemon also exited before it could process
-// the kmod's do_exit hook for that pid. Without this sweep, leaked MQs
-// accumulate against `RLIMIT_MSGQUEUE` (per real UID) across repeated launch
-// cycles until `mq_open` returns EMFILE.
+// Self-heals POSIX MQs left behind by an abnormally-exited bridge_manager
+// (SIGKILL, crash) when the previous `poll_for_unlink` daemon also died
+// before processing the kmod's `do_exit` hook for that pid. Without this,
+// leaked MQs accumulate against `RLIMIT_MSGQUEUE` (per real UID) across
+// launch cycles until `mq_open` returns EMFILE.
 //
-// Idempotent and bounded (`/dev/mqueue/` is small). Pid reuse race is benign:
-// if a leaked MQ's pid happens to be alive again (= a different process), we
-// skip it and the leak persists at most until the next sweep.
+// Pid reuse race is benign: live owners are skipped, so the leak persists
+// at most until the next sweep.
 static void sweep_orphan_agnocast_mqs()
 {
   DIR * d = opendir("/dev/mqueue");
@@ -539,16 +536,10 @@ struct initialize_agnocast_result initialize_agnocast(
     exit(EXIT_FAILURE);
   }
 
-  // Self-heal POSIX MQs left behind by previous runs where a bridge_manager
-  // exited abnormally (SIGKILL, crash) before its destructor could `mq_unlink`
-  // its own MQs. Without this, leaked MQs accumulate against
-  // `RLIMIT_MSGQUEUE` (per real UID) across repeated launch cycles until
-  // `mq_open` returns EMFILE. Done here (every Agnocast process init) rather
-  // than in `poll_for_unlink` only, because the unlink-daemon fork is gated
-  // on the kmod's `ret_unlink_daemon_exist` and the second+ Agnocast process
-  // in the same IPC NS would otherwise never get a chance to sweep.
-  // Idempotent and bounded (`/dev/mqueue/` is small). Pid reuse race is
-  // benign: live owners are skipped.
+  // Called on every Agnocast process init rather than only in
+  // `poll_for_unlink` because the unlink-daemon fork is gated on the kmod's
+  // `ret_unlink_daemon_exist`; the second+ Agnocast process in the same IPC
+  // NS would otherwise never get a chance to sweep.
   sweep_orphan_agnocast_mqs();
 
   union ioctl_add_process_args add_process_args = {};

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -103,6 +103,11 @@ std::string create_mq_name_for_daemon_bridge(const pid_t pid)
   return std::string(DAEMON_BRIDGE_MQ_PREFIX) + "@" + std::to_string(pid);
 }
 
+std::string create_mq_name_for_factory_register(const pid_t pid)
+{
+  return std::string(FACTORY_REGISTER_MQ_PREFIX) + "@" + std::to_string(pid);
+}
+
 uint64_t get_self_ipc_ns_inode()
 {
   struct stat st

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -87,6 +87,19 @@ std::string create_mq_name_for_bridge(const pid_t pid)
   return name;
 }
 
+std::string create_mq_name_for_daemon_bridge(const pid_t pid)
+{
+  if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
+    std::string name = PERFORMANCE_DAEMON_BRIDGE_MQ_NAME;
+    const char * domain_id = getenv("ROS_DOMAIN_ID");
+    if (domain_id != nullptr) {
+      name += "_d" + std::string(domain_id);
+    }
+    return name;
+  }
+  return std::string(DAEMON_BRIDGE_MQ_PREFIX) + "@" + std::to_string(pid);
+}
+
 std::string create_shm_name(const pid_t pid)
 {
   return "/agnocast@" + std::to_string(pid);

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -3,8 +3,11 @@
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
+#include <sys/stat.h>
+
 #include <cstdlib>
 #include <cstring>
+#include <system_error>
 
 namespace agnocast
 {
@@ -98,6 +101,17 @@ std::string create_mq_name_for_daemon_bridge(const pid_t pid)
     return name;
   }
   return std::string(DAEMON_BRIDGE_MQ_PREFIX) + "@" + std::to_string(pid);
+}
+
+uint64_t get_self_ipc_ns_inode()
+{
+  struct stat st
+  {
+  };
+  if (stat("/proc/self/ns/ipc", &st) != 0) {
+    throw std::system_error(errno, std::generic_category(), "stat(/proc/self/ns/ipc)");
+  }
+  return static_cast<uint64_t>(st.st_ino);
 }
 
 std::string create_shm_name(const pid_t pid)

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -95,7 +95,7 @@ std::string create_mq_name_for_daemon_bridge(const pid_t pid)
   if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
     std::string name = PERFORMANCE_DAEMON_BRIDGE_MQ_NAME;
     const char * domain_id = getenv("ROS_DOMAIN_ID");
-    if (domain_id != nullptr) {
+    if (domain_id != nullptr && domain_id[0] != '\0') {
       name += "_d" + std::string(domain_id);
     }
     return name;

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -62,10 +62,17 @@ void PerformanceBridgeManager::run()
   // non-fatal: the bridge_manager continues to handle in-process requests via
   // the primary MQ.
   try {
+    const auto daemon_mq_name = create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
     event_loop_.register_aux_mq(
-      create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID),
-      DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
+      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
     event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+    RCLCPP_INFO(
+      logger_,
+      "Listening on MQ '%s' for daemon-originated bridge requests. "
+      "If cross-IPC-namespace bridges are expected and never appear, verify "
+      "that the discovery agent is running in this IPC namespace "
+      "(ros2 run ros2agnocast_discovery_agent discovery_agent).",
+      daemon_mq_name.c_str());
   } catch (const std::exception & e) {
     RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
   }

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -161,14 +161,14 @@ void PerformanceBridgeManager::create_daemon_pubsub_bridge_if_needed(const MqMsg
   }
 
   try {
-    rclcpp::QoS target_qos = rclcpp::QoS(req.qos_depth)
-                               .durability(
-                                 req.qos_is_transient_local
-                                   ? rclcpp::DurabilityPolicy::TransientLocal
-                                   : rclcpp::DurabilityPolicy::Volatile)
-                               .reliability(
-                                 req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
-                                                     : rclcpp::ReliabilityPolicy::BestEffort);
+    rclcpp::QoS target_qos =
+      rclcpp::QoS(req.qos_depth)
+        .durability(
+          req.qos_is_transient_local ? rclcpp::DurabilityPolicy::TransientLocal
+                                     : rclcpp::DurabilityPolicy::Volatile)
+        .reliability(
+          req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                              : rclcpp::ReliabilityPolicy::BestEffort);
 
     PerformancePubsubBridgeResult result;
     if (is_r2a) {

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -57,6 +57,19 @@ void PerformanceBridgeManager::run()
   event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
 
+  // Register the per-IPC-namespace daemon-originated bridge request MQ
+  // (`/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]`). Failures here are
+  // non-fatal: the bridge_manager continues to handle in-process requests via
+  // the primary MQ.
+  try {
+    event_loop_.register_aux_mq(
+      create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID),
+      DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
+    event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
+  }
+
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
       RCLCPP_ERROR(logger_, "Event loop spin failed.");
@@ -120,6 +133,80 @@ void PerformanceBridgeManager::on_mq_request(int fd)
 
     create_pubsub_bridge_if_needed(
       topic_name, request_cache_[topic_name], message_type, msg.direction);
+  }
+}
+
+void PerformanceBridgeManager::on_daemon_mq_request(int fd)
+{
+  MqMsgDaemonBridge req{};
+  while (mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr) > 0) {
+    if (shutdown_requested_) {
+      break;
+    }
+    create_daemon_pubsub_bridge_if_needed(req);
+  }
+}
+
+void PerformanceBridgeManager::create_daemon_pubsub_bridge_if_needed(const MqMsgDaemonBridge & req)
+{
+  const std::string topic_name = static_cast<const char *>(req.topic_name);
+  const std::string message_type = static_cast<const char *>(req.type_name);
+  const bool is_r2a = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST);
+
+  if (is_r2a && active_pubsub_r2a_bridges_.count(topic_name) > 0) {
+    return;
+  }
+  if (!is_r2a && active_pubsub_a2r_bridges_.count(topic_name) > 0) {
+    return;
+  }
+
+  try {
+    rclcpp::QoS target_qos = rclcpp::QoS(req.qos_depth)
+                               .durability(
+                                 req.qos_is_transient_local
+                                   ? rclcpp::DurabilityPolicy::TransientLocal
+                                   : rclcpp::DurabilityPolicy::Volatile)
+                               .reliability(
+                                 req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                                                     : rclcpp::ReliabilityPolicy::BestEffort);
+
+    PerformancePubsubBridgeResult result;
+    if (is_r2a) {
+      result =
+        loader_.create_r2a_pubsub_bridge(container_node_, topic_name, message_type, target_qos);
+    } else {
+      result =
+        loader_.create_a2r_pubsub_bridge(container_node_, topic_name, message_type, target_qos);
+    }
+
+    if (!result.entity_handle) {
+      RCLCPP_ERROR(
+        logger_, "Daemon bridge loader returned null for '%s' (type '%s')", topic_name.c_str(),
+        message_type.c_str());
+      return;
+    }
+
+    if (is_r2a) {
+      if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_r2a_bridges_[topic_name] = result;
+    } else {
+      if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_a2r_bridges_[topic_name] = result;
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      logger_, "Failed to create daemon bridge for '%s' (type '%s'): %s", topic_name.c_str(),
+      message_type.c_str(), e.what());
+  } catch (...) {
+    RCLCPP_WARN(
+      logger_, "Unknown error creating daemon bridge for '%s' (type '%s')", topic_name.c_str(),
+      message_type.c_str());
   }
 }
 

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -64,8 +64,8 @@ void PerformanceBridgeManager::run()
   try {
     const auto daemon_mq_name = create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
     event_loop_.register_aux_mq(
-      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
-    event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE,
+      [this](int fd) { this->on_daemon_mq_request(fd); });
     RCLCPP_INFO(
       logger_,
       "Listening on MQ '%s' for daemon-originated bridge requests. "

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -76,8 +76,8 @@ void StandardBridgeManager::run()
   try {
     const auto daemon_mq_name = create_mq_name_for_daemon_bridge(getpid());
     event_loop_.register_aux_mq(
-      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
-    event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE,
+      [this](int fd) { this->on_daemon_mq_request(fd); });
     RCLCPP_INFO(
       logger_,
       "Listening on MQ '%s' for daemon-originated bridge requests. "
@@ -87,6 +87,33 @@ void StandardBridgeManager::run()
       daemon_mq_name.c_str());
   } catch (const std::exception & e) {
     RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
+  }
+
+  // Register the user-process factory pre-registration MQ
+  // (`/agnocast_factory_register@<pid>`). The bridge_manager is a fork()
+  // child of the user process, so the user's Publisher<T> / Subscription<T>
+  // constructors run *after* this fork and the local BridgeFactoryRegistry
+  // here is empty by default — factory registrations performed in the
+  // parent after fork do not propagate. The user process therefore mirrors
+  // each register_bridge_factory<T>() call into this MQ so the bridge_manager
+  // can populate its own registry. Without this, daemon-originated bridge
+  // requests for any type land with the WARN
+  // "no factory registered in this process" and bridges never come up.
+  //
+  // TODO: Replace with kmod-side type info when a need-minor-update release
+  // becomes available — the kmod can carry the message type alongside the
+  // existing topic / node info and the bridge_manager would pre-populate
+  // its registry directly from there, retiring this MQ.
+  try {
+    const auto factory_mq_name = create_mq_name_for_factory_register(getpid());
+    event_loop_.register_aux_mq(
+      factory_mq_name, FACTORY_REGISTER_MQ_MAX_MESSAGES, FACTORY_REGISTER_MQ_MESSAGE_SIZE,
+      [this](int fd) { this->on_factory_register_request(fd); });
+    RCLCPP_INFO(
+      logger_, "Listening on MQ '%s' for user-process factory pre-registrations.",
+      factory_mq_name.c_str());
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Failed to register factory register MQ: %s", e.what());
   }
 
   while (!shutdown_requested_) {
@@ -150,6 +177,38 @@ void StandardBridgeManager::on_daemon_mq_request(mqd_t fd)
       break;
     }
     create_daemon_pubsub_bridge_if_needed(req);
+  }
+}
+
+void StandardBridgeManager::on_factory_register_request(mqd_t fd)
+{
+  // Type aliases that match the template signatures of
+  // `agnocast::start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`. The
+  // user process sends these as raw uintptr_t in the MqMsgFactoryRegister
+  // message; we recast and stash them in this process's
+  // BridgeFactoryRegistry, keyed by type_name, so daemon-originated
+  // MqMsgDaemonBridge requests can resolve them later.
+  using StartFn = std::shared_ptr<PubsubBridgeBase> (*)(
+    rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &);
+
+  MqMsgFactoryRegister req{};
+  while (mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr) > 0) {
+    if (shutdown_requested_) {
+      break;
+    }
+    const std::string type_name = static_cast<const char *>(req.type_name);
+    if (type_name.empty() || req.fn_a2r == 0 || req.fn_r2a == 0) {
+      RCLCPP_WARN(
+        logger_, "Skipping malformed factory register msg (type='%s', a2r=%p, r2a=%p).",
+        type_name.c_str(), reinterpret_cast<void *>(req.fn_a2r),
+        reinterpret_cast<void *>(req.fn_r2a));
+      continue;
+    }
+    auto fn_a2r = reinterpret_cast<StartFn>(req.fn_a2r);
+    auto fn_r2a = reinterpret_cast<StartFn>(req.fn_r2a);
+    internal::BridgeFactoryEntry entry{fn_a2r, fn_r2a};
+    internal::BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
+    RCLCPP_INFO(logger_, "Registered factory for type '%s'.", type_name.c_str());
   }
 }
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
+#include "agnocast/internal/bridge_factory_registry.hpp"
 
 #include <sys/prctl.h>
 #include <unistd.h>
@@ -69,6 +70,18 @@ void StandardBridgeManager::run()
   event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
 
+  // Register the daemon-originated bridge request MQ
+  // (`/agnocast_daemon_bridge@<pid>`). Failures here are non-fatal: the
+  // bridge_manager continues to handle in-process requests via the primary MQ.
+  try {
+    event_loop_.register_aux_mq(
+      create_mq_name_for_daemon_bridge(getpid()), DAEMON_BRIDGE_MQ_MAX_MESSAGES,
+      DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
+    event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
+  }
+
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
       break;
@@ -119,6 +132,100 @@ void StandardBridgeManager::on_mq_request(mqd_t fd)
     } else {
       register_pubsub_request(req);
     }
+  }
+}
+
+void StandardBridgeManager::on_daemon_mq_request(mqd_t fd)
+{
+  MqMsgDaemonBridge req{};
+  while (mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr) > 0) {
+    if (shutdown_requested_) {
+      break;
+    }
+    create_daemon_pubsub_bridge_if_needed(req);
+  }
+}
+
+void StandardBridgeManager::create_daemon_pubsub_bridge_if_needed(const MqMsgDaemonBridge & req)
+{
+  const std::string topic_name = static_cast<const char *>(req.topic_name);
+  const std::string type_name = static_cast<const char *>(req.type_name);
+
+  std::string_view suffix = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? SUFFIX_PUBSUB_R2A
+                                                                                 : SUFFIX_PUBSUB_A2R;
+  const std::string topic_name_with_direction = topic_name + std::string(suffix);
+
+  if (active_pubsub_bridges_.count(topic_name_with_direction) != 0U) {
+    return;
+  }
+
+  internal::BridgeFactoryEntry entry;
+  if (!internal::BridgeFactoryRegistry::instance().lookup(type_name, entry)) {
+    RCLCPP_WARN(
+      logger_,
+      "Daemon bridge request for topic '%s' (type '%s') skipped: no factory registered in this "
+      "process.",
+      topic_name.c_str(), type_name.c_str());
+    return;
+  }
+
+  const bool is_r2a = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST);
+
+  // Ensure the kernel-side bridge ownership is recorded for this process so
+  // that subsequent ref-bit accounting works the same as for self-issued
+  // requests. If another process already owns the bridge we drop the request
+  // — that other process should be servicing the same topic.
+  auto [status, owner_pid, kernel_has_r2a, kernel_has_a2r] =
+    try_add_pubsub_bridge_to_kernel(topic_name, is_r2a);
+  (void)owner_pid;
+  (void)kernel_has_r2a;
+  (void)kernel_has_a2r;
+
+  if (status == AddBridgeResult::EXIST) {
+    return;
+  }
+  if (status == AddBridgeResult::ERROR) {
+    RCLCPP_ERROR(
+      logger_, "Daemon bridge request: failed to add bridge for '%s' to kernel", topic_name.c_str());
+    return;
+  }
+
+  try {
+    rclcpp::QoS target_qos = rclcpp::QoS(req.qos_depth)
+                               .durability(
+                                 req.qos_is_transient_local
+                                   ? rclcpp::DurabilityPolicy::TransientLocal
+                                   : rclcpp::DurabilityPolicy::Volatile)
+                               .reliability(
+                                 req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                                                     : rclcpp::ReliabilityPolicy::BestEffort);
+    auto bridge = is_r2a ? entry.r2a(container_node_, topic_name, target_qos)
+                         : entry.a2r(container_node_, topic_name, target_qos);
+    if (!bridge) {
+      RCLCPP_ERROR(
+        logger_, "Daemon bridge factory returned null for '%s'", topic_name_with_direction.c_str());
+      rollback_pubsub_bridge_from_kernel(topic_name, is_r2a);
+      return;
+    }
+
+    if (is_r2a) {
+      if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
+      }
+    } else {
+      if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
+      }
+    }
+
+    active_pubsub_bridges_[topic_name_with_direction] = bridge;
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      logger_, "Failed to activate daemon bridge for '%s': %s", topic_name_with_direction.c_str(),
+      e.what());
+    rollback_pubsub_bridge_from_kernel(topic_name, is_r2a);
   }
 }
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -93,21 +93,10 @@ void StandardBridgeManager::run()
     RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
   }
 
-  // Register the user-process factory pre-registration MQ
-  // (`/agnocast_factory_register@<pid>`). The bridge_manager is a fork()
-  // child of the user process, so the user's Publisher<T> / Subscription<T>
-  // constructors run *after* this fork and the local BridgeFactoryRegistry
-  // here is empty by default — factory registrations performed in the
-  // parent after fork do not propagate. The user process therefore mirrors
-  // each register_bridge_factory<T>() call into this MQ so the bridge_manager
-  // can populate its own registry. Without this, daemon-originated bridge
-  // requests for any type land with the WARN
-  // "no factory registered in this process" and bridges never come up.
-  //
-  // TODO: Replace with kmod-side type info when a need-minor-update release
-  // becomes available — the kmod can carry the message type alongside the
-  // existing topic / node info and the bridge_manager would pre-populate
-  // its registry directly from there, retiring this MQ.
+  // Receiver side of MqMsgFactoryRegister (see the struct's doc comment
+  // for the why). Without this MQ the bridge_manager's local
+  // BridgeFactoryRegistry stays empty and every daemon-originated bridge
+  // request lands on the "no factory registered in this process" WARN.
   try {
     const auto factory_mq_name = create_mq_name_for_factory_register(getpid());
     event_loop_.register_aux_mq(
@@ -186,13 +175,10 @@ void StandardBridgeManager::on_daemon_mq_request(mqd_t fd)
 
 void StandardBridgeManager::on_factory_register_request(mqd_t fd)
 {
-  // The user process sends (type_name, shared_lib_path, fn_offset_a2r,
-  // fn_offset_r2a). We dlopen the library here (it may have been loaded
-  // post-fork via composable_node and so is absent from our address
-  // space), read its load base via dlinfo, and reconstruct each factory
-  // function's address as `base + offset`. The address is then stored as
-  // a raw function pointer in our own BridgeFactoryRegistry so the
-  // daemon-originated MqMsgDaemonBridge handler can resolve and call it.
+  // dlopen the library named in the message (in addition to letting us
+  // reconstruct the function address by offset, this is what brings the
+  // library into our address space when it was only dlopen()'d in the
+  // parent post-fork — e.g. composable_node libraries).
   using StartFn = std::shared_ptr<PubsubBridgeBase> (*)(
     rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &);
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -4,15 +4,19 @@
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 #include "agnocast/internal/bridge_factory_registry.hpp"
 
+#include <dlfcn.h>
+#include <link.h>
 #include <sys/prctl.h>
 #include <unistd.h>
 
 #include <algorithm>
 #include <csignal>
 #include <cstring>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace agnocast
 {
@@ -182,12 +186,13 @@ void StandardBridgeManager::on_daemon_mq_request(mqd_t fd)
 
 void StandardBridgeManager::on_factory_register_request(mqd_t fd)
 {
-  // Type aliases that match the template signatures of
-  // `agnocast::start_a2r_pubsub_node<T>` / `start_r2a_pubsub_node<T>`. The
-  // user process sends these as raw uintptr_t in the MqMsgFactoryRegister
-  // message; we recast and stash them in this process's
-  // BridgeFactoryRegistry, keyed by type_name, so daemon-originated
-  // MqMsgDaemonBridge requests can resolve them later.
+  // The user process sends (type_name, shared_lib_path, fn_offset_a2r,
+  // fn_offset_r2a). We dlopen the library here (it may have been loaded
+  // post-fork via composable_node and so is absent from our address
+  // space), read its load base via dlinfo, and reconstruct each factory
+  // function's address as `base + offset`. The address is then stored as
+  // a raw function pointer in our own BridgeFactoryRegistry so the
+  // daemon-originated MqMsgDaemonBridge handler can resolve and call it.
   using StartFn = std::shared_ptr<PubsubBridgeBase> (*)(
     rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &);
 
@@ -197,18 +202,54 @@ void StandardBridgeManager::on_factory_register_request(mqd_t fd)
       break;
     }
     const std::string type_name = static_cast<const char *>(req.type_name);
-    if (type_name.empty() || req.fn_a2r == 0 || req.fn_r2a == 0) {
+    const std::string lib_path = static_cast<const char *>(req.shared_lib_path);
+    if (type_name.empty() || lib_path.empty()) {
       RCLCPP_WARN(
-        logger_, "Skipping malformed factory register msg (type='%s', a2r=%p, r2a=%p).",
-        type_name.c_str(), reinterpret_cast<void *>(req.fn_a2r),
-        reinterpret_cast<void *>(req.fn_r2a));
+        logger_, "Skipping malformed factory register msg (type='%s', lib='%s').",
+        type_name.c_str(), lib_path.c_str());
       continue;
     }
-    auto fn_a2r = reinterpret_cast<StartFn>(req.fn_a2r);
-    auto fn_r2a = reinterpret_cast<StartFn>(req.fn_r2a);
+
+    // Decide whether the path refers to the main executable or to a
+    // separate shared library. For the main executable, `dlopen(nullptr)`
+    // is the canonical handle.
+    std::error_code ec;
+    auto self_path = std::filesystem::read_symlink("/proc/self/exe", ec);
+    bool is_self_exe = false;
+    if (!ec) {
+      if (std::filesystem::equivalent(std::filesystem::path(lib_path), self_path, ec)) {
+        is_self_exe = true;
+      }
+    }
+    void * handle = is_self_exe ? dlopen(nullptr, RTLD_NOW)
+                                : dlopen(lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+      const char * err = dlerror();
+      RCLCPP_WARN(
+        logger_, "dlopen('%s') failed: %s; skipping factory for type '%s'.",
+        lib_path.c_str(), err != nullptr ? err : "unknown", type_name.c_str());
+      continue;
+    }
+    struct link_map * lmap = nullptr;
+    if (dlinfo(handle, RTLD_DI_LINKMAP, &lmap) != 0 || lmap == nullptr) {
+      RCLCPP_WARN(
+        logger_, "dlinfo failed for '%s'; skipping factory for type '%s'.",
+        lib_path.c_str(), type_name.c_str());
+      dlclose(handle);
+      continue;
+    }
+    const uintptr_t base = static_cast<uintptr_t>(lmap->l_addr);
+    auto fn_a2r = reinterpret_cast<StartFn>(base + req.fn_offset_a2r);
+    auto fn_r2a = reinterpret_cast<StartFn>(base + req.fn_offset_r2a);
     internal::BridgeFactoryEntry entry{fn_a2r, fn_r2a};
     internal::BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
-    RCLCPP_INFO(logger_, "Registered factory for type '%s'.", type_name.c_str());
+    // NB: we intentionally don't dlclose() — the handle must stay alive
+    // for the duration of any bridge node built from these factories. The
+    // library is small and only one handle per type, so the leak is bounded
+    // by the cardinality of distinct registered types.
+    RCLCPP_INFO(
+      logger_, "Registered factory for type '%s' from library '%s'.",
+      type_name.c_str(), lib_path.c_str());
   }
 }
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -74,10 +74,17 @@ void StandardBridgeManager::run()
   // (`/agnocast_daemon_bridge@<pid>`). Failures here are non-fatal: the
   // bridge_manager continues to handle in-process requests via the primary MQ.
   try {
+    const auto daemon_mq_name = create_mq_name_for_daemon_bridge(getpid());
     event_loop_.register_aux_mq(
-      create_mq_name_for_daemon_bridge(getpid()), DAEMON_BRIDGE_MQ_MAX_MESSAGES,
-      DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
+      daemon_mq_name, DAEMON_BRIDGE_MQ_MAX_MESSAGES, DAEMON_BRIDGE_MQ_MESSAGE_SIZE);
     event_loop_.set_aux_mq_handler([this](int fd) { this->on_daemon_mq_request(fd); });
+    RCLCPP_INFO(
+      logger_,
+      "Listening on MQ '%s' for daemon-originated bridge requests. "
+      "If cross-IPC-namespace bridges are expected and never appear, verify "
+      "that the discovery agent is running in this IPC namespace "
+      "(ros2 run ros2agnocast_discovery_agent discovery_agent).",
+      daemon_mq_name.c_str());
   } catch (const std::exception & e) {
     RCLCPP_WARN(logger_, "Failed to register daemon bridge MQ: %s", e.what());
   }

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -151,8 +151,8 @@ void StandardBridgeManager::create_daemon_pubsub_bridge_if_needed(const MqMsgDae
   const std::string topic_name = static_cast<const char *>(req.topic_name);
   const std::string type_name = static_cast<const char *>(req.type_name);
 
-  std::string_view suffix = (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? SUFFIX_PUBSUB_R2A
-                                                                                 : SUFFIX_PUBSUB_A2R;
+  std::string_view suffix =
+    (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? SUFFIX_PUBSUB_R2A : SUFFIX_PUBSUB_A2R;
   const std::string topic_name_with_direction = topic_name + std::string(suffix);
 
   if (active_pubsub_bridges_.count(topic_name_with_direction) != 0U) {
@@ -186,19 +186,20 @@ void StandardBridgeManager::create_daemon_pubsub_bridge_if_needed(const MqMsgDae
   }
   if (status == AddBridgeResult::ERROR) {
     RCLCPP_ERROR(
-      logger_, "Daemon bridge request: failed to add bridge for '%s' to kernel", topic_name.c_str());
+      logger_, "Daemon bridge request: failed to add bridge for '%s' to kernel",
+      topic_name.c_str());
     return;
   }
 
   try {
-    rclcpp::QoS target_qos = rclcpp::QoS(req.qos_depth)
-                               .durability(
-                                 req.qos_is_transient_local
-                                   ? rclcpp::DurabilityPolicy::TransientLocal
-                                   : rclcpp::DurabilityPolicy::Volatile)
-                               .reliability(
-                                 req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
-                                                     : rclcpp::ReliabilityPolicy::BestEffort);
+    rclcpp::QoS target_qos =
+      rclcpp::QoS(req.qos_depth)
+        .durability(
+          req.qos_is_transient_local ? rclcpp::DurabilityPolicy::TransientLocal
+                                     : rclcpp::DurabilityPolicy::Volatile)
+        .reliability(
+          req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                              : rclcpp::ReliabilityPolicy::BestEffort);
     auto bridge = is_r2a ? entry.r2a(container_node_, topic_name, target_qos)
                          : entry.a2r(container_node_, topic_name, target_qos);
     if (!bridge) {

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -207,20 +207,20 @@ void StandardBridgeManager::on_factory_register_request(mqd_t fd)
         is_self_exe = true;
       }
     }
-    void * handle = is_self_exe ? dlopen(nullptr, RTLD_NOW)
-                                : dlopen(lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    void * handle =
+      is_self_exe ? dlopen(nullptr, RTLD_NOW) : dlopen(lib_path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (handle == nullptr) {
       const char * err = dlerror();
       RCLCPP_WARN(
-        logger_, "dlopen('%s') failed: %s; skipping factory for type '%s'.",
-        lib_path.c_str(), err != nullptr ? err : "unknown", type_name.c_str());
+        logger_, "dlopen('%s') failed: %s; skipping factory for type '%s'.", lib_path.c_str(),
+        err != nullptr ? err : "unknown", type_name.c_str());
       continue;
     }
     struct link_map * lmap = nullptr;
     if (dlinfo(handle, RTLD_DI_LINKMAP, &lmap) != 0 || lmap == nullptr) {
       RCLCPP_WARN(
-        logger_, "dlinfo failed for '%s'; skipping factory for type '%s'.",
-        lib_path.c_str(), type_name.c_str());
+        logger_, "dlinfo failed for '%s'; skipping factory for type '%s'.", lib_path.c_str(),
+        type_name.c_str());
       dlclose(handle);
       continue;
     }
@@ -234,8 +234,8 @@ void StandardBridgeManager::on_factory_register_request(mqd_t fd)
     // library is small and only one handle per type, so the leak is bounded
     // by the cardinality of distinct registered types.
     RCLCPP_INFO(
-      logger_, "Registered factory for type '%s' from library '%s'.",
-      type_name.c_str(), lib_path.c_str());
+      logger_, "Registered factory for type '%s' from library '%s'.", type_name.c_str(),
+      lib_path.c_str());
   }
 }
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
+#include "agnocast/bridge/standard/agnocast_standard_bridge_loader.hpp"
 #include "agnocast/internal/bridge_factory_registry.hpp"
 
 #include <dlfcn.h>
@@ -225,8 +226,24 @@ void StandardBridgeManager::on_factory_register_request(mqd_t fd)
       continue;
     }
     const uintptr_t base = static_cast<uintptr_t>(lmap->l_addr);
-    auto fn_a2r = reinterpret_cast<StartFn>(base + req.fn_offset_a2r);
-    auto fn_r2a = reinterpret_cast<StartFn>(base + req.fn_offset_r2a);
+    const uintptr_t addr_a2r = base + req.fn_offset_a2r;
+    const uintptr_t addr_r2a = base + req.fn_offset_r2a;
+    // Refuse to register a function pointer outside the library's code
+    // segments — otherwise the bridge could later jump anywhere.
+    if (
+      !StandardBridgeLoader::is_address_in_library_code_segment(handle, addr_a2r) ||
+      !StandardBridgeLoader::is_address_in_library_code_segment(handle, addr_r2a)) {
+      RCLCPP_WARN(
+        logger_,
+        "Factory function offsets for type '%s' resolve outside the executable segments of "
+        "'%s' (a2r=0x%lx r2a=0x%lx); skipping registration.",
+        type_name.c_str(), lib_path.c_str(), static_cast<unsigned long>(addr_a2r),
+        static_cast<unsigned long>(addr_r2a));
+      dlclose(handle);
+      continue;
+    }
+    auto fn_a2r = reinterpret_cast<StartFn>(addr_a2r);
+    auto fn_r2a = reinterpret_cast<StartFn>(addr_r2a);
     internal::BridgeFactoryEntry entry{fn_a2r, fn_r2a};
     internal::BridgeFactoryRegistry::instance().register_entry(type_name, std::move(entry));
     // NB: we intentionally don't dlclose() — the handle must stay alive

--- a/src/agnocastlib/src/internal/type_registry_writer.cpp
+++ b/src/agnocastlib/src/internal/type_registry_writer.cpp
@@ -148,7 +148,7 @@ void TypeRegistryWriter::ensure_open_locked()
 
 void TypeRegistryWriter::register_type(
   const std::string & topic_name, const std::string & type_name, const std::string & role,
-  const std::string & node_name)
+  const std::string & node_name, pid_t bridge_manager_pid)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   ensure_open_locked();
@@ -156,12 +156,15 @@ void TypeRegistryWriter::register_type(
     return;
   }
 
+  std::string bm_pid_str = std::to_string(bridge_manager_pid);
   std::string line;
-  line.reserve(topic_name.size() + type_name.size() + role.size() + node_name.size() + 4);
+  line.reserve(
+    topic_name.size() + type_name.size() + role.size() + node_name.size() + bm_pid_str.size() + 5);
   line.append(topic_name).push_back('\t');
   line.append(type_name).push_back('\t');
   line.append(role).push_back('\t');
-  line.append(node_name).push_back('\n');
+  line.append(node_name).push_back('\t');
+  line.append(bm_pid_str).push_back('\n');
 
   // `write` is atomic up to PIPE_BUF for regular files on Linux; lines are
   // well under that. We retry on EINTR but ignore short writes (a partial

--- a/src/agnocastlib/src/internal/type_registry_writer.cpp
+++ b/src/agnocastlib/src/internal/type_registry_writer.cpp
@@ -22,10 +22,29 @@ namespace agnocast::internal
 
 namespace
 {
-// Default tmpfs root. `/dev/shm/` is world-writable (1777) on Linux so any
-// user process can create entries without needing root. Overridable for
-// tests via `set_base_dir_for_test()`.
-std::string g_base_dir = "/dev/shm/agnocast_type_registry";  // NOLINT(runtime/string)
+// Tmpfs root for the type registry. Defaults to `/dev/shm/` because that
+// path is world-writable (1777) on Linux so any user process can create
+// entries without elevation; the daemon and CLI mirror the same default.
+//
+// Hardened container deployments where `/dev/shm` is absent, capped,
+// or remounted with restrictive perms can override the parent directory
+// via the `AGNOCAST_TMPFS_DIR` environment variable. The writer
+// appends `/agnocast_type_registry` to whatever the user supplies, so
+// `AGNOCAST_TMPFS_DIR=/run/myapp` yields
+// `/run/myapp/agnocast_type_registry/<ns_inode>/<pid>.txt`.
+//
+// **Size requirement**: each registered Publisher/Subscription appends
+// roughly 80–256 bytes. A typical Autoware deployment (~100 processes
+// × ~10 endpoints) fits in well under 1 MiB; the writer never deletes
+// entries during a process's lifetime so the tmpfs must accommodate
+// the peak. Allocate at least 4 MiB if you tune `/dev/shm` size.
+//
+// Overridable for tests via `set_base_dir_for_test()`.
+std::string g_base_dir = []() {
+  const char * env = std::getenv("AGNOCAST_TMPFS_DIR");
+  std::string root = (env != nullptr && env[0] != '\0') ? env : "/dev/shm";
+  return root + "/agnocast_type_registry";
+}();  // NOLINT(runtime/string)
 
 bool ensure_dir(const std::string & path, mode_t mode)
 {
@@ -75,22 +94,31 @@ void TypeRegistryWriter::ensure_open_locked()
     return;
   }
 
-  // Best-effort mkdir of base + ns directory. Both `0755` so the daemon
-  // can read; the per-process file is `0644` (set via open mode below).
+  // Both directories are `0755` so the daemon can read; the per-process
+  // file is `0644` (set via open mode below). The cross-namespace bridge
+  // and observability features rely on this tmpfs being writable, so any
+  // failure here is logged as an ERROR (not a transient warning).
   if (!ensure_dir(g_base_dir, 0755)) {
-    RCLCPP_WARN(
+    RCLCPP_ERROR(
       rclcpp::get_logger("Agnocast"),
-      "TypeRegistryWriter: mkdir '%s' failed: %s. Cross-namespace observability and bridge "
-      "auto-generation will not work in this process.",
+      "TypeRegistryWriter: mkdir '%s' failed: %s. Cross-IPC-namespace bridge "
+      "auto-generation and observability will silently NOT work in this "
+      "process. Check that the parent directory exists and is writable; "
+      "override the root with the AGNOCAST_TMPFS_DIR environment variable "
+      "if /dev/shm is unavailable (e.g. inside a hardened container).",
       g_base_dir.c_str(), std::strerror(errno));
     open_failed_warned_ = true;
     return;
   }
   const std::string ns_dir = g_base_dir + "/" + std::to_string(ns_inode);
   if (!ensure_dir(ns_dir, 0755)) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("Agnocast"), "TypeRegistryWriter: mkdir '%s' failed: %s.", ns_dir.c_str(),
-      std::strerror(errno));
+    RCLCPP_ERROR(
+      rclcpp::get_logger("Agnocast"),
+      "TypeRegistryWriter: mkdir '%s' failed: %s. Verify the tmpfs has free "
+      "space — typical deployments need at most a few MiB, but a tightly "
+      "capped /dev/shm (e.g. Docker's 64 MiB default) shared with other "
+      "tmpfs users can run out.",
+      ns_dir.c_str(), std::strerror(errno));
     open_failed_warned_ = true;
     return;
   }
@@ -99,9 +127,11 @@ void TypeRegistryWriter::ensure_open_locked()
   fd_ =
     ::open(path_.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);  // NOLINT(runtime/int)
   if (fd_ == -1) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("Agnocast"), "TypeRegistryWriter: open('%s') failed: %s.", path_.c_str(),
-      std::strerror(errno));
+    RCLCPP_ERROR(
+      rclcpp::get_logger("Agnocast"),
+      "TypeRegistryWriter: open('%s') failed: %s. Check the parent directory "
+      "permissions and the tmpfs free space.",
+      path_.c_str(), std::strerror(errno));
     open_failed_warned_ = true;
     return;
   }

--- a/src/agnocastlib/src/internal/type_registry_writer.cpp
+++ b/src/agnocastlib/src/internal/type_registry_writer.cpp
@@ -1,0 +1,184 @@
+// Copyright 2025
+// SPDX-License-Identifier: Apache-2.0
+
+#include "agnocast/internal/type_registry_writer.hpp"
+
+#include "agnocast/agnocast_utils.hpp"
+
+#include <rclcpp/logging.hpp>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace agnocast::internal
+{
+
+namespace
+{
+// Default tmpfs root. Overridable for tests via `set_base_dir_for_test()`.
+std::string g_base_dir = "/run/agnocast";  // NOLINT(runtime/string)
+
+bool ensure_dir(const std::string & path, mode_t mode)
+{
+  if (mkdir(path.c_str(), mode) == 0) {
+    return true;
+  }
+  if (errno == EEXIST) {
+    return true;
+  }
+  return false;
+}
+}  // namespace
+
+TypeRegistryWriter & TypeRegistryWriter::instance()
+{
+  static TypeRegistryWriter inst;
+  return inst;
+}
+
+void TypeRegistryWriter::set_base_dir_for_test(const std::string & dir)
+{
+  g_base_dir = dir;
+}
+
+std::string TypeRegistryWriter::current_path_for_test() const
+{
+  return path_;
+}
+
+void TypeRegistryWriter::ensure_open_locked()
+{
+  if (fd_ != -1) {
+    return;
+  }
+  if (open_failed_warned_) {
+    return;
+  }
+
+  uint64_t ns_inode = 0;
+  try {
+    ns_inode = get_self_ipc_ns_inode();
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("Agnocast"), "TypeRegistryWriter: failed to read IPC namespace inode: %s",
+      e.what());
+    open_failed_warned_ = true;
+    return;
+  }
+
+  // Best-effort mkdir of base + ns directory. Both `0755` so the daemon
+  // can read; the per-process file is `0644` (set via open mode below).
+  if (!ensure_dir(g_base_dir, 0755)) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("Agnocast"),
+      "TypeRegistryWriter: mkdir '%s' failed: %s. Cross-namespace observability and bridge "
+      "auto-generation will not work in this process.",
+      g_base_dir.c_str(), std::strerror(errno));
+    open_failed_warned_ = true;
+    return;
+  }
+  const std::string ns_dir = g_base_dir + "/" + std::to_string(ns_inode);
+  if (!ensure_dir(ns_dir, 0755)) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("Agnocast"), "TypeRegistryWriter: mkdir '%s' failed: %s.", ns_dir.c_str(),
+      std::strerror(errno));
+    open_failed_warned_ = true;
+    return;
+  }
+
+  path_ = ns_dir + "/" + std::to_string(getpid()) + ".txt";
+  fd_ =
+    ::open(path_.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);  // NOLINT(runtime/int)
+  if (fd_ == -1) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("Agnocast"), "TypeRegistryWriter: open('%s') failed: %s.", path_.c_str(),
+      std::strerror(errno));
+    open_failed_warned_ = true;
+    return;
+  }
+
+  // Register a one-shot atexit handler the first time we open the file
+  // successfully. SIGKILL bypasses this; the daemon's `/proc/<pid>` sweep
+  // handles those stale files.
+  static bool atexit_registered = false;
+  if (!atexit_registered) {
+    std::atexit(&TypeRegistryWriter::on_process_exit);
+    atexit_registered = true;
+  }
+}
+
+void TypeRegistryWriter::register_type(
+  const std::string & topic_name, const std::string & type_name, const std::string & role,
+  const std::string & node_name)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  ensure_open_locked();
+  if (fd_ == -1) {
+    return;
+  }
+
+  std::string line;
+  line.reserve(topic_name.size() + type_name.size() + role.size() + node_name.size() + 4);
+  line.append(topic_name).push_back('\t');
+  line.append(type_name).push_back('\t');
+  line.append(role).push_back('\t');
+  line.append(node_name).push_back('\n');
+
+  // `write` is atomic up to PIPE_BUF for regular files on Linux; lines are
+  // well under that. We retry on EINTR but ignore short writes (a partial
+  // line ends without `\n` and the daemon's parser skips unterminated
+  // tails).
+  const char * data = line.data();
+  size_t remaining = line.size();
+  while (remaining > 0) {
+    const ssize_t n = ::write(fd_, data, remaining);
+    if (n > 0) {
+      data += n;
+      remaining -= static_cast<size_t>(n);
+      continue;
+    }
+    if (n == -1 && errno == EINTR) {
+      continue;
+    }
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger("Agnocast"),
+      "TypeRegistryWriter: write to '%s' failed: %s. Further write failures will be silent.",
+      path_.c_str(), std::strerror(errno));
+    return;
+  }
+}
+
+void TypeRegistryWriter::reset_for_test()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (fd_ != -1) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+  path_.clear();
+  open_failed_warned_ = false;
+}
+
+void TypeRegistryWriter::on_process_exit()
+{
+  auto & inst = TypeRegistryWriter::instance();
+  std::lock_guard<std::mutex> lock(inst.mutex_);
+  if (inst.fd_ != -1) {
+    ::close(inst.fd_);
+    inst.fd_ = -1;
+  }
+  if (!inst.path_.empty()) {
+    // Best-effort. If unlink fails the daemon's `cleanup_dead_pids()` will
+    // notice the dead pid and remove the file.
+    (void)::unlink(inst.path_.c_str());
+  }
+}
+
+}  // namespace agnocast::internal

--- a/src/agnocastlib/src/internal/type_registry_writer.cpp
+++ b/src/agnocastlib/src/internal/type_registry_writer.cpp
@@ -22,8 +22,10 @@ namespace agnocast::internal
 
 namespace
 {
-// Default tmpfs root. Overridable for tests via `set_base_dir_for_test()`.
-std::string g_base_dir = "/run/agnocast";  // NOLINT(runtime/string)
+// Default tmpfs root. `/dev/shm/` is world-writable (1777) on Linux so any
+// user process can create entries without needing root. Overridable for
+// tests via `set_base_dir_for_test()`.
+std::string g_base_dir = "/dev/shm/agnocast_type_registry";  // NOLINT(runtime/string)
 
 bool ensure_dir(const std::string & path, mode_t mode)
 {

--- a/src/agnocastlib/src/internal/type_registry_writer.cpp
+++ b/src/agnocastlib/src/internal/type_registry_writer.cpp
@@ -52,7 +52,17 @@ bool ensure_dir(const std::string & path, mode_t mode)
     return true;
   }
   if (errno == EEXIST) {
-    return true;
+    // Verify the existing entry is actually a directory. A regular file at
+    // the same path would let mkdir succeed-via-EEXIST and then surface
+    // confusing failures further down (e.g. when opening the per-pid file
+    // inside it).
+    struct stat st
+    {
+    };
+    if (stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+      return true;
+    }
+    return false;
   }
   return false;
 }
@@ -166,10 +176,12 @@ void TypeRegistryWriter::register_type(
   line.append(node_name).push_back('\t');
   line.append(bm_pid_str).push_back('\n');
 
-  // `write` is atomic up to PIPE_BUF for regular files on Linux; lines are
-  // well under that. We retry on EINTR but ignore short writes (a partial
-  // line ends without `\n` and the daemon's parser skips unterminated
-  // tails).
+  // Concurrent-writer safety here comes from `mutex_` (single writer per
+  // process at a time) and `O_APPEND` on the underlying fd (each `write`
+  // is positioned at end-of-file by the kernel). PIPE_BUF atomicity does
+  // not apply to regular files. We retry on EINTR but tolerate short
+  // writes — a partial line ends without `\n` and the daemon's parser
+  // skips unterminated tails.
   const char * data = line.data();
   size_t remaining = line.size();
   while (remaining > 0) {

--- a/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
@@ -1,4 +1,4 @@
-// Unit tests for the process-local BridgeFactoryRegistry (F1).
+// Unit tests for the process-local BridgeFactoryRegistry.
 //
 // We do not instantiate real bridge factory functions here — those would
 // require a fully-initialized agnocast runtime (kmod, ioctl, etc.). Instead

--- a/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
@@ -1,0 +1,102 @@
+// Unit tests for the process-local BridgeFactoryRegistry (F1).
+//
+// We do not instantiate real bridge factory functions here — those would
+// require a fully-initialized agnocast runtime (kmod, ioctl, etc.). Instead
+// we exercise the registry's own contract: register / lookup / overwrite,
+// and the SFINAE gate on `register_bridge_factory<T>()` (no-op for service
+// types).
+
+#include "agnocast/internal/bridge_factory_registry.hpp"
+
+#include <rcl_interfaces/srv/get_parameters.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace
+{
+
+agnocast::internal::BridgeFactoryEntry make_dummy_entry()
+{
+  agnocast::internal::BridgeFactoryEntry entry;
+  entry.a2r = [](rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &) {
+    return std::shared_ptr<agnocast::PubsubBridgeBase>{};
+  };
+  entry.r2a = [](rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &) {
+    return std::shared_ptr<agnocast::PubsubBridgeBase>{};
+  };
+  return entry;
+}
+
+}  // namespace
+
+TEST(BridgeFactoryRegistry, RegisterAndLookupRoundTrip)
+{
+  auto & registry = agnocast::internal::BridgeFactoryRegistry::instance();
+  registry.register_entry("test/unit/RoundTrip", make_dummy_entry());
+
+  agnocast::internal::BridgeFactoryEntry got;
+  ASSERT_TRUE(registry.lookup("test/unit/RoundTrip", got));
+  EXPECT_TRUE(static_cast<bool>(got.a2r));
+  EXPECT_TRUE(static_cast<bool>(got.r2a));
+}
+
+TEST(BridgeFactoryRegistry, LookupReturnsFalseForUnregisteredType)
+{
+  auto & registry = agnocast::internal::BridgeFactoryRegistry::instance();
+  agnocast::internal::BridgeFactoryEntry got;
+  EXPECT_FALSE(registry.lookup("test/unit/NeverRegistered", got));
+}
+
+TEST(BridgeFactoryRegistry, RegisterReplacesExistingEntry)
+{
+  auto & registry = agnocast::internal::BridgeFactoryRegistry::instance();
+
+  auto first = make_dummy_entry();
+  first.a2r = [marker = std::make_shared<int>(1)](
+                rclcpp::Node::SharedPtr, const std::string &,
+                const rclcpp::QoS &) { return std::shared_ptr<agnocast::PubsubBridgeBase>{}; };
+  registry.register_entry("test/unit/Replaceable", first);
+
+  auto second = make_dummy_entry();
+  second.a2r = [marker = std::make_shared<int>(2)](
+                 rclcpp::Node::SharedPtr, const std::string &,
+                 const rclcpp::QoS &) { return std::shared_ptr<agnocast::PubsubBridgeBase>{}; };
+  registry.register_entry("test/unit/Replaceable", second);
+
+  agnocast::internal::BridgeFactoryEntry got;
+  ASSERT_TRUE(registry.lookup("test/unit/Replaceable", got));
+  // Confirm an entry is still resolvable after the second register call.
+  EXPECT_TRUE(static_cast<bool>(got.a2r));
+  EXPECT_TRUE(static_cast<bool>(got.r2a));
+}
+
+// `register_bridge_factory<T>()` must compile and be a no-op for service
+// types — `BasicService<ServiceT>` instantiates it internally and triggers
+// `static_assert` in `rclcpp::Publisher<ServiceType>` if the SFINAE gate
+// regresses.
+TEST(BridgeFactoryRegistry, RegisterIsNoOpForServiceType)
+{
+  using ServiceT = rcl_interfaces::srv::GetParameters;
+  agnocast::internal::register_bridge_factory<ServiceT>();
+  // The type name is the service name, not a message name; nothing should
+  // have been added under it.
+  agnocast::internal::BridgeFactoryEntry got;
+  auto & registry = agnocast::internal::BridgeFactoryRegistry::instance();
+  EXPECT_FALSE(registry.lookup(rosidl_generator_traits::name<ServiceT>(), got));
+}
+
+TEST(BridgeFactoryRegistry, RegisterIsObservableForMessageType)
+{
+  using MessageT = std_msgs::msg::Int32;
+  agnocast::internal::register_bridge_factory<MessageT>();
+  agnocast::internal::BridgeFactoryEntry got;
+  auto & registry = agnocast::internal::BridgeFactoryRegistry::instance();
+  // After registration, lookup by the message's rosidl name must succeed.
+  ASSERT_TRUE(registry.lookup(rosidl_generator_traits::name<MessageT>(), got));
+  EXPECT_TRUE(static_cast<bool>(got.a2r));
+  EXPECT_TRUE(static_cast<bool>(got.r2a));
+}

--- a/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
@@ -9,6 +9,7 @@
 #include "agnocast/internal/bridge_factory_registry.hpp"
 
 #include <rcl_interfaces/srv/get_parameters.hpp>
+
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 
@@ -57,14 +58,16 @@ TEST(BridgeFactoryRegistry, RegisterReplacesExistingEntry)
 
   auto first = make_dummy_entry();
   first.a2r = [marker = std::make_shared<int>(1)](
-                rclcpp::Node::SharedPtr, const std::string &,
-                const rclcpp::QoS &) { return std::shared_ptr<agnocast::PubsubBridgeBase>{}; };
+                rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &) {
+    return std::shared_ptr<agnocast::PubsubBridgeBase>{};
+  };
   registry.register_entry("test/unit/Replaceable", first);
 
   auto second = make_dummy_entry();
   second.a2r = [marker = std::make_shared<int>(2)](
-                 rclcpp::Node::SharedPtr, const std::string &,
-                 const rclcpp::QoS &) { return std::shared_ptr<agnocast::PubsubBridgeBase>{}; };
+                 rclcpp::Node::SharedPtr, const std::string &, const rclcpp::QoS &) {
+    return std::shared_ptr<agnocast::PubsubBridgeBase>{};
+  };
   registry.register_entry("test/unit/Replaceable", second);
 
   agnocast::internal::BridgeFactoryEntry got;

--- a/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_factory_registry.cpp
@@ -6,6 +6,15 @@
 // and the SFINAE gate on `register_bridge_factory<T>()` (no-op for service
 // types).
 
+// `agnocast/agnocast.hpp` is included (in addition to
+// `agnocast/internal/bridge_factory_registry.hpp`) because
+// `register_bridge_factory<T>()` builds lambdas that call
+// `start_{a2r,r2a}_pubsub_node<MessageT>()`. Those templates are only
+// *defined* in `agnocast/bridge/agnocast_bridge_node.hpp` (which the
+// umbrella header pulls in); on toolchains that diagnose implicit
+// instantiation of an undefined template, omitting it can fail to
+// compile.
+#include "agnocast/agnocast.hpp"
 #include "agnocast/internal/bridge_factory_registry.hpp"
 
 #include <rcl_interfaces/srv/get_parameters.hpp>

--- a/src/agnocastlib/test/unit/test_type_registry_writer.cpp
+++ b/src/agnocastlib/test/unit/test_type_registry_writer.cpp
@@ -4,7 +4,7 @@
 // Unit tests for the process-local `TypeRegistryWriter`. We verify that:
 //
 //  * the first `register_type()` call creates `<base>/<ns_inode>/<pid>.txt`
-//    with the expected `<topic>\t<type>\t<role>\t<node>\n` content,
+//    with the expected `<topic>\t<type>\t<role>\t<node>\t<bm_pid>\n` content,
 //  * subsequent calls append (the file grows, not truncates),
 //  * concurrent registrations do not interleave within a single line.
 //
@@ -70,7 +70,8 @@ protected:
 TEST_F(TypeRegistryWriterTest, RegisterTypeWritesExpectedLine)
 {
   auto & writer = agnocast::internal::TypeRegistryWriter::instance();
-  writer.register_type("/chatter", "std_msgs/msg/Int32", "pub", "/talker_node");
+  writer.register_type(
+    "/chatter", "std_msgs/msg/Int32", "pub", "/talker_node", /*bridge_manager_pid=*/4242);
 
   const std::string path = writer.current_path_for_test();
   ASSERT_FALSE(path.empty());
@@ -82,19 +83,22 @@ TEST_F(TypeRegistryWriterTest, RegisterTypeWritesExpectedLine)
   EXPECT_EQ(path.substr(0, base_dir_.size()), base_dir_);
 
   const std::string body = read_file(path);
-  EXPECT_NE(body.find("/chatter\tstd_msgs/msg/Int32\tpub\t/talker_node\n"), std::string::npos);
+  EXPECT_NE(
+    body.find("/chatter\tstd_msgs/msg/Int32\tpub\t/talker_node\t4242\n"), std::string::npos);
 }
 
 TEST_F(TypeRegistryWriterTest, RegisterTypeAppendsAdditionalLines)
 {
   auto & writer = agnocast::internal::TypeRegistryWriter::instance();
-  writer.register_type("/topic_a", "std_msgs/msg/Int32", "pub", "/node_a");
-  writer.register_type("/topic_b", "std_msgs/msg/String", "sub", "/node_b");
+  writer.register_type(
+    "/topic_a", "std_msgs/msg/Int32", "pub", "/node_a", /*bridge_manager_pid=*/4242);
+  writer.register_type(
+    "/topic_b", "std_msgs/msg/String", "sub", "/node_b", /*bridge_manager_pid=*/4242);
 
   const std::string body = read_file(writer.current_path_for_test());
   // Both lines should be present (order matches call order).
-  const auto pos_a = body.find("/topic_a\tstd_msgs/msg/Int32\tpub\t/node_a\n");
-  const auto pos_b = body.find("/topic_b\tstd_msgs/msg/String\tsub\t/node_b\n");
+  const auto pos_a = body.find("/topic_a\tstd_msgs/msg/Int32\tpub\t/node_a\t4242\n");
+  const auto pos_b = body.find("/topic_b\tstd_msgs/msg/String\tsub\t/node_b\t4242\n");
   ASSERT_NE(pos_a, std::string::npos);
   ASSERT_NE(pos_b, std::string::npos);
   EXPECT_LT(pos_a, pos_b);
@@ -112,7 +116,7 @@ TEST_F(TypeRegistryWriterTest, ConcurrentRegisterTypeDoesNotInterleaveLines)
       for (int i = 0; i < kPerThread; ++i) {
         writer.register_type(
           "/topic_" + std::to_string(t), "std_msgs/msg/Int32", "pub",
-          "/node_" + std::to_string(t) + "_" + std::to_string(i));
+          "/node_" + std::to_string(t) + "_" + std::to_string(i), /*bridge_manager_pid=*/4242);
       }
     });
   }
@@ -120,7 +124,8 @@ TEST_F(TypeRegistryWriterTest, ConcurrentRegisterTypeDoesNotInterleaveLines)
     th.join();
   }
 
-  // Every line should have exactly 3 tabs (4 fields) and end in `\n`.
+  // Every line should have exactly 4 tabs (5 fields: topic, type, role,
+  // node, bridge_manager_pid) and end in `\n`.
   const std::string body = read_file(writer.current_path_for_test());
   std::stringstream ss(body);
   std::string line;
@@ -130,7 +135,7 @@ TEST_F(TypeRegistryWriterTest, ConcurrentRegisterTypeDoesNotInterleaveLines)
     for (char c : line) {
       if (c == '\t') ++tabs;
     }
-    EXPECT_EQ(tabs, 3) << "garbled line: " << line;
+    EXPECT_EQ(tabs, 4) << "garbled line: " << line;
     ++count;
   }
   // Every register_type call must produce exactly one line.

--- a/src/agnocastlib/test/unit/test_type_registry_writer.cpp
+++ b/src/agnocastlib/test/unit/test_type_registry_writer.cpp
@@ -21,9 +21,11 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -58,8 +60,8 @@ protected:
   void TearDown() override
   {
     agnocast::internal::TypeRegistryWriter::instance().reset_for_test();
-    const std::string cmd = "rm -rf " + base_dir_;
-    (void)std::system(cmd.c_str());
+    std::error_code ec;
+    std::filesystem::remove_all(base_dir_, ec);  // best-effort cleanup
   }
 
   std::string base_dir_;

--- a/src/agnocastlib/test/unit/test_type_registry_writer.cpp
+++ b/src/agnocastlib/test/unit/test_type_registry_writer.cpp
@@ -1,0 +1,138 @@
+// Copyright 2025
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the process-local `TypeRegistryWriter`. We verify that:
+//
+//  * the first `register_type()` call creates `<base>/<ns_inode>/<pid>.txt`
+//    with the expected `<topic>\t<type>\t<role>\t<node>\n` content,
+//  * subsequent calls append (the file grows, not truncates),
+//  * concurrent registrations do not interleave within a single line.
+//
+// We do not exercise the `atexit` cleanup path here — the gtest process
+// would have to actually exit to fire it, which is awkward in a single
+// binary. The cleanup is best-effort and the daemon's `/proc/<pid>`
+// sweep is the load-bearing path.
+
+#include "agnocast/agnocast_utils.hpp"
+#include "agnocast/internal/type_registry_writer.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+std::string read_file(const std::string & path)
+{
+  std::ifstream in(path);
+  std::stringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+// The writer is a process-local singleton. Each test gets a fresh
+// `mkdtemp` base dir; `reset_for_test()` then closes the cached fd so
+// the next `register_type()` re-opens against the new base.
+
+class TypeRegistryWriterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    char tmpl[] = "/tmp/agnocast_trw_test_XXXXXX";
+    const char * created = mkdtemp(tmpl);
+    ASSERT_NE(created, nullptr);
+    base_dir_ = created;
+    agnocast::internal::TypeRegistryWriter::set_base_dir_for_test(base_dir_);
+    agnocast::internal::TypeRegistryWriter::instance().reset_for_test();
+  }
+
+  void TearDown() override
+  {
+    agnocast::internal::TypeRegistryWriter::instance().reset_for_test();
+    const std::string cmd = "rm -rf " + base_dir_;
+    (void)std::system(cmd.c_str());
+  }
+
+  std::string base_dir_;
+};
+
+TEST_F(TypeRegistryWriterTest, RegisterTypeWritesExpectedLine)
+{
+  auto & writer = agnocast::internal::TypeRegistryWriter::instance();
+  writer.register_type("/chatter", "std_msgs/msg/Int32", "pub", "/talker_node");
+
+  const std::string path = writer.current_path_for_test();
+  ASSERT_FALSE(path.empty());
+
+  // path must be `<base>/<ns_inode>/<pid>.txt`
+  const std::string expected_suffix = "/" + std::to_string(getpid()) + ".txt";
+  ASSERT_GE(path.size(), expected_suffix.size());
+  EXPECT_EQ(path.substr(path.size() - expected_suffix.size()), expected_suffix);
+  EXPECT_EQ(path.substr(0, base_dir_.size()), base_dir_);
+
+  const std::string body = read_file(path);
+  EXPECT_NE(body.find("/chatter\tstd_msgs/msg/Int32\tpub\t/talker_node\n"), std::string::npos);
+}
+
+TEST_F(TypeRegistryWriterTest, RegisterTypeAppendsAdditionalLines)
+{
+  auto & writer = agnocast::internal::TypeRegistryWriter::instance();
+  writer.register_type("/topic_a", "std_msgs/msg/Int32", "pub", "/node_a");
+  writer.register_type("/topic_b", "std_msgs/msg/String", "sub", "/node_b");
+
+  const std::string body = read_file(writer.current_path_for_test());
+  // Both lines should be present (order matches call order).
+  const auto pos_a = body.find("/topic_a\tstd_msgs/msg/Int32\tpub\t/node_a\n");
+  const auto pos_b = body.find("/topic_b\tstd_msgs/msg/String\tsub\t/node_b\n");
+  ASSERT_NE(pos_a, std::string::npos);
+  ASSERT_NE(pos_b, std::string::npos);
+  EXPECT_LT(pos_a, pos_b);
+}
+
+TEST_F(TypeRegistryWriterTest, ConcurrentRegisterTypeDoesNotInterleaveLines)
+{
+  auto & writer = agnocast::internal::TypeRegistryWriter::instance();
+  constexpr int kThreads = 8;
+  constexpr int kPerThread = 32;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([t, &writer]() {
+      for (int i = 0; i < kPerThread; ++i) {
+        writer.register_type(
+          "/topic_" + std::to_string(t), "std_msgs/msg/Int32", "pub",
+          "/node_" + std::to_string(t) + "_" + std::to_string(i));
+      }
+    });
+  }
+  for (auto & th : threads) {
+    th.join();
+  }
+
+  // Every line should have exactly 3 tabs (4 fields) and end in `\n`.
+  const std::string body = read_file(writer.current_path_for_test());
+  std::stringstream ss(body);
+  std::string line;
+  int count = 0;
+  while (std::getline(ss, line)) {
+    int tabs = 0;
+    for (char c : line) {
+      if (c == '\t') ++tabs;
+    }
+    EXPECT_EQ(tabs, 3) << "garbled line: " << line;
+    ++count;
+  }
+  // Every register_type call must produce exactly one line.
+  EXPECT_EQ(count, kThreads * kPerThread);
+}
+
+}  // namespace

--- a/src/ros2agnocast/package.xml
+++ b/src/ros2agnocast/package.xml
@@ -22,6 +22,8 @@
 
   <exec_depend>agnocast_ioctl_wrapper</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2agnocast_discovery_msgs</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/ros2agnocast/package.xml
+++ b/src/ros2agnocast/package.xml
@@ -25,6 +25,11 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2agnocast_discovery_msgs</exec_depend>
 
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -22,10 +22,19 @@ LIVELINESS_LEASE_SEC = 30.0
 
 
 def gossip_qos() -> QoSProfile:
-    """QoS profile matching the discovery agent's publisher.
+    """QoS profile for subscribing to the gossip topic.
 
-    Subscribers must match these settings to receive the late-joiner snapshot
-    via TransientLocal.
+    Reliability, durability, liveliness, and lease duration must match the
+    discovery agent's publisher (see
+    ``ros2agnocast_discovery_agent/agent.py::_gossip_qos``) so that DDS
+    accepts the match and the TransientLocal late-joiner snapshot is
+    delivered. ``depth`` is intentionally larger here: the publisher only
+    keeps the latest snapshot per (host, NS) (depth=1 is enough — one
+    daemon writes exactly one msg per NS, so no overwriting collisions),
+    while CLI subscribers may receive snapshots from many daemons at once
+    and want enough history buffer to absorb a burst at startup. Mismatched
+    ``depth`` does not affect QoS compatibility (it's a per-endpoint
+    setting).
     """
     return QoSProfile(
         reliability=ReliabilityPolicy.RELIABLE,
@@ -92,9 +101,20 @@ def is_stale(msg: AgnocastDaemonState, now_sec: float,
 
 
 def filter_fresh(snapshots: list,
-                 stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> list:
-    """Drop snapshots older than ``stale_after_sec`` seconds (best-effort)."""
-    now_sec = time.time()
+                 stale_after_sec: float = DEFAULT_STALE_AFTER_SEC,
+                 node=None) -> list:
+    """Drop snapshots older than ``stale_after_sec`` seconds (best-effort).
+
+    Pass ``node`` so the staleness check uses the same ROS clock the
+    discovery agent stamps ``msg.timestamp`` with. Otherwise we fall back
+    to wall-clock ``time.time()`` — fine for default `use_sim_time=false`
+    but it will produce false stale/fresh classifications when sim time is
+    in use (a wall second is not a sim second).
+    """
+    if node is not None:
+        now_sec = node.get_clock().now().nanoseconds * 1e-9
+    else:
+        now_sec = time.time()
     return [m for m in snapshots if not is_stale(m, now_sec, stale_after_sec)]
 
 

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -1,0 +1,133 @@
+"""Shared helper for subscribing to /_agnocast_discovery and aggregating gossip.
+
+CLI verbs use this to collect AgnocastDaemonState snapshots from every
+per-IPC-NS daemon reachable on the same ROS_DOMAIN_ID and to fold the
+combined view into the existing local-ioctl / DDS merge.
+"""
+
+import time
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, LivelinessPolicy, QoSProfile, ReliabilityPolicy
+
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+
+
+GOSSIP_TOPIC = '/_agnocast_discovery'
+DEFAULT_COLLECT_TIMEOUT_SEC = 2.0
+DEFAULT_STALE_AFTER_SEC = 10.0
+LIVELINESS_LEASE_SEC = 30.0
+
+
+def gossip_qos() -> QoSProfile:
+    """QoS profile matching the discovery agent's publisher.
+
+    Subscribers must match these settings to receive the late-joiner snapshot
+    via TransientLocal.
+    """
+    return QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=64,
+        liveliness=LivelinessPolicy.AUTOMATIC,
+        liveliness_lease_duration=Duration(seconds=LIVELINESS_LEASE_SEC),
+    )
+
+
+def collect_announcements(
+    node,
+    timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
+) -> list:
+    """Subscribe to the gossip topic and collect snapshots for `timeout_sec`.
+
+    Returns a list of AgnocastDaemonState messages, one (latest) per (host_uuid,
+    ipc_ns_inode) pair seen during the window.
+    """
+    snapshots = {}
+
+    def on_msg(msg: AgnocastDaemonState) -> None:
+        snapshots[(msg.host_uuid, msg.ipc_ns_inode)] = msg
+
+    sub = node.create_subscription(
+        AgnocastDaemonState, GOSSIP_TOPIC, on_msg, gossip_qos())
+    try:
+        deadline = time.monotonic() + timeout_sec
+        while time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.05)
+    finally:
+        node.destroy_subscription(sub)
+
+    return list(snapshots.values())
+
+
+def is_stale(msg: AgnocastDaemonState, now_sec: float,
+             stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> bool:
+    """Return True if the snapshot is older than `stale_after_sec` seconds."""
+    msg_sec = msg.timestamp.sec + msg.timestamp.nanosec * 1e-9
+    return (now_sec - msg_sec) > stale_after_sec
+
+
+def filter_fresh(snapshots: list,
+                 stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> list:
+    """Drop snapshots older than `stale_after_sec` seconds (best-effort)."""
+    now_sec = time.time()
+    return [m for m in snapshots if not is_stale(m, now_sec, stale_after_sec)]
+
+
+def all_topic_names(snapshots: list) -> set:
+    """Union of topic names across all snapshots."""
+    return {topic.topic_name for snap in snapshots for topic in snap.topics}
+
+
+def all_nodes(snapshots: list) -> set:
+    """Union of (node_name) seen as a publisher or subscriber across all snapshots.
+
+    Node identity is just name here because the CLI's existing presentation is
+    name-based; pid is best-effort empty in the gossip schema.
+    """
+    nodes = set()
+    for snap in snapshots:
+        for topic in snap.topics:
+            for endpoint in topic.publishers:
+                nodes.add(endpoint.node_name)
+            for endpoint in topic.subscribers:
+                nodes.add(endpoint.node_name)
+    return nodes
+
+
+def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
+    """Return (publishers, subscribers) across all snapshots for `topic_name`.
+
+    Each element is an AgnocastEndpoint message. The same (node_name) appearing
+    in multiple snapshots is preserved (the caller is responsible for dedup).
+    """
+    publishers = []
+    subscribers = []
+    for snap in snapshots:
+        for topic in snap.topics:
+            if topic.topic_name != topic_name:
+                continue
+            publishers.extend(topic.publishers)
+            subscribers.extend(topic.subscribers)
+    return publishers, subscribers
+
+
+def topics_of_node(snapshots: list, node_name: str) -> tuple:
+    """Return (publish_topics, subscribe_topics) for `node_name`.
+
+    Each list contains AgnocastTopic-like dicts with topic_name and type_name.
+    """
+    pubs, subs = [], []
+    for snap in snapshots:
+        for topic in snap.topics:
+            for endpoint in topic.publishers:
+                if endpoint.node_name == node_name:
+                    pubs.append({'topic_name': topic.topic_name,
+                                 'type_name': topic.type_name})
+            for endpoint in topic.subscribers:
+                if endpoint.node_name == node_name:
+                    subs.append({'topic_name': topic.topic_name,
+                                 'type_name': topic.type_name})
+    return pubs, subs

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -41,7 +41,7 @@ def collect_announcements(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
 ) -> list:
-    """Subscribe to the gossip topic and collect snapshots for `timeout_sec`.
+    """Subscribe to the gossip topic and collect snapshots for ``timeout_sec``.
 
     Returns a list of AgnocastDaemonState messages, one (latest) per (host_uuid,
     ipc_ns_inode) pair seen during the window.
@@ -86,14 +86,14 @@ def warn_if_no_announcements(snapshots: list, timeout_sec: float) -> None:
 
 def is_stale(msg: AgnocastDaemonState, now_sec: float,
              stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> bool:
-    """Return True if the snapshot is older than `stale_after_sec` seconds."""
+    """Return True if the snapshot is older than ``stale_after_sec`` seconds."""
     msg_sec = msg.timestamp.sec + msg.timestamp.nanosec * 1e-9
     return (now_sec - msg_sec) > stale_after_sec
 
 
 def filter_fresh(snapshots: list,
                  stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> list:
-    """Drop snapshots older than `stale_after_sec` seconds (best-effort)."""
+    """Drop snapshots older than ``stale_after_sec`` seconds (best-effort)."""
     now_sec = time.time()
     return [m for m in snapshots if not is_stale(m, now_sec, stale_after_sec)]
 
@@ -120,7 +120,7 @@ def all_nodes(snapshots: list) -> set:
 
 
 def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
-    """Return (publishers, subscribers) across all snapshots for `topic_name`.
+    """Return (publishers, subscribers) across all snapshots for ``topic_name``.
 
     Each element is an AgnocastEndpoint message. The same (node_name) appearing
     in multiple snapshots is preserved (the caller is responsible for dedup).
@@ -137,7 +137,7 @@ def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
 
 
 def topics_of_node(snapshots: list, node_name: str) -> tuple:
-    """Return (publish_topics, subscribe_topics) for `node_name`.
+    """Return (publish_topics, subscribe_topics) for ``node_name``.
 
     Each list contains AgnocastTopic-like dicts with topic_name and type_name.
     """

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -5,6 +5,7 @@ per-IPC-NS daemon reachable on the same ROS_DOMAIN_ID and to fold the
 combined view into the existing local-ioctl / DDS merge.
 """
 
+import sys
 import time
 
 import rclpy
@@ -60,6 +61,27 @@ def collect_announcements(
         node.destroy_subscription(sub)
 
     return list(snapshots.values())
+
+
+def warn_if_no_announcements(snapshots: list, timeout_sec: float) -> None:
+    """Print a stderr hint when zero gossip snapshots were collected.
+
+    A non-zero timeout that yielded no AgnocastDaemonState messages usually
+    means the per-IPC-namespace discovery agent is not running in this IPC
+    namespace, so the CLI sees only its own local ioctl view. This warning
+    is best-effort and does not change exit codes.
+    """
+    if timeout_sec <= 0:
+        return
+    if snapshots:
+        return
+    print(
+        'WARNING: no /_agnocast_discovery announcements received within '
+        f'{timeout_sec:.1f}s — cross-namespace / cross-ECU Agnocast endpoints '
+        "will not appear. Start the discovery agent in this IPC namespace via "
+        '`ros2 run ros2agnocast_discovery_agent discovery_agent`, or pass '
+        '`--gossip-timeout 0` to skip this check.',
+        file=sys.stderr)
 
 
 def is_stale(msg: AgnocastDaemonState, now_sec: float,

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -1,12 +1,15 @@
 """Shared helper for subscribing to /_agnocast_discovery and aggregating gossip.
 
-CLI verbs use this to collect AgnocastDaemonState snapshots from every
-per-IPC-NS daemon reachable on the same ROS_DOMAIN_ID and to fold the
-combined view into the existing local-ioctl / DDS merge.
+The local NS is excluded from gossip so the CLI does not double-count
+what it already reads via ioctl. Staleness is bounded by the publisher's
+DDS Liveliness lease; no separate freshness filter.
 """
 
+import argparse
+import os
 import sys
 import time
+import uuid
 
 import rclpy
 from rclpy.duration import Duration
@@ -17,24 +20,40 @@ from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
 DEFAULT_COLLECT_TIMEOUT_SEC = 2.0
-DEFAULT_STALE_AFTER_SEC = 10.0
 LIVELINESS_LEASE_SEC = 30.0
+BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id'
+SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
+
+
+def add_gossip_timeout_arg(parser) -> None:
+    """Add the hidden, transitional ``--gossip-timeout`` flag to a verb's parser.
+
+    Suppressed from ``--help`` because the plan is to replace the fixed
+    wait with a ros2-daemon-driven stop condition. Use
+    :func:`warn_if_gossip_timeout_overridden` in ``main()`` to nudge any
+    operator who passes it explicitly.
+    """
+    parser.add_argument(
+        '--gossip-timeout',
+        type=float,
+        default=DEFAULT_COLLECT_TIMEOUT_SEC,
+        help=argparse.SUPPRESS)
+
+
+def warn_if_gossip_timeout_overridden(args) -> None:
+    """Print a stderr WARN when ``--gossip-timeout`` is set to a non-default."""
+    if args.gossip_timeout != DEFAULT_COLLECT_TIMEOUT_SEC:
+        print(
+            'WARNING: --gossip-timeout is unsupported and will be '
+            'removed once ros2-daemon-driven discovery lands.',
+            file=sys.stderr)
 
 
 def gossip_qos() -> QoSProfile:
-    """QoS profile for subscribing to the gossip topic.
+    """QoS profile for the gossip subscription.
 
-    Reliability, durability, liveliness, and lease duration must match the
-    discovery agent's publisher (see
-    ``ros2agnocast_discovery_agent/agent.py::_gossip_qos``) so that DDS
-    accepts the match and the TransientLocal late-joiner snapshot is
-    delivered. ``depth`` is intentionally larger here: the publisher only
-    keeps the latest snapshot per (host, NS) (depth=1 is enough — one
-    daemon writes exactly one msg per NS, so no overwriting collisions),
-    while CLI subscribers may receive snapshots from many daemons at once
-    and want enough history buffer to absorb a burst at startup. Mismatched
-    ``depth`` does not affect QoS compatibility (it's a per-endpoint
-    setting).
+    Must match ``ros2agnocast_discovery_agent.agent._gossip_qos`` on every
+    field except depth (per-endpoint) so DDS accepts the match.
     """
     return QoSProfile(
         reliability=ReliabilityPolicy.RELIABLE,
@@ -46,76 +65,93 @@ def gossip_qos() -> QoSProfile:
     )
 
 
+def _local_host_uuid() -> str:
+    """Return the host's boot UUID (matches what the discovery agent stamps)."""
+    try:
+        with open(BOOT_ID_PATH) as fp:
+            return str(uuid.UUID(fp.read().strip()))
+    except (OSError, ValueError):
+        return ''
+
+
+def _local_ipc_ns_inode() -> int:
+    """Return the IPC namespace inode of the calling process."""
+    return os.stat(SELF_IPC_NS_PATH).st_ino
+
+
 def collect_announcements(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
 ) -> list:
-    """Subscribe to the gossip topic and collect snapshots for ``timeout_sec``.
-
-    Returns a list of AgnocastDaemonState messages, one (latest) per (host_uuid,
-    ipc_ns_inode) pair seen during the window.
-    """
+    """Collect one latest snapshot per remote ``(host_uuid, ipc_ns_inode)``."""
     snapshots = {}
+    local_host_uuid = _local_host_uuid()
+    local_ipc_ns_inode = _local_ipc_ns_inode()
 
     def on_msg(msg: AgnocastDaemonState) -> None:
+        if msg.host_uuid == local_host_uuid and msg.ipc_ns_inode == local_ipc_ns_inode:
+            return
         snapshots[(msg.host_uuid, msg.ipc_ns_inode)] = msg
 
-    sub = node.create_subscription(
+    spin_node = _resolve_spin_node(node)
+    sub = spin_node.create_subscription(
         AgnocastDaemonState, GOSSIP_TOPIC, on_msg, gossip_qos())
     try:
         deadline = time.monotonic() + timeout_sec
         while time.monotonic() < deadline:
-            rclpy.spin_once(node, timeout_sec=0.05)
+            rclpy.spin_once(spin_node, timeout_sec=0.05)
     finally:
-        node.destroy_subscription(sub)
+        spin_node.destroy_subscription(sub)
 
     return list(snapshots.values())
 
 
-def warn_if_no_announcements(snapshots: list, timeout_sec: float) -> None:
-    """Print a stderr hint when zero gossip snapshots were collected.
+def _resolve_spin_node(node):
+    """Return the underlying ``rclpy.Node`` if ``node`` is a ``NodeStrategy``.
 
-    A non-zero timeout that yielded no AgnocastDaemonState messages usually
-    means the per-IPC-namespace discovery agent is not running in this IPC
-    namespace, so the CLI sees only its own local ioctl view. This warning
-    is best-effort and does not change exit codes.
+    ``NodeStrategy`` is a ros2cli dispatcher, not an ``rclpy.Node``; passing
+    it to executor APIs like ``rclpy.spin_once`` is outside its intended use.
     """
+    direct = getattr(node, 'direct_node', None)
+    if direct is None:
+        return node
+    return getattr(direct, 'node', direct)
+
+
+def warn_if_no_announcements(node, snapshots: list, timeout_sec: float) -> None:
+    """Best-effort stderr hint when no gossip arrived; does not change exit code."""
     if timeout_sec <= 0:
         return
     if snapshots:
         return
-    print(
-        'WARNING: no /_agnocast_discovery announcements received within '
-        f'{timeout_sec:.1f}s — cross-namespace / cross-ECU Agnocast endpoints '
-        "will not appear. Start the discovery agent in this IPC namespace via "
-        '`ros2 run ros2agnocast_discovery_agent discovery_agent`, or pass '
-        '`--gossip-timeout 0` to skip this check.',
-        file=sys.stderr)
 
+    spin_node = _resolve_spin_node(node)
+    try:
+        publishers = spin_node.get_publishers_info_by_topic(GOSSIP_TOPIC)
+    except Exception:
+        publishers = []
 
-def is_stale(msg: AgnocastDaemonState, now_sec: float,
-             stale_after_sec: float = DEFAULT_STALE_AFTER_SEC) -> bool:
-    """Return True if the snapshot is older than ``stale_after_sec`` seconds."""
-    msg_sec = msg.timestamp.sec + msg.timestamp.nanosec * 1e-9
-    return (now_sec - msg_sec) > stale_after_sec
+    domain_id = os.environ.get('ROS_DOMAIN_ID', '0')
 
-
-def filter_fresh(snapshots: list,
-                 stale_after_sec: float = DEFAULT_STALE_AFTER_SEC,
-                 node=None) -> list:
-    """Drop snapshots older than ``stale_after_sec`` seconds (best-effort).
-
-    Pass ``node`` so the staleness check uses the same ROS clock the
-    discovery agent stamps ``msg.timestamp`` with. Otherwise we fall back
-    to wall-clock ``time.time()`` — fine for default `use_sim_time=false`
-    but it will produce false stale/fresh classifications when sim time is
-    in use (a wall second is not a sim second).
-    """
-    if node is not None:
-        now_sec = node.get_clock().now().nanoseconds * 1e-9
+    if not publishers:
+        print(
+            f'WARNING: no /_agnocast_discovery publisher visible in '
+            f'ROS_DOMAIN_ID={domain_id} within {timeout_sec:.1f}s. Common '
+            'causes: (1) no discovery agent running on this domain (start one '
+            'with `ros2 run ros2agnocast_discovery_agent discovery_agent`); '
+            '(2) RMW mismatch between agent and CLI. Pass '
+            '`--gossip-timeout 0` to skip this check.',
+            file=sys.stderr)
     else:
-        now_sec = time.time()
-    return [m for m in snapshots if not is_stale(m, now_sec, stale_after_sec)]
+        print(
+            f'WARNING: /_agnocast_discovery has {len(publishers)} publisher(s) '
+            f'visible but no snapshot was received in {timeout_sec:.1f}s. Common '
+            'causes: (1) the ros2 daemon was started before `install/setup.bash` '
+            'was sourced and is missing the discovery msg package on its '
+            'PYTHONPATH (try `ros2 daemon stop && ros2 daemon start`); '
+            '(2) QoS / type mismatch on the publisher side. Pass '
+            '`--gossip-timeout 0` to skip this check.',
+            file=sys.stderr)
 
 
 def all_topic_names(snapshots: list) -> set:
@@ -124,11 +160,7 @@ def all_topic_names(snapshots: list) -> set:
 
 
 def all_nodes(snapshots: list) -> set:
-    """Union of (node_name) seen as a publisher or subscriber across all snapshots.
-
-    Node identity is just name here because the CLI's existing presentation is
-    name-based; pid is best-effort empty in the gossip schema.
-    """
+    """Union of node names across all snapshots."""
     nodes = set()
     for snap in snapshots:
         for topic in snap.topics:
@@ -140,11 +172,7 @@ def all_nodes(snapshots: list) -> set:
 
 
 def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
-    """Return (publishers, subscribers) across all snapshots for ``topic_name``.
-
-    Each element is an AgnocastEndpoint message. The same (node_name) appearing
-    in multiple snapshots is preserved (the caller is responsible for dedup).
-    """
+    """Return (publishers, subscribers) for ``topic_name``; caller dedups."""
     publishers = []
     subscribers = []
     for snap in snapshots:
@@ -157,10 +185,7 @@ def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
 
 
 def topics_of_node(snapshots: list, node_name: str) -> tuple:
-    """Return (publish_topics, subscribe_topics) for ``node_name``.
-
-    Each list contains AgnocastTopic-like dicts with topic_name and type_name.
-    """
+    """Return (pub topics, sub topics) for ``node_name`` as {topic_name, type_name} dicts."""
     pubs, subs = [], []
     for snap in snapshots:
         for topic in snap.topics:
@@ -173,3 +198,20 @@ def topics_of_node(snapshots: list, node_name: str) -> tuple:
                     subs.append({'topic_name': topic.topic_name,
                                  'type_name': topic.type_name})
     return pubs, subs
+
+
+def gossip_has_bridge_endpoint(snapshots: list, topic_name: str) -> tuple:
+    """Return (has_pub_bridge, has_sub_bridge) seen on remote NSes via gossip."""
+    has_pub_bridge = False
+    has_sub_bridge = False
+    for snap in snapshots:
+        for topic in snap.topics:
+            if topic.topic_name != topic_name:
+                continue
+            for endpoint in topic.publishers:
+                if endpoint.is_bridge:
+                    has_pub_bridge = True
+            for endpoint in topic.subscribers:
+                if endpoint.is_bridge:
+                    has_sub_bridge = True
+    return has_pub_bridge, has_sub_bridge

--- a/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
@@ -134,7 +134,7 @@ class ListAgnocastVerb(VerbExtension):
             raw_snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
             warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots)
+            snapshots = filter_fresh(raw_snapshots, node=node)
             for name in all_topic_names(snapshots):
                 if not name.startswith('/AGNOCAST_SRV_'):
                     agnocast_topics.append(name)

--- a/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
@@ -10,6 +10,7 @@ from ros2agnocast.discovery import (
     all_topic_names,
     collect_announcements,
     filter_fresh,
+    warn_if_no_announcements,
 )
 
 class BridgeStatus(Enum):
@@ -130,8 +131,10 @@ class ListAgnocastVerb(VerbExtension):
 
             # Merge in topics seen via /_agnocast_discovery gossip (other IPC
             # namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            snapshots = filter_fresh(collect_announcements(
-                node, timeout_sec=args.gossip_timeout))
+            raw_snapshots = collect_announcements(
+                node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
+            snapshots = filter_fresh(raw_snapshots)
             for name in all_topic_names(snapshots):
                 if not name.startswith('/AGNOCAST_SRV_'):
                     agnocast_topics.append(name)

--- a/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
@@ -5,6 +5,13 @@ from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.verb import VerbExtension
 
+from ros2agnocast.discovery import (
+    DEFAULT_COLLECT_TIMEOUT_SEC,
+    all_topic_names,
+    collect_announcements,
+    filter_fresh,
+)
+
 class BridgeStatus(Enum):
     NONE = 0
     ROS2_TO_AGNOCAST = 1
@@ -23,6 +30,14 @@ class TopicInfoRet(ctypes.Structure):
     ]
 class ListAgnocastVerb(VerbExtension):
     "Output a list of available topics including Agnocast"
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '--gossip-timeout',
+            type=float,
+            default=DEFAULT_COLLECT_TIMEOUT_SEC,
+            help='Seconds to wait for /_agnocast_discovery gossip from peer '
+                 'namespaces / ECUs (default: %(default)ss).')
 
     def main(self, *, args):
         with NodeStrategy(None) as node:
@@ -112,7 +127,15 @@ class ListAgnocastVerb(VerbExtension):
                 lib.free_agnocast_topics(agnocast_topic_array, topic_count)
 
             agnocast_topics = remove_service_topic(agnocast_topics)
-            
+
+            # Merge in topics seen via /_agnocast_discovery gossip (other IPC
+            # namespaces and other ECUs in the same ROS_DOMAIN_ID).
+            snapshots = filter_fresh(collect_announcements(
+                node, timeout_sec=args.gossip_timeout))
+            for name in all_topic_names(snapshots):
+                if not name.startswith('/AGNOCAST_SRV_'):
+                    agnocast_topics.append(name)
+
             # Get ros2 topics
             ros2_topics_data = get_topic_names_and_types(node=node)
             ros2_all_topics = set(name for name, _ in ros2_topics_data)

--- a/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/list_agnocast.py
@@ -6,10 +6,11 @@ from ros2topic.api import get_topic_names_and_types
 from ros2topic.verb import VerbExtension
 
 from ros2agnocast.discovery import (
-    DEFAULT_COLLECT_TIMEOUT_SEC,
+    add_gossip_timeout_arg,
     all_topic_names,
     collect_announcements,
-    filter_fresh,
+    gossip_has_bridge_endpoint,
+    warn_if_gossip_timeout_overridden,
     warn_if_no_announcements,
 )
 
@@ -33,14 +34,10 @@ class ListAgnocastVerb(VerbExtension):
     "Output a list of available topics including Agnocast"
 
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
-            '--gossip-timeout',
-            type=float,
-            default=DEFAULT_COLLECT_TIMEOUT_SEC,
-            help='Seconds to wait for /_agnocast_discovery gossip from peer '
-                 'namespaces / ECUs (default: %(default)ss).')
+        add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
+        warn_if_gossip_timeout_overridden(args)
         with NodeStrategy(None) as node:
             lib = ctypes.CDLL("libagnocast_ioctl_wrapper.so")
             lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
@@ -66,7 +63,7 @@ class ListAgnocastVerb(VerbExtension):
                     if array:
                         lib.free_agnocast_topic_info_ret(array)
 
-            def get_bridge_status(topic_name):
+            def get_bridge_status(topic_name, snapshots):
                 name_b = topic_name.encode('utf-8')
 
                 has_sub_bridge = False
@@ -86,6 +83,12 @@ class ListAgnocastVerb(VerbExtension):
                             has_pub_bridge = True
                         else:
                             has_agnocast_pub = True
+
+                # ioctl can't see bridge endpoints in other IPC NSes.
+                gossip_pub_bridge, gossip_sub_bridge = gossip_has_bridge_endpoint(
+                    snapshots, topic_name)
+                has_pub_bridge = has_pub_bridge or gossip_pub_bridge
+                has_sub_bridge = has_sub_bridge or gossip_sub_bridge
 
                 mapping = {
                     (True, True):   BridgeStatus.BIDIRECTION,
@@ -129,15 +132,11 @@ class ListAgnocastVerb(VerbExtension):
 
             agnocast_topics = remove_service_topic(agnocast_topics)
 
-            # Merge in topics seen via /_agnocast_discovery gossip (other IPC
-            # namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            raw_snapshots = collect_announcements(
+            # Merge topics visible only via gossip (other IPC NSes / ECUs).
+            snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots, node=node)
-            for name in all_topic_names(snapshots):
-                if not name.startswith('/AGNOCAST_SRV_'):
-                    agnocast_topics.append(name)
+            warn_if_no_announcements(node, snapshots, args.gossip_timeout)
+            agnocast_topics.extend(remove_service_topic(all_topic_names(snapshots)))
 
             # Get ros2 topics
             ros2_topics_data = get_topic_names_and_types(node=node)
@@ -163,7 +162,7 @@ class ListAgnocastVerb(VerbExtension):
                 elif topic in ros2_topics_set and topic not in agnocast_topics_set:
                     suffix = ""
                 else:
-                    bridge_status, has_agnocast_pub, has_agnocast_sub = get_bridge_status(topic)
+                    bridge_status, has_agnocast_pub, has_agnocast_sub = get_bridge_status(topic, snapshots)
                     needs_r2a = has_agnocast_sub and topic in ros2_pub_topics_set
                     needs_a2r = has_agnocast_pub and topic in ros2_sub_topics_set
                     match bridge_status:

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -208,7 +208,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
             raw_snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
             warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots)
+            snapshots = filter_fresh(raw_snapshots, node=node)
             gossip_pubs, gossip_subs = topics_of_node(snapshots, node_name)
             # Remember each topic's type_name from gossip so Agnocast-only
             # topics (not visible to DDS, so absent from ros2_topic_dir) can

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -14,6 +14,7 @@ from ros2agnocast.discovery import (
     collect_announcements,
     filter_fresh,
     topics_of_node,
+    warn_if_no_announcements,
 )
 
 class BridgeStatus(Enum):
@@ -204,8 +205,10 @@ class NodeInfoAgnocastVerb(VerbExtension):
 
             # Merge in cross-NS / cross-ECU topics for this node from
             # /_agnocast_discovery gossip.
-            snapshots = filter_fresh(collect_announcements(
-                node, timeout_sec=args.gossip_timeout))
+            raw_snapshots = collect_announcements(
+                node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
+            snapshots = filter_fresh(raw_snapshots)
             gossip_pubs, gossip_subs = topics_of_node(snapshots, node_name)
             for entry in gossip_pubs:
                 if entry['topic_name'] not in agnocast_publishers:

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -9,6 +9,13 @@ from ros2node.api import (
 from ros2topic.api import get_topic_names_and_types
 from ros2node.verb import VerbExtension
 
+from ros2agnocast.discovery import (
+    DEFAULT_COLLECT_TIMEOUT_SEC,
+    collect_announcements,
+    filter_fresh,
+    topics_of_node,
+)
+
 class BridgeStatus(Enum):
     NONE = 0
     ROS2_TO_AGNOCAST = 1
@@ -45,6 +52,12 @@ class NodeInfoAgnocastVerb(VerbExtension):
         parser.add_argument(
             'node_name',
             help='Fully qualified node name to request information with Agnocast topics')
+        parser.add_argument(
+            '--gossip-timeout',
+            type=float,
+            default=DEFAULT_COLLECT_TIMEOUT_SEC,
+            help='Seconds to wait for /_agnocast_discovery gossip from peer '
+                 'namespaces / ECUs (default: %(default)ss).')
 
     def main(self, *, args):
         node_name = args.node_name
@@ -188,6 +201,18 @@ class NodeInfoAgnocastVerb(VerbExtension):
             # Get Agnocast node info directly by node name (2 ioctl calls instead of 2*N)
             node_name_bytes = node_name.encode('utf-8')
             agnocast_subscribers, agnocast_publishers, agnocast_servers, agnocast_clients = get_agnocast_node_topics(node_name_bytes)
+
+            # Merge in cross-NS / cross-ECU topics for this node from
+            # /_agnocast_discovery gossip.
+            snapshots = filter_fresh(collect_announcements(
+                node, timeout_sec=args.gossip_timeout))
+            gossip_pubs, gossip_subs = topics_of_node(snapshots, node_name)
+            for entry in gossip_pubs:
+                if entry['topic_name'] not in agnocast_publishers:
+                    agnocast_publishers.append(entry['topic_name'])
+            for entry in gossip_subs:
+                if entry['topic_name'] not in agnocast_subscribers:
+                    agnocast_subscribers.append(entry['topic_name'])
 
             # Get ros2 all node names
             ros2_node_name_list = get_node_names(node=node, include_hidden_nodes=True)

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -210,12 +210,20 @@ class NodeInfoAgnocastVerb(VerbExtension):
             warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
             snapshots = filter_fresh(raw_snapshots)
             gossip_pubs, gossip_subs = topics_of_node(snapshots, node_name)
+            # Remember each topic's type_name from gossip so Agnocast-only
+            # topics (not visible to DDS, so absent from ros2_topic_dir) can
+            # still show their resolved type in the printed output.
+            gossip_topic_types: dict = {}
             for entry in gossip_pubs:
                 if entry['topic_name'] not in agnocast_publishers:
                     agnocast_publishers.append(entry['topic_name'])
+                if entry.get('type_name'):
+                    gossip_topic_types[entry['topic_name']] = entry['type_name']
             for entry in gossip_subs:
                 if entry['topic_name'] not in agnocast_subscribers:
                     agnocast_subscribers.append(entry['topic_name'])
+                if entry.get('type_name'):
+                    gossip_topic_types[entry['topic_name']] = entry['type_name']
 
             # Get ros2 all node names
             ros2_node_name_list = get_node_names(node=node, include_hidden_nodes=True)
@@ -276,7 +284,8 @@ class NodeInfoAgnocastVerb(VerbExtension):
                     topic_types = '; '.join([', '.join(topic['types']) for topic in matching_topics])
                     print(f"    {agnocast_sub}: {topic_types} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics)}")
                 else:
-                    print(f"    {agnocast_sub}: <UNKNOWN> {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics)}")
+                    type_label = gossip_topic_types.get(agnocast_sub, '<UNKNOWN>')
+                    print(f"    {agnocast_sub}: {type_label} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics)}")
 
             # ======== Publishers ========
             print("  Publishers:")
@@ -297,7 +306,8 @@ class NodeInfoAgnocastVerb(VerbExtension):
                     topic_types = '; '.join([', '.join(topic['types']) for topic in matching_topics])
                     print(f"    {agnocast_pub}: {topic_types} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics)}")
                 else:
-                    print(f"    {agnocast_pub}: <UNKNOWN> {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics)}")
+                    type_label = gossip_topic_types.get(agnocast_pub, '<UNKNOWN>')
+                    print(f"    {agnocast_pub}: {type_label} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics)}")
 
             # ======== Service ========
             print("  Service Servers:")

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -10,10 +10,11 @@ from ros2topic.api import get_topic_names_and_types
 from ros2node.verb import VerbExtension
 
 from ros2agnocast.discovery import (
-    DEFAULT_COLLECT_TIMEOUT_SEC,
+    add_gossip_timeout_arg,
     collect_announcements,
-    filter_fresh,
+    gossip_has_bridge_endpoint,
     topics_of_node,
+    warn_if_gossip_timeout_overridden,
     warn_if_no_announcements,
 )
 
@@ -53,14 +54,10 @@ class NodeInfoAgnocastVerb(VerbExtension):
         parser.add_argument(
             'node_name',
             help='Fully qualified node name to request information with Agnocast topics')
-        parser.add_argument(
-            '--gossip-timeout',
-            type=float,
-            default=DEFAULT_COLLECT_TIMEOUT_SEC,
-            help='Seconds to wait for /_agnocast_discovery gossip from peer '
-                 'namespaces / ECUs (default: %(default)ss).')
+        add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
+        warn_if_gossip_timeout_overridden(args)
         node_name = args.node_name
 
 
@@ -106,7 +103,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
                     if array:
                         lib.free_agnocast_topics(array, count)
 
-            def get_bridge_status(topic_name): 
+            def get_bridge_status(topic_name, snapshots):
                 name_b = topic_name.encode('utf-8')
 
                 has_sub_bridge = False
@@ -117,6 +114,12 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 with agnocast_info_array(lib.get_agnocast_pub_nodes, name_b) as nodes:
                     has_pub_bridge = any(n.is_bridge for n in nodes)
 
+                # ioctl can't see bridge endpoints in other IPC NSes.
+                gossip_pub_bridge, gossip_sub_bridge = gossip_has_bridge_endpoint(
+                    snapshots, topic_name)
+                has_pub_bridge = has_pub_bridge or gossip_pub_bridge
+                has_sub_bridge = has_sub_bridge or gossip_sub_bridge
+
                 mapping = {
                     (True, True):   BridgeStatus.BIDIRECTION,
                     (True, False):  BridgeStatus.AGNOCAST_TO_ROS2,
@@ -126,14 +129,14 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 
                 return mapping[(has_sub_bridge, has_pub_bridge)]
 
-            def get_agnocast_label(topic_name, ros2_sub_topics, ros2_pub_topics):
+            def get_agnocast_label(topic_name, ros2_sub_topics, ros2_pub_topics, snapshots):
                 """Get the appropriate label for an Agnocast-enabled topic."""
 
                 suffix = "(Agnocast enabled)"
                 if topic_name not in ros2_sub_topics and topic_name not in ros2_pub_topics:
                     return suffix  # No bridge info if only one endpoint exists
 
-                match get_bridge_status(topic_name):
+                match get_bridge_status(topic_name, snapshots):
                     case BridgeStatus.BIDIRECTION:
                         suffix = "(Agnocast enabled, bridged)"
                     case BridgeStatus.ROS2_TO_AGNOCAST:
@@ -203,12 +206,9 @@ class NodeInfoAgnocastVerb(VerbExtension):
             node_name_bytes = node_name.encode('utf-8')
             agnocast_subscribers, agnocast_publishers, agnocast_servers, agnocast_clients = get_agnocast_node_topics(node_name_bytes)
 
-            # Merge in cross-NS / cross-ECU topics for this node from
-            # /_agnocast_discovery gossip.
-            raw_snapshots = collect_announcements(
-                node, timeout_sec=args.gossip_timeout)
-            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots, node=node)
+            # Merge gossip-only topics for this node (other IPC NSes / ECUs).
+            snapshots = collect_announcements(node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(node, snapshots, args.gossip_timeout)
             gossip_pubs, gossip_subs = topics_of_node(snapshots, node_name)
             # Remember each topic's type_name from gossip so Agnocast-only
             # topics (not visible to DDS, so absent from ros2_topic_dir) can
@@ -270,7 +270,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
             agnocast_sub_set = set(agnocast_subscribers)
             for sub in subscribers:
                 if sub.name in agnocast_sub_set:
-                    label = get_agnocast_label(sub.name, ros2_sub_topics, ros2_pub_topics)
+                    label = get_agnocast_label(sub.name, ros2_sub_topics, ros2_pub_topics, snapshots)
                     print(f"    {sub.name}: {', '.join(sub.types)} {label}")
                 else:
                     print(f"    {sub.name}: {', '.join(sub.types)}")
@@ -282,17 +282,17 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 matching_topics = [topic for topic in ros2_topic_dir if topic['name'] == agnocast_sub]
                 if matching_topics:
                     topic_types = '; '.join([', '.join(topic['types']) for topic in matching_topics])
-                    print(f"    {agnocast_sub}: {topic_types} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics)}")
+                    print(f"    {agnocast_sub}: {topic_types} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics, snapshots)}")
                 else:
                     type_label = gossip_topic_types.get(agnocast_sub, '<UNKNOWN>')
-                    print(f"    {agnocast_sub}: {type_label} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics)}")
+                    print(f"    {agnocast_sub}: {type_label} {get_agnocast_label(agnocast_sub, ros2_sub_topics, ros2_pub_topics, snapshots)}")
 
             # ======== Publishers ========
             print("  Publishers:")
             agnocast_pub_set = set(agnocast_publishers)
             for pub in publishers:
                 if pub.name in agnocast_pub_set:
-                    label = get_agnocast_label(pub.name, ros2_sub_topics, ros2_pub_topics)
+                    label = get_agnocast_label(pub.name, ros2_sub_topics, ros2_pub_topics, snapshots)
                     print(f"    {pub.name}: {', '.join(pub.types)} {label}")
                 else:
                     print(f"    {pub.name}: {', '.join(pub.types)}")
@@ -304,10 +304,10 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 matching_topics = [topic for topic in ros2_topic_dir if topic['name'] == agnocast_pub]
                 if matching_topics:
                     topic_types = '; '.join([', '.join(topic['types']) for topic in matching_topics])
-                    print(f"    {agnocast_pub}: {topic_types} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics)}")
+                    print(f"    {agnocast_pub}: {topic_types} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics, snapshots)}")
                 else:
                     type_label = gossip_topic_types.get(agnocast_pub, '<UNKNOWN>')
-                    print(f"    {agnocast_pub}: {type_label} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics)}")
+                    print(f"    {agnocast_pub}: {type_label} {get_agnocast_label(agnocast_pub, ros2_sub_topics, ros2_pub_topics, snapshots)}")
 
             # ======== Service ========
             print("  Service Servers:")
@@ -315,14 +315,14 @@ class NodeInfoAgnocastVerb(VerbExtension):
                 print(f"    {service.name}: {', '.join(service.types)}")
 
             for service_name in agnocast_servers:
-                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics)}")
+                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics, snapshots)}")
 
             print("  Service Clients:")
             for client in service_clients:
                 print(f"    {client.name}: {', '.join(client.types)}")
 
             for service_name in agnocast_clients:
-                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics)}")
+                print(f"    {service_name}: <UNKNOWN> {get_agnocast_label(service_name, ros2_sub_topics, ros2_pub_topics, snapshots)}")
 
             # ======== Action ========
             print("  Action Servers:")

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -10,6 +10,7 @@ from ros2agnocast.discovery import (
     all_nodes,
     collect_announcements,
     filter_fresh,
+    warn_if_no_announcements,
 )
 
 def split_fqn(fqn):
@@ -102,8 +103,10 @@ class ListAgnocastVerb(VerbExtension):
 
             # Merge in nodes seen via /_agnocast_discovery gossip (other IPC
             # namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            snapshots = filter_fresh(collect_announcements(
-                node, timeout_sec=args.gossip_timeout))
+            raw_snapshots = collect_announcements(
+                node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
+            snapshots = filter_fresh(raw_snapshots)
             agnocast_node_name |= all_nodes(snapshots)
 
             # TODO(bdm-k): The current impl determines shadow nodes in a heuristic way. We need to

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -106,7 +106,7 @@ class ListAgnocastVerb(VerbExtension):
             raw_snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
             warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots)
+            snapshots = filter_fresh(raw_snapshots, node=node)
             agnocast_node_name |= all_nodes(snapshots)
 
             # TODO(bdm-k): The current impl determines shadow nodes in a heuristic way. We need to

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -5,6 +5,13 @@ from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
 from ros2topic.verb import VerbExtension
 
+from ros2agnocast.discovery import (
+    DEFAULT_COLLECT_TIMEOUT_SEC,
+    all_nodes,
+    collect_announcements,
+    filter_fresh,
+)
+
 def split_fqn(fqn):
     namespace, _, name = fqn.rpartition('/')
     return (namespace or '/'), name
@@ -33,6 +40,12 @@ class ListAgnocastVerb(VerbExtension):
         parser.add_argument(
             '-d', '--debug', action='store_true',
             help='Include internal bridge nodes (agnocast_bridge_node_*) in the output')
+        parser.add_argument(
+            '--gossip-timeout',
+            type=float,
+            default=DEFAULT_COLLECT_TIMEOUT_SEC,
+            help='Seconds to wait for /_agnocast_discovery gossip from peer '
+                 'namespaces / ECUs (default: %(default)ss).')
 
     def main(self, *, args):
         with NodeStrategy(None) as node:
@@ -86,6 +99,12 @@ class ListAgnocastVerb(VerbExtension):
             agnocast_node_name = set()
             for topic in agnocast_topics:
                 agnocast_node_name = agnocast_node_name | get_node_name_set(topic)
+
+            # Merge in nodes seen via /_agnocast_discovery gossip (other IPC
+            # namespaces and other ECUs in the same ROS_DOMAIN_ID).
+            snapshots = filter_fresh(collect_announcements(
+                node, timeout_sec=args.gossip_timeout))
+            agnocast_node_name |= all_nodes(snapshots)
 
             # TODO(bdm-k): The current impl determines shadow nodes in a heuristic way. We need to
             # invent a deterministic way to identify shadow nodes.

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -6,10 +6,10 @@ from ros2node.api import get_node_names
 from ros2topic.verb import VerbExtension
 
 from ros2agnocast.discovery import (
-    DEFAULT_COLLECT_TIMEOUT_SEC,
+    add_gossip_timeout_arg,
     all_nodes,
     collect_announcements,
-    filter_fresh,
+    warn_if_gossip_timeout_overridden,
     warn_if_no_announcements,
 )
 
@@ -41,14 +41,10 @@ class ListAgnocastVerb(VerbExtension):
         parser.add_argument(
             '-d', '--debug', action='store_true',
             help='Include internal bridge nodes (agnocast_bridge_node_*) in the output')
-        parser.add_argument(
-            '--gossip-timeout',
-            type=float,
-            default=DEFAULT_COLLECT_TIMEOUT_SEC,
-            help='Seconds to wait for /_agnocast_discovery gossip from peer '
-                 'namespaces / ECUs (default: %(default)ss).')
+        add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
+        warn_if_gossip_timeout_overridden(args)
         with NodeStrategy(None) as node:
             lib = ctypes.CDLL("libagnocast_ioctl_wrapper.so")
             lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
@@ -101,12 +97,9 @@ class ListAgnocastVerb(VerbExtension):
             for topic in agnocast_topics:
                 agnocast_node_name = agnocast_node_name | get_node_name_set(topic)
 
-            # Merge in nodes seen via /_agnocast_discovery gossip (other IPC
-            # namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            raw_snapshots = collect_announcements(
-                node, timeout_sec=args.gossip_timeout)
-            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots, node=node)
+            # Merge nodes visible only via gossip (other IPC NSes / ECUs).
+            snapshots = collect_announcements(node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(node, snapshots, args.gossip_timeout)
             agnocast_node_name |= all_nodes(snapshots)
 
             # TODO(bdm-k): The current impl determines shadow nodes in a heuristic way. We need to
@@ -143,7 +136,7 @@ class ListAgnocastVerb(VerbExtension):
             if not args.all and not args.debug:
                 merged_node_name = {node for node in merged_node_name if not node.startswith("/agnocast_bridge_node_")}
             if args.count_nodes:
-                total_nodes = len(agnocast_node_name | ros2_node_name)
+                total_nodes = len(merged_node_name)
                 print(total_nodes)
             else:
                 for node_name in sorted(merged_node_name):

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -9,6 +9,7 @@ from ros2agnocast.discovery import (
     collect_announcements,
     filter_fresh,
     topic_endpoints,
+    warn_if_no_announcements,
 )
 
 class TopicInfoRet(ctypes.Structure):
@@ -185,8 +186,10 @@ class TopicInfoAgnocastVerb(VerbExtension):
 
             # Merge in endpoints visible via /_agnocast_discovery gossip
             # (other IPC namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            snapshots = filter_fresh(collect_announcements(
-                node, timeout_sec=args.gossip_timeout))
+            raw_snapshots = collect_announcements(
+                node, timeout_sec=args.gossip_timeout)
+            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
+            snapshots = filter_fresh(raw_snapshots)
             gossip_pubs, gossip_subs = topic_endpoints(snapshots, topic_name)
             seen_pub_keys = {(r['node_name'], r['qos_depth']) for r in pub_topic_info_rets}
             seen_sub_keys = {(r['node_name'], r['qos_depth']) for r in sub_topic_info_rets}

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -189,7 +189,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
             raw_snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
             warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots)
+            snapshots = filter_fresh(raw_snapshots, node=node)
             gossip_pubs, gossip_subs = topic_endpoints(snapshots, topic_name)
             seen_pub_keys = {(r['node_name'], r['qos_depth']) for r in pub_topic_info_rets}
             seen_sub_keys = {(r['node_name'], r['qos_depth']) for r in sub_topic_info_rets}
@@ -197,6 +197,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
                 key = (endpoint.node_name, endpoint.qos_depth)
                 if key in seen_pub_keys:
                     continue
+                seen_pub_keys.add(key)
                 pub_topic_info_rets.append({
                     "node_name": endpoint.node_name,
                     "qos_depth": endpoint.qos_depth,
@@ -207,6 +208,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
                 key = (endpoint.node_name, endpoint.qos_depth)
                 if key in seen_sub_keys:
                     continue
+                seen_sub_keys.add(key)
                 sub_topic_info_rets.append({
                     "node_name": endpoint.node_name,
                     "qos_depth": endpoint.qos_depth,

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -4,6 +4,13 @@ from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import TopicNameCompleter
 from ros2node.verb import VerbExtension
 
+from ros2agnocast.discovery import (
+    DEFAULT_COLLECT_TIMEOUT_SEC,
+    collect_announcements,
+    filter_fresh,
+    topic_endpoints,
+)
+
 class TopicInfoRet(ctypes.Structure):
     _fields_ = [
         ("node_name", ctypes.c_char * 256),
@@ -36,6 +43,12 @@ class TopicInfoAgnocastVerb(VerbExtension):
             '-d',
             action='store_true',
             help='Include internal bridge nodes (agnocast_bridge_node_*) in the output')
+        parser.add_argument(
+            '--gossip-timeout',
+            type=float,
+            default=DEFAULT_COLLECT_TIMEOUT_SEC,
+            help='Seconds to wait for /_agnocast_discovery gossip from peer '
+                 'namespaces / ECUs (default: %(default)ss).')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
 
@@ -170,6 +183,41 @@ class TopicInfoAgnocastVerb(VerbExtension):
             if pub_topic_info_ret_count.value != 0 and pub_topic_info_ret_array is not None:
                 lib.free_agnocast_topic_info_ret(pub_topic_info_ret_array)
 
+            # Merge in endpoints visible via /_agnocast_discovery gossip
+            # (other IPC namespaces and other ECUs in the same ROS_DOMAIN_ID).
+            snapshots = filter_fresh(collect_announcements(
+                node, timeout_sec=args.gossip_timeout))
+            gossip_pubs, gossip_subs = topic_endpoints(snapshots, topic_name)
+            seen_pub_keys = {(r['node_name'], r['qos_depth']) for r in pub_topic_info_rets}
+            seen_sub_keys = {(r['node_name'], r['qos_depth']) for r in sub_topic_info_rets}
+            for endpoint in gossip_pubs:
+                key = (endpoint.node_name, endpoint.qos_depth)
+                if key in seen_pub_keys:
+                    continue
+                pub_topic_info_rets.append({
+                    "node_name": endpoint.node_name,
+                    "qos_depth": endpoint.qos_depth,
+                    "qos_is_transient_local": endpoint.qos_is_transient_local,
+                    "is_bridge": endpoint.is_bridge,
+                })
+            for endpoint in gossip_subs:
+                key = (endpoint.node_name, endpoint.qos_depth)
+                if key in seen_sub_keys:
+                    continue
+                sub_topic_info_rets.append({
+                    "node_name": endpoint.node_name,
+                    "qos_depth": endpoint.qos_depth,
+                    "qos_is_transient_local": endpoint.qos_is_transient_local,
+                    "is_bridge": endpoint.is_bridge,
+                })
+
+            # Resolve type from gossip when DDS does not provide one.
+            gossip_type_name = next(
+                (topic.type_name for snap in snapshots
+                 for topic in snap.topics
+                 if topic.topic_name == topic_name and topic.type_name),
+                '')
+
             # get bridge node names
             bridge_node_names = set()
             for info in sub_topic_info_rets + pub_topic_info_rets:
@@ -203,10 +251,13 @@ class TopicInfoAgnocastVerb(VerbExtension):
 
             # check if topic exists
             if not topic_types:
-                if sub_topic_info_ret_count.value == 0 and pub_topic_info_ret_count.value == 0:
+                if (sub_topic_info_ret_count.value == 0
+                        and pub_topic_info_ret_count.value == 0
+                        and not pub_topic_info_rets
+                        and not sub_topic_info_rets):
                     return 'Unknown topic: %s' % topic_name
                 else:
-                    topic_types = ['<UNKNOWN>']
+                    topic_types = [gossip_type_name] if gossip_type_name else ['<UNKNOWN>']
 
             ########################################################################
             # print topic info

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -5,10 +5,10 @@ from ros2topic.api import TopicNameCompleter
 from ros2node.verb import VerbExtension
 
 from ros2agnocast.discovery import (
-    DEFAULT_COLLECT_TIMEOUT_SEC,
+    add_gossip_timeout_arg,
     collect_announcements,
-    filter_fresh,
     topic_endpoints,
+    warn_if_gossip_timeout_overridden,
     warn_if_no_announcements,
 )
 
@@ -44,12 +44,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
             '-d',
             action='store_true',
             help='Include internal bridge nodes (agnocast_bridge_node_*) in the output')
-        parser.add_argument(
-            '--gossip-timeout',
-            type=float,
-            default=DEFAULT_COLLECT_TIMEOUT_SEC,
-            help='Seconds to wait for /_agnocast_discovery gossip from peer '
-                 'namespaces / ECUs (default: %(default)ss).')
+        add_gossip_timeout_arg(parser)
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
 
@@ -184,20 +179,17 @@ class TopicInfoAgnocastVerb(VerbExtension):
             if pub_topic_info_ret_count.value != 0 and pub_topic_info_ret_array is not None:
                 lib.free_agnocast_topic_info_ret(pub_topic_info_ret_array)
 
-            # Merge in endpoints visible via /_agnocast_discovery gossip
-            # (other IPC namespaces and other ECUs in the same ROS_DOMAIN_ID).
-            raw_snapshots = collect_announcements(
+            warn_if_gossip_timeout_overridden(args)
+
+            # Merge endpoints visible only via gossip (other IPC NSes / ECUs).
+            snapshots = collect_announcements(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_no_announcements(raw_snapshots, args.gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots, node=node)
+            warn_if_no_announcements(node, snapshots, args.gossip_timeout)
             gossip_pubs, gossip_subs = topic_endpoints(snapshots, topic_name)
-            seen_pub_keys = {(r['node_name'], r['qos_depth']) for r in pub_topic_info_rets}
-            seen_sub_keys = {(r['node_name'], r['qos_depth']) for r in sub_topic_info_rets}
+            # collect_announcements() drops the local NS from gossip, so
+            # ioctl-side and gossip-side endpoint sets are disjoint by
+            # construction; no per-verb dedup needed.
             for endpoint in gossip_pubs:
-                key = (endpoint.node_name, endpoint.qos_depth)
-                if key in seen_pub_keys:
-                    continue
-                seen_pub_keys.add(key)
                 pub_topic_info_rets.append({
                     "node_name": endpoint.node_name,
                     "qos_depth": endpoint.qos_depth,
@@ -205,10 +197,6 @@ class TopicInfoAgnocastVerb(VerbExtension):
                     "is_bridge": endpoint.is_bridge,
                 })
             for endpoint in gossip_subs:
-                key = (endpoint.node_name, endpoint.qos_depth)
-                if key in seen_sub_keys:
-                    continue
-                seen_sub_keys.add(key)
                 sub_topic_info_rets.append({
                     "node_name": endpoint.node_name,
                     "qos_depth": endpoint.qos_depth,

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -21,6 +21,7 @@ from ros2agnocast.discovery import (
     is_stale,
     topic_endpoints,
     topics_of_node,
+    warn_if_no_announcements,
 )
 
 
@@ -115,3 +116,21 @@ def test_filter_fresh_drops_old_snapshots():
     old = _state('b', 2, ts_sec=int(time.time()) - 999)
     kept = filter_fresh([fresh, old], stale_after_sec=10)
     assert kept == [fresh]
+
+
+def test_warn_if_no_announcements_silent_when_snapshots_present(capsys):
+    snap = _state('a', 1)
+    warn_if_no_announcements([snap], timeout_sec=2.0)
+    assert capsys.readouterr().err == ''
+
+
+def test_warn_if_no_announcements_silent_when_timeout_zero(capsys):
+    warn_if_no_announcements([], timeout_sec=0)
+    assert capsys.readouterr().err == ''
+
+
+def test_warn_if_no_announcements_emits_hint_when_empty(capsys):
+    warn_if_no_announcements([], timeout_sec=2.0)
+    err = capsys.readouterr().err
+    assert 'WARNING' in err
+    assert 'discovery_agent' in err

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -1,0 +1,117 @@
+"""Unit tests for ros2agnocast.discovery helpers.
+
+These tests do not require DDS; they exercise the projection helpers with
+hand-built AgnocastDaemonState messages.
+"""
+
+import time
+
+from builtin_interfaces.msg import Time
+
+from ros2agnocast_discovery_msgs.msg import (
+    AgnocastDaemonState,
+    AgnocastEndpoint,
+    AgnocastTopic,
+)
+
+from ros2agnocast.discovery import (
+    all_nodes,
+    all_topic_names,
+    filter_fresh,
+    is_stale,
+    topic_endpoints,
+    topics_of_node,
+)
+
+
+def _endpoint(node_name: str, *, is_bridge: bool = False, qos_depth: int = 10) -> AgnocastEndpoint:
+    ep = AgnocastEndpoint()
+    ep.node_name = node_name
+    ep.pid = 0
+    ep.qos_depth = qos_depth
+    ep.qos_is_transient_local = False
+    ep.qos_is_reliable = True
+    ep.is_bridge = is_bridge
+    return ep
+
+
+def _topic(topic_name: str, *, pubs=None, subs=None, type_name: str = '') -> AgnocastTopic:
+    topic = AgnocastTopic()
+    topic.topic_name = topic_name
+    topic.type_name = type_name
+    topic.domain_id = 0
+    topic.publishers = pubs or []
+    topic.subscribers = subs or []
+    return topic
+
+
+def _state(host: str, ipc_ns: int, *, topics=None, ts_sec: int = 0) -> AgnocastDaemonState:
+    state = AgnocastDaemonState()
+    state.schema_version = 1
+    state.agnocast_version = ''
+    state.host_uuid = host
+    state.host_hostname = host
+    state.timestamp = Time(sec=ts_sec, nanosec=0) if ts_sec else Time(sec=int(time.time()), nanosec=0)
+    state.ipc_ns_inode = ipc_ns
+    state.topics = topics or []
+    return state
+
+
+def test_all_topic_names_unions_across_snapshots():
+    snap_a = _state('a', 1, topics=[_topic('/foo'), _topic('/bar')])
+    snap_b = _state('b', 2, topics=[_topic('/bar'), _topic('/baz')])
+    assert all_topic_names([snap_a, snap_b]) == {'/foo', '/bar', '/baz'}
+
+
+def test_all_topic_names_empty_when_no_snapshots():
+    assert all_topic_names([]) == set()
+
+
+def test_all_nodes_includes_both_publishers_and_subscribers():
+    pub = _endpoint('/talker')
+    sub = _endpoint('/listener')
+    snap = _state('a', 1, topics=[_topic('/foo', pubs=[pub], subs=[sub])])
+    assert all_nodes([snap]) == {'/talker', '/listener'}
+
+
+def test_topic_endpoints_returns_pubs_and_subs_for_named_topic():
+    pub1 = _endpoint('/talker_a')
+    pub2 = _endpoint('/talker_b')
+    sub = _endpoint('/listener')
+    snap_a = _state('a', 1, topics=[_topic('/foo', pubs=[pub1])])
+    snap_b = _state('b', 2, topics=[_topic('/foo', subs=[sub]), _topic('/bar', pubs=[pub2])])
+    pubs, subs = topic_endpoints([snap_a, snap_b], '/foo')
+    assert [p.node_name for p in pubs] == ['/talker_a']
+    assert [s.node_name for s in subs] == ['/listener']
+
+
+def test_topic_endpoints_returns_empty_for_unknown_topic():
+    snap = _state('a', 1, topics=[_topic('/foo')])
+    pubs, subs = topic_endpoints([snap], '/missing')
+    assert pubs == []
+    assert subs == []
+
+
+def test_topics_of_node_collects_pub_and_sub_topics():
+    pub = _endpoint('/talker')
+    sub = _endpoint('/talker')  # same node also subscribes elsewhere
+    snap = _state('a', 1, topics=[
+        _topic('/foo', pubs=[pub], type_name='std_msgs/msg/String'),
+        _topic('/bar', subs=[sub]),
+    ])
+    pubs, subs = topics_of_node([snap], '/talker')
+    assert pubs == [{'topic_name': '/foo', 'type_name': 'std_msgs/msg/String'}]
+    assert subs == [{'topic_name': '/bar', 'type_name': ''}]
+
+
+def test_is_stale_detects_old_timestamp():
+    msg = _state('a', 1, ts_sec=100)
+    assert is_stale(msg, now_sec=200, stale_after_sec=10) is True
+    assert is_stale(msg, now_sec=105, stale_after_sec=10) is False
+
+
+def test_filter_fresh_drops_old_snapshots():
+    fresh = _state('a', 1, ts_sec=int(time.time()))
+    old = _state('b', 2, ts_sec=int(time.time()) - 999)
+    kept = filter_fresh([fresh, old], stale_after_sec=10)
+    assert kept == [fresh]

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -4,9 +4,7 @@ These tests do not require DDS; they exercise the projection helpers with
 hand-built AgnocastDaemonState messages.
 """
 
-import time
-
-from builtin_interfaces.msg import Time
+from unittest.mock import MagicMock
 
 from ros2agnocast_discovery_msgs.msg import (
     AgnocastDaemonState,
@@ -15,10 +13,10 @@ from ros2agnocast_discovery_msgs.msg import (
 )
 
 from ros2agnocast.discovery import (
+    _resolve_spin_node,
     all_nodes,
     all_topic_names,
-    filter_fresh,
-    is_stale,
+    gossip_has_bridge_endpoint,
     topic_endpoints,
     topics_of_node,
     warn_if_no_announcements,
@@ -46,13 +44,12 @@ def _topic(topic_name: str, *, pubs=None, subs=None, type_name: str = '') -> Agn
     return topic
 
 
-def _state(host: str, ipc_ns: int, *, topics=None, ts_sec: int = 0) -> AgnocastDaemonState:
+def _state(host: str, ipc_ns: int, *, topics=None) -> AgnocastDaemonState:
     state = AgnocastDaemonState()
     state.schema_version = 1
     state.agnocast_version = ''
     state.host_uuid = host
     state.host_hostname = host
-    state.timestamp = Time(sec=ts_sec, nanosec=0) if ts_sec else Time(sec=int(time.time()), nanosec=0)
     state.ipc_ns_inode = ipc_ns
     state.topics = topics or []
     return state
@@ -105,32 +102,65 @@ def test_topics_of_node_collects_pub_and_sub_topics():
     assert subs == [{'topic_name': '/bar', 'type_name': ''}]
 
 
-def test_is_stale_detects_old_timestamp():
-    msg = _state('a', 1, ts_sec=100)
-    assert is_stale(msg, now_sec=200, stale_after_sec=10) is True
-    assert is_stale(msg, now_sec=105, stale_after_sec=10) is False
+def test_gossip_has_bridge_endpoint_picks_up_bridge_endpoints():
+    bridge_pub = _endpoint('/agnocast_bridge_node_xxx', is_bridge=True)
+    sub = _endpoint('/listener')
+    snap = _state('a', 1, topics=[_topic('/foo', pubs=[bridge_pub], subs=[sub])])
+    pub_b, sub_b = gossip_has_bridge_endpoint([snap], '/foo')
+    assert pub_b is True
+    assert sub_b is False
 
 
-def test_filter_fresh_drops_old_snapshots():
-    fresh = _state('a', 1, ts_sec=int(time.time()))
-    old = _state('b', 2, ts_sec=int(time.time()) - 999)
-    kept = filter_fresh([fresh, old], stale_after_sec=10)
-    assert kept == [fresh]
+def test_gossip_has_bridge_endpoint_returns_false_when_no_bridge():
+    pub = _endpoint('/talker')
+    snap = _state('a', 1, topics=[_topic('/foo', pubs=[pub])])
+    pub_b, sub_b = gossip_has_bridge_endpoint([snap], '/foo')
+    assert pub_b is False
+    assert sub_b is False
+
+
+def test_resolve_spin_node_returns_node_as_is_when_not_nodestrategy():
+    plain = MagicMock(spec=[])
+    assert _resolve_spin_node(plain) is plain
+
+
+def test_resolve_spin_node_unwraps_nodestrategy_to_underlying_node():
+    inner_node = MagicMock(spec=[])
+    direct_node = MagicMock()
+    direct_node.node = inner_node
+    strategy = MagicMock()
+    strategy.direct_node = direct_node
+    assert _resolve_spin_node(strategy) is inner_node
+
+
+def _plain_node(publishers=None):
+    """Build a mock that _resolve_spin_node treats as a plain rclpy.Node (no NodeStrategy)."""
+    node = MagicMock(spec=['get_publishers_info_by_topic'])
+    node.get_publishers_info_by_topic.return_value = publishers or []
+    return node
 
 
 def test_warn_if_no_announcements_silent_when_snapshots_present(capsys):
     snap = _state('a', 1)
-    warn_if_no_announcements([snap], timeout_sec=2.0)
+    warn_if_no_announcements(_plain_node(), [snap], timeout_sec=2.0)
     assert capsys.readouterr().err == ''
 
 
 def test_warn_if_no_announcements_silent_when_timeout_zero(capsys):
-    warn_if_no_announcements([], timeout_sec=0)
+    warn_if_no_announcements(_plain_node(), [], timeout_sec=0)
     assert capsys.readouterr().err == ''
 
 
-def test_warn_if_no_announcements_emits_hint_when_empty(capsys):
-    warn_if_no_announcements([], timeout_sec=2.0)
+def test_warn_if_no_announcements_says_no_publisher_when_dds_sees_none(capsys):
+    warn_if_no_announcements(_plain_node(publishers=[]), [], timeout_sec=2.0)
     err = capsys.readouterr().err
     assert 'WARNING' in err
-    assert 'discovery_agent' in err
+    assert 'no /_agnocast_discovery publisher visible' in err
+    assert 'ROS_DOMAIN_ID' in err
+
+
+def test_warn_if_no_announcements_says_qos_or_pythonpath_when_publisher_visible(capsys):
+    warn_if_no_announcements(_plain_node(publishers=[MagicMock()]), [], timeout_sec=2.0)
+    err = capsys.readouterr().err
+    assert 'WARNING' in err
+    assert 'publisher(s) visible but no snapshot' in err

--- a/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
+++ b/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+  <!--
+    Spawn the per-IPC-namespace Agnocast discovery agent. Include this from
+    any top-level launch that runs inside an IPC namespace where Agnocast
+    observability and bridge generation are desired. Exactly one daemon
+    should run per IPC namespace.
+  -->
+  <node pkg="ros2agnocast_discovery_agent"
+        exec="discovery_agent"
+        name="agnocast_discovery_agent"
+        output="screen"/>
+</launch>

--- a/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
+++ b/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
@@ -5,8 +5,10 @@
     observability and bridge generation are desired. Exactly one daemon
     should run per IPC namespace.
   -->
+  <!-- No `name=` attribute: the agent picks a unique node name itself
+       (`agnocast_discovery_agent_<host8hex>_<ipc_ns_inode>`). Setting
+       `name=` here would remap and break the per-NS uniqueness. -->
   <node pkg="ros2agnocast_discovery_agent"
         exec="discovery_agent"
-        name="agnocast_discovery_agent"
         output="screen"/>
 </launch>

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2agnocast_discovery_agent</name>
+  <version>2.3.3</version>
+  <description>
+    Per-IPC-namespace daemon that reads the local Agnocast state via the
+    existing NS-scoped ioctl and publishes it on /_agnocast_discovery so
+    other namespaces and ECUs running ros2agnocast tooling can build a
+    cross-NS / cross-ECU view (F3) and request bridges on demand (F1).
+  </description>
+
+  <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
+  <license>Apache License 2.0</license>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2agnocast_discovery_msgs</exec_depend>
+  <exec_depend>agnocast_ioctl_wrapper</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -7,7 +7,7 @@
     Per-IPC-namespace daemon that reads the local Agnocast state via the
     existing NS-scoped ioctl and publishes it on /_agnocast_discovery so
     other namespaces and ECUs running ros2agnocast tooling can build a
-    cross-NS / cross-ECU view (F3) and request bridges on demand (F1).
+    cross-NS / cross-ECU view and request bridges on demand.
   </description>
 
   <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2agnocast_discovery_agent</name>
-  <version>2.3.3</version>
+  <version>2.3.4</version>
   <description>
     Per-IPC-namespace daemon that reads the local Agnocast state via the
     existing NS-scoped ioctl and publishes it on /_agnocast_discovery so

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -11,6 +11,9 @@
   </description>
 
   <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
+  <maintainer email="sykwer@gmail.com">Takahiro Ishikawa-Aso</maintainer>
+  <maintainer email="koichi.imai.2@tier4.jp">Koichi Imai</maintainer>
+  <maintainer email="ryuta.kambe@tier4.jp">Ryuta Kambe</maintainer>
   <license>Apache License 2.0</license>
 
   <exec_depend>rclpy</exec_depend>

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -13,7 +13,7 @@
   <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
   <maintainer email="sykwer@gmail.com">Takahiro Ishikawa-Aso</maintainer>
   <maintainer email="koichi.imai.2@tier4.jp">Koichi Imai</maintainer>
-  <maintainer email="ryuta.kambe@tier4.jp">Ryuta Kambe</maintainer>
+  <maintainer email="primenumber_2_3_5@yahoo.co.jp">Takumi Jin</maintainer>
   <license>Apache License 2.0</license>
 
   <exec_depend>rclpy</exec_depend>

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -36,14 +36,22 @@ PUBLISH_INTERVAL_SEC = 1.0
 LIVELINESS_LEASE_SEC = 30.0
 MACHINE_ID_PATH = '/etc/machine-id'
 SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
+# Kept separate from TOPIC_NAME_BUFFER_SIZE because the C side (`agnocast_kmod`)
+# defines NODE_NAME_BUFFER_SIZE and TOPIC_NAME_BUFFER_SIZE as independent
+# constants — they happen to share the value 256 today.
+NODE_NAME_BUFFER_SIZE = 256
 TOPIC_NAME_BUFFER_SIZE = 256
+# How long a remote daemon's last snapshot may sit in _remote_states without
+# being refreshed before we drop it. Matches the gossip Liveliness lease so
+# DDS-side liveliness loss and local prune happen on the same timescale.
+REMOTE_STATE_STALE_SEC = 30.0
 
 
 class TopicInfoRet(ctypes.Structure):
     """Mirror of ``struct topic_info_ret`` in agnocast_ioctl.hpp."""
 
     _fields_ = [
-        ('node_name', ctypes.c_char * TOPIC_NAME_BUFFER_SIZE),
+        ('node_name', ctypes.c_char * NODE_NAME_BUFFER_SIZE),
         ('qos_depth', ctypes.c_uint32),
         ('qos_is_transient_local', ctypes.c_bool),
         ('qos_is_reliable', ctypes.c_bool),
@@ -193,7 +201,32 @@ class DiscoveryAgent(Node):
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode}')
 
     def _on_tick(self) -> None:
+        self._prune_stale_remote_states()
         self.publish_snapshot()
+
+    def _prune_stale_remote_states(
+            self, now_sec: float | None = None,
+            stale_after_sec: float = REMOTE_STATE_STALE_SEC) -> None:
+        """Drop remote-snapshot entries whose timestamp is older than the threshold.
+
+        Without this, a daemon that disappears (host dies, NS torn down, etc.)
+        would leave its last snapshot in ``_remote_states`` forever, slowly
+        growing memory in long-running deployments. The DDS Liveliness lease
+        already forces the publisher off the topic at the same timescale; we
+        mirror it here so the in-memory cache agrees.
+
+        ``now_sec`` is exposed for tests; production code lets the method read
+        ``self.get_clock()`` directly.
+        """
+        if now_sec is None:
+            now_sec = self.get_clock().now().nanoseconds / 1e9
+        stale_keys = [
+            key for key, msg in self._remote_states.items()
+            if now_sec - (msg.timestamp.sec + msg.timestamp.nanosec / 1e9)
+            > stale_after_sec
+        ]
+        for key in stale_keys:
+            del self._remote_states[key]
 
     def publish_snapshot(self) -> None:
         """Build and publish the current local AgnocastDaemonState."""

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -40,7 +40,7 @@ TOPIC_NAME_BUFFER_SIZE = 256
 
 
 class TopicInfoRet(ctypes.Structure):
-    """Mirror of `struct topic_info_ret` in agnocast_ioctl.hpp."""
+    """Mirror of ``struct topic_info_ret`` in agnocast_ioctl.hpp."""
 
     _fields_ = [
         ('node_name', ctypes.c_char * TOPIC_NAME_BUFFER_SIZE),
@@ -74,10 +74,10 @@ def _load_ioctl_wrapper():
 
 
 def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
-    """Convert one `topic_info_ret` row to an AgnocastEndpoint msg.
+    """Convert one ``topic_info_ret`` row to an AgnocastEndpoint msg.
 
-    `pid` is best-effort 0 because the existing ioctl does not expose it; the
-    bridge decider may fill it via `/proc` walk when routing bridge requests.
+    ``pid`` is best-effort 0 because the existing ioctl does not expose it; the
+    bridge decider may fill it via ``/proc`` walk when routing bridge requests.
     """
     ep = AgnocastEndpoint()
     ep.node_name = info.node_name.decode('utf-8', errors='replace')

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -3,7 +3,7 @@
 Reads the local Agnocast state via the existing NS-scoped ioctl wrapper
 (libagnocast_ioctl_wrapper.so) and publishes it as AgnocastDaemonState on
 ``/_agnocast_discovery`` so other namespaces and ECUs running ros2agnocast
-tooling can observe and (in F1) make bridge generation decisions.
+tooling can observe and make bridge generation decisions.
 
 One daemon process is intended to run per IPC namespace. Lifecycle is the
 user's responsibility (systemd unit, ros2 launch include, container
@@ -76,8 +76,8 @@ def _load_ioctl_wrapper():
 def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
     """Convert one `topic_info_ret` row to an AgnocastEndpoint msg.
 
-    `pid` is best-effort 0 because the existing ioctl does not expose it; F1 may
-    fill it via `/proc` walk when routing bridge requests.
+    `pid` is best-effort 0 because the existing ioctl does not expose it; the
+    bridge decider may fill it via `/proc` walk when routing bridge requests.
     """
     ep = AgnocastEndpoint()
     ep.node_name = info.node_name.decode('utf-8', errors='replace')
@@ -167,9 +167,9 @@ def _gossip_qos() -> QoSProfile:
 class DiscoveryAgent(Node):
     """rclpy Node that publishes the local Agnocast state every PUBLISH_INTERVAL_SEC.
 
-    Also subscribes to its own gossip topic so subsequent F1 logic can observe
-    remote namespace state; today the callback only records the latest snapshot
-    keyed by ``(host_uuid, ipc_ns_inode)``.
+    Also subscribes to its own gossip topic so the bridge decider can observe
+    remote namespace state; the callback records the latest snapshot keyed by
+    ``(host_uuid, ipc_ns_inode)``.
     """
 
     def __init__(self, ioctl_lib=None):

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -1,0 +1,242 @@
+"""Per-IPC-namespace discovery agent.
+
+Reads the local Agnocast state via the existing NS-scoped ioctl wrapper
+(libagnocast_ioctl_wrapper.so) and publishes it as AgnocastDaemonState on
+``/_agnocast_discovery`` so other namespaces and ECUs running ros2agnocast
+tooling can observe and (in F1) make bridge generation decisions.
+
+One daemon process is intended to run per IPC namespace. Lifecycle is the
+user's responsibility (systemd unit, ros2 launch include, container
+entrypoint, etc.).
+"""
+
+import ctypes
+import os
+import socket
+import sys
+import uuid
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, LivelinessPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.duration import Duration
+
+from builtin_interfaces.msg import Time
+from ros2agnocast_discovery_msgs.msg import (
+    AgnocastDaemonState,
+    AgnocastEndpoint,
+    AgnocastTopic,
+)
+
+
+GOSSIP_TOPIC = '/_agnocast_discovery'
+SCHEMA_VERSION = 1
+PUBLISH_INTERVAL_SEC = 1.0
+LIVELINESS_LEASE_SEC = 30.0
+MACHINE_ID_PATH = '/etc/machine-id'
+SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
+TOPIC_NAME_BUFFER_SIZE = 256
+
+
+class TopicInfoRet(ctypes.Structure):
+    """Mirror of `struct topic_info_ret` in agnocast_ioctl.hpp."""
+
+    _fields_ = [
+        ('node_name', ctypes.c_char * TOPIC_NAME_BUFFER_SIZE),
+        ('qos_depth', ctypes.c_uint32),
+        ('qos_is_transient_local', ctypes.c_bool),
+        ('qos_is_reliable', ctypes.c_bool),
+        ('is_bridge', ctypes.c_bool),
+    ]
+
+
+def _load_ioctl_wrapper():
+    """Load libagnocast_ioctl_wrapper.so and set argtypes for the symbols we use."""
+    lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+
+    lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_topics.restype = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))
+    lib.free_agnocast_topics.argtypes = [
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_char)),
+        ctypes.c_int,
+    ]
+    lib.free_agnocast_topics.restype = None
+
+    lib.get_agnocast_sub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_sub_nodes.restype = ctypes.POINTER(TopicInfoRet)
+    lib.get_agnocast_pub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
+    lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
+    lib.free_agnocast_topic_info_ret.restype = None
+
+    return lib
+
+
+def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
+    """Convert one `topic_info_ret` row to an AgnocastEndpoint msg.
+
+    `pid` is best-effort 0 because the existing ioctl does not expose it; F1 may
+    fill it via `/proc` walk when routing bridge requests.
+    """
+    ep = AgnocastEndpoint()
+    ep.node_name = info.node_name.decode('utf-8', errors='replace')
+    ep.pid = 0
+    ep.qos_depth = info.qos_depth
+    ep.qos_is_transient_local = info.qos_is_transient_local
+    ep.qos_is_reliable = info.qos_is_reliable
+    ep.is_bridge = info.is_bridge
+    return ep
+
+
+def read_local_topics(lib) -> list:
+    """Snapshot the current namespace's Agnocast topics via the ioctl wrapper.
+
+    Returns a list of AgnocastTopic msgs. The ioctl returns only the caller's
+    IPC namespace, so the daemon process just being inside that namespace is
+    sufficient to scope the result.
+    """
+    topic_count = ctypes.c_int()
+    topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count))
+    topics = []
+    if not topic_names_ptr:
+        return topics
+
+    try:
+        for i in range(topic_count.value):
+            topic_name_b = ctypes.cast(topic_names_ptr[i], ctypes.c_char_p).value
+            topic_name = topic_name_b.decode('utf-8', errors='replace')
+
+            agnocast_topic = AgnocastTopic()
+            agnocast_topic.topic_name = topic_name
+            # type_name is best-effort empty here; resolved by future work
+            # (procfs/topic_info exposing message_type, or kmod ioctl extension)
+            agnocast_topic.type_name = ''
+            agnocast_topic.domain_id = 0
+            agnocast_topic.publishers = _collect_endpoints(lib.get_agnocast_pub_nodes, lib, topic_name_b)
+            agnocast_topic.subscribers = _collect_endpoints(lib.get_agnocast_sub_nodes, lib, topic_name_b)
+            topics.append(agnocast_topic)
+    finally:
+        lib.free_agnocast_topics(topic_names_ptr, topic_count.value)
+
+    return topics
+
+
+def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
+    count = ctypes.c_int()
+    array = getter(topic_name_b, ctypes.byref(count))
+    endpoints = []
+    if not array:
+        return endpoints
+    try:
+        for i in range(count.value):
+            endpoints.append(_ioctl_to_endpoint(array[i]))
+    finally:
+        lib.free_agnocast_topic_info_ret(array)
+    return endpoints
+
+
+def _read_machine_id() -> str:
+    """Return /etc/machine-id formatted as a UUID, fallback to a random UUID."""
+    try:
+        with open(MACHINE_ID_PATH) as fp:
+            raw = fp.read().strip()
+        if len(raw) == 32 and all(c in '0123456789abcdef' for c in raw):
+            return str(uuid.UUID(raw))
+    except OSError:
+        pass
+    return str(uuid.uuid4())
+
+
+def _read_ipc_ns_inode() -> int:
+    """Return the inode number of the daemon's own IPC namespace."""
+    return os.stat(SELF_IPC_NS_PATH).st_ino
+
+
+def _gossip_qos() -> QoSProfile:
+    return QoSProfile(
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
+        liveliness=LivelinessPolicy.AUTOMATIC,
+        liveliness_lease_duration=Duration(seconds=LIVELINESS_LEASE_SEC),
+    )
+
+
+class DiscoveryAgent(Node):
+    """rclpy Node that publishes the local Agnocast state every PUBLISH_INTERVAL_SEC.
+
+    Also subscribes to its own gossip topic so subsequent F1 logic can observe
+    remote namespace state; today the callback only records the latest snapshot
+    keyed by ``(host_uuid, ipc_ns_inode)``.
+    """
+
+    def __init__(self, ioctl_lib=None):
+        super().__init__('agnocast_discovery_agent')
+        self._lib = ioctl_lib if ioctl_lib is not None else _load_ioctl_wrapper()
+        self._host_uuid = _read_machine_id()
+        self._host_hostname = socket.gethostname()
+        self._ipc_ns_inode = _read_ipc_ns_inode()
+        self._agnocast_version = os.environ.get('AGNOCAST_VERSION', '')
+
+        qos = _gossip_qos()
+        self._pub = self.create_publisher(AgnocastDaemonState, GOSSIP_TOPIC, qos)
+        self._sub = self.create_subscription(
+            AgnocastDaemonState, GOSSIP_TOPIC, self._on_remote_state, qos)
+        self._remote_states = {}
+
+        self._timer = self.create_timer(PUBLISH_INTERVAL_SEC, self._on_tick)
+
+        self.get_logger().info(
+            f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
+            f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode}')
+
+    def _on_tick(self) -> None:
+        self.publish_snapshot()
+
+    def publish_snapshot(self) -> None:
+        """Build and publish the current local AgnocastDaemonState."""
+        msg = self.build_state()
+        self._pub.publish(msg)
+
+    def build_state(self) -> AgnocastDaemonState:
+        msg = AgnocastDaemonState()
+        msg.schema_version = SCHEMA_VERSION
+        msg.agnocast_version = self._agnocast_version
+        msg.host_uuid = self._host_uuid
+        msg.host_hostname = self._host_hostname
+        now = self.get_clock().now().to_msg()
+        msg.timestamp = Time(sec=now.sec, nanosec=now.nanosec)
+        msg.ipc_ns_inode = self._ipc_ns_inode
+        msg.topics = read_local_topics(self._lib)
+        return msg
+
+    def _on_remote_state(self, msg: AgnocastDaemonState) -> None:
+        # Skip our own messages.
+        if msg.host_uuid == self._host_uuid and msg.ipc_ns_inode == self._ipc_ns_inode:
+            return
+        self._remote_states[(msg.host_uuid, msg.ipc_ns_inode)] = msg
+
+    @property
+    def remote_states(self) -> dict:
+        """Latest gossip snapshots from other (host, namespace) pairs."""
+        return self._remote_states
+
+
+def main(argv=None) -> int:
+    rclpy.init(args=argv)
+    node = DiscoveryAgent()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -11,18 +11,21 @@ entrypoint, etc.).
 """
 
 import ctypes
+import importlib.metadata
+import logging
 import os
 import socket
 import sys
 import uuid
 
 import rclpy
+from rclpy.clock import Clock, ClockType
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, LivelinessPolicy, QoSProfile, ReliabilityPolicy
 from rclpy.duration import Duration
 
-from builtin_interfaces.msg import Time
 from ros2agnocast_discovery_msgs.msg import (
     AgnocastDaemonState,
     AgnocastEndpoint,
@@ -34,7 +37,9 @@ GOSSIP_TOPIC = '/_agnocast_discovery'
 SCHEMA_VERSION = 1
 PUBLISH_INTERVAL_SEC = 1.0
 LIVELINESS_LEASE_SEC = 30.0
-MACHINE_ID_PATH = '/etc/machine-id'
+# Preferred over /etc/machine-id: avoids the systemd dep and the
+# baked-into-image case where every ECU collides on one host_uuid.
+BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id'
 SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
 # Kept separate from TOPIC_NAME_BUFFER_SIZE because the C side (`agnocast_kmod`)
 # defines NODE_NAME_BUFFER_SIZE and TOPIC_NAME_BUFFER_SIZE as independent
@@ -144,16 +149,18 @@ def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
     return endpoints
 
 
-def _read_machine_id() -> str:
-    """Return /etc/machine-id formatted as a UUID, fallback to a random UUID."""
+def _read_host_uuid() -> str:
+    """Return the boot UUID; fall back to a random UUID with a WARN log."""
     try:
-        with open(MACHINE_ID_PATH) as fp:
-            raw = fp.read().strip()
-        if len(raw) == 32 and all(c in '0123456789abcdef' for c in raw):
-            return str(uuid.UUID(raw))
-    except OSError:
-        pass
-    return str(uuid.uuid4())
+        with open(BOOT_ID_PATH) as fp:
+            return str(uuid.UUID(fp.read().strip()))
+    except (OSError, ValueError) as exc:
+        fallback = str(uuid.uuid4())
+        logging.warning(
+            'agnocast_discovery_agent: failed to read %s (%s); '
+            'falling back to random host_uuid=%s',
+            BOOT_ID_PATH, exc, fallback)
+        return fallback
 
 
 def _read_ipc_ns_inode() -> int:
@@ -167,9 +174,20 @@ def _gossip_qos() -> QoSProfile:
         durability=DurabilityPolicy.TRANSIENT_LOCAL,
         history=HistoryPolicy.KEEP_LAST,
         depth=1,
+        # AUTOMATIC: rclpy (Humble) does not expose ``assert_liveliness`` on
+        # Publisher, so MANUAL_BY_TOPIC cannot be driven reliably from Python.
+        # AUTOMATIC keeps the publisher alive as long as the participant is up.
         liveliness=LivelinessPolicy.AUTOMATIC,
         liveliness_lease_duration=Duration(seconds=LIVELINESS_LEASE_SEC),
     )
+
+
+def _read_agent_version() -> str:
+    """Return this package's installed version, or '' if running from source."""
+    try:
+        return importlib.metadata.version('ros2agnocast_discovery_agent')
+    except importlib.metadata.PackageNotFoundError:
+        return ''
 
 
 class DiscoveryAgent(Node):
@@ -180,13 +198,24 @@ class DiscoveryAgent(Node):
     ``(host_uuid, ipc_ns_inode)``.
     """
 
-    def __init__(self, ioctl_lib=None):
-        super().__init__('agnocast_discovery_agent')
-        self._lib = ioctl_lib if ioctl_lib is not None else _load_ioctl_wrapper()
-        self._host_uuid = _read_machine_id()
+    def __init__(self):
+        self._host_uuid = _read_host_uuid()
         self._host_hostname = socket.gethostname()
         self._ipc_ns_inode = _read_ipc_ns_inode()
-        self._agnocast_version = os.environ.get('AGNOCAST_VERSION', '')
+        # Multiple agents may run on one ECU (one per IPC NS); disambiguate.
+        host_short = self._host_uuid.replace('-', '')[:8]
+        # Force use_sim_time=False so the 1 Hz timer + clock reads are
+        # wall-clock regardless of /clock; sim-time playback would otherwise
+        # stretch the publish cadence past the liveliness lease window.
+        super().__init__(
+            f'agnocast_discovery_agent_{host_short}_{self._ipc_ns_inode}',
+            parameter_overrides=[Parameter('use_sim_time', value=False)],
+        )
+        self._lib = _load_ioctl_wrapper()
+        self._agnocast_version = _read_agent_version()
+        # Independent wall-clock for prune / receive timestamps so they stay
+        # consistent even if a future change accidentally enables sim time.
+        self._clock = Clock(clock_type=ClockType.SYSTEM_TIME)
 
         qos = _gossip_qos()
         self._pub = self.create_publisher(AgnocastDaemonState, GOSSIP_TOPIC, qos)
@@ -198,7 +227,8 @@ class DiscoveryAgent(Node):
 
         self.get_logger().info(
             f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
-            f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode}')
+            f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode} '
+            f'version={self._agnocast_version}')
 
     def _on_tick(self) -> None:
         self._prune_stale_remote_states()
@@ -207,23 +237,17 @@ class DiscoveryAgent(Node):
     def _prune_stale_remote_states(
             self, now_sec: float | None = None,
             stale_after_sec: float = REMOTE_STATE_STALE_SEC) -> None:
-        """Drop remote-snapshot entries whose timestamp is older than the threshold.
+        """Drop ``_remote_states`` entries whose local arrival time is too old.
 
-        Without this, a daemon that disappears (host dies, NS torn down, etc.)
-        would leave its last snapshot in ``_remote_states`` forever, slowly
-        growing memory in long-running deployments. The DDS Liveliness lease
-        already forces the publisher off the topic at the same timescale; we
-        mirror it here so the in-memory cache agrees.
-
-        ``now_sec`` is exposed for tests; production code lets the method read
-        ``self.get_clock()`` directly.
+        Mirrors the DDS Liveliness lease so dead-peer snapshots don't leak
+        memory. Cross-ECU clocks aren't synced, so local arrival time is
+        the freshness reference rather than the publisher's stamp.
         """
         if now_sec is None:
-            now_sec = self.get_clock().now().nanoseconds / 1e9
+            now_sec = self._clock.now().nanoseconds / 1e9
         stale_keys = [
-            key for key, msg in self._remote_states.items()
-            if now_sec - (msg.timestamp.sec + msg.timestamp.nanosec / 1e9)
-            > stale_after_sec
+            key for key, (_msg, received_at) in self._remote_states.items()
+            if now_sec - received_at > stale_after_sec
         ]
         for key in stale_keys:
             del self._remote_states[key]
@@ -239,21 +263,19 @@ class DiscoveryAgent(Node):
         msg.agnocast_version = self._agnocast_version
         msg.host_uuid = self._host_uuid
         msg.host_hostname = self._host_hostname
-        now = self.get_clock().now().to_msg()
-        msg.timestamp = Time(sec=now.sec, nanosec=now.nanosec)
         msg.ipc_ns_inode = self._ipc_ns_inode
         msg.topics = read_local_topics(self._lib)
         return msg
 
     def _on_remote_state(self, msg: AgnocastDaemonState) -> None:
-        # Skip our own messages.
         if msg.host_uuid == self._host_uuid and msg.ipc_ns_inode == self._ipc_ns_inode:
             return
-        self._remote_states[(msg.host_uuid, msg.ipc_ns_inode)] = msg
+        received_at = self._clock.now().nanoseconds / 1e9
+        self._remote_states[(msg.host_uuid, msg.ipc_ns_inode)] = (msg, received_at)
 
     @property
     def remote_states(self) -> dict:
-        """Latest gossip snapshots from other (host, namespace) pairs."""
+        """Map of ``(host_uuid, ipc_ns_inode)`` to ``(msg, received_at_sec)``."""
         return self._remote_states
 
 

--- a/src/ros2agnocast_discovery_agent/scripts/discovery_agent
+++ b/src/ros2agnocast_discovery_agent/scripts/discovery_agent
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Console-script wrapper so `ros2 run ros2agnocast_discovery_agent discovery_agent` works.
+
+ament_python's `entry_points` would normally produce a binary in `bin/`, but
+`ros2 run` looks in `lib/<pkg>/`. The setup.py installs this file to
+`lib/<pkg>/discovery_agent` so the standard ros2 run discovery rule finds it.
+"""
+import sys
+
+from ros2agnocast_discovery_agent.agent import main
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+package_name = 'ros2agnocast_discovery_agent'
+
+setup(
+    name=package_name,
+    version='2.3.3',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name + '/launch', ['launch/discovery_agent.launch.xml']),
+        ('lib/' + package_name, ['scripts/discovery_agent']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Keita Morisaki',
+    maintainer_email='keita.morisaki@tier4.jp',
+    description='Per-IPC-namespace daemon publishing Agnocast state on '
+                '/_agnocast_discovery for cross-NS/ECU observability and bridge generation.',
+    license='Apache License 2.0',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'discovery_agent = ros2agnocast_discovery_agent.agent:main',
+        ],
+    },
+)

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -4,7 +4,7 @@ package_name = 'ros2agnocast_discovery_agent'
 
 setup(
     name=package_name,
-    version='2.3.3',
+    version='2.3.4',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -20,7 +20,6 @@ setup(
     description='Per-IPC-namespace daemon publishing Agnocast state on '
                 '/_agnocast_discovery for cross-NS/ECU observability and bridge generation.',
     license='Apache License 2.0',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'discovery_agent = ros2agnocast_discovery_agent.agent:main',

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -15,8 +15,11 @@ setup(
     ],
     install_requires=['setuptools'],
     zip_safe=True,
-    maintainer='Keita Morisaki',
-    maintainer_email='keita.morisaki@tier4.jp',
+    maintainer='Keita Morisaki, Takahiro Ishikawa-Aso, Koichi Imai, Takumi Jin',
+    maintainer_email=(
+        'keita.morisaki@tier4.jp, sykwer@gmail.com, '
+        'koichi.imai.2@tier4.jp, primenumber_2_3_5@yahoo.co.jp'
+    ),
     description='Per-IPC-namespace daemon publishing Agnocast state on '
                 '/_agnocast_discovery for cross-NS/ECU observability and bridge generation.',
     license='Apache License 2.0',

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -1,0 +1,145 @@
+"""Unit tests for the discovery agent's ioctl-to-msg conversion and gossip wiring.
+
+These tests do not require the kmod or DDS; they exercise the conversion
+helpers directly with a mock ctypes library.
+"""
+
+import ctypes
+from unittest.mock import MagicMock
+
+import pytest
+
+from ros2agnocast_discovery_agent.agent import (
+    TOPIC_NAME_BUFFER_SIZE,
+    TopicInfoRet,
+    _ioctl_to_endpoint,
+    _read_machine_id,
+    read_local_topics,
+)
+
+
+def _make_info(node_name: str, qos_depth: int = 10,
+               qos_is_transient_local: bool = False,
+               qos_is_reliable: bool = True,
+               is_bridge: bool = False) -> TopicInfoRet:
+    info = TopicInfoRet()
+    encoded = node_name.encode('utf-8')
+    info.node_name = encoded + b'\x00' * (TOPIC_NAME_BUFFER_SIZE - len(encoded))
+    info.qos_depth = qos_depth
+    info.qos_is_transient_local = qos_is_transient_local
+    info.qos_is_reliable = qos_is_reliable
+    info.is_bridge = is_bridge
+    return info
+
+
+def test_ioctl_to_endpoint_copies_all_fields():
+    info = _make_info(
+        '/talker_node',
+        qos_depth=7,
+        qos_is_transient_local=True,
+        qos_is_reliable=False,
+        is_bridge=True,
+    )
+    ep = _ioctl_to_endpoint(info)
+    assert ep.node_name == '/talker_node'
+    assert ep.pid == 0  # best-effort empty
+    assert ep.qos_depth == 7
+    assert ep.qos_is_transient_local is True
+    assert ep.qos_is_reliable is False
+    assert ep.is_bridge is True
+
+
+def test_ioctl_to_endpoint_handles_short_name():
+    info = _make_info('/x')
+    ep = _ioctl_to_endpoint(info)
+    assert ep.node_name == '/x'
+
+
+def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
+    """Build a ctypes-flavoured mock that returns the given topic data."""
+    lib = MagicMock()
+
+    topic_names = list(topic_to_endpoints.keys())
+
+    name_storage = []
+    for name in topic_names:
+        buf = ctypes.create_string_buffer(name.encode('utf-8'))
+        name_storage.append(buf)
+
+    char_pp = (ctypes.POINTER(ctypes.c_char) * len(name_storage))(
+        *(ctypes.cast(b, ctypes.POINTER(ctypes.c_char)) for b in name_storage))
+
+    def get_topics(count_ptr):
+        count_ptr._obj.value = len(topic_names)
+        return char_pp
+
+    lib.get_agnocast_topics = MagicMock(side_effect=get_topics)
+    lib.free_agnocast_topics = MagicMock()
+
+    def make_endpoints_getter(direction):
+        def getter(topic_name_b, count_ptr):
+            name = topic_name_b.decode('utf-8')
+            infos = topic_to_endpoints.get(name, {}).get(direction, [])
+            count_ptr._obj.value = len(infos)
+            if not infos:
+                return ctypes.POINTER(TopicInfoRet)()
+            arr = (TopicInfoRet * len(infos))(*infos)
+            return ctypes.cast(arr, ctypes.POINTER(TopicInfoRet))
+        return getter
+
+    lib.get_agnocast_pub_nodes = MagicMock(side_effect=make_endpoints_getter('pub'))
+    lib.get_agnocast_sub_nodes = MagicMock(side_effect=make_endpoints_getter('sub'))
+    lib.free_agnocast_topic_info_ret = MagicMock()
+
+    return lib
+
+
+def test_read_local_topics_combines_pub_and_sub():
+    pub_info = _make_info('/talker_node', qos_depth=3)
+    sub_info = _make_info('/listener_node', qos_depth=5)
+
+    lib = _make_mock_lib({
+        '/chatter': {
+            'pub': [pub_info],
+            'sub': [sub_info],
+        },
+    })
+
+    topics = read_local_topics(lib)
+    assert len(topics) == 1
+    topic = topics[0]
+    assert topic.topic_name == '/chatter'
+    assert topic.type_name == ''  # best-effort empty
+    assert topic.domain_id == 0
+    assert len(topic.publishers) == 1
+    assert topic.publishers[0].node_name == '/talker_node'
+    assert topic.publishers[0].qos_depth == 3
+    assert len(topic.subscribers) == 1
+    assert topic.subscribers[0].node_name == '/listener_node'
+
+
+def test_read_local_topics_returns_empty_when_no_topics():
+    lib = _make_mock_lib({})
+    assert read_local_topics(lib) == []
+
+
+def test_read_local_topics_handles_topic_without_subscribers():
+    pub_info = _make_info('/orphan_pub_node')
+    lib = _make_mock_lib({
+        '/orphan_topic': {'pub': [pub_info], 'sub': []},
+    })
+    topics = read_local_topics(lib)
+    assert len(topics) == 1
+    assert topics[0].topic_name == '/orphan_topic'
+    assert len(topics[0].publishers) == 1
+    assert topics[0].subscribers == []
+
+
+def test_read_machine_id_returns_string():
+    machine_id = _read_machine_id()
+    assert isinstance(machine_id, str)
+    assert len(machine_id) > 0
+    # Either a valid UUID from /etc/machine-id or a random fallback; both
+    # should parse as UUIDs.
+    import uuid
+    uuid.UUID(machine_id)

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from ros2agnocast_discovery_agent.agent import (
-    TOPIC_NAME_BUFFER_SIZE,
+    NODE_NAME_BUFFER_SIZE,
     TopicInfoRet,
     _ioctl_to_endpoint,
     _read_machine_id,
@@ -24,7 +24,7 @@ def _make_info(node_name: str, qos_depth: int = 10,
                is_bridge: bool = False) -> TopicInfoRet:
     info = TopicInfoRet()
     encoded = node_name.encode('utf-8')
-    info.node_name = encoded + b'\x00' * (TOPIC_NAME_BUFFER_SIZE - len(encoded))
+    info.node_name = encoded + b'\x00' * (NODE_NAME_BUFFER_SIZE - len(encoded))
     info.qos_depth = qos_depth
     info.qos_is_transient_local = qos_is_transient_local
     info.qos_is_reliable = qos_is_reliable

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -13,7 +13,7 @@ from ros2agnocast_discovery_agent.agent import (
     NODE_NAME_BUFFER_SIZE,
     TopicInfoRet,
     _ioctl_to_endpoint,
-    _read_machine_id,
+    _read_host_uuid,
     read_local_topics,
 )
 
@@ -135,11 +135,11 @@ def test_read_local_topics_handles_topic_without_subscribers():
     assert topics[0].subscribers == []
 
 
-def test_read_machine_id_returns_string():
-    machine_id = _read_machine_id()
-    assert isinstance(machine_id, str)
-    assert len(machine_id) > 0
-    # Either a valid UUID from /etc/machine-id or a random fallback; both
-    # should parse as UUIDs.
+def test_read_host_uuid_returns_uuid_string():
+    host_uuid = _read_host_uuid()
+    assert isinstance(host_uuid, str)
+    assert len(host_uuid) > 0
+    # Either a valid UUID from /proc/sys/kernel/random/boot_id or a random
+    # fallback; both should parse as UUIDs.
     import uuid
-    uuid.UUID(machine_id)
+    uuid.UUID(host_uuid)

--- a/src/ros2agnocast_discovery_msgs/CMakeLists.txt
+++ b/src/ros2agnocast_discovery_msgs/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.14)
+project(ros2agnocast_discovery_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/AgnocastEndpoint.msg"
+  "msg/AgnocastTopic.msg"
+  "msg/AgnocastDaemonState.msg"
+  DEPENDENCIES builtin_interfaces
+)
+
+ament_package()

--- a/src/ros2agnocast_discovery_msgs/CMakeLists.txt
+++ b/src/ros2agnocast_discovery_msgs/CMakeLists.txt
@@ -6,7 +6,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 if(BUILD_TESTING)
@@ -18,7 +17,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/AgnocastEndpoint.msg"
   "msg/AgnocastTopic.msg"
   "msg/AgnocastDaemonState.msg"
-  DEPENDENCIES builtin_interfaces
 )
 
 ament_package()

--- a/src/ros2agnocast_discovery_msgs/msg/AgnocastDaemonState.msg
+++ b/src/ros2agnocast_discovery_msgs/msg/AgnocastDaemonState.msg
@@ -1,0 +1,17 @@
+# Snapshot of the Agnocast state of a single IPC namespace, published by
+# the discovery agent. One message per IPC namespace.
+#
+# Schema is versioned: v1 is the initial form; future bumps add fields
+# without breaking existing readers (CLI checks `schema_version` and
+# degrades gracefully on unknown values).
+
+uint32 schema_version
+# Agnocast library / runtime version of the publisher. Redundant with
+# `schema_version` for correctness but useful for debugging mixed-version
+# deployments.
+string agnocast_version
+string host_uuid                   # ECU identity; /etc/machine-id recommended
+string host_hostname               # Human-readable hostname
+builtin_interfaces/Time timestamp  # For stale detection
+uint64 ipc_ns_inode                # NS this message describes
+AgnocastTopic[] topics

--- a/src/ros2agnocast_discovery_msgs/msg/AgnocastDaemonState.msg
+++ b/src/ros2agnocast_discovery_msgs/msg/AgnocastDaemonState.msg
@@ -10,8 +10,7 @@ uint32 schema_version
 # `schema_version` for correctness but useful for debugging mixed-version
 # deployments.
 string agnocast_version
-string host_uuid                   # ECU identity; /etc/machine-id recommended
+string host_uuid                   # ECU identity (per-boot, from /proc/sys/kernel/random/boot_id)
 string host_hostname               # Human-readable hostname
-builtin_interfaces/Time timestamp  # For stale detection
 uint64 ipc_ns_inode                # NS this message describes
 AgnocastTopic[] topics

--- a/src/ros2agnocast_discovery_msgs/msg/AgnocastEndpoint.msg
+++ b/src/ros2agnocast_discovery_msgs/msg/AgnocastEndpoint.msg
@@ -1,0 +1,9 @@
+# One publisher or subscriber endpoint on an Agnocast topic. Field names
+# mirror libagnocast_ioctl_wrapper's `topic_info_ret` so CLI merge code can
+# reuse a single shape.
+string node_name
+int32 pid
+uint32 qos_depth
+bool qos_is_transient_local
+bool qos_is_reliable
+bool is_bridge

--- a/src/ros2agnocast_discovery_msgs/msg/AgnocastTopic.msg
+++ b/src/ros2agnocast_discovery_msgs/msg/AgnocastTopic.msg
@@ -1,0 +1,10 @@
+# One Agnocast topic and its endpoints within a single IPC namespace.
+string topic_name
+# Canonical ROS 2 message type name (e.g. "std_msgs/msg/String"). Empty
+# string when the daemon cannot resolve the type (best-effort).
+string type_name
+# Reserved. The kmod currently has a single domain, so this is always 0.
+# Will carry meaningful values once per-domain topic keys land.
+uint32 domain_id
+AgnocastEndpoint[] publishers
+AgnocastEndpoint[] subscribers

--- a/src/ros2agnocast_discovery_msgs/package.xml
+++ b/src/ros2agnocast_discovery_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2agnocast_discovery_msgs</name>
-  <version>2.3.3</version>
+  <version>2.3.4</version>
   <description>
     Messages published by ros2agnocast_discovery_agent to expose per-NS
     Agnocast topic/endpoint state to ros2agnocast CLI across IPC namespaces

--- a/src/ros2agnocast_discovery_msgs/package.xml
+++ b/src/ros2agnocast_discovery_msgs/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2agnocast_discovery_msgs</name>
+  <version>2.3.3</version>
+  <description>
+    Messages published by ros2agnocast_discovery_agent to expose per-NS
+    Agnocast topic/endpoint state to ros2agnocast CLI across IPC namespaces
+    and ECUs.
+  </description>
+
+  <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros2agnocast_discovery_msgs/package.xml
+++ b/src/ros2agnocast_discovery_msgs/package.xml
@@ -10,19 +10,20 @@
   </description>
 
   <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
+  <maintainer email="sykwer@gmail.com">Takahiro Ishikawa-Aso</maintainer>
+  <maintainer email="koichi.imai.2@tier4.jp">Koichi Imai</maintainer>
+  <maintainer email="ryuta.kambe@tier4.jp">Ryuta Kambe</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <exec_depend>builtin_interfaces</exec_depend>
-
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/ros2agnocast_discovery_msgs/package.xml
+++ b/src/ros2agnocast_discovery_msgs/package.xml
@@ -12,7 +12,7 @@
   <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
   <maintainer email="sykwer@gmail.com">Takahiro Ishikawa-Aso</maintainer>
   <maintainer email="koichi.imai.2@tier4.jp">Koichi Imai</maintainer>
-  <maintainer email="ryuta.kambe@tier4.jp">Ryuta Kambe</maintainer>
+  <maintainer email="primenumber_2_3_5@yahoo.co.jp">Takumi Jin</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
## Description

The `agnocastlib` infrastructure for cross-IPC-namespace bridge auto-generation. Today, Agnocast endpoints in different IPC namespaces have no automatic bridge between them — to make a cross-NS pub/sub pair talk, the operator has to hand-place a node that subscribes on one side and republishes on the other. The cross-NS bridge design lands an automatic path where a per-IPC-NS *discovery agent* gossips local Agnocast state and asks the right `bridge_manager` to spin up that bridge node itself. The agent lives in #1353; this PR is the `agnocastlib` half it talks to. Nothing fires end-to-end from this PR alone — bridge_managers listen on MQs nobody writes to, and tmpfs files are written for no reader. #1353 connects everything.

## Messages between the three processes

Three processes participate in cross-NS bridge generation:

- **Agnocast node process** — runs the user's `Publisher<T>` / `Subscription<T>`. Owns the C++ template instantiations.
- **`bridge_manager`** — `fork()`'d from each Agnocast node process. Spawns the actual ROS 2 bridge node when asked.
- **Discovery agent** — one per IPC namespace. Compares local Agnocast state against Agnocast state in other NSes (via gossip) and decides which bridges to request.

Spawning a bridge node means the bridge_manager calls `start_{a2r,r2a}_pubsub_node<T>()` for the right `T`, topic name, direction, and QoS. Those pieces are held by different processes:

| Needed | Held by | Gap |
|--------|---------|-----|
| Topic name, owning node | Already exposed by the kmod via ioctl | — |
| Message type `T` | Agnocast node process | Agent and bridge_manager both need it |
| Direction (A2R / R2A) + QoS | Agent picks the direction by comparing local vs gossip; QoS is captured at the same time | — |
| Bridge_manager pid for a given endpoint | Agnocast node process (parent–child relationship) | Agent needs it to send the request to the right bridge_manager |
| Factory for `T` (how to call `start_..._pubsub_node<T>`) | Agnocast node process | Bridge_manager needs it to generate a bridge |

Filling those gaps requires three messages between the three processes:

| Message | Payload | From → To | Transport |
|---------|---------|-----------|-----------|
| **Endpoint type registration** | `<topic, type, role, node, owning bridge_manager pid>` | Agnocast node process → agent | One Agnocast node creates a Tmpfs file `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns>/<pid>.txt`. The agent picks files up in its existing 1 Hz poll. |
| **Bridge factory** | `<type name, shared-library path, function offsets for the A2R/R2A pubsub-node starters>` | Agnocast node process → bridge_manager | Agnocast node process sends a POSIX MQ msg to `/agnocast_factory_register@<bm_pid>` (`bm_pid`: bridge_manager's PID). The bridge_manager reuses the existing MQ event loop (a new `IpcEventLoopBase::register_aux_mq` hook lets it watch multiple MQs). |
| **Bridge request** | `<topic, type, direction, qos>` | agent → bridge_manager | The agent sends bridge_manager a POSIX MQ to ask for a bridge generation. (Standard mode: `/agnocast_daemon_bridge@<bm_pid>`, one per bridge_manager. Performance mode: `/agnocast_daemon_bridge_perf`, one per IPC NS) |


## MQ limitation

Each POSIX MQ counts against the caller's per-UID `RLIMIT_MSGQUEUE` quota (default 819200 bytes on Linux). The kernel charges ~3.3 KB fixed overhead per MQ (the `mqueue_inode_info` struct + the per-MQ message-pointer array), plus `max_messages × msg_size` for the queue capacity.

This PR adds two MQs per bridge_manager on top of the existing primary one. With `MAX_MESSAGES = 2` and a 512-byte `shared_lib_path` buffer in the factory payload (instead of `PATH_MAX`), each bridge_manager consumes ~18.6 KB total → **~44 simultaneous bridge_managers per UID**. In practice `e2e_test_1to1` is bound at `-p 8` *because of this PR*: the extra per-bridge_manager setup makes DDS discovery race under heavier parallelism. The MQ-quota ceiling above is not the binding limit.

### Side fix: pre-existing MQ leak

While sizing the new MQs we found a leak the primary MQ has had since day one. SIGKILL'd bridge_managers never run `cleanup_resources()`; the existing `poll_for_unlink` reaps them via the kmod's `do_exit` hook, but only while *it* itself is alive — so across launch cycles where every Agnocast process dies, MQs leak forever against `RLIMIT_MSGQUEUE`. At ~10 KB the primary MQ rarely hit the quota, but the new aux MQs surfaced the bug once `e2e_test_1to1.bash` reproducibly returned `mq_open ... EMFILE`. Fixes: `poll_for_unlink` also reaps the two new aux MQs (covers within a single run); `initialize_agnocast()` sweeps `/dev/mqueue/` at startup and unlinks any agnocast MQ whose `@<pid>` is no longer in `/proc/` (heals leaks from prior runs).

## Follow-up tasks

To keep this change `need-patch-update`, several workarounds sit on top of the current kmod ABI. They all go away in the next `need-minor-update`, which extends the per-endpoint ioctl that agnocastlib already polls (it currently returns topic name and owning node) to also return the **message type**, the **owning bridge_manager pid**, and to let **QoS be looked up by endpoint id**. Each workaround is marked `TODO:` in the source.

| Today's workaround | Limitation / drawback | Replaced by |
|--------------------|------------------------|-------------|
| `MqMsgFactoryRegister` MQ + `notify_bridge_manager_of_factory()` retry on `EAGAIN` | One extra MQ per bridge_manager; node-startup bursts retry-loop for up to 10 s; `.so` paths longer than 512 bytes hit a one-shot WARN and disable the cross-NS bridge for that type | bridge_manager reads each endpoint's message type from the extended ioctl and resolves the factory from its own image. The `MqMsgFactoryRegister` MQ, the retry loop, and the 512-byte `shared_lib_path` buffer are all deleted. |
| 5th tmpfs field (`bridge_manager_pid`) | The tmpfs line format adds a field that agnocastlib and the discovery agent must keep in lockstep | The agent reads the bridge_manager pid from the extended ioctl. The tmpfs line goes back to 4 fields, no lockstep needed. |
| `MqMsgDaemonBridge.qos_*` fields | Larger wire struct; QoS is bookkeeping the agnocastlib could otherwise read directly | The agent passes the endpoint id in `MqMsgDaemonBridge` and the bridge_manager looks the QoS up via the extended ioctl. The `qos_*` fields are removed from the wire struct. |
| `DAEMON_BRIDGE` + `FACTORY_REGISTER` MQs sized to fit `RLIMIT_MSGQUEUE` | ~44 simultaneous bridge_managers per UID ceiling | `FACTORY_REGISTER` MQ is deleted entirely (see row 1). Only `DAEMON_BRIDGE` + primary MQ remain per bridge_manager, so `RLIMIT_MSGQUEUE` budget per bridge_manager shrinks back to nearly the pre-PR baseline. |

## Related links

- Design doc: <https://tier4.atlassian.net/wiki/x/2YFtNwE> (TIER IV internal)
- Jira: T4DEV-51976 (TIER IV internal), parent epic T4DEV-52095
- Merge order: #1350 (shared base) → #1351 (CLI gossip subscribe) → **#1352 (this PR)** → #1353 (discovery agent: connect everything)

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) — 128/128 PASS at `-p 8` (RLIMIT_MSGQUEUE arithmetic ceiling is `-p 22`, but a DDS-discovery race is the tighter empirical bound at `-p 8`).
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A: kmod untouched.
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) — N/A: same reason. (Multi-workspace shells need #1354 to find heaphook.)
- [ ] sample application
- [x] Added automated tests (all pass locally): `colcon test --packages-select agnocastlib --ctest-args -R 'BridgeFactoryRegistry|TypeRegistryWriter'` — 8 gtests covering registry register/lookup/no-op-on-service-type plus writer single-line/repeated-append/concurrent-write.

## Notes for reviewers

This PR is non-functional standalone: the bridge_manager listens on new MQs nobody writes to yet, and tmpfs files are written for no reader. End-to-end behaviour activates with #1353. Concentrated review surfaces:

1. **SFINAE gate on `register_bridge_factory<T>()`** (`internal/bridge_factory_registry.hpp`) — without `if constexpr (is_message<T>::value)`, `BasicService<ServiceT>` force-instantiates `start_a2r_pubsub_node<ServiceT>` and trips a `static_assert` in `rclcpp::Publisher`. A dedicated gtest case guards this regression.
2. **Tmpfs lifecycle assumptions** (design doc §8.2):
   - Autoware launches after the discovery agent has started.
   - The discovery agent does not crash during the run.
   - If either is violated, the writer's `atexit` unlink misses or the agent's sweep does not catch the file. #1353 ships `ros2 agnocast discovery_daemon_status` for operator-side detection.

## Version Update Label (Required)

- `need-patch-update`

`agnocastlib` only — all additions are new headers, new structs, and new method overloads. kmod ABI, existing ioctls, and the existing `MqMsgBridge` / `MqMsgPerformanceBridge` wire structs are byte-for-byte unchanged. See CONTRIBUTING.md §"Versioning rules".
