### PR TITLE
feat(ros2agnocast_discovery_agent): consume tmpfs registry + dispatch bridges by pid + liveness CLI

### DIFF
--- a/scripts/test/e2e_test_daemon_bridge_mq.bash
+++ b/scripts/test/e2e_test_daemon_bridge_mq.bash
@@ -118,5 +118,36 @@ if ! ls /dev/mqueue/agnocast_daemon_bridge@* > /dev/null 2>&1; then
 fi
 green "✓ daemon decider tick stayed quiescent with empty remote_states"
 
+# ----- tmpfs type registry populated -----
+# agnocastlib should have created /run/agnocast/<ns>/<pid>.txt with at
+# least the talker's publisher row.
+talker_pid=$(pgrep -f "agnocast_sample_application/.*talker" | head -1)
+ns_inode=$(stat -c '%i' /proc/self/ns/ipc)
+registry_file="/run/agnocast/${ns_inode}/${talker_pid}.txt"
+if [ -z "$talker_pid" ] || [ ! -f "$registry_file" ]; then
+    fail "tmpfs type registry file missing: expected $registry_file"
+fi
+if ! grep -q "/my_topic"$'\t'"std_msgs/msg/" "$registry_file"; then
+    fail "tmpfs type registry has no /my_topic / std_msgs/msg/* entry" "$(cat "$registry_file")"
+fi
+green "✓ tmpfs type registry has /my_topic with non-empty type"
+
+# ----- gossip carries the actual type_name (not empty) -----
+# /_agnocast_discovery is RELIABLE+TRANSIENT_LOCAL so a fresh subscriber
+# can read the latest snapshot. Allow a short window for the daemon to
+# observe the registry on its next tick.
+sleep 2
+gossip=$(timeout 5 ros2 topic echo --once /_agnocast_discovery 2>&1 || true)
+if ! grep -q "type_name: std_msgs/msg/" <<<"$gossip"; then
+    fail "gossip msg has no concrete type_name (expected std_msgs/msg/...)" "$gossip"
+fi
+green "✓ gossip msg carries concrete type_name"
+
+# ----- gossip carries non-zero pid for the talker endpoint -----
+if ! grep -E "^  pid: [0-9]+" <<<"$gossip" | grep -vE "pid: 0$" > /dev/null; then
+    fail "no AgnocastEndpoint with non-zero pid in gossip" "$gossip"
+fi
+green "✓ gossip msg carries a non-zero endpoint pid"
+
 green ""
 green "===== ALL CHECKS PASSED ====="

--- a/scripts/test/e2e_test_daemon_bridge_mq.bash
+++ b/scripts/test/e2e_test_daemon_bridge_mq.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# E2E regression smoke test for the F1 daemon-originated bridge MQ
+# E2E regression smoke test for the daemon-originated bridge MQ
 # wiring. Verifies that:
 #
 #   * A running bridge_manager (forked by an Agnocast process) creates
@@ -119,18 +119,21 @@ fi
 green "✓ daemon decider tick stayed quiescent with empty remote_states"
 
 # ----- tmpfs type registry populated -----
-# agnocastlib should have created /run/agnocast/<ns>/<pid>.txt with at
-# least the talker's publisher row.
-talker_pid=$(pgrep -f "agnocast_sample_application/.*talker" | head -1)
-ns_inode=$(stat -c '%i' /proc/self/ns/ipc)
-registry_file="/run/agnocast/${ns_inode}/${talker_pid}.txt"
-if [ -z "$talker_pid" ] || [ ! -f "$registry_file" ]; then
-    fail "tmpfs type registry file missing: expected $registry_file"
+# agnocastlib writes /dev/shm/agnocast_type_registry/<ns>/<pid>.txt with a
+# `<topic>\t<type>\t<role>\t<node>` row per Publisher / Subscription
+# construction. We do not pin by pid because (a) `ros2 launch` forks
+# multiple talker copies under the same cmdline (bridge_manager etc.),
+# and (b) the test harness may live in a different IPC namespace from
+# the launched process. Any file under the registry root containing a
+# `/my_topic` row with a concrete type counts.
+registry_file=$(grep -l "/my_topic" /dev/shm/agnocast_type_registry/*/*.txt 2>/dev/null | head -1)
+if [ -z "$registry_file" ] || [ ! -f "$registry_file" ]; then
+    fail "no /dev/shm/agnocast_type_registry/<ns>/<pid>.txt file contains /my_topic"
 fi
-if ! grep -q "/my_topic"$'\t'"std_msgs/msg/" "$registry_file"; then
-    fail "tmpfs type registry has no /my_topic / std_msgs/msg/* entry" "$(cat "$registry_file")"
+if ! grep -q "/my_topic"$'\t'"agnocast_sample_interfaces/msg/" "$registry_file"; then
+    fail "registry has /my_topic but no concrete type" "$(cat "$registry_file")"
 fi
-green "✓ tmpfs type registry has /my_topic with non-empty type"
+green "✓ tmpfs type registry has /my_topic with concrete type ($registry_file)"
 
 # ----- gossip carries the actual type_name (not empty) -----
 # /_agnocast_discovery is RELIABLE+TRANSIENT_LOCAL so a fresh subscriber
@@ -138,13 +141,15 @@ green "✓ tmpfs type registry has /my_topic with non-empty type"
 # observe the registry on its next tick.
 sleep 2
 gossip=$(timeout 5 ros2 topic echo --once /_agnocast_discovery 2>&1 || true)
-if ! grep -q "type_name: std_msgs/msg/" <<<"$gossip"; then
-    fail "gossip msg has no concrete type_name (expected std_msgs/msg/...)" "$gossip"
+if ! grep -q "type_name: agnocast_sample_interfaces/msg/" <<<"$gossip"; then
+    fail "gossip msg has no concrete type_name (expected agnocast_sample_interfaces/msg/...)" "$gossip"
 fi
 green "✓ gossip msg carries concrete type_name"
 
 # ----- gossip carries non-zero pid for the talker endpoint -----
-if ! grep -E "^  pid: [0-9]+" <<<"$gossip" | grep -vE "pid: 0$" > /dev/null; then
+# `ros2 topic echo` indents endpoint fields with 4 spaces in YAML; match
+# any whitespace prefix to stay format-tolerant.
+if ! grep -E "^[[:space:]]+pid: [0-9]+" <<<"$gossip" | grep -vE "pid: 0$" > /dev/null; then
     fail "no AgnocastEndpoint with non-zero pid in gossip" "$gossip"
 fi
 green "✓ gossip msg carries a non-zero endpoint pid"

--- a/scripts/test/e2e_test_daemon_bridge_mq.bash
+++ b/scripts/test/e2e_test_daemon_bridge_mq.bash
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# E2E regression smoke test for the F1 daemon-originated bridge MQ
+# wiring. Verifies that:
+#
+#   * A running bridge_manager (forked by an Agnocast process) creates
+#     the new `agnocast_daemon_bridge@<pid>` MQ on top of the existing
+#     `agnocast_bridge_manager@<pid>` MQ.
+#   * The discovery agent comes up alongside without errors and runs the
+#     bridge decider tick without crashing when remote_states is empty.
+#   * Injecting a synthetic remote AgnocastDaemonState that lists an
+#     Agnocast subscriber on the local talker's topic causes the daemon
+#     to dispatch an MqMsgDaemonBridge — observable indirectly as the
+#     bridge_manager neither crashes nor leaks an extra MQ.
+#
+# This is a single-namespace smoke test. Real cross-IPC-namespace
+# verification is left to a manual `unshare -i` test plan (documented
+# separately) because CI does not currently grant CAP_SYS_ADMIN.
+#
+# Requires:
+#   * agnocast kernel module loaded
+#   * workspace built (bash scripts/dev/build_all.bash)
+#
+# Usage:
+#   bash scripts/test/e2e_test_daemon_bridge_mq.bash
+#
+# Exit codes:
+#   0 - all checks passed
+#   1 - prerequisite failure
+#   2 - assertion failure
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+DAEMON_WARMUP_SEC=${DAEMON_WARMUP_SEC:-2}
+TALKER_WARMUP_SEC=${TALKER_WARMUP_SEC:-4}
+DISPATCH_WARMUP_SEC=${DISPATCH_WARMUP_SEC:-3}
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+if ! grep -q "^agnocast " /proc/modules; then
+    red "ERROR: agnocast kmod not loaded."
+    echo "  -> sudo insmod $ROOT_DIR/agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+if [ ! -f "$ROOT_DIR/install/setup.bash" ]; then
+    red "ERROR: workspace not built ($ROOT_DIR/install/setup.bash missing)."
+    echo "  -> bash $ROOT_DIR/scripts/dev/build_all.bash" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$ROOT_DIR/install/setup.bash"
+set -u
+green "✓ kmod loaded and workspace sourced"
+
+LOG_DIR=$(mktemp -d)
+cleanup() {
+    pkill -P $$ 2>/dev/null || true
+    sleep 1
+    rm -rf "$LOG_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    red "ERROR: $1"
+    [ -n "${2:-}" ] && { echo "----- output -----" >&2; printf '%s\n' "$2" >&2; }
+    [ -f "$LOG_DIR/agent.log" ]  && { echo "----- agent log -----"  >&2; cat "$LOG_DIR/agent.log"  >&2; }
+    [ -f "$LOG_DIR/talker.log" ] && { echo "----- talker log -----" >&2; cat "$LOG_DIR/talker.log" >&2; }
+    exit 2
+}
+
+# ----- launch talker (forks a bridge_manager) -----
+yellow "Starting agnocast talker (forks a bridge_manager)..."
+ros2 launch agnocast_sample_application talker.launch.xml > "$LOG_DIR/talker.log" 2>&1 &
+sleep "$TALKER_WARMUP_SEC"
+
+# bridge_manager registers `/agnocast_bridge_manager@<pid>` AND
+# `/agnocast_daemon_bridge@<pid>` for the same pid. Find any of the
+# daemon MQs as the success signal.
+mq_files=$(ls /dev/mqueue/agnocast_daemon_bridge@* 2>/dev/null || true)
+if [ -z "$mq_files" ]; then
+    fail "no /dev/mqueue/agnocast_daemon_bridge@<pid> entry created by talker's bridge_manager"
+fi
+green "✓ bridge_manager exposed daemon bridge MQ:"
+ls -la $mq_files
+
+# Verify the matching primary MQ also exists (sanity).
+primary_mq=$(ls /dev/mqueue/agnocast_bridge_manager@* 2>/dev/null || true)
+if [ -z "$primary_mq" ]; then
+    fail "missing primary /dev/mqueue/agnocast_bridge_manager@<pid> entry"
+fi
+green "✓ primary bridge_manager MQ still present"
+
+# ----- launch daemon -----
+yellow "Starting discovery_agent..."
+ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+sleep "$DAEMON_WARMUP_SEC"
+
+if ! grep -q "discovery_agent up" "$LOG_DIR/agent.log"; then
+    fail "daemon did not log startup within ${DAEMON_WARMUP_SEC}s"
+fi
+green "✓ daemon up"
+
+# ----- daemon decider quiescence (no remote state -> no dispatch) -----
+# With no other discovery agents present on the bus, `remote_states` stays
+# empty and the bridge decider must not emit anything. We assert quiescence
+# negatively: the daemon log must not contain a dispatch warning and the
+# bridge_manager MQ must still exist.
+sleep "$DISPATCH_WARMUP_SEC"
+
+if grep -q "Traceback" "$LOG_DIR/agent.log"; then
+    fail "daemon crashed during decider tick" "$(cat "$LOG_DIR/agent.log")"
+fi
+
+if ! ls /dev/mqueue/agnocast_daemon_bridge@* > /dev/null 2>&1; then
+    fail "daemon bridge MQ vanished after warmup -- bridge_manager likely died"
+fi
+green "✓ daemon decider tick stayed quiescent with empty remote_states"
+
+green ""
+green "===== ALL CHECKS PASSED ====="

--- a/scripts/test/e2e_test_daemon_bridge_mq.bash
+++ b/scripts/test/e2e_test_daemon_bridge_mq.bash
@@ -65,8 +65,7 @@ trap cleanup EXIT
 fail() {
     red "ERROR: $1"
     [ -n "${2:-}" ] && { echo "----- output -----" >&2; printf '%s\n' "$2" >&2; }
-    [ -f "$LOG_DIR/agent.log" ]  && { echo "----- agent log -----"  >&2; cat "$LOG_DIR/agent.log"  >&2; }
-    [ -f "$LOG_DIR/talker.log" ] && { echo "----- talker log -----" >&2; cat "$LOG_DIR/talker.log" >&2; }
+    [ -f "$LOG_DIR/talker.log" ] && { echo "----- talker log (incl. discovery_agent) -----" >&2; cat "$LOG_DIR/talker.log" >&2; }
     exit 2
 }
 
@@ -92,13 +91,16 @@ if [ -z "$primary_mq" ]; then
 fi
 green "✓ primary bridge_manager MQ still present"
 
-# ----- launch daemon -----
-yellow "Starting discovery_agent..."
-ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+# ----- verify discovery_agent is up -----
+# talker.launch.xml brings up exactly one discovery_agent in this IPC
+# namespace via `<include discovery_agent.launch.xml ... if="..."/>`. The
+# agent's own `flock(2)` singleton check guarantees one per namespace, so
+# we don't spawn a second one here — just confirm the launched agent
+# emitted its startup banner.
 sleep "$DAEMON_WARMUP_SEC"
 
-if ! grep -q "discovery_agent up" "$LOG_DIR/agent.log"; then
-    fail "daemon did not log startup within ${DAEMON_WARMUP_SEC}s"
+if ! grep -q "discovery_agent up" "$LOG_DIR/talker.log"; then
+    fail "discovery_agent did not log startup within (${TALKER_WARMUP_SEC}+${DAEMON_WARMUP_SEC})s"
 fi
 green "✓ daemon up"
 
@@ -109,8 +111,8 @@ green "✓ daemon up"
 # bridge_manager MQ must still exist.
 sleep "$DISPATCH_WARMUP_SEC"
 
-if grep -q "Traceback" "$LOG_DIR/agent.log"; then
-    fail "daemon crashed during decider tick" "$(cat "$LOG_DIR/agent.log")"
+if grep -q "Traceback" "$LOG_DIR/talker.log"; then
+    fail "discovery_agent crashed during decider tick" "$(cat "$LOG_DIR/talker.log")"
 fi
 
 if ! ls /dev/mqueue/agnocast_daemon_bridge@* > /dev/null 2>&1; then

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -15,8 +15,9 @@ Checks performed (each prints OK / NG with detail):
     on the current `ROS_DOMAIN_ID` and a snapshot is received within
     the timeout.
   * **type_registry** — the tmpfs directory
-    `/run/agnocast/<ipc_ns_inode>/` exists and contains at least one
-    `<pid>.txt` (proves at least one Agnocast process has registered).
+    `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/` exists and
+    contains at least one `<pid>.txt` (proves at least one Agnocast
+    process has registered).
 
 Exit code:
 
@@ -36,7 +37,7 @@ from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
 
 
 _GOSSIP_TOPIC = '/_agnocast_discovery'
-_TYPE_REGISTRY_BASE = '/run/agnocast'
+_TYPE_REGISTRY_BASE = '/dev/shm/agnocast_type_registry'
 
 
 def _self_ipc_ns_inode():

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -2,21 +2,21 @@
 
 The agent is responsible for (a) publishing the local Agnocast state on
 ``/_agnocast_discovery`` for cross-namespace observability and (b)
-dispatching `MqMsgDaemonBridge` requests so that cross-IPC-NS bridges
+dispatching ``MqMsgDaemonBridge`` requests so that cross-IPC-NS bridges
 are auto-generated. If the daemon is not running (or running in a
 different IPC namespace), both features silently stop working — this
 verb gives the operator a single place to confirm liveness.
 
 Checks performed (each prints OK / NG with detail):
 
-  * **process** — any `ros2agnocast_discovery_agent` process is running
-    in **this** IPC namespace (matched by `/proc/<pid>/ns/ipc`).
-  * **gossip** — `/_agnocast_discovery` has at least one DDS publisher
-    on the current `ROS_DOMAIN_ID` and a snapshot is received within
+  * **process** — any ``ros2agnocast_discovery_agent`` process is running
+    in **this** IPC namespace (matched by ``/proc/<pid>/ns/ipc``).
+  * **gossip** — ``/_agnocast_discovery`` has at least one DDS publisher
+    on the current ``ROS_DOMAIN_ID`` and a snapshot is received within
     the timeout.
   * **type_registry** — the tmpfs directory
-    `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/` exists and
-    contains at least one `<pid>.txt` (proves at least one Agnocast
+    ``/dev/shm/agnocast_type_registry/<ipc_ns_inode>/`` exists and
+    contains at least one ``<pid>.txt`` (proves at least one Agnocast
     process has registered).
 
 Exit code:
@@ -40,7 +40,7 @@ _GOSSIP_TOPIC = '/_agnocast_discovery'
 
 
 def _type_registry_base() -> str:
-    """Resolve the tmpfs root, honoring `AGNOCAST_TMPFS_DIR` like the writer."""
+    """Resolve the tmpfs root, honoring ``AGNOCAST_TMPFS_DIR`` like the writer."""
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
     return os.path.join(root, 'agnocast_type_registry')
 
@@ -64,7 +64,7 @@ def _check_daemon_process(my_ns_inode):
                 comm = fp.read().strip()
         except (FileNotFoundError, PermissionError):
             continue
-        # The discovery agent runs as a python script; its `comm` is the
+        # The discovery agent runs as a python script; its ``comm`` is the
         # python interpreter. We check cmdline for the agent's module name.
         try:
             with open(f'/proc/{pid}/cmdline', 'rb') as fp:

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -1,0 +1,152 @@
+"""Check that the per-IPC-namespace Agnocast discovery agent is alive.
+
+The agent is responsible for (a) publishing the local Agnocast state on
+``/_agnocast_discovery`` for cross-namespace observability and (b)
+dispatching `MqMsgDaemonBridge` requests so that cross-IPC-NS bridges
+are auto-generated. If the daemon is not running (or running in a
+different IPC namespace), both features silently stop working — this
+verb gives the operator a single place to confirm liveness.
+
+Checks performed (each prints OK / NG with detail):
+
+  * **process** — any `ros2agnocast_discovery_agent` process is running
+    in **this** IPC namespace (matched by `/proc/<pid>/ns/ipc`).
+  * **gossip** — `/_agnocast_discovery` has at least one DDS publisher
+    on the current `ROS_DOMAIN_ID` and a snapshot is received within
+    the timeout.
+  * **type_registry** — the tmpfs directory
+    `/run/agnocast/<ipc_ns_inode>/` exists and contains at least one
+    `<pid>.txt` (proves at least one Agnocast process has registered).
+
+Exit code:
+
+  * 0 — all OK
+  * 1 — at least one NG (operator should investigate)
+"""
+
+import os
+import time
+
+import rclpy
+from rclpy.node import Node
+from ros2cli.node.strategy import NodeStrategy
+from ros2cli.verb import VerbExtension
+
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+
+
+_GOSSIP_TOPIC = '/_agnocast_discovery'
+_TYPE_REGISTRY_BASE = '/run/agnocast'
+
+
+def _self_ipc_ns_inode():
+    return os.stat('/proc/self/ns/ipc').st_ino
+
+
+def _check_daemon_process(my_ns_inode):
+    """Return (ok, detail) for the daemon-process check."""
+    found_pids = []
+    for pid_str in os.listdir('/proc'):
+        if not pid_str.isdigit():
+            continue
+        pid = int(pid_str)
+        try:
+            with open(f'/proc/{pid}/comm') as fp:
+                comm = fp.read().strip()
+        except (FileNotFoundError, PermissionError):
+            continue
+        # The discovery agent runs as a python script; its `comm` is the
+        # python interpreter. We check cmdline for the agent's module name.
+        try:
+            with open(f'/proc/{pid}/cmdline', 'rb') as fp:
+                cmdline = fp.read().replace(b'\0', b' ').decode('utf-8', errors='replace')
+        except (FileNotFoundError, PermissionError):
+            continue
+        if 'ros2agnocast_discovery_agent' not in cmdline:
+            continue
+        # Must be in the same IPC namespace as the caller.
+        try:
+            their_ns = os.stat(f'/proc/{pid}/ns/ipc').st_ino
+        except (FileNotFoundError, PermissionError):
+            continue
+        if their_ns != my_ns_inode:
+            continue
+        found_pids.append(pid)
+
+    if not found_pids:
+        return False, 'no discovery_agent process found in this IPC namespace'
+    if len(found_pids) > 1:
+        return True, f'pid(s)={found_pids} (warning: multiple daemons running in this NS)'
+    return True, f'pid={found_pids[0]}'
+
+
+def _check_gossip(timeout_sec=2.0):
+    """Return (ok, detail) for the gossip-subscription check."""
+    rclpy_was_initialized = rclpy.ok()
+    if not rclpy_was_initialized:
+        rclpy.init()
+    try:
+        with NodeStrategy(None) as node:
+            from ros2agnocast.discovery import gossip_qos
+            received = []
+
+            def cb(msg: AgnocastDaemonState) -> None:
+                received.append(msg)
+
+            sub = node.create_subscription(
+                AgnocastDaemonState, _GOSSIP_TOPIC, cb, gossip_qos())
+            try:
+                deadline = time.monotonic() + timeout_sec
+                while time.monotonic() < deadline and not received:
+                    rclpy.spin_once(node, timeout_sec=0.05)
+            finally:
+                node.destroy_subscription(sub)
+
+            if not received:
+                return False, (
+                    f'no AgnocastDaemonState received on {_GOSSIP_TOPIC} within '
+                    f'{timeout_sec}s')
+            return True, f'received {len(received)} snapshot(s) on {_GOSSIP_TOPIC}'
+    finally:
+        # Only shutdown rclpy if we initialized it here. Otherwise leave
+        # the caller's context intact.
+        if not rclpy_was_initialized and rclpy.ok():
+            rclpy.shutdown()
+
+
+def _check_type_registry(my_ns_inode):
+    """Return (ok, detail) for the tmpfs type registry check."""
+    ns_dir = os.path.join(_TYPE_REGISTRY_BASE, str(my_ns_inode))
+    if not os.path.isdir(ns_dir):
+        return False, f'directory missing: {ns_dir}'
+    files = [f for f in os.listdir(ns_dir) if f.endswith('.txt')]
+    if not files:
+        return False, f'{ns_dir} contains no <pid>.txt registrations'
+    return True, f'{ns_dir} has {len(files)} registration file(s)'
+
+
+class DiscoveryDaemonStatusVerb(VerbExtension):
+    """Check the per-IPC-namespace Agnocast discovery agent's liveness."""
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '--gossip-timeout', type=float, default=2.0,
+            help='Seconds to wait for a /_agnocast_discovery snapshot (default: 2.0)')
+
+    def main(self, *, args):
+        my_ns_inode = _self_ipc_ns_inode()
+        print(f'IPC namespace inode: {my_ns_inode}')
+
+        any_ng = False
+        for name, fn in [
+            ('process       ', lambda: _check_daemon_process(my_ns_inode)),
+            ('gossip        ', lambda: _check_gossip(args.gossip_timeout)),
+            ('type_registry ', lambda: _check_type_registry(my_ns_inode)),
+        ]:
+            ok, detail = fn()
+            status = 'OK' if ok else 'NG'
+            print(f'  {name}{status}: {detail}')
+            if not ok:
+                any_ng = True
+
+        return 1 if any_ng else 0

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -37,7 +37,15 @@ from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
 
 
 _GOSSIP_TOPIC = '/_agnocast_discovery'
-_TYPE_REGISTRY_BASE = '/dev/shm/agnocast_type_registry'
+
+
+def _type_registry_base() -> str:
+    """Resolve the tmpfs root, honoring `AGNOCAST_TMPFS_DIR` like the writer."""
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, 'agnocast_type_registry')
+
+
+_TYPE_REGISTRY_BASE = _type_registry_base()
 
 
 def _self_ipc_ns_inode():

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -45,9 +45,6 @@ def _type_registry_base() -> str:
     return os.path.join(root, 'agnocast_type_registry')
 
 
-_TYPE_REGISTRY_BASE = _type_registry_base()
-
-
 def _self_ipc_ns_inode():
     return os.stat('/proc/self/ns/ipc').st_ino
 
@@ -59,13 +56,8 @@ def _check_daemon_process(my_ns_inode):
         if not pid_str.isdigit():
             continue
         pid = int(pid_str)
-        try:
-            with open(f'/proc/{pid}/comm') as fp:
-                comm = fp.read().strip()
-        except (FileNotFoundError, PermissionError):
-            continue
-        # The discovery agent runs as a python script; its ``comm`` is the
-        # python interpreter. We check cmdline for the agent's module name.
+        # The discovery agent runs as a python script — its ``comm`` is the
+        # python interpreter — so match on cmdline instead.
         try:
             with open(f'/proc/{pid}/cmdline', 'rb') as fp:
                 cmdline = fp.read().replace(b'\0', b' ').decode('utf-8', errors='replace')
@@ -125,7 +117,7 @@ def _check_gossip(timeout_sec=2.0):
 
 def _check_type_registry(my_ns_inode):
     """Return (ok, detail) for the tmpfs type registry check."""
-    ns_dir = os.path.join(_TYPE_REGISTRY_BASE, str(my_ns_inode))
+    ns_dir = os.path.join(_type_registry_base(), str(my_ns_inode))
     if not os.path.isdir(ns_dir):
         return False, f'directory missing: {ns_dir}'
     files = [f for f in os.listdir(ns_dir) if f.endswith('.txt')]

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -27,6 +27,7 @@ setup(
         'ros2agnocast.verb': [
             'generate-bridge-plugins = ros2agnocast.verb.generate_bridge_plugins:GenerateBridgePluginsVerb',
             'version = ros2agnocast.verb.version:VersionVerb',
+            'discovery_daemon_status = ros2agnocast.verb.discovery_daemon_status:DiscoveryDaemonStatusVerb',
         ],
         'ros2topic.verb': [
             'list_agnocast = ros2agnocast.verb.list_agnocast:ListAgnocastVerb',

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,0 +1,59 @@
+"""Pure-logic tests for the discovery_daemon_status verb.
+
+The verb itself talks to /proc and DDS, but the small helpers are
+exercised here with a tmp directory in place of `/run/agnocast`.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from ros2agnocast.verb import discovery_daemon_status as ds
+
+
+def test_check_type_registry_missing_dir_returns_ng():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+            ok, detail = ds._check_type_registry(999999)
+        assert ok is False
+        assert 'missing' in detail
+
+
+def test_check_type_registry_empty_dir_returns_ng():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 12345
+        os.makedirs(os.path.join(tmpdir, str(ns_inode)))
+        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+            ok, detail = ds._check_type_registry(ns_inode)
+        assert ok is False
+        assert 'no <pid>.txt' in detail
+
+
+def test_check_type_registry_with_files_returns_ok():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 12345
+        ns_dir = os.path.join(tmpdir, str(ns_inode))
+        os.makedirs(ns_dir)
+        with open(os.path.join(ns_dir, '4242.txt'), 'w') as fp:
+            fp.write('/topic\ttype\tpub\t/node\n')
+        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+            ok, detail = ds._check_type_registry(ns_inode)
+        assert ok is True
+        assert '1' in detail
+
+
+def test_check_daemon_process_self_ns_no_match():
+    """When no discovery_agent is running in this NS, returns NG.
+
+    This test runs in the pytest process's own IPC NS, where no
+    discovery_agent should be present unless the test runner happens to
+    overlap with one — extremely unlikely under normal CI.
+    """
+    my_ns_inode = ds._self_ipc_ns_inode()
+    ok, detail = ds._check_daemon_process(my_ns_inode)
+    # Either no daemon (most cases) or one is genuinely running. Both
+    # are valid outputs; we just assert the function returns the
+    # expected tuple shape and detail string is non-empty.
+    assert isinstance(ok, bool)
+    assert isinstance(detail, str)
+    assert detail

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -57,3 +57,12 @@ def test_check_daemon_process_self_ns_no_match():
     assert isinstance(ok, bool)
     assert isinstance(detail, str)
     assert detail
+
+
+def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):
+    """`AGNOCAST_TMPFS_DIR` overrides the `/dev/shm` default consistently with the writer."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
+    assert ds._type_registry_base() == '/run/custom/agnocast_type_registry'
+
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    assert ds._type_registry_base() == '/dev/shm/agnocast_type_registry'

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,7 +1,7 @@
 """Pure-logic tests for the discovery_daemon_status verb.
 
 The verb itself talks to /proc and DDS, but the small helpers are
-exercised here with a tmp directory in place of `/run/agnocast`.
+exercised here with a tmp directory in place of ``/run/agnocast``.
 """
 
 import os
@@ -60,7 +60,7 @@ def test_check_daemon_process_self_ns_no_match():
 
 
 def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):
-    """`AGNOCAST_TMPFS_DIR` overrides the `/dev/shm` default consistently with the writer."""
+    """``AGNOCAST_TMPFS_DIR`` overrides the ``/dev/shm`` default consistently with the writer."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
     assert ds._type_registry_base() == '/run/custom/agnocast_type_registry'
 

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -13,7 +13,7 @@ from ros2agnocast.verb import discovery_daemon_status as ds
 
 def test_check_type_registry_missing_dir_returns_ng():
     with tempfile.TemporaryDirectory() as tmpdir:
-        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
             ok, detail = ds._check_type_registry(999999)
         assert ok is False
         assert 'missing' in detail
@@ -23,7 +23,7 @@ def test_check_type_registry_empty_dir_returns_ng():
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 12345
         os.makedirs(os.path.join(tmpdir, str(ns_inode)))
-        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
             ok, detail = ds._check_type_registry(ns_inode)
         assert ok is False
         assert 'no <pid>.txt' in detail
@@ -36,7 +36,7 @@ def test_check_type_registry_with_files_returns_ok():
         os.makedirs(ns_dir)
         with open(os.path.join(ns_dir, '4242.txt'), 'w') as fp:
             fp.write('/topic\ttype\tpub\t/node\n')
-        with patch.object(ds, '_TYPE_REGISTRY_BASE', tmpdir):
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
             ok, detail = ds._check_type_registry(ns_inode)
         assert ok is True
         assert '1' in detail

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -278,7 +278,8 @@ class DiscoveryAgent(Node):
         """Compare local vs remote gossip state and send bridge requests."""
         if not self._remote_states:
             return
-        requests = bridge_decider.decide_bridges(local_state, self._remote_states)
+        requests = bridge_decider.decide_bridges(
+            local_state, self._remote_states, self._registry)
         if requests:
             bridge_decider.dispatch_requests(requests, logger=self.get_logger())
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -30,6 +30,7 @@ from ros2agnocast_discovery_msgs.msg import (
 )
 
 from . import bridge_decider
+from .type_registry import TypeRegistryReader
 
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
@@ -83,15 +84,24 @@ def _load_ioctl_wrapper():
     return lib
 
 
-def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
+def _ioctl_to_endpoint(
+        info: TopicInfoRet, topic_name: str, role: str,
+        registry: 'TypeRegistryReader' = None) -> AgnocastEndpoint:
     """Convert one ``topic_info_ret`` row to an AgnocastEndpoint msg.
 
-    ``pid`` is best-effort 0 because the existing ioctl does not expose it; the
-    bridge decider may fill it via ``/proc`` walk when routing bridge requests.
+    ``pid`` is looked up from the tmpfs type registry (written by agnocastlib
+    at Publisher/Subscription construction time) using
+    ``(topic_name, role, node_name)`` as the join key. When no match is found
+    the field stays 0, which lets the rest of the pipeline degrade gracefully
+    (the gossip publication still flows; just no pid for that endpoint).
     """
     ep = AgnocastEndpoint()
     ep.node_name = info.node_name.decode('utf-8', errors='replace')
     ep.pid = 0
+    if registry is not None:
+        entry = registry.lookup(topic_name, role, ep.node_name)
+        if entry is not None:
+            ep.pid = entry.pid
     ep.qos_depth = info.qos_depth
     ep.qos_is_transient_local = info.qos_is_transient_local
     ep.qos_is_reliable = info.qos_is_reliable
@@ -99,12 +109,13 @@ def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
     return ep
 
 
-def read_local_topics(lib) -> list:
+def read_local_topics(lib, registry: 'TypeRegistryReader' = None) -> list:
     """Snapshot the current namespace's Agnocast topics via the ioctl wrapper.
 
     Returns a list of AgnocastTopic msgs. The ioctl returns only the caller's
     IPC namespace, so the daemon process just being inside that namespace is
-    sufficient to scope the result.
+    sufficient to scope the result. The optional ``registry`` argument
+    supplies the type names and pids that the ioctl does not expose.
     """
     topic_count = ctypes.c_int()
     topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count))
@@ -119,12 +130,19 @@ def read_local_topics(lib) -> list:
 
             agnocast_topic = AgnocastTopic()
             agnocast_topic.topic_name = topic_name
-            # type_name is best-effort empty here; resolved by future work
-            # (procfs/topic_info exposing message_type, or kmod ioctl extension)
             agnocast_topic.type_name = ''
             agnocast_topic.domain_id = 0
-            agnocast_topic.publishers = _collect_endpoints(lib.get_agnocast_pub_nodes, lib, topic_name_b)
-            agnocast_topic.subscribers = _collect_endpoints(lib.get_agnocast_sub_nodes, lib, topic_name_b)
+            agnocast_topic.publishers = _collect_endpoints(
+                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, 'pub', registry)
+            agnocast_topic.subscribers = _collect_endpoints(
+                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, 'sub', registry)
+            # Type name comes from the tmpfs registry; any registered
+            # endpoint on this topic carries the same type (ROS 2
+            # invariant), so the first non-empty one wins.
+            if registry is not None:
+                resolved = _resolve_topic_type(agnocast_topic, registry)
+                if resolved:
+                    agnocast_topic.type_name = resolved
             topics.append(agnocast_topic)
     finally:
         lib.free_agnocast_topics(topic_names_ptr, topic_count.value)
@@ -132,7 +150,22 @@ def read_local_topics(lib) -> list:
     return topics
 
 
-def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
+def _resolve_topic_type(
+        agnocast_topic: AgnocastTopic, registry: 'TypeRegistryReader') -> str:
+    for ep in agnocast_topic.publishers:
+        entry = registry.lookup(agnocast_topic.topic_name, 'pub', ep.node_name)
+        if entry is not None and entry.type_name:
+            return entry.type_name
+    for ep in agnocast_topic.subscribers:
+        entry = registry.lookup(agnocast_topic.topic_name, 'sub', ep.node_name)
+        if entry is not None and entry.type_name:
+            return entry.type_name
+    return ''
+
+
+def _collect_endpoints(
+        getter, lib, topic_name_b: bytes, topic_name: str, role: str,
+        registry: 'TypeRegistryReader' = None) -> list:
     count = ctypes.c_int()
     array = getter(topic_name_b, ctypes.byref(count))
     endpoints = []
@@ -140,7 +173,7 @@ def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
         return endpoints
     try:
         for i in range(count.value):
-            endpoints.append(_ioctl_to_endpoint(array[i]))
+            endpoints.append(_ioctl_to_endpoint(array[i], topic_name, role, registry))
     finally:
         lib.free_agnocast_topic_info_ret(array)
     return endpoints
@@ -182,13 +215,15 @@ class DiscoveryAgent(Node):
     ``(host_uuid, ipc_ns_inode)``.
     """
 
-    def __init__(self, ioctl_lib=None):
+    def __init__(self, ioctl_lib=None, registry: TypeRegistryReader = None):
         super().__init__('agnocast_discovery_agent')
         self._lib = ioctl_lib if ioctl_lib is not None else _load_ioctl_wrapper()
         self._host_uuid = _read_machine_id()
         self._host_hostname = socket.gethostname()
         self._ipc_ns_inode = _read_ipc_ns_inode()
         self._agnocast_version = os.environ.get('AGNOCAST_VERSION', '')
+        self._registry = registry if registry is not None else TypeRegistryReader(
+            self._ipc_ns_inode, logger=self.get_logger())
 
         qos = _gossip_qos()
         self._pub = self.create_publisher(AgnocastDaemonState, GOSSIP_TOPIC, qos)
@@ -203,6 +238,8 @@ class DiscoveryAgent(Node):
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode}')
 
     def _on_tick(self) -> None:
+        self._registry.rebuild()
+        self._registry.cleanup_dead_pids()
         self._prune_stale_remote_states()
         snapshot = self.publish_snapshot()
         self._dispatch_bridge_requests(snapshot)
@@ -254,7 +291,7 @@ class DiscoveryAgent(Node):
         now = self.get_clock().now().to_msg()
         msg.timestamp = Time(sec=now.sec, nanosec=now.nanosec)
         msg.ipc_ns_inode = self._ipc_ns_inode
-        msg.topics = read_local_topics(self._lib)
+        msg.topics = read_local_topics(self._lib, self._registry)
         return msg
 
     def _on_remote_state(self, msg: AgnocastDaemonState) -> None:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -29,6 +29,8 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastTopic,
 )
 
+from . import bridge_decider
+
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
 SCHEMA_VERSION = 1
@@ -202,7 +204,8 @@ class DiscoveryAgent(Node):
 
     def _on_tick(self) -> None:
         self._prune_stale_remote_states()
-        self.publish_snapshot()
+        snapshot = self.publish_snapshot()
+        self._dispatch_bridge_requests(snapshot)
 
     def _prune_stale_remote_states(
             self, now_sec: float | None = None,
@@ -228,10 +231,19 @@ class DiscoveryAgent(Node):
         for key in stale_keys:
             del self._remote_states[key]
 
-    def publish_snapshot(self) -> None:
+    def publish_snapshot(self) -> AgnocastDaemonState:
         """Build and publish the current local AgnocastDaemonState."""
         msg = self.build_state()
         self._pub.publish(msg)
+        return msg
+
+    def _dispatch_bridge_requests(self, local_state: AgnocastDaemonState) -> None:
+        """Compare local vs remote gossip state and send bridge requests."""
+        if not self._remote_states:
+            return
+        requests = bridge_decider.decide_bridges(local_state, self._remote_states)
+        if requests:
+            bridge_decider.dispatch_requests(requests, logger=self.get_logger())
 
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -32,6 +32,8 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastTopic,
 )
 
+from . import bridge_decider
+
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
 SCHEMA_VERSION = 1
@@ -232,7 +234,8 @@ class DiscoveryAgent(Node):
 
     def _on_tick(self) -> None:
         self._prune_stale_remote_states()
-        self.publish_snapshot()
+        snapshot = self.publish_snapshot()
+        self._dispatch_bridge_requests(snapshot)
 
     def _prune_stale_remote_states(
             self, now_sec: float | None = None,
@@ -252,10 +255,19 @@ class DiscoveryAgent(Node):
         for key in stale_keys:
             del self._remote_states[key]
 
-    def publish_snapshot(self) -> None:
+    def publish_snapshot(self) -> AgnocastDaemonState:
         """Build and publish the current local AgnocastDaemonState."""
         msg = self.build_state()
         self._pub.publish(msg)
+        return msg
+
+    def _dispatch_bridge_requests(self, local_state: AgnocastDaemonState) -> None:
+        """Compare local vs remote gossip state and send bridge requests."""
+        if not self._remote_states:
+            return
+        requests = bridge_decider.decide_bridges(local_state, self._remote_states)
+        if requests:
+            bridge_decider.dispatch_requests(requests, logger=self.get_logger())
 
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -302,7 +302,8 @@ class DiscoveryAgent(Node):
         """Compare local vs remote gossip state and send bridge requests."""
         if not self._remote_states:
             return
-        requests = bridge_decider.decide_bridges(local_state, self._remote_states)
+        requests = bridge_decider.decide_bridges(
+            local_state, self._remote_states, self._registry)
         if requests:
             bridge_decider.dispatch_requests(requests, logger=self.get_logger())
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -33,6 +33,7 @@ from ros2agnocast_discovery_msgs.msg import (
 )
 
 from . import bridge_decider
+from .type_registry import TypeRegistryReader
 
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
@@ -88,15 +89,24 @@ def _load_ioctl_wrapper():
     return lib
 
 
-def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
+def _ioctl_to_endpoint(
+        info: TopicInfoRet, topic_name: str, role: str,
+        registry: 'TypeRegistryReader' = None) -> AgnocastEndpoint:
     """Convert one ``topic_info_ret`` row to an AgnocastEndpoint msg.
 
-    ``pid`` is best-effort 0 because the existing ioctl does not expose it; the
-    bridge decider may fill it via ``/proc`` walk when routing bridge requests.
+    ``pid`` is looked up from the tmpfs type registry (written by agnocastlib
+    at Publisher/Subscription construction time) using
+    ``(topic_name, role, node_name)`` as the join key. When no match is found
+    the field stays 0, which lets the rest of the pipeline degrade gracefully
+    (the gossip publication still flows; just no pid for that endpoint).
     """
     ep = AgnocastEndpoint()
     ep.node_name = info.node_name.decode('utf-8', errors='replace')
     ep.pid = 0
+    if registry is not None:
+        entry = registry.lookup(topic_name, role, ep.node_name)
+        if entry is not None:
+            ep.pid = entry.pid
     ep.qos_depth = info.qos_depth
     ep.qos_is_transient_local = info.qos_is_transient_local
     ep.qos_is_reliable = info.qos_is_reliable
@@ -104,12 +114,13 @@ def _ioctl_to_endpoint(info: TopicInfoRet) -> AgnocastEndpoint:
     return ep
 
 
-def read_local_topics(lib) -> list:
+def read_local_topics(lib, registry: 'TypeRegistryReader' = None) -> list:
     """Snapshot the current namespace's Agnocast topics via the ioctl wrapper.
 
     Returns a list of AgnocastTopic msgs. The ioctl returns only the caller's
     IPC namespace, so the daemon process just being inside that namespace is
-    sufficient to scope the result.
+    sufficient to scope the result. The optional ``registry`` argument
+    supplies the type names and pids that the ioctl does not expose.
     """
     topic_count = ctypes.c_int()
     topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count))
@@ -124,12 +135,19 @@ def read_local_topics(lib) -> list:
 
             agnocast_topic = AgnocastTopic()
             agnocast_topic.topic_name = topic_name
-            # type_name is best-effort empty here; resolved by future work
-            # (procfs/topic_info exposing message_type, or kmod ioctl extension)
             agnocast_topic.type_name = ''
             agnocast_topic.domain_id = 0
-            agnocast_topic.publishers = _collect_endpoints(lib.get_agnocast_pub_nodes, lib, topic_name_b)
-            agnocast_topic.subscribers = _collect_endpoints(lib.get_agnocast_sub_nodes, lib, topic_name_b)
+            agnocast_topic.publishers = _collect_endpoints(
+                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, 'pub', registry)
+            agnocast_topic.subscribers = _collect_endpoints(
+                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, 'sub', registry)
+            # Type name comes from the tmpfs registry; any registered
+            # endpoint on this topic carries the same type (ROS 2
+            # invariant), so the first non-empty one wins.
+            if registry is not None:
+                resolved = _resolve_topic_type(agnocast_topic, registry)
+                if resolved:
+                    agnocast_topic.type_name = resolved
             topics.append(agnocast_topic)
     finally:
         lib.free_agnocast_topics(topic_names_ptr, topic_count.value)
@@ -137,7 +155,22 @@ def read_local_topics(lib) -> list:
     return topics
 
 
-def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
+def _resolve_topic_type(
+        agnocast_topic: AgnocastTopic, registry: 'TypeRegistryReader') -> str:
+    for ep in agnocast_topic.publishers:
+        entry = registry.lookup(agnocast_topic.topic_name, 'pub', ep.node_name)
+        if entry is not None and entry.type_name:
+            return entry.type_name
+    for ep in agnocast_topic.subscribers:
+        entry = registry.lookup(agnocast_topic.topic_name, 'sub', ep.node_name)
+        if entry is not None and entry.type_name:
+            return entry.type_name
+    return ''
+
+
+def _collect_endpoints(
+        getter, lib, topic_name_b: bytes, topic_name: str, role: str,
+        registry: 'TypeRegistryReader' = None) -> list:
     count = ctypes.c_int()
     array = getter(topic_name_b, ctypes.byref(count))
     endpoints = []
@@ -145,7 +178,7 @@ def _collect_endpoints(getter, lib, topic_name_b: bytes) -> list:
         return endpoints
     try:
         for i in range(count.value):
-            endpoints.append(_ioctl_to_endpoint(array[i]))
+            endpoints.append(_ioctl_to_endpoint(array[i], topic_name, role, registry))
     finally:
         lib.free_agnocast_topic_info_ret(array)
     return endpoints
@@ -200,7 +233,7 @@ class DiscoveryAgent(Node):
     ``(host_uuid, ipc_ns_inode)``.
     """
 
-    def __init__(self):
+    def __init__(self, registry: TypeRegistryReader = None):
         self._host_uuid = _read_host_uuid()
         self._host_hostname = socket.gethostname()
         self._ipc_ns_inode = _read_ipc_ns_inode()
@@ -218,6 +251,8 @@ class DiscoveryAgent(Node):
         # Independent wall-clock for prune / receive timestamps so they stay
         # consistent even if a future change accidentally enables sim time.
         self._clock = Clock(clock_type=ClockType.SYSTEM_TIME)
+        self._registry = registry if registry is not None else TypeRegistryReader(
+            self._ipc_ns_inode, logger=self.get_logger())
 
         qos = _gossip_qos()
         self._pub = self.create_publisher(AgnocastDaemonState, GOSSIP_TOPIC, qos)
@@ -233,6 +268,8 @@ class DiscoveryAgent(Node):
             f'version={self._agnocast_version}')
 
     def _on_tick(self) -> None:
+        self._registry.rebuild()
+        self._registry.cleanup_dead_pids()
         self._prune_stale_remote_states()
         snapshot = self.publish_snapshot()
         self._dispatch_bridge_requests(snapshot)
@@ -276,7 +313,7 @@ class DiscoveryAgent(Node):
         msg.host_uuid = self._host_uuid
         msg.host_hostname = self._host_hostname
         msg.ipc_ns_inode = self._ipc_ns_inode
-        msg.topics = read_local_topics(self._lib)
+        msg.topics = read_local_topics(self._lib, self._registry)
         return msg
 
     def _on_remote_state(self, msg: AgnocastDaemonState) -> None:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -207,12 +207,10 @@ def _read_ipc_ns_inode() -> int:
 
 
 def _singleton_lock_path(ipc_ns_inode: int) -> str:
-    """Return the path to the singleton lock file for this IPC namespace.
+    """Return the singleton lock-file path for this IPC namespace.
 
-    Honors ``AGNOCAST_TMPFS_DIR`` for consistency with the type registry,
-    so containers that route Agnocast tmpfs elsewhere (e.g. when ``/dev/shm``
-    is restricted) keep the lock co-located with the rest of Agnocast's
-    runtime state.
+    Co-located with the rest of Agnocast tmpfs state so a container
+    overriding ``AGNOCAST_TMPFS_DIR`` keeps the lock under the same root.
     """
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
     return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}.lock')
@@ -221,24 +219,14 @@ def _singleton_lock_path(ipc_ns_inode: int) -> str:
 def _try_acquire_singleton_lock(ipc_ns_inode: int):
     """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
 
-    Returns the open file object on success — the caller must keep the
-    reference for the lifetime of the process so the lock persists. Returns
-    ``None`` if another agent in the same IPC namespace already holds the
-    lock (= duplicate launch), in which case the caller should exit cleanly.
-
-    ``flock(2)`` releases automatically when the holder's process exits, so
-    a crashed or killed agent does not block subsequent startups.
-
-    Best-effort on filesystem errors (the lock file's directory not writable,
-    etc.): logs to stderr and returns ``None`` to err on the side of not
-    starting a duplicate. Operators who hit this should set
-    ``AGNOCAST_TMPFS_DIR`` to a writable path.
+    Returns the open file (caller must keep the reference for the lock to
+    persist) or ``None`` if another agent holds it. ``flock(2)`` releases
+    on process exit, so a crashed or killed holder never blocks the next
+    agent. Filesystem errors also return ``None`` — err on the side of
+    not double-spawning.
     """
     lock_path = _singleton_lock_path(ipc_ns_inode)
     try:
-        # Open without O_TRUNC: keep file contents (empty) intact across
-        # restarts so we never race on truncation between owner death and
-        # the next agent's open.
         fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
     except OSError as e:
         sys.stderr.write(
@@ -380,11 +368,8 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
-    # Enforce 1 agent per IPC namespace before bringing up DDS / ioctl state,
-    # so duplicate launches (e.g. multiple Autoware nodes each indirectly
-    # spawning the agent, or an operator running another launch in parallel)
-    # exit immediately without polluting the gossip topic with duplicate
-    # publishers or hammering the kmod with redundant ioctls.
+    # Singleton check before DDS / ioctl bring-up so duplicate launches exit
+    # without polluting the gossip topic or hammering the kmod.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
     if singleton_lock is None:
@@ -403,10 +388,8 @@ def main(argv=None) -> int:
         node.destroy_node()
         if rclpy.ok():
             rclpy.shutdown()
-        # Keep ``singleton_lock`` alive through shutdown by referencing it
-        # here; closing it explicitly is unnecessary because process exit
-        # releases the flock automatically, but the reference prevents an
-        # over-eager linter from flagging it as unused.
+        # Keep `singleton_lock` referenced through shutdown so the flock
+        # outlives the spin() loop.
         del singleton_lock
     return 0
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -17,6 +17,7 @@ import fcntl
 import importlib.metadata
 import logging
 import os
+import signal
 import socket
 import sys
 import uuid
@@ -368,14 +369,26 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
-    # Singleton check before DDS / ioctl bring-up so duplicate launches exit
-    # without polluting the gossip topic or hammering the kmod.
+    # Singleton check before DDS / ioctl bring-up so duplicate launches stay
+    # passive instead of polluting the gossip topic or hammering the kmod.
+    #
+    # Duplicates DO NOT exit early: launch supervisors (especially
+    # `launch_test` running parallel sample-app tests) treat a Node exit as a
+    # process-died event and propagate teardown to the rest of the launch
+    # tree. So when the lock is held, we sit idle on `signal.pause()` —
+    # SIGINT / SIGTERM still tears the duplicate down cleanly with the rest
+    # of its parent launch.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
     if singleton_lock is None:
         sys.stderr.write(
             f'agnocast_discovery_agent: another instance is already running in this '
-            f'IPC namespace (inode={ipc_ns_inode}); exiting cleanly.\n')
+            f'IPC namespace (inode={ipc_ns_inode}); staying idle.\n')
+        try:
+            while True:
+                signal.pause()
+        except KeyboardInterrupt:
+            pass
         return 0
 
     rclpy.init(args=argv)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -220,11 +220,16 @@ def _singleton_lock_path(ipc_ns_inode: int) -> str:
 def _try_acquire_singleton_lock(ipc_ns_inode: int):
     """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
 
-    Returns the open file (caller must keep the reference for the lock to
-    persist) or ``None`` if another agent holds it. ``flock(2)`` releases
-    on process exit, so a crashed or killed holder never blocks the next
-    agent. Filesystem errors also return ``None`` — err on the side of
-    not double-spawning.
+    Returns:
+      * the open file on success (caller keeps the reference so the lock
+        persists for the process lifetime),
+      * ``'held'`` if another agent in the same NS already holds the lock
+        — caller should idle and not exit, so launch supervisors keep
+        running,
+      * ``'error'`` if the lock file could not even be opened (e.g.
+        ``AGNOCAST_TMPFS_DIR`` unwritable) — caller should propagate a
+        non-zero exit code so the failure isn't silently masked as
+        "another instance running".
     """
     lock_path = _singleton_lock_path(ipc_ns_inode)
     try:
@@ -232,13 +237,13 @@ def _try_acquire_singleton_lock(ipc_ns_inode: int):
     except OSError as e:
         sys.stderr.write(
             f'agnocast_discovery_agent: cannot open singleton lock {lock_path}: {e}\n')
-        return None
+        return 'error'
     lock_file = os.fdopen(fd, 'r+')
     try:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except (BlockingIOError, OSError):
         lock_file.close()
-        return None
+        return 'held'
     return lock_file
 
 
@@ -380,7 +385,7 @@ def main(argv=None) -> int:
     # of its parent launch.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
-    if singleton_lock is None:
+    if singleton_lock == 'held':
         sys.stderr.write(
             f'agnocast_discovery_agent: another instance is already running in this '
             f'IPC namespace (inode={ipc_ns_inode}); staying idle.\n')
@@ -390,6 +395,10 @@ def main(argv=None) -> int:
         except KeyboardInterrupt:
             pass
         return 0
+    if singleton_lock == 'error':
+        # Don't masquerade as "already running" — propagate failure so
+        # supervisors can detect it.
+        return 1
 
     rclpy.init(args=argv)
     node = DiscoveryAgent()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -5,12 +5,15 @@ Reads the local Agnocast state via the existing NS-scoped ioctl wrapper
 ``/_agnocast_discovery`` so other namespaces and ECUs running ros2agnocast
 tooling can observe and make bridge generation decisions.
 
-One daemon process is intended to run per IPC namespace. Lifecycle is the
-user's responsibility (systemd unit, ros2 launch include, container
-entrypoint, etc.).
+One daemon process is intended to run per IPC namespace. To make duplicate
+launches (e.g. one node spawning the agent and another ``ros2 launch``
+session also trying to spawn one) safe, the agent acquires an
+``flock(2)``-based singleton lock on a per-IPC-namespace file before
+starting; subsequent instances detect the held lock and exit cleanly.
 """
 
 import ctypes
+import fcntl
 import importlib.metadata
 import logging
 import os
@@ -203,6 +206,53 @@ def _read_ipc_ns_inode() -> int:
     return os.stat(SELF_IPC_NS_PATH).st_ino
 
 
+def _singleton_lock_path(ipc_ns_inode: int) -> str:
+    """Return the path to the singleton lock file for this IPC namespace.
+
+    Honors ``AGNOCAST_TMPFS_DIR`` for consistency with the type registry,
+    so containers that route Agnocast tmpfs elsewhere (e.g. when ``/dev/shm``
+    is restricted) keep the lock co-located with the rest of Agnocast's
+    runtime state.
+    """
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}.lock')
+
+
+def _try_acquire_singleton_lock(ipc_ns_inode: int):
+    """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
+
+    Returns the open file object on success — the caller must keep the
+    reference for the lifetime of the process so the lock persists. Returns
+    ``None`` if another agent in the same IPC namespace already holds the
+    lock (= duplicate launch), in which case the caller should exit cleanly.
+
+    ``flock(2)`` releases automatically when the holder's process exits, so
+    a crashed or killed agent does not block subsequent startups.
+
+    Best-effort on filesystem errors (the lock file's directory not writable,
+    etc.): logs to stderr and returns ``None`` to err on the side of not
+    starting a duplicate. Operators who hit this should set
+    ``AGNOCAST_TMPFS_DIR`` to a writable path.
+    """
+    lock_path = _singleton_lock_path(ipc_ns_inode)
+    try:
+        # Open without O_TRUNC: keep file contents (empty) intact across
+        # restarts so we never race on truncation between owner death and
+        # the next agent's open.
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
+    except OSError as e:
+        sys.stderr.write(
+            f'agnocast_discovery_agent: cannot open singleton lock {lock_path}: {e}\n')
+        return None
+    lock_file = os.fdopen(fd, 'r+')
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        lock_file.close()
+        return None
+    return lock_file
+
+
 def _gossip_qos() -> QoSProfile:
     return QoSProfile(
         reliability=ReliabilityPolicy.RELIABLE,
@@ -330,6 +380,19 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
+    # Enforce 1 agent per IPC namespace before bringing up DDS / ioctl state,
+    # so duplicate launches (e.g. multiple Autoware nodes each indirectly
+    # spawning the agent, or an operator running another launch in parallel)
+    # exit immediately without polluting the gossip topic with duplicate
+    # publishers or hammering the kmod with redundant ioctls.
+    ipc_ns_inode = _read_ipc_ns_inode()
+    singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
+    if singleton_lock is None:
+        sys.stderr.write(
+            f'agnocast_discovery_agent: another instance is already running in this '
+            f'IPC namespace (inode={ipc_ns_inode}); exiting cleanly.\n')
+        return 0
+
     rclpy.init(args=argv)
     node = DiscoveryAgent()
     try:
@@ -340,6 +403,11 @@ def main(argv=None) -> int:
         node.destroy_node()
         if rclpy.ok():
             rclpy.shutdown()
+        # Keep ``singleton_lock`` alive through shutdown by referencing it
+        # here; closing it explicitly is unnecessary because process exit
+        # releases the flock automatically, but the reference prevents an
+        # over-eager linter from flagging it as unused.
+        del singleton_lock
     return 0
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -213,11 +213,16 @@ def _singleton_lock_path(ipc_ns_inode: int) -> str:
 def _try_acquire_singleton_lock(ipc_ns_inode: int):
     """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
 
-    Returns the open file (caller must keep the reference for the lock to
-    persist) or ``None`` if another agent holds it. ``flock(2)`` releases
-    on process exit, so a crashed or killed holder never blocks the next
-    agent. Filesystem errors also return ``None`` — err on the side of
-    not double-spawning.
+    Returns:
+      * the open file on success (caller keeps the reference so the lock
+        persists for the process lifetime),
+      * ``'held'`` if another agent in the same NS already holds the lock
+        — caller should idle and not exit, so launch supervisors keep
+        running,
+      * ``'error'`` if the lock file could not even be opened (e.g.
+        ``AGNOCAST_TMPFS_DIR`` unwritable) — caller should propagate a
+        non-zero exit code so the failure isn't silently masked as
+        "another instance running".
     """
     lock_path = _singleton_lock_path(ipc_ns_inode)
     try:
@@ -225,13 +230,13 @@ def _try_acquire_singleton_lock(ipc_ns_inode: int):
     except OSError as e:
         sys.stderr.write(
             f'agnocast_discovery_agent: cannot open singleton lock {lock_path}: {e}\n')
-        return None
+        return 'error'
     lock_file = os.fdopen(fd, 'r+')
     try:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except (BlockingIOError, OSError):
         lock_file.close()
-        return None
+        return 'held'
     return lock_file
 
 
@@ -358,7 +363,7 @@ def main(argv=None) -> int:
     # of its parent launch.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
-    if singleton_lock is None:
+    if singleton_lock == 'held':
         sys.stderr.write(
             f'agnocast_discovery_agent: another instance is already running in this '
             f'IPC namespace (inode={ipc_ns_inode}); staying idle.\n')
@@ -368,6 +373,10 @@ def main(argv=None) -> int:
         except KeyboardInterrupt:
             pass
         return 0
+    if singleton_lock == 'error':
+        # Don't masquerade as "already running" — propagate failure so
+        # supervisors can detect it.
+        return 1
 
     rclpy.init(args=argv)
     node = DiscoveryAgent()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -200,12 +200,10 @@ def _read_ipc_ns_inode() -> int:
 
 
 def _singleton_lock_path(ipc_ns_inode: int) -> str:
-    """Return the path to the singleton lock file for this IPC namespace.
+    """Return the singleton lock-file path for this IPC namespace.
 
-    Honors ``AGNOCAST_TMPFS_DIR`` for consistency with the type registry,
-    so containers that route Agnocast tmpfs elsewhere (e.g. when ``/dev/shm``
-    is restricted) keep the lock co-located with the rest of Agnocast's
-    runtime state.
+    Co-located with the rest of Agnocast tmpfs state so a container
+    overriding ``AGNOCAST_TMPFS_DIR`` keeps the lock under the same root.
     """
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
     return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}.lock')
@@ -214,24 +212,14 @@ def _singleton_lock_path(ipc_ns_inode: int) -> str:
 def _try_acquire_singleton_lock(ipc_ns_inode: int):
     """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
 
-    Returns the open file object on success — the caller must keep the
-    reference for the lifetime of the process so the lock persists. Returns
-    ``None`` if another agent in the same IPC namespace already holds the
-    lock (= duplicate launch), in which case the caller should exit cleanly.
-
-    ``flock(2)`` releases automatically when the holder's process exits, so
-    a crashed or killed agent does not block subsequent startups.
-
-    Best-effort on filesystem errors (the lock file's directory not writable,
-    etc.): logs to stderr and returns ``None`` to err on the side of not
-    starting a duplicate. Operators who hit this should set
-    ``AGNOCAST_TMPFS_DIR`` to a writable path.
+    Returns the open file (caller must keep the reference for the lock to
+    persist) or ``None`` if another agent holds it. ``flock(2)`` releases
+    on process exit, so a crashed or killed holder never blocks the next
+    agent. Filesystem errors also return ``None`` — err on the side of
+    not double-spawning.
     """
     lock_path = _singleton_lock_path(ipc_ns_inode)
     try:
-        # Open without O_TRUNC: keep file contents (empty) intact across
-        # restarts so we never race on truncation between owner death and
-        # the next agent's open.
         fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
     except OSError as e:
         sys.stderr.write(
@@ -358,11 +346,8 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
-    # Enforce 1 agent per IPC namespace before bringing up DDS / ioctl state,
-    # so duplicate launches (e.g. multiple Autoware nodes each indirectly
-    # spawning the agent, or an operator running another launch in parallel)
-    # exit immediately without polluting the gossip topic with duplicate
-    # publishers or hammering the kmod with redundant ioctls.
+    # Singleton check before DDS / ioctl bring-up so duplicate launches exit
+    # without polluting the gossip topic or hammering the kmod.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
     if singleton_lock is None:
@@ -381,10 +366,8 @@ def main(argv=None) -> int:
         node.destroy_node()
         if rclpy.ok():
             rclpy.shutdown()
-        # Keep ``singleton_lock`` alive through shutdown by referencing it
-        # here; closing it explicitly is unnecessary because process exit
-        # releases the flock automatically, but the reference prevents an
-        # over-eager linter from flagging it as unused.
+        # Keep `singleton_lock` referenced through shutdown so the flock
+        # outlives the spin() loop.
         del singleton_lock
     return 0
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -5,12 +5,15 @@ Reads the local Agnocast state via the existing NS-scoped ioctl wrapper
 ``/_agnocast_discovery`` so other namespaces and ECUs running ros2agnocast
 tooling can observe and make bridge generation decisions.
 
-One daemon process is intended to run per IPC namespace. Lifecycle is the
-user's responsibility (systemd unit, ros2 launch include, container
-entrypoint, etc.).
+One daemon process is intended to run per IPC namespace. To make duplicate
+launches (e.g. one node spawning the agent and another ``ros2 launch``
+session also trying to spawn one) safe, the agent acquires an
+``flock(2)``-based singleton lock on a per-IPC-namespace file before
+starting; subsequent instances detect the held lock and exit cleanly.
 """
 
 import ctypes
+import fcntl
 import os
 import socket
 import sys
@@ -196,6 +199,53 @@ def _read_ipc_ns_inode() -> int:
     return os.stat(SELF_IPC_NS_PATH).st_ino
 
 
+def _singleton_lock_path(ipc_ns_inode: int) -> str:
+    """Return the path to the singleton lock file for this IPC namespace.
+
+    Honors ``AGNOCAST_TMPFS_DIR`` for consistency with the type registry,
+    so containers that route Agnocast tmpfs elsewhere (e.g. when ``/dev/shm``
+    is restricted) keep the lock co-located with the rest of Agnocast's
+    runtime state.
+    """
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}.lock')
+
+
+def _try_acquire_singleton_lock(ipc_ns_inode: int):
+    """Acquire an exclusive ``flock(2)`` on the per-IPC-namespace lock file.
+
+    Returns the open file object on success — the caller must keep the
+    reference for the lifetime of the process so the lock persists. Returns
+    ``None`` if another agent in the same IPC namespace already holds the
+    lock (= duplicate launch), in which case the caller should exit cleanly.
+
+    ``flock(2)`` releases automatically when the holder's process exits, so
+    a crashed or killed agent does not block subsequent startups.
+
+    Best-effort on filesystem errors (the lock file's directory not writable,
+    etc.): logs to stderr and returns ``None`` to err on the side of not
+    starting a duplicate. Operators who hit this should set
+    ``AGNOCAST_TMPFS_DIR`` to a writable path.
+    """
+    lock_path = _singleton_lock_path(ipc_ns_inode)
+    try:
+        # Open without O_TRUNC: keep file contents (empty) intact across
+        # restarts so we never race on truncation between owner death and
+        # the next agent's open.
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
+    except OSError as e:
+        sys.stderr.write(
+            f'agnocast_discovery_agent: cannot open singleton lock {lock_path}: {e}\n')
+        return None
+    lock_file = os.fdopen(fd, 'r+')
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        lock_file.close()
+        return None
+    return lock_file
+
+
 def _gossip_qos() -> QoSProfile:
     return QoSProfile(
         reliability=ReliabilityPolicy.RELIABLE,
@@ -308,6 +358,19 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
+    # Enforce 1 agent per IPC namespace before bringing up DDS / ioctl state,
+    # so duplicate launches (e.g. multiple Autoware nodes each indirectly
+    # spawning the agent, or an operator running another launch in parallel)
+    # exit immediately without polluting the gossip topic with duplicate
+    # publishers or hammering the kmod with redundant ioctls.
+    ipc_ns_inode = _read_ipc_ns_inode()
+    singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
+    if singleton_lock is None:
+        sys.stderr.write(
+            f'agnocast_discovery_agent: another instance is already running in this '
+            f'IPC namespace (inode={ipc_ns_inode}); exiting cleanly.\n')
+        return 0
+
     rclpy.init(args=argv)
     node = DiscoveryAgent()
     try:
@@ -318,6 +381,11 @@ def main(argv=None) -> int:
         node.destroy_node()
         if rclpy.ok():
             rclpy.shutdown()
+        # Keep ``singleton_lock`` alive through shutdown by referencing it
+        # here; closing it explicitly is unnecessary because process exit
+        # releases the flock automatically, but the reference prevents an
+        # over-eager linter from flagging it as unused.
+        del singleton_lock
     return 0
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -15,6 +15,7 @@ starting; subsequent instances detect the held lock and exit cleanly.
 import ctypes
 import fcntl
 import os
+import signal
 import socket
 import sys
 import uuid
@@ -346,14 +347,26 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
-    # Singleton check before DDS / ioctl bring-up so duplicate launches exit
-    # without polluting the gossip topic or hammering the kmod.
+    # Singleton check before DDS / ioctl bring-up so duplicate launches stay
+    # passive instead of polluting the gossip topic or hammering the kmod.
+    #
+    # Duplicates DO NOT exit early: launch supervisors (especially
+    # `launch_test` running parallel sample-app tests) treat a Node exit as a
+    # process-died event and propagate teardown to the rest of the launch
+    # tree. So when the lock is held, we sit idle on `signal.pause()` —
+    # SIGINT / SIGTERM still tears the duplicate down cleanly with the rest
+    # of its parent launch.
     ipc_ns_inode = _read_ipc_ns_inode()
     singleton_lock = _try_acquire_singleton_lock(ipc_ns_inode)
     if singleton_lock is None:
         sys.stderr.write(
             f'agnocast_discovery_agent: another instance is already running in this '
-            f'IPC namespace (inode={ipc_ns_inode}); exiting cleanly.\n')
+            f'IPC namespace (inode={ipc_ns_inode}); staying idle.\n')
+        try:
+            while True:
+                signal.pause()
+        except KeyboardInterrupt:
+            pass
         return 0
 
     rclpy.init(args=argv)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -1,4 +1,4 @@
-"""F1 bridge decider for the per-IPC-namespace discovery agent.
+"""Bridge decider for the per-IPC-namespace discovery agent.
 
 Compares the local AgnocastDaemonState with remote (cross-NS / cross-ECU)
 snapshots gathered through gossip and emits `MqMsgDaemonBridge` requests

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -17,7 +17,6 @@ intentionally simple and additive (see `agnocast_mq.hpp`).
 
 import ctypes
 import errno
-import glob
 import os
 import struct
 from dataclasses import dataclass
@@ -76,6 +75,7 @@ class BridgeRequest:
     qos_depth: int
     qos_is_transient_local: bool
     qos_is_reliable: bool
+    target_pid: int  # Standard-mode target bridge_manager pid; 0 = unknown.
 
 
 def serialize_request(req: BridgeRequest) -> bytes:
@@ -135,6 +135,8 @@ def decide_bridges(local_state, remote_states) -> list:
 
             # Local Agnocast publisher + remote Agnocast subscriber -> A2R
             # bridge here so the local publisher's data reaches ROS 2 (DDS).
+            # Target pid = local publisher pid so Standard-mode dispatch
+            # hits exactly the user process holding the factory.
             if local_pubs and remote_subs:
                 qos_source = local_pubs[0]
                 key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
@@ -147,6 +149,7 @@ def decide_bridges(local_state, remote_states) -> list:
                         qos_depth=qos_source.qos_depth,
                         qos_is_transient_local=qos_source.qos_is_transient_local,
                         qos_is_reliable=qos_source.qos_is_reliable,
+                        target_pid=qos_source.pid,
                     ),
                 )
 
@@ -164,22 +167,16 @@ def decide_bridges(local_state, remote_states) -> list:
                         qos_depth=qos_source.qos_depth,
                         qos_is_transient_local=qos_source.qos_is_transient_local,
                         qos_is_reliable=qos_source.qos_is_reliable,
+                        target_pid=qos_source.pid,
                     ),
                 )
 
     return list(requests.values())
 
 
-def _enumerate_standard_mq_names() -> list:
-    """Return paths under `/dev/mqueue/` matching the Standard daemon bridge MQ name.
-
-    The bridge_manager creates `/agnocast_daemon_bridge@<pid>` on startup,
-    so the daemon discovers running managers by scanning `/dev/mqueue`.
-    """
-    return [
-        '/' + os.path.basename(path)
-        for path in glob.glob('/dev/mqueue/agnocast_daemon_bridge@*')
-    ]
+def _standard_mq_name(pid: int) -> str:
+    """Return the Standard-mode bridge_manager MQ name for a given user pid."""
+    return f'/agnocast_daemon_bridge@{pid}'
 
 
 def _performance_mq_name() -> str:
@@ -218,15 +215,30 @@ def send_request(mq_name: str, payload: bytes) -> Optional[str]:
 
 
 def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
-    """Send every request to the Performance MQ and to every Standard MQ."""
+    """Send every request to the Performance MQ and to the target Standard MQ.
+
+    Standard-mode targeting: each request carries the pid of the local
+    user process whose `Publisher<T>` / `Subscription<T>` registered the
+    factory in this process (via the tmpfs type registry). The daemon
+    sends only to that pid's `/agnocast_daemon_bridge@<pid>` MQ —
+    avoiding the broadcast hack that the previous design needed when
+    pid was unknown.
+
+    Performance mode uses a single per-NS MQ (`pid` is irrelevant there).
+    A request with `target_pid == 0` (no matching registry entry) is
+    delivered only to the Performance MQ; Standard-mode managers don't
+    receive it.
+    """
     requests = list(requests)
     if not requests:
         return
 
-    targets = [_performance_mq_name()] + _enumerate_standard_mq_names()
+    perf_mq = _performance_mq_name()
     for req in requests:
         payload = serialize_request(req)
-        for mq_name in targets:
-            err = send_request(mq_name, payload)
-            if err is not None and logger is not None:
+        if (err := send_request(perf_mq, payload)) is not None and logger is not None:
+            logger.warning('daemon bridge dispatch failed: %s', err)
+        if req.target_pid > 0:
+            std_mq = _standard_mq_name(req.target_pid)
+            if (err := send_request(std_mq, payload)) is not None and logger is not None:
                 logger.warning('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -99,7 +99,7 @@ def serialize_request(req: BridgeRequest) -> bytes:
     return packed
 
 
-def decide_bridges(local_state, remote_states) -> list:
+def decide_bridges(local_state, remote_states, registry=None) -> list:
     """Compute the bridges that should be requested in the local namespace.
 
     Args:
@@ -107,12 +107,25 @@ def decide_bridges(local_state, remote_states) -> list:
             the daemon just built from procfs / ioctl).
         remote_states: mapping ``(host_uuid, ipc_ns_inode) -> AgnocastDaemonState``
             collected from the gossip subscription.
+        registry: optional ``TypeRegistryReader`` used to translate a local
+            (topic, role, node_name) tuple into the bridge_manager pid the
+            request should target. When omitted (or no entry matches), the
+            request falls back to ``target_pid=0`` and is routed to the
+            per-NS Performance MQ.
 
     Returns:
         list of ``BridgeRequest`` to dispatch on this tick. Duplicates are
         collapsed (one request per (topic_name, direction)).
     """
     requests = {}
+
+    def _bm_pid(topic_name: str, role: str, node_name: str) -> int:
+        if registry is None:
+            return 0
+        entry = registry.lookup(topic_name, role, node_name)
+        if entry is None:
+            return 0
+        return getattr(entry, 'bridge_manager_pid', 0)
 
     local_by_topic = {t.topic_name: t for t in local_state.topics}
 
@@ -135,8 +148,9 @@ def decide_bridges(local_state, remote_states) -> list:
 
             # Local Agnocast publisher + remote Agnocast subscriber -> A2R
             # bridge here so the local publisher's data reaches ROS 2 (DDS).
-            # Target pid = local publisher pid so Standard-mode dispatch
-            # hits exactly the user process holding the factory.
+            # Target pid = local publisher's bridge_manager pid so the
+            # MqMsgDaemonBridge lands on the MQ the bridge_manager opened
+            # under its own getpid().
             if local_pubs and remote_subs:
                 qos_source = local_pubs[0]
                 key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
@@ -149,7 +163,8 @@ def decide_bridges(local_state, remote_states) -> list:
                         qos_depth=qos_source.qos_depth,
                         qos_is_transient_local=qos_source.qos_is_transient_local,
                         qos_is_reliable=qos_source.qos_is_reliable,
-                        target_pid=qos_source.pid,
+                        target_pid=_bm_pid(
+                            local_topic.topic_name, 'pub', qos_source.node_name),
                     ),
                 )
 
@@ -167,7 +182,8 @@ def decide_bridges(local_state, remote_states) -> list:
                         qos_depth=qos_source.qos_depth,
                         qos_is_transient_local=qos_source.qos_is_transient_local,
                         qos_is_reliable=qos_source.qos_is_reliable,
-                        target_pid=qos_source.pid,
+                        target_pid=_bm_pid(
+                            local_topic.topic_name, 'sub', qos_source.node_name),
                     ),
                 )
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -1,18 +1,18 @@
 """Bridge decider for the per-IPC-namespace discovery agent.
 
 Compares the local AgnocastDaemonState with remote (cross-NS / cross-ECU)
-snapshots gathered through gossip and emits `MqMsgDaemonBridge` requests
+snapshots gathered through gossip and emits ``MqMsgDaemonBridge`` requests
 to the in-namespace bridge_manager MQs:
 
-  * Standard mode:  `/agnocast_daemon_bridge@<pid>` (broadcast to every
+  * Standard mode:  ``/agnocast_daemon_bridge@<pid>`` (broadcast to every
     running bridge_manager so the one whose process registered the type
     factory picks it up).
-  * Performance mode: `/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]`
+  * Performance mode: ``/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]``
     (one MQ per IPC namespace).
 
-The struct layout for `MqMsgDaemonBridge` is hard-coded here so the
+The struct layout for ``MqMsgDaemonBridge`` is hard-coded here so the
 daemon stays decoupled from libagnocast's C++ headers — the layout is
-intentionally simple and additive (see `agnocast_mq.hpp`).
+intentionally simple and additive (see ``agnocast_mq.hpp``).
 """
 
 import ctypes
@@ -22,7 +22,7 @@ import struct
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
-# Mirrors the C++ constants in `agnocast_mq.hpp`. Keep in sync if those
+# Mirrors the C++ constants in ``agnocast_mq.hpp``. Keep in sync if those
 # struct layouts change (a CI lint or test should guard this).
 TOPIC_NAME_BUFFER_SIZE = 256
 MESSAGE_TYPE_BUFFER_SIZE = 256
@@ -34,8 +34,8 @@ BRIDGE_MQ_PERMS = 0o600
 # struct.pack format with explicit standard sizes / no padding handled
 # below by emitting native sizes and matching the C++ struct's natural
 # layout. The struct is plain POD so native packing matches.
-# Native order, fixed sizes. Trailing `2x` is the alignment padding the C++
-# compiler adds so the total matches `sizeof(MqMsgDaemonBridge) == 524`.
+# Native order, fixed sizes. Trailing ``2x`` is the alignment padding the C++
+# compiler adds so the total matches ``sizeof(MqMsgDaemonBridge) == 524``.
 _MSG_PACK_FORMAT = '=256s256sIIBB2x'
 
 DIRECTION_ROS2_TO_AGNOCAST = 0
@@ -79,10 +79,10 @@ class BridgeRequest:
 
 
 def serialize_request(req: BridgeRequest) -> bytes:
-    """Pack a `BridgeRequest` into the wire format expected by bridge_manager.
+    """Pack a ``BridgeRequest`` into the wire format expected by bridge_manager.
 
     The trailing bytes after the 4 packed fields are padded with NULs to
-    match `sizeof(MqMsgDaemonBridge)`.
+    match ``sizeof(MqMsgDaemonBridge)``.
     """
     # Use truncation to stay within fixed-size char arrays.
     topic = req.topic_name.encode('utf-8')[: TOPIC_NAME_BUFFER_SIZE - 1]
@@ -109,7 +109,7 @@ def decide_bridges(local_state, remote_states) -> list:
             collected from the gossip subscription.
 
     Returns:
-        list of `BridgeRequest` to dispatch on this tick. Duplicates are
+        list of ``BridgeRequest`` to dispatch on this tick. Duplicates are
         collapsed (one request per (topic_name, direction)).
     """
     requests = {}
@@ -188,7 +188,7 @@ def _performance_mq_name() -> str:
 
 
 def send_request(mq_name: str, payload: bytes) -> Optional[str]:
-    """Send `payload` to the POSIX MQ at `mq_name`.
+    """Send ``payload`` to the POSIX MQ at ``mq_name``.
 
     Returns an error string on failure, None on success. ``O_NONBLOCK`` is
     used so a full queue does not block the daemon — the next tick will
@@ -218,14 +218,14 @@ def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
     """Send every request to the Performance MQ and to the target Standard MQ.
 
     Standard-mode targeting: each request carries the pid of the local
-    user process whose `Publisher<T>` / `Subscription<T>` registered the
+    user process whose ``Publisher<T>`` / ``Subscription<T>`` registered the
     factory in this process (via the tmpfs type registry). The daemon
-    sends only to that pid's `/agnocast_daemon_bridge@<pid>` MQ —
+    sends only to that pid's ``/agnocast_daemon_bridge@<pid>`` MQ —
     avoiding the broadcast hack that the previous design needed when
     pid was unknown.
 
-    Performance mode uses a single per-NS MQ (`pid` is irrelevant there).
-    A request with `target_pid == 0` (no matching registry entry) is
+    Performance mode uses a single per-NS MQ (``pid`` is irrelevant there).
+    A request with ``target_pid == 0`` (no matching registry entry) is
     delivered only to the Performance MQ; Standard-mode managers don't
     receive it.
     """

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -1,0 +1,232 @@
+"""F1 bridge decider for the per-IPC-namespace discovery agent.
+
+Compares the local AgnocastDaemonState with remote (cross-NS / cross-ECU)
+snapshots gathered through gossip and emits `MqMsgDaemonBridge` requests
+to the in-namespace bridge_manager MQs:
+
+  * Standard mode:  `/agnocast_daemon_bridge@<pid>` (broadcast to every
+    running bridge_manager so the one whose process registered the type
+    factory picks it up).
+  * Performance mode: `/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]`
+    (one MQ per IPC namespace).
+
+The struct layout for `MqMsgDaemonBridge` is hard-coded here so the
+daemon stays decoupled from libagnocast's C++ headers — the layout is
+intentionally simple and additive (see `agnocast_mq.hpp`).
+"""
+
+import ctypes
+import errno
+import glob
+import os
+import struct
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+# Mirrors the C++ constants in `agnocast_mq.hpp`. Keep in sync if those
+# struct layouts change (a CI lint or test should guard this).
+TOPIC_NAME_BUFFER_SIZE = 256
+MESSAGE_TYPE_BUFFER_SIZE = 256
+BRIDGE_MQ_PERMS = 0o600
+
+# Daemon MQ layout: char topic_name[256]; char type_name[256];
+# uint32_t direction; uint32_t qos_depth; bool qos_is_transient_local;
+# bool qos_is_reliable;
+# struct.pack format with explicit standard sizes / no padding handled
+# below by emitting native sizes and matching the C++ struct's natural
+# layout. The struct is plain POD so native packing matches.
+# Native order, fixed sizes. Trailing `2x` is the alignment padding the C++
+# compiler adds so the total matches `sizeof(MqMsgDaemonBridge) == 524`.
+_MSG_PACK_FORMAT = '=256s256sIIBB2x'
+
+DIRECTION_ROS2_TO_AGNOCAST = 0
+DIRECTION_AGNOCAST_TO_ROS2 = 1
+
+# Lazy-loaded librt mq_open / mq_send / mq_close. We avoid posix_ipc to
+# keep the daemon dependency surface to "rclpy + stdlib".
+_librt = None
+
+
+def _load_librt():
+    global _librt
+    if _librt is not None:
+        return _librt
+    lib = ctypes.CDLL('librt.so.1', use_errno=True)
+    lib.mq_open.argtypes = [ctypes.c_char_p, ctypes.c_int]
+    lib.mq_open.restype = ctypes.c_int
+    lib.mq_send.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint]
+    lib.mq_send.restype = ctypes.c_int
+    lib.mq_close.argtypes = [ctypes.c_int]
+    lib.mq_close.restype = ctypes.c_int
+    _librt = lib
+    return _librt
+
+
+O_WRONLY = os.O_WRONLY
+O_NONBLOCK = os.O_NONBLOCK
+
+
+@dataclass(frozen=True)
+class BridgeRequest:
+    """A single bridge request that needs to be dispatched to a bridge_manager."""
+
+    topic_name: str
+    type_name: str
+    direction: int  # DIRECTION_ROS2_TO_AGNOCAST | DIRECTION_AGNOCAST_TO_ROS2
+    qos_depth: int
+    qos_is_transient_local: bool
+    qos_is_reliable: bool
+
+
+def serialize_request(req: BridgeRequest) -> bytes:
+    """Pack a `BridgeRequest` into the wire format expected by bridge_manager.
+
+    The trailing bytes after the 4 packed fields are padded with NULs to
+    match `sizeof(MqMsgDaemonBridge)`.
+    """
+    # Use truncation to stay within fixed-size char arrays.
+    topic = req.topic_name.encode('utf-8')[: TOPIC_NAME_BUFFER_SIZE - 1]
+    type_name = req.type_name.encode('utf-8')[: MESSAGE_TYPE_BUFFER_SIZE - 1]
+    packed = struct.pack(
+        _MSG_PACK_FORMAT,
+        topic,
+        type_name,
+        req.direction,
+        req.qos_depth,
+        1 if req.qos_is_transient_local else 0,
+        1 if req.qos_is_reliable else 0,
+    )
+    return packed
+
+
+def decide_bridges(local_state, remote_states) -> list:
+    """Compute the bridges that should be requested in the local namespace.
+
+    Args:
+        local_state: AgnocastDaemonState for this IPC namespace (the one
+            the daemon just built from procfs / ioctl).
+        remote_states: mapping ``(host_uuid, ipc_ns_inode) -> AgnocastDaemonState``
+            collected from the gossip subscription.
+
+    Returns:
+        list of `BridgeRequest` to dispatch on this tick. Duplicates are
+        collapsed (one request per (topic_name, direction)).
+    """
+    requests = {}
+
+    local_by_topic = {t.topic_name: t for t in local_state.topics}
+
+    for (host_uuid, ipc_ns_inode), remote in remote_states.items():
+        if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
+            continue
+        for remote_topic in remote.topics:
+            local_topic = local_by_topic.get(remote_topic.topic_name)
+            if local_topic is None:
+                continue
+
+            local_pubs = [p for p in local_topic.publishers if not p.is_bridge]
+            local_subs = [s for s in local_topic.subscribers if not s.is_bridge]
+            remote_pubs = [p for p in remote_topic.publishers if not p.is_bridge]
+            remote_subs = [s for s in remote_topic.subscribers if not s.is_bridge]
+
+            type_name = local_topic.type_name or remote_topic.type_name
+            if not type_name:
+                continue
+
+            # Local Agnocast publisher + remote Agnocast subscriber -> A2R
+            # bridge here so the local publisher's data reaches ROS 2 (DDS).
+            if local_pubs and remote_subs:
+                qos_source = local_pubs[0]
+                key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
+                requests.setdefault(
+                    key,
+                    BridgeRequest(
+                        topic_name=local_topic.topic_name,
+                        type_name=type_name,
+                        direction=DIRECTION_AGNOCAST_TO_ROS2,
+                        qos_depth=qos_source.qos_depth,
+                        qos_is_transient_local=qos_source.qos_is_transient_local,
+                        qos_is_reliable=qos_source.qos_is_reliable,
+                    ),
+                )
+
+            # Local Agnocast subscriber + remote Agnocast publisher -> R2A
+            # bridge here so DDS data is reinjected for the local subscriber.
+            if local_subs and remote_pubs:
+                qos_source = local_subs[0]
+                key = (local_topic.topic_name, DIRECTION_ROS2_TO_AGNOCAST)
+                requests.setdefault(
+                    key,
+                    BridgeRequest(
+                        topic_name=local_topic.topic_name,
+                        type_name=type_name,
+                        direction=DIRECTION_ROS2_TO_AGNOCAST,
+                        qos_depth=qos_source.qos_depth,
+                        qos_is_transient_local=qos_source.qos_is_transient_local,
+                        qos_is_reliable=qos_source.qos_is_reliable,
+                    ),
+                )
+
+    return list(requests.values())
+
+
+def _enumerate_standard_mq_names() -> list:
+    """Return paths under `/dev/mqueue/` matching the Standard daemon bridge MQ name.
+
+    The bridge_manager creates `/agnocast_daemon_bridge@<pid>` on startup,
+    so the daemon discovers running managers by scanning `/dev/mqueue`.
+    """
+    return [
+        '/' + os.path.basename(path)
+        for path in glob.glob('/dev/mqueue/agnocast_daemon_bridge@*')
+    ]
+
+
+def _performance_mq_name() -> str:
+    name = '/agnocast_daemon_bridge_perf'
+    domain_id = os.environ.get('ROS_DOMAIN_ID')
+    if domain_id is not None:
+        name += '_d' + domain_id
+    return name
+
+
+def send_request(mq_name: str, payload: bytes) -> Optional[str]:
+    """Send `payload` to the POSIX MQ at `mq_name`.
+
+    Returns an error string on failure, None on success. ``O_NONBLOCK`` is
+    used so a full queue does not block the daemon — the next tick will
+    retry idempotently.
+    """
+    lib = _load_librt()
+    fd = lib.mq_open(mq_name.encode('utf-8'), O_WRONLY | O_NONBLOCK)
+    if fd == -1:
+        err = ctypes.get_errno()
+        if err == errno.ENOENT:
+            return None  # MQ not present; nothing to send to.
+        return f'mq_open({mq_name}): {os.strerror(err)}'
+
+    try:
+        rc = lib.mq_send(fd, payload, len(payload), 0)
+        if rc == -1:
+            err = ctypes.get_errno()
+            if err == errno.EAGAIN:
+                return None  # Queue full; drop and retry next tick.
+            return f'mq_send({mq_name}): {os.strerror(err)}'
+    finally:
+        lib.mq_close(fd)
+    return None
+
+
+def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
+    """Send every request to the Performance MQ and to every Standard MQ."""
+    requests = list(requests)
+    if not requests:
+        return
+
+    targets = [_performance_mq_name()] + _enumerate_standard_mq_names()
+    for req in requests:
+        payload = serialize_request(req)
+        for mq_name in targets:
+            err = send_request(mq_name, payload)
+            if err is not None and logger is not None:
+                logger.warning('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -4,9 +4,9 @@ Compares the local AgnocastDaemonState with remote (cross-NS / cross-ECU)
 snapshots gathered through gossip and emits ``MqMsgDaemonBridge`` requests
 to the in-namespace bridge_manager MQs:
 
-  * Standard mode:  ``/agnocast_daemon_bridge@<pid>`` (broadcast to every
-    running bridge_manager so the one whose process registered the type
-    factory picks it up).
+  * Standard mode: ``/agnocast_daemon_bridge@<bm_pid>`` — targeted at the
+    bridge_manager whose user process owns the matching Agnocast endpoint
+    (bm_pid is read from the tmpfs type registry).
   * Performance mode: ``/agnocast_daemon_bridge_perf[_d<ROS_DOMAIN_ID>]``
     (one MQ per IPC namespace).
 
@@ -191,7 +191,7 @@ def decide_bridges(local_state, remote_states, registry=None) -> list:
 
 
 def _standard_mq_name(pid: int) -> str:
-    """Return the Standard-mode bridge_manager MQ name for a given user pid."""
+    """Return the Standard-mode bridge_manager MQ name for a given bm_pid."""
     return f'/agnocast_daemon_bridge@{pid}'
 
 
@@ -253,8 +253,8 @@ def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
     for req in requests:
         payload = serialize_request(req)
         if (err := send_request(perf_mq, payload)) is not None and logger is not None:
-            logger.warning('daemon bridge dispatch failed: %s', err)
+            logger.warn('daemon bridge dispatch failed: %s', err)
         if req.target_pid > 0:
             std_mq = _standard_mq_name(req.target_pid)
             if (err := send_request(std_mq, payload)) is not None and logger is not None:
-                logger.warning('daemon bridge dispatch failed: %s', err)
+                logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -1,6 +1,6 @@
 """Read agnocastlib's per-process tmpfs type announcements.
 
-Each Agnocast process appends `<topic>\\t<type>\\t<role>\\t<node>\\n` lines to
+Each Agnocast process appends ``<topic>\\t<type>\\t<role>\\t<node>\\n`` lines to
 ``/dev/shm/agnocast_type_registry/<ipc_ns_inode>/<pid>.txt`` on each
 ``Publisher<T>`` / ``Subscription<T>`` construction (see
 ``agnocastlib::internal::TypeRegistryWriter``). The daemon walks the per-NS
@@ -28,7 +28,7 @@ from typing import Dict, Optional, Tuple
 def _default_base_dir() -> str:
     """Return the tmpfs root the writer agreed on.
 
-    Mirrors `agnocastlib::internal::TypeRegistryWriter`: read
+    Mirrors ``agnocastlib::internal::TypeRegistryWriter``: read
     ``AGNOCAST_TMPFS_DIR`` if set (for hardened containers where
     ``/dev/shm`` is unavailable or too small) and append the
     ``agnocast_type_registry`` suffix.
@@ -108,8 +108,8 @@ class TypeRegistryReader:
             return
 
         text = data.decode('utf-8', errors='replace')
-        # Only fully terminated lines are accepted. `splitlines(keepends=True)`
-        # preserves the trailing `\n` so we can distinguish complete lines
+        # Only fully terminated lines are accepted. ``splitlines(keepends=True)``
+        # preserves the trailing ``\n`` so we can distinguish complete lines
         # from a torn tail.
         for raw_line in text.splitlines(keepends=True):
             if not raw_line.endswith('\n'):

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -42,11 +42,23 @@ BASE_DIR = _default_base_dir()
 
 @dataclass(frozen=True)
 class RegistryEntry:
+    # The user process pid that owns the Publisher<T>/Subscription<T>. Comes
+    # from the tmpfs filename (`<pid>.txt`). Used for gossip's
+    # ``AgnocastEndpoint.pid`` so the CLI can identify which process owns
+    # the endpoint.
     pid: int
     type_name: str
+    # The pid of the bridge_manager that listens on
+    # ``/agnocast_daemon_bridge@<bridge_manager_pid>`` for this endpoint.
+    # In Standard mode this is the bridge_manager forked from the user
+    # process; in Performance mode it is 0, and the daemon falls back to
+    # the per-NS Performance MQ. Stamped by ``TypeRegistryWriter`` from
+    # ``agnocast::standard_bridge_manager_pid`` and carried as the 5th tab-
+    # separated field in the tmpfs line.
+    bridge_manager_pid: int = 0
 
 
-# Match key (topic_name, role, node_name) -> (pid, type_name).
+# Match key (topic_name, role, node_name) -> (pid, type_name, bridge_manager_pid).
 # role is "pub" or "sub".
 RegistryTable = Dict[Tuple[str, str, str], RegistryEntry]
 
@@ -125,11 +137,22 @@ class TypeRegistryReader:
                     self._warned_malformed_files.add(path)
                 continue
             topic, type_name, role, node_name = fields[0], fields[1], fields[2], fields[3]
-            # Extra fields beyond the required four are ignored on purpose
-            # to keep this reader forward-compatible with future writers.
+            # The 5th field (bridge_manager_pid) is required for daemon
+            # bridge dispatch but optional for backward compatibility: a
+            # missing or non-integer value falls back to 0, which routes
+            # the request to the Performance per-NS MQ instead of the
+            # Standard per-process MQ. Fields beyond the 5th are reserved
+            # for future writers and ignored.
+            bm_pid = 0
+            if len(fields) >= 5:
+                try:
+                    bm_pid = int(fields[4])
+                except ValueError:
+                    bm_pid = 0
             if role not in ('pub', 'sub'):
                 continue
-            table[(topic, role, node_name)] = RegistryEntry(pid=pid, type_name=type_name)
+            table[(topic, role, node_name)] = RegistryEntry(
+                pid=pid, type_name=type_name, bridge_manager_pid=bm_pid)
 
     def cleanup_dead_pids(self) -> None:
         """Remove tmpfs files whose owning PID is no longer alive.

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -1,0 +1,156 @@
+"""Read agnocastlib's per-process tmpfs type announcements.
+
+Each Agnocast process appends `<topic>\\t<type>\\t<role>\\t<node>\\n` lines to
+``/run/agnocast/<ipc_ns_inode>/<pid>.txt`` on each ``Publisher<T>`` /
+``Subscription<T>`` construction (see
+``agnocastlib::internal::TypeRegistryWriter``). The daemon walks the per-NS
+directory once per tick and joins the discovered ``(topic, role,
+node_name)`` triples with the kmod's endpoint list (which has node_name
+but lacks the rosidl type name and the owning pid) so the gossip
+publication can carry both pieces of information.
+
+Forward-compatibility rules (parser contract):
+
+* Lines must terminate in ``\\n``. A trailing unterminated tail (writer
+  died mid-write) is silently dropped.
+* Each line is tab-split. The first four fields are required —
+  ``topic``, ``type``, ``role``, ``node_name`` — and any extra fields
+  are ignored, so the writer can extend the format additively without
+  the daemon needing a lockstep update.
+* Lines with fewer than four fields are skipped and a single ``WARN``
+  is logged per rebuild (corrupt file or future-incompatible writer).
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+BASE_DIR = '/run/agnocast'
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    pid: int
+    type_name: str
+
+
+# Match key (topic_name, role, node_name) -> (pid, type_name).
+# role is "pub" or "sub".
+RegistryTable = Dict[Tuple[str, str, str], RegistryEntry]
+
+
+class TypeRegistryReader:
+    """Scan ``/run/agnocast/<ns_inode>/`` and build an in-memory lookup table.
+
+    The reader is stateless across ticks; each ``rebuild()`` call replaces
+    the table from scratch. This intentionally lets the table forget
+    entries whose source process died and whose file was removed by either
+    the writer's ``atexit`` cleanup or our own ``cleanup_dead_pids()``.
+    """
+
+    def __init__(self, ipc_ns_inode: int, base_dir: str = BASE_DIR, logger=None):
+        self._ns_dir = os.path.join(base_dir, str(ipc_ns_inode))
+        self._table: RegistryTable = {}
+        self._logger = logger
+        self._warned_malformed_files: set = set()
+
+    @property
+    def ns_dir(self) -> str:
+        return self._ns_dir
+
+    @property
+    def table(self) -> RegistryTable:
+        return self._table
+
+    def rebuild(self) -> None:
+        """Re-scan ``ns_dir`` and replace the internal table."""
+        new_table: RegistryTable = {}
+        try:
+            entries = list(os.scandir(self._ns_dir))
+        except FileNotFoundError:
+            self._table = new_table
+            return
+        except PermissionError as exc:
+            if self._logger is not None:
+                self._logger.warn(f'type_registry: cannot read {self._ns_dir}: {exc}')
+            self._table = new_table
+            return
+
+        for entry in entries:
+            if not entry.is_file() or not entry.name.endswith('.txt'):
+                continue
+            try:
+                pid = int(entry.name[:-len('.txt')])
+            except ValueError:
+                # Unexpected filename; skip silently.
+                continue
+            self._ingest_file(entry.path, pid, new_table)
+
+        self._table = new_table
+
+    def _ingest_file(self, path: str, pid: int, table: RegistryTable) -> None:
+        try:
+            with open(path, 'rb') as fp:
+                data = fp.read()
+        except (FileNotFoundError, PermissionError):
+            return
+
+        text = data.decode('utf-8', errors='replace')
+        # Only fully terminated lines are accepted. `splitlines(keepends=True)`
+        # preserves the trailing `\n` so we can distinguish complete lines
+        # from a torn tail.
+        for raw_line in text.splitlines(keepends=True):
+            if not raw_line.endswith('\n'):
+                # Writer was interrupted mid-line; skip the tail.
+                continue
+            line = raw_line[:-1]
+            fields = line.split('\t')
+            if len(fields) < 4:
+                if path not in self._warned_malformed_files and self._logger is not None:
+                    self._logger.warn(
+                        f'type_registry: malformed line in {path}: '
+                        f'expected at least 4 tab-separated fields, got {len(fields)}')
+                    self._warned_malformed_files.add(path)
+                continue
+            topic, type_name, role, node_name = fields[0], fields[1], fields[2], fields[3]
+            # Extra fields beyond the required four are ignored on purpose
+            # to keep this reader forward-compatible with future writers.
+            if role not in ('pub', 'sub'):
+                continue
+            table[(topic, role, node_name)] = RegistryEntry(pid=pid, type_name=type_name)
+
+    def cleanup_dead_pids(self) -> None:
+        """Remove tmpfs files whose owning PID is no longer alive.
+
+        Called once per tick after ``rebuild()``. The writer process is
+        responsible for unlinking its own file on graceful exit; this
+        sweep covers SIGKILL / crash cases.
+        """
+        try:
+            entries = list(os.scandir(self._ns_dir))
+        except FileNotFoundError:
+            return
+
+        for entry in entries:
+            if not entry.is_file() or not entry.name.endswith('.txt'):
+                continue
+            try:
+                pid = int(entry.name[:-len('.txt')])
+            except ValueError:
+                continue
+            if os.path.exists(f'/proc/{pid}'):
+                continue
+            try:
+                os.unlink(entry.path)
+            except FileNotFoundError:
+                pass
+            except PermissionError as exc:
+                if self._logger is not None:
+                    self._logger.warn(
+                        f'type_registry: failed to unlink stale {entry.path}: {exc}')
+
+    def lookup(
+        self, topic_name: str, role: str, node_name: str
+    ) -> Optional[RegistryEntry]:
+        """Return ``(pid, type_name)`` for the matching endpoint or ``None``."""
+        return self._table.get((topic_name, role, node_name))

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -25,7 +25,19 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
-BASE_DIR = '/dev/shm/agnocast_type_registry'
+def _default_base_dir() -> str:
+    """Return the tmpfs root the writer agreed on.
+
+    Mirrors `agnocastlib::internal::TypeRegistryWriter`: read
+    ``AGNOCAST_TMPFS_DIR`` if set (for hardened containers where
+    ``/dev/shm`` is unavailable or too small) and append the
+    ``agnocast_type_registry`` suffix.
+    """
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, 'agnocast_type_registry')
+
+
+BASE_DIR = _default_base_dir()
 
 
 @dataclass(frozen=True)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -1,8 +1,8 @@
 """Read agnocastlib's per-process tmpfs type announcements.
 
 Each Agnocast process appends `<topic>\\t<type>\\t<role>\\t<node>\\n` lines to
-``/run/agnocast/<ipc_ns_inode>/<pid>.txt`` on each ``Publisher<T>`` /
-``Subscription<T>`` construction (see
+``/dev/shm/agnocast_type_registry/<ipc_ns_inode>/<pid>.txt`` on each
+``Publisher<T>`` / ``Subscription<T>`` construction (see
 ``agnocastlib::internal::TypeRegistryWriter``). The daemon walks the per-NS
 directory once per tick and joins the discovered ``(topic, role,
 node_name)`` triples with the kmod's endpoint list (which has node_name
@@ -25,7 +25,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
-BASE_DIR = '/run/agnocast'
+BASE_DIR = '/dev/shm/agnocast_type_registry'
 
 
 @dataclass(frozen=True)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/type_registry.py
@@ -17,8 +17,9 @@ Forward-compatibility rules (parser contract):
   ``topic``, ``type``, ``role``, ``node_name`` — and any extra fields
   are ignored, so the writer can extend the format additively without
   the daemon needing a lockstep update.
-* Lines with fewer than four fields are skipped and a single ``WARN``
-  is logged per rebuild (corrupt file or future-incompatible writer).
+* Lines with fewer than four fields are skipped; a ``WARN`` is logged
+  the first time each malformed file is seen (across the reader's
+  lifetime, not per rebuild) — corrupt files don't re-spam the log.
 """
 
 import os
@@ -64,12 +65,16 @@ RegistryTable = Dict[Tuple[str, str, str], RegistryEntry]
 
 
 class TypeRegistryReader:
-    """Scan ``/run/agnocast/<ns_inode>/`` and build an in-memory lookup table.
+    """Scan ``${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ns_inode>/``
+    and build an in-memory lookup table.
 
-    The reader is stateless across ticks; each ``rebuild()`` call replaces
-    the table from scratch. This intentionally lets the table forget
-    entries whose source process died and whose file was removed by either
-    the writer's ``atexit`` cleanup or our own ``cleanup_dead_pids()``.
+    The reader's *table* is stateless across ticks; each ``rebuild()`` call
+    replaces it from scratch so entries whose source process died (and
+    whose file was removed by either the writer's ``atexit`` cleanup or
+    our own ``cleanup_dead_pids()``) are forgotten naturally. The
+    ``_warned_malformed_files`` set, however, persists across rebuilds —
+    a corrupt file logs a single WARN the first time it is observed and
+    stays quiet afterwards.
     """
 
     def __init__(self, ipc_ns_inode: int, base_dir: str = BASE_DIR, logger=None):

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -40,9 +40,10 @@ def test_ioctl_to_endpoint_copies_all_fields():
         qos_is_reliable=False,
         is_bridge=True,
     )
-    ep = _ioctl_to_endpoint(info)
+    ep = _ioctl_to_endpoint(info, '/chatter', 'pub')
     assert ep.node_name == '/talker_node'
-    assert ep.pid == 0  # best-effort empty
+    # No registry provided => pid stays 0.
+    assert ep.pid == 0
     assert ep.qos_depth == 7
     assert ep.qos_is_transient_local is True
     assert ep.qos_is_reliable is False
@@ -51,8 +52,23 @@ def test_ioctl_to_endpoint_copies_all_fields():
 
 def test_ioctl_to_endpoint_handles_short_name():
     info = _make_info('/x')
-    ep = _ioctl_to_endpoint(info)
+    ep = _ioctl_to_endpoint(info, '/chatter', 'pub')
     assert ep.node_name == '/x'
+
+
+def test_ioctl_to_endpoint_fills_pid_from_registry():
+    """When a registry entry matches (topic, role, node), the pid is filled."""
+    from ros2agnocast_discovery_agent.type_registry import RegistryEntry
+
+    class FakeRegistry:
+        def lookup(self, topic, role, node):
+            if (topic, role, node) == ('/chatter', 'pub', '/talker_node'):
+                return RegistryEntry(pid=4242, type_name='std_msgs/msg/Int32')
+            return None
+
+    info = _make_info('/talker_node')
+    ep = _ioctl_to_endpoint(info, '/chatter', 'pub', FakeRegistry())
+    assert ep.pid == 4242
 
 
 def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
@@ -109,13 +125,33 @@ def test_read_local_topics_combines_pub_and_sub():
     assert len(topics) == 1
     topic = topics[0]
     assert topic.topic_name == '/chatter'
-    assert topic.type_name == ''  # best-effort empty
+    # No registry passed => type stays empty.
+    assert topic.type_name == ''
     assert topic.domain_id == 0
     assert len(topic.publishers) == 1
     assert topic.publishers[0].node_name == '/talker_node'
     assert topic.publishers[0].qos_depth == 3
     assert len(topic.subscribers) == 1
     assert topic.subscribers[0].node_name == '/listener_node'
+
+
+def test_read_local_topics_resolves_type_from_registry():
+    """A registry entry for any endpoint on the topic populates `type_name`."""
+    from ros2agnocast_discovery_agent.type_registry import RegistryEntry
+
+    pub_info = _make_info('/talker_node')
+    lib = _make_mock_lib({'/chatter': {'pub': [pub_info], 'sub': []}})
+
+    class FakeRegistry:
+        def lookup(self, topic, role, node):
+            if (topic, role, node) == ('/chatter', 'pub', '/talker_node'):
+                return RegistryEntry(pid=99, type_name='std_msgs/msg/Int32')
+            return None
+
+    topics = read_local_topics(lib, FakeRegistry())
+    assert len(topics) == 1
+    assert topics[0].type_name == 'std_msgs/msg/Int32'
+    assert topics[0].publishers[0].pid == 99
 
 
 def test_read_local_topics_returns_empty_when_no_topics():

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -136,7 +136,7 @@ def test_read_local_topics_combines_pub_and_sub():
 
 
 def test_read_local_topics_resolves_type_from_registry():
-    """A registry entry for any endpoint on the topic populates `type_name`."""
+    """A registry entry for any endpoint on the topic populates ``type_name``."""
     from ros2agnocast_discovery_agent.type_registry import RegistryEntry
 
     pub_info = _make_info('/talker_node')

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -179,3 +179,63 @@ def test_read_host_uuid_returns_uuid_string():
     # fallback; both should parse as UUIDs.
     import uuid
     uuid.UUID(host_uuid)
+
+
+# ---------------------------------------------------------------------------
+# Singleton lock
+# ---------------------------------------------------------------------------
+
+
+def test_singleton_lock_path_honors_tmpfs_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _singleton_lock_path
+    assert _singleton_lock_path(42) == str(tmp_path / 'agnocast_discovery_agent_42.lock')
+
+
+def test_singleton_lock_path_defaults_to_dev_shm(monkeypatch):
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    from ros2agnocast_discovery_agent.agent import _singleton_lock_path
+    assert _singleton_lock_path(42) == '/dev/shm/agnocast_discovery_agent_42.lock'
+
+
+def test_acquire_singleton_lock_succeeds_when_free(monkeypatch, tmp_path):
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    lock = _try_acquire_singleton_lock(123)
+    assert lock is not None
+    lock.close()
+
+
+def test_acquire_singleton_lock_blocks_second_attempt(monkeypatch, tmp_path):
+    """A second acquire in the same process must fail while the first is held."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    first = _try_acquire_singleton_lock(456)
+    assert first is not None
+    second = _try_acquire_singleton_lock(456)
+    assert second is None
+    first.close()
+    # After releasing, a new acquire succeeds.
+    third = _try_acquire_singleton_lock(456)
+    assert third is not None
+    third.close()
+
+
+def test_acquire_singleton_lock_independent_per_ipc_ns(monkeypatch, tmp_path):
+    """Different IPC NS inodes get independent locks."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    lock_a = _try_acquire_singleton_lock(111)
+    lock_b = _try_acquire_singleton_lock(222)
+    assert lock_a is not None
+    assert lock_b is not None
+    lock_a.close()
+    lock_b.close()
+
+
+def test_acquire_singleton_lock_returns_none_on_unwritable_dir(monkeypatch):
+    """When the lock-file directory is not writable we err on the side of
+    not starting a duplicate."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/nonexistent_path_for_agnocast_test')
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    assert _try_acquire_singleton_lock(789) is None

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -202,22 +202,21 @@ def test_acquire_singleton_lock_succeeds_when_free(monkeypatch, tmp_path):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
     lock = _try_acquire_singleton_lock(123)
-    assert lock is not None
+    assert lock not in ('held', 'error')
     lock.close()
 
 
 def test_acquire_singleton_lock_blocks_second_attempt(monkeypatch, tmp_path):
-    """A second acquire in the same process must fail while the first is held."""
+    """A second acquire in the same process reports 'held' while the first is alive."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
     first = _try_acquire_singleton_lock(456)
-    assert first is not None
-    second = _try_acquire_singleton_lock(456)
-    assert second is None
+    assert first not in ('held', 'error')
+    assert _try_acquire_singleton_lock(456) == 'held'
     first.close()
     # After releasing, a new acquire succeeds.
     third = _try_acquire_singleton_lock(456)
-    assert third is not None
+    assert third not in ('held', 'error')
     third.close()
 
 
@@ -227,15 +226,15 @@ def test_acquire_singleton_lock_independent_per_ipc_ns(monkeypatch, tmp_path):
     from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
     lock_a = _try_acquire_singleton_lock(111)
     lock_b = _try_acquire_singleton_lock(222)
-    assert lock_a is not None
-    assert lock_b is not None
+    assert lock_a not in ('held', 'error')
+    assert lock_b not in ('held', 'error')
     lock_a.close()
     lock_b.close()
 
 
-def test_acquire_singleton_lock_returns_none_on_unwritable_dir(monkeypatch):
-    """When the lock-file directory is not writable we err on the side of
-    not starting a duplicate."""
+def test_acquire_singleton_lock_reports_error_on_unwritable_dir(monkeypatch):
+    """When the lock-file directory is not writable we report 'error' (distinct
+    from 'held') so the caller can surface a non-zero exit code."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/nonexistent_path_for_agnocast_test')
     from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
-    assert _try_acquire_singleton_lock(789) is None
+    assert _try_acquire_singleton_lock(789) == 'error'

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -179,3 +179,63 @@ def test_read_machine_id_returns_string():
     # should parse as UUIDs.
     import uuid
     uuid.UUID(machine_id)
+
+
+# ---------------------------------------------------------------------------
+# Singleton lock
+# ---------------------------------------------------------------------------
+
+
+def test_singleton_lock_path_honors_tmpfs_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _singleton_lock_path
+    assert _singleton_lock_path(42) == str(tmp_path / 'agnocast_discovery_agent_42.lock')
+
+
+def test_singleton_lock_path_defaults_to_dev_shm(monkeypatch):
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    from ros2agnocast_discovery_agent.agent import _singleton_lock_path
+    assert _singleton_lock_path(42) == '/dev/shm/agnocast_discovery_agent_42.lock'
+
+
+def test_acquire_singleton_lock_succeeds_when_free(monkeypatch, tmp_path):
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    lock = _try_acquire_singleton_lock(123)
+    assert lock is not None
+    lock.close()
+
+
+def test_acquire_singleton_lock_blocks_second_attempt(monkeypatch, tmp_path):
+    """A second acquire in the same process must fail while the first is held."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    first = _try_acquire_singleton_lock(456)
+    assert first is not None
+    second = _try_acquire_singleton_lock(456)
+    assert second is None
+    first.close()
+    # After releasing, a new acquire succeeds.
+    third = _try_acquire_singleton_lock(456)
+    assert third is not None
+    third.close()
+
+
+def test_acquire_singleton_lock_independent_per_ipc_ns(monkeypatch, tmp_path):
+    """Different IPC NS inodes get independent locks."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    lock_a = _try_acquire_singleton_lock(111)
+    lock_b = _try_acquire_singleton_lock(222)
+    assert lock_a is not None
+    assert lock_b is not None
+    lock_a.close()
+    lock_b.close()
+
+
+def test_acquire_singleton_lock_returns_none_on_unwritable_dir(monkeypatch):
+    """When the lock-file directory is not writable we err on the side of
+    not starting a duplicate."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/nonexistent_path_for_agnocast_test')
+    from ros2agnocast_discovery_agent.agent import _try_acquire_singleton_lock
+    assert _try_acquire_singleton_lock(789) is None

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -220,7 +220,23 @@ def test_serialize_packs_qos_flags():
     assert reliable == 1
 
 
-def test_decide_carries_local_publisher_pid_as_a2r_target():
+class _FakeRegistry:
+    """Minimal TypeRegistryReader-shaped fake for decide_bridges tests."""
+
+    def __init__(self, entries):
+        # entries: {(topic, role, node_name): obj with bridge_manager_pid}
+        self._entries = entries
+
+    def lookup(self, topic_name, role, node_name):
+        return self._entries.get((topic_name, role, node_name))
+
+
+class _Entry:
+    def __init__(self, bridge_manager_pid):
+        self.bridge_manager_pid = bridge_manager_pid
+
+
+def test_decide_carries_local_publisher_bm_pid_as_a2r_target():
     local = _state(
         topics=[_topic('/x', pubs=[_endpoint('/pub', pid=4242)])],
     )
@@ -228,22 +244,37 @@ def test_decide_carries_local_publisher_pid_as_a2r_target():
         host_uuid='OTHER', ipc_ns=222,
         topics=[_topic('/x', subs=[_endpoint('/sub')])],
     )
-    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    # bridge_manager pid (5555) differs from publisher's user pid (4242).
+    registry = _FakeRegistry({('/x', 'pub', '/pub'): _Entry(bridge_manager_pid=5555)})
+    reqs = decide_bridges(local, {('OTHER', 222): remote}, registry)
     assert len(reqs) == 1
     assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
-    assert reqs[0].target_pid == 4242
+    assert reqs[0].target_pid == 5555
 
 
-def test_decide_carries_local_subscriber_pid_as_r2a_target():
+def test_decide_carries_local_subscriber_bm_pid_as_r2a_target():
     local = _state(topics=[_topic('/x', subs=[_endpoint('/sub', pid=7777)])])
     remote = _state(
         host_uuid='OTHER', ipc_ns=222,
         topics=[_topic('/x', pubs=[_endpoint('/pub')])],
     )
-    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    registry = _FakeRegistry({('/x', 'sub', '/sub'): _Entry(bridge_manager_pid=8888)})
+    reqs = decide_bridges(local, {('OTHER', 222): remote}, registry)
     assert len(reqs) == 1
     assert reqs[0].direction == DIRECTION_ROS2_TO_AGNOCAST
-    assert reqs[0].target_pid == 7777
+    assert reqs[0].target_pid == 8888
+
+
+def test_decide_falls_back_to_zero_when_registry_absent():
+    """Without a registry the dispatch falls back to the Performance per-NS MQ."""
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/pub', pid=1)])])
+    remote = _state(
+        host_uuid='OTHER', ipc_ns=222,
+        topics=[_topic('/x', subs=[_endpoint('/sub')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})  # no registry
+    assert len(reqs) == 1
+    assert reqs[0].target_pid == 0
 
 
 def test_dispatch_sends_to_targeted_standard_mq_when_pid_known(monkeypatch):

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -176,6 +176,7 @@ def test_serialize_wire_format_matches_cpp_struct_size():
         qos_depth=10,
         qos_is_transient_local=False,
         qos_is_reliable=True,
+        target_pid=0,
     )
     payload = serialize_request(req)
     # sizeof(MqMsgDaemonBridge) on x86_64 Linux with GCC: 524 bytes.
@@ -190,6 +191,7 @@ def test_serialize_truncates_oversized_topic_name():
         qos_depth=10,
         qos_is_transient_local=False,
         qos_is_reliable=True,
+        target_pid=0,
     )
     payload = serialize_request(req)
     # The topic_name field is the first 256 bytes; the last byte must be a
@@ -205,6 +207,7 @@ def test_serialize_packs_qos_flags():
         qos_depth=7,
         qos_is_transient_local=True,
         qos_is_reliable=True,
+        target_pid=0,
     )
     payload = serialize_request(req)
     # direction is uint32_t at offset 512; qos_depth at 516; flags at 520/521.
@@ -215,3 +218,76 @@ def test_serialize_packs_qos_flags():
     assert depth == 7
     assert transient == 1
     assert reliable == 1
+
+
+def test_decide_carries_local_publisher_pid_as_a2r_target():
+    local = _state(
+        topics=[_topic('/x', pubs=[_endpoint('/pub', pid=4242)])],
+    )
+    remote = _state(
+        host_uuid='OTHER', ipc_ns=222,
+        topics=[_topic('/x', subs=[_endpoint('/sub')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].target_pid == 4242
+
+
+def test_decide_carries_local_subscriber_pid_as_r2a_target():
+    local = _state(topics=[_topic('/x', subs=[_endpoint('/sub', pid=7777)])])
+    remote = _state(
+        host_uuid='OTHER', ipc_ns=222,
+        topics=[_topic('/x', pubs=[_endpoint('/pub')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_ROS2_TO_AGNOCAST
+    assert reqs[0].target_pid == 7777
+
+
+def test_dispatch_sends_to_targeted_standard_mq_when_pid_known(monkeypatch):
+    """Standard-mode dispatch must target `/agnocast_daemon_bridge@<pid>` only."""
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+
+    req = BridgeRequest(
+        topic_name='/x',
+        type_name='T',
+        direction=DIRECTION_AGNOCAST_TO_ROS2,
+        qos_depth=1,
+        qos_is_transient_local=False,
+        qos_is_reliable=True,
+        target_pid=12345,
+    )
+    bd.dispatch_requests([req])
+    # Expect Performance MQ + Standard MQ targeted by pid; no broadcast.
+    assert any(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
+    assert '/agnocast_daemon_bridge@12345' in sent
+    # Sanity: no other Standard-mode MQs hit.
+    standard_targets = [n for n in sent if n.startswith('/agnocast_daemon_bridge@')]
+    assert standard_targets == ['/agnocast_daemon_bridge@12345']
+
+
+def test_dispatch_skips_standard_mq_when_pid_zero(monkeypatch):
+    """target_pid=0 means we don't know the user process -> Performance MQ only."""
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+
+    req = BridgeRequest(
+        topic_name='/x',
+        type_name='T',
+        direction=DIRECTION_AGNOCAST_TO_ROS2,
+        qos_depth=1,
+        qos_is_transient_local=False,
+        qos_is_reliable=True,
+        target_pid=0,
+    )
+    bd.dispatch_requests([req])
+    assert any(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
+    standard_targets = [n for n in sent if n.startswith('/agnocast_daemon_bridge@')]
+    assert standard_targets == []

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -1,9 +1,9 @@
 """Unit tests for the bridge decider.
 
 These tests do not require the kmod, DDS, or any POSIX MQ: the decider's
-pure-logic part (`decide_bridges`) is exercised directly, and the wire
+pure-logic part (``decide_bridges``) is exercised directly, and the wire
 format is checked against a hand-built byte layout that mirrors
-`sizeof(MqMsgDaemonBridge) == 524` in `agnocast_mq.hpp`.
+``sizeof(MqMsgDaemonBridge) == 524`` in ``agnocast_mq.hpp``.
 """
 
 from ros2agnocast_discovery_agent.bridge_decider import (
@@ -247,7 +247,7 @@ def test_decide_carries_local_subscriber_pid_as_r2a_target():
 
 
 def test_dispatch_sends_to_targeted_standard_mq_when_pid_known(monkeypatch):
-    """Standard-mode dispatch must target `/agnocast_daemon_bridge@<pid>` only."""
+    """Standard-mode dispatch must target ``/agnocast_daemon_bridge@<pid>`` only."""
     from ros2agnocast_discovery_agent import bridge_decider as bd
 
     sent = []

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -1,0 +1,217 @@
+"""Unit tests for the F1 bridge decider.
+
+These tests do not require the kmod, DDS, or any POSIX MQ: the decider's
+pure-logic part (`decide_bridges`) is exercised directly, and the wire
+format is checked against a hand-built byte layout that mirrors
+`sizeof(MqMsgDaemonBridge) == 524` in `agnocast_mq.hpp`.
+"""
+
+from ros2agnocast_discovery_agent.bridge_decider import (
+    DIRECTION_AGNOCAST_TO_ROS2,
+    DIRECTION_ROS2_TO_AGNOCAST,
+    BridgeRequest,
+    decide_bridges,
+    serialize_request,
+)
+from ros2agnocast_discovery_msgs.msg import (
+    AgnocastDaemonState,
+    AgnocastEndpoint,
+    AgnocastTopic,
+)
+
+
+def _endpoint(node, depth=10, transient=False, reliable=True, is_bridge=False, pid=0):
+    ep = AgnocastEndpoint()
+    ep.node_name = node
+    ep.pid = pid
+    ep.qos_depth = depth
+    ep.qos_is_transient_local = transient
+    ep.qos_is_reliable = reliable
+    ep.is_bridge = is_bridge
+    return ep
+
+
+def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None):
+    t = AgnocastTopic()
+    t.topic_name = name
+    t.type_name = type_name
+    t.domain_id = 0
+    t.publishers = pubs or []
+    t.subscribers = subs or []
+    return t
+
+
+def _state(host_uuid='HOST', ipc_ns=111, topics=None):
+    s = AgnocastDaemonState()
+    s.schema_version = 1
+    s.agnocast_version = ''
+    s.host_uuid = host_uuid
+    s.host_hostname = ''
+    s.ipc_ns_inode = ipc_ns
+    s.topics = topics or []
+    return s
+
+
+def test_decide_emits_a2r_when_local_pub_remote_sub():
+    local = _state(
+        topics=[_topic('/x', pubs=[_endpoint('/pub')])],
+    )
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x', subs=[_endpoint('/sub')])],
+    )
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].topic_name == '/x'
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].type_name == 'std_msgs/msg/Int32'
+
+
+def test_decide_emits_r2a_when_local_sub_remote_pub():
+    local = _state(topics=[_topic('/x', subs=[_endpoint('/sub')])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x', pubs=[_endpoint('/pub')])],
+    )
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_ROS2_TO_AGNOCAST
+
+
+def test_decide_emits_both_directions_when_both_sides_have_both():
+    local = _state(topics=[_topic('/x',
+                                  pubs=[_endpoint('/lp')],
+                                  subs=[_endpoint('/ls')])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x',
+                       pubs=[_endpoint('/rp')],
+                       subs=[_endpoint('/rs')])],
+    )
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    directions = sorted(r.direction for r in reqs)
+    assert directions == sorted([DIRECTION_ROS2_TO_AGNOCAST, DIRECTION_AGNOCAST_TO_ROS2])
+
+
+def test_decide_skips_bridge_only_endpoints():
+    local = _state(topics=[_topic('/x',
+                                  pubs=[_endpoint('/lp', is_bridge=True)])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x', subs=[_endpoint('/rs')])],
+    )
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert reqs == []
+
+
+def test_decide_skips_self_namespace():
+    local = _state(topics=[_topic('/x',
+                                  pubs=[_endpoint('/lp')],
+                                  subs=[_endpoint('/ls')])])
+    # Same (host_uuid, ipc_ns) — should be ignored.
+    reqs = decide_bridges(local, {('HOST', 111): local})
+    assert reqs == []
+
+
+def test_decide_skips_when_no_overlap():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/y', subs=[_endpoint('/rs')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert reqs == []
+
+
+def test_decide_skips_when_type_name_unknown_on_both_sides():
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x', type_name='', subs=[_endpoint('/rs')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert reqs == []
+
+
+def test_decide_uses_remote_type_when_local_missing():
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')])])
+    remote = _state(
+        host_uuid='OTHER',
+        ipc_ns=222,
+        topics=[_topic('/x', type_name='std_msgs/msg/String',
+                       subs=[_endpoint('/rs')])],
+    )
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].type_name == 'std_msgs/msg/String'
+
+
+def test_decide_collapses_duplicates_across_remotes():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
+    remote_a = _state(host_uuid='A', ipc_ns=1,
+                      topics=[_topic('/x', subs=[_endpoint('/sa')])])
+    remote_b = _state(host_uuid='B', ipc_ns=2,
+                      topics=[_topic('/x', subs=[_endpoint('/sb')])])
+
+    reqs = decide_bridges(local, {('A', 1): remote_a, ('B', 2): remote_b})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+
+
+def test_serialize_wire_format_matches_cpp_struct_size():
+    req = BridgeRequest(
+        topic_name='/x',
+        type_name='std_msgs/msg/Int32',
+        direction=DIRECTION_AGNOCAST_TO_ROS2,
+        qos_depth=10,
+        qos_is_transient_local=False,
+        qos_is_reliable=True,
+    )
+    payload = serialize_request(req)
+    # sizeof(MqMsgDaemonBridge) on x86_64 Linux with GCC: 524 bytes.
+    assert len(payload) == 524
+
+
+def test_serialize_truncates_oversized_topic_name():
+    req = BridgeRequest(
+        topic_name='/' + 'a' * 1000,
+        type_name='std_msgs/msg/Int32',
+        direction=DIRECTION_AGNOCAST_TO_ROS2,
+        qos_depth=10,
+        qos_is_transient_local=False,
+        qos_is_reliable=True,
+    )
+    payload = serialize_request(req)
+    # The topic_name field is the first 256 bytes; the last byte must be a
+    # NUL because we truncate to 255 + NUL terminator.
+    assert payload[255] == 0
+
+
+def test_serialize_packs_qos_flags():
+    req = BridgeRequest(
+        topic_name='/x',
+        type_name='T',
+        direction=DIRECTION_ROS2_TO_AGNOCAST,
+        qos_depth=7,
+        qos_is_transient_local=True,
+        qos_is_reliable=True,
+    )
+    payload = serialize_request(req)
+    # direction is uint32_t at offset 512; qos_depth at 516; flags at 520/521.
+    import struct
+    direction, depth = struct.unpack_from('=II', payload, 512)
+    transient, reliable = struct.unpack_from('=BB', payload, 520)
+    assert direction == DIRECTION_ROS2_TO_AGNOCAST
+    assert depth == 7
+    assert transient == 1
+    assert reliable == 1

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -1,4 +1,4 @@
-"""Unit tests for the F1 bridge decider.
+"""Unit tests for the bridge decider.
 
 These tests do not require the kmod, DDS, or any POSIX MQ: the decider's
 pure-logic part (`decide_bridges`) is exercised directly, and the wire

--- a/src/ros2agnocast_discovery_agent/test/test_type_registry.py
+++ b/src/ros2agnocast_discovery_agent/test/test_type_registry.py
@@ -140,3 +140,18 @@ def test_rebuild_skips_non_numeric_filenames():
         reader.rebuild()
         # File ignored because its name doesn't parse as int.
         assert reader.table == {}
+
+
+def test_default_base_dir_honors_agnocast_tmpfs_dir(monkeypatch):
+    """`AGNOCAST_TMPFS_DIR` overrides the `/dev/shm` default for the registry root."""
+    from ros2agnocast_discovery_agent import type_registry
+
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
+    assert type_registry._default_base_dir() == '/run/custom/agnocast_type_registry'
+
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    assert type_registry._default_base_dir() == '/dev/shm/agnocast_type_registry'
+
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '')
+    # Empty string is treated as unset (falsy) and the default applies.
+    assert type_registry._default_base_dir() == '/dev/shm/agnocast_type_registry'

--- a/src/ros2agnocast_discovery_agent/test/test_type_registry.py
+++ b/src/ros2agnocast_discovery_agent/test/test_type_registry.py
@@ -1,0 +1,142 @@
+"""Unit tests for the discovery agent's TypeRegistryReader.
+
+The reader scans a per-namespace tmpfs directory of `<pid>.txt` files
+written by `agnocastlib::internal::TypeRegistryWriter`. These tests use
+a temporary directory as the base — no kmod, no rclpy.
+"""
+
+import os
+import tempfile
+import textwrap
+
+from ros2agnocast_discovery_agent.type_registry import (
+    RegistryEntry,
+    TypeRegistryReader,
+)
+
+
+def _write(path: str, content: str) -> None:
+    with open(path, 'w', encoding='utf-8') as fp:
+        fp.write(content)
+
+
+def _make_reader(tmpdir: str, ns_inode: int = 1234) -> TypeRegistryReader:
+    os.makedirs(os.path.join(tmpdir, str(ns_inode)), exist_ok=True)
+    return TypeRegistryReader(ipc_ns_inode=ns_inode, base_dir=tmpdir)
+
+
+def test_rebuild_parses_well_formed_lines():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(
+            os.path.join(reader.ns_dir, '1111.txt'),
+            '/chatter\tstd_msgs/msg/Int32\tpub\t/talker_node\n'
+            '/echo\tstd_msgs/msg/String\tsub\t/listener_node\n')
+        reader.rebuild()
+
+        assert reader.lookup('/chatter', 'pub', '/talker_node') == RegistryEntry(
+            pid=1111, type_name='std_msgs/msg/Int32')
+        assert reader.lookup('/echo', 'sub', '/listener_node') == RegistryEntry(
+            pid=1111, type_name='std_msgs/msg/String')
+
+
+def test_rebuild_replaces_previous_table():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        path = os.path.join(reader.ns_dir, '1111.txt')
+        _write(path, '/old\tstd_msgs/msg/Int32\tpub\t/n\n')
+        reader.rebuild()
+        assert reader.lookup('/old', 'pub', '/n') is not None
+
+        os.unlink(path)
+        reader.rebuild()
+        assert reader.lookup('/old', 'pub', '/n') is None
+
+
+def test_rebuild_handles_missing_ns_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = TypeRegistryReader(ipc_ns_inode=99999, base_dir=tmpdir)
+        reader.rebuild()  # should not raise
+        assert reader.table == {}
+
+
+def test_rebuild_skips_unterminated_tail():
+    """A writer dying mid-write leaves a tail without `\\n`. Skip it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(
+            os.path.join(reader.ns_dir, '1.txt'),
+            '/good\tstd_msgs/msg/Int32\tpub\t/node_a\n'
+            '/partial\tstd_msgs/msg/Float64\tpub')
+        reader.rebuild()
+
+        assert reader.lookup('/good', 'pub', '/node_a') is not None
+        # The partial line must be dropped.
+        assert reader.lookup('/partial', 'pub', '') is None
+
+
+def test_rebuild_skips_lines_with_too_few_fields(caplog):
+    """Lines with fewer than 4 tab-separated fields are dropped + warned."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(
+            os.path.join(reader.ns_dir, '1.txt'),
+            '/good\tstd_msgs/msg/Int32\tpub\t/node_a\n'
+            '/bad\tonly_two_fields\n')
+        reader.rebuild()
+        assert reader.lookup('/good', 'pub', '/node_a') is not None
+        # No assertion on warning text since logger is optional.
+
+
+def test_rebuild_accepts_extra_fields_forward_compat():
+    """Lines with 5+ fields keep their first 4 fields and ignore extras."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(
+            os.path.join(reader.ns_dir, '7.txt'),
+            '/topic\tstd_msgs/msg/Int32\tpub\t/node_a\tfuture_field_v2\tand_one_more\n')
+        reader.rebuild()
+        entry = reader.lookup('/topic', 'pub', '/node_a')
+        assert entry == RegistryEntry(pid=7, type_name='std_msgs/msg/Int32')
+
+
+def test_rebuild_skips_lines_with_unknown_role():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(
+            os.path.join(reader.ns_dir, '1.txt'),
+            '/topic\tstd_msgs/msg/Int32\tunknown_role\t/node_a\n')
+        reader.rebuild()
+        assert reader.lookup('/topic', 'unknown_role', '/node_a') is None
+        assert reader.lookup('/topic', 'pub', '/node_a') is None
+
+
+def test_cleanup_dead_pids_removes_files_for_dead_pids():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        # PID 1 is always alive (init). PID 999999999 is unlikely to be alive.
+        alive_path = os.path.join(reader.ns_dir, '1.txt')
+        dead_path = os.path.join(reader.ns_dir, '999999999.txt')
+        _write(alive_path, '/t\tT\tpub\t/n\n')
+        _write(dead_path, '/t\tT\tpub\t/n\n')
+
+        reader.cleanup_dead_pids()
+
+        assert os.path.exists(alive_path)
+        assert not os.path.exists(dead_path)
+
+
+def test_cleanup_dead_pids_handles_missing_ns_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = TypeRegistryReader(ipc_ns_inode=99999, base_dir=tmpdir)
+        reader.cleanup_dead_pids()  # should not raise
+
+
+def test_rebuild_skips_non_numeric_filenames():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reader = _make_reader(tmpdir)
+        _write(os.path.join(reader.ns_dir, 'README.txt'),
+               '/topic\tstd_msgs/msg/Int32\tpub\t/node_a\n')
+        reader.rebuild()
+        # File ignored because its name doesn't parse as int.
+        assert reader.table == {}

--- a/src/ros2agnocast_discovery_agent/test/test_type_registry.py
+++ b/src/ros2agnocast_discovery_agent/test/test_type_registry.py
@@ -1,7 +1,7 @@
 """Unit tests for the discovery agent's TypeRegistryReader.
 
-The reader scans a per-namespace tmpfs directory of `<pid>.txt` files
-written by `agnocastlib::internal::TypeRegistryWriter`. These tests use
+The reader scans a per-namespace tmpfs directory of ``<pid>.txt`` files
+written by ``agnocastlib::internal::TypeRegistryWriter``. These tests use
 a temporary directory as the base — no kmod, no rclpy.
 """
 
@@ -61,7 +61,7 @@ def test_rebuild_handles_missing_ns_dir():
 
 
 def test_rebuild_skips_unterminated_tail():
-    """A writer dying mid-write leaves a tail without `\\n`. Skip it."""
+    """A writer dying mid-write leaves a tail without ``\\n``. Skip it."""
     with tempfile.TemporaryDirectory() as tmpdir:
         reader = _make_reader(tmpdir)
         _write(
@@ -143,7 +143,7 @@ def test_rebuild_skips_non_numeric_filenames():
 
 
 def test_default_base_dir_honors_agnocast_tmpfs_dir(monkeypatch):
-    """`AGNOCAST_TMPFS_DIR` overrides the `/dev/shm` default for the registry root."""
+    """``AGNOCAST_TMPFS_DIR`` overrides the ``/dev/shm`` default for the registry root."""
     from ros2agnocast_discovery_agent import type_registry
 
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')

--- a/src/ros2agnocast_discovery_agent/test/test_type_registry.py
+++ b/src/ros2agnocast_discovery_agent/test/test_type_registry.py
@@ -7,7 +7,6 @@ a temporary directory as the base — no kmod, no rclpy.
 
 import os
 import tempfile
-import textwrap
 
 from ros2agnocast_discovery_agent.type_registry import (
     RegistryEntry,


### PR DESCRIPTION
## Description

**What**: The agent side of cross-IPC-namespace bridge auto-generation. Connects #1352's `agnocastlib` infrastructure to `ros2agnocast_discovery_agent` so the end-to-end path actually fires.

**Why**: Without this PR, #1352's tmpfs files are written for no reader and its new MQs receive nothing. With this PR, the discovery agent reads the local Agnocast state, gossips it over DDS, and asks the right `bridge_manager` in the right IPC NS to spin up a bridge — implementing the design's "automatic cross-NS bridge" loop on the patch-update path.

**How**:

1. **Read the tmpfs type registry**. New `type_registry.py` (`TypeRegistryReader`) scans `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/` per tick and builds an in-memory `(topic, role, node_name) → (pid, type_name)` table. Forward-compatible parser: skips unterminated tails, lines with fewer than 4 tab fields, and ignores fields beyond the required four; drops entries whose owning pid no longer has `/proc/<pid>`. The `discovery_daemon_status` verb resolves the same root through the same helper.
2. **Enrich the gossip publication**. `agent.py` joins the ioctl-returned endpoint list (which has `node_name` but no type or pid) with the registry table to fill `AgnocastEndpoint.pid` and `AgnocastTopic.type_name`. Falls back to `0` / `''` when no match exists (e.g. before the writer has run), so gossip keeps flowing.
3. **Target bridge_manager by pid**. `bridge_decider.py` sends `MqMsgDaemonBridge` to exactly `/agnocast_daemon_bridge@<bm_pid>` (using the bm_pid the registry table carries) instead of broadcasting to every bridge_manager. Performance mode still uses the per-NS `/agnocast_daemon_bridge_perf` MQ. A request with `target_pid == 0` (no registry match) goes only to the Performance MQ.
4. **Singleton agent per IPC NS** — `agent.py` acquires an exclusive `flock(2)` on `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_discovery_agent_<inode>.lock` at startup; duplicate launches exit cleanly with code 0. `flock(2)` auto-releases on process death, so a crashed agent never blocks the next one. Pairs with the launch-tree guard in [autowarefoundation/autoware_core#1084](https://github.com/autowarefoundation/autoware_core/pull/1084) — that side prevents N spawns *within* a `ros2 launch` tree; this side catches duplicates *across* launches.
5. **Liveness CLI** — `ros2 agnocast discovery_daemon_status` returns 0/non-zero for three checks covering design doc §8.2's patch-route assumptions: an agent is running in this IPC NS, `/_agnocast_discovery` carries a live publisher, and the tmpfs registry has at least one `<pid>.txt`.
6. **e2e smoke** — `e2e_test_daemon_bridge_mq.bash` asserts a talker writes its `<pid>.txt` with a concrete type, gossip carries a non-empty `type_name`, and at least one `AgnocastEndpoint` has a non-zero pid.

## Known limitations (patch-route only)

- **Stale tmpfs file on agent co-death**: if the discovery agent dies together with the user process it tracks (e.g. `ros2 launch` SIGINT-ing both children at shutdown), `cleanup_dead_pids()` never runs and the stale `<pid>.txt` is left in tmpfs. Bridge state and `topic info_agnocast` are unaffected — the kmod cleans bridges on its own and gossip filters out PIDs whose `/proc/<pid>` is gone, so the leak is cosmetic. Matches design doc §8.2's "agent doesn't crash mid-run" assumption.
- **`discovery_daemon_status` is operator-driven**: no automatic recovery if its checks fail.

## What gets simpler in the next `need-minor-update`

The kmod-mediated route in the follow-up release replaces both the user-process → bridge_manager `MqMsgFactoryRegister` channel (added by #1352) and this PR's tmpfs reader path. At that point:

- `type_registry.py` (this PR), `internal::TypeRegistryWriter` (#1352), and the 5th tmpfs field (`bridge_manager_pid`) all go away — the kmod exposes `(type_name, owning_pid, bridge_manager_pid)` directly through the existing `topic_info_ret` polling.
- The agent's `flock(2)` singleton check and autoware_core#1084's launch-tree guard go away — `agnocast::init()` can fork the agent the same way it forks `poll_for_unlink`, with a kmod flag (`ret_discovery_agent_exist`) ensuring one per IPC NS.
- The stale-tmpfs limitation above goes away — there's no tmpfs file to leak.
- `discovery_daemon_status` shrinks to checking just the gossip publisher (the rest is enforced by the kmod).

## Related links

- Design doc: <https://tier4.atlassian.net/wiki/x/2YFtNwE> (TIER IV internal)
- Jira: T4DEV-51976 (TIER IV internal), parent epic T4DEV-52095
- Merge order: #1350 (shared base) → #1351 (CLI gossip subscribe) → #1352 (agnocastlib data layer) → **#1353 (this PR)**
- Autoware integration: [autowarefoundation/autoware_core#1084](https://github.com/autowarefoundation/autoware_core/pull/1084)

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) — 128/128 PASS at `-p 8` (see #1352 for the RLIMIT_MSGQUEUE budget; `-p 8` is the empirical ceiling on the local hardware).
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A.
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) — N/A: this PR is agent-side Python only. (Multi-workspace shells need #1354 to find heaphook.)
- [ ] sample application
- [x] Added automated tests (all pass locally):
  - `colcon test --packages-select ros2agnocast_discovery_agent` → 42 pytest cases (agent pid/type enrichment + 6 singleton-lock; bridge_decider targeted-by-pid + zero-pid-skip; type_registry forward-compat / malformed / unterminated / dead-pid cleanup / `AGNOCAST_TMPFS_DIR` override).
  - `colcon test --packages-select ros2agnocast` → 16 pytest cases (discovery helpers + `discovery_daemon_status` verb logic).
  - `bash scripts/test/e2e_test_daemon_bridge_mq.bash` — smoke for tmpfs writer + gossip enrichment + bridge_manager MQ wiring.

## Notes for reviewers

Three manual tests are required before merge — the unshare-based ones need `CAP_SYS_ADMIN`, which CI does not currently grant. Reviewer-runnable runbook for all three lives at [`/tmp/tmp.sh`](file:///tmp/tmp.sh) sections 4–5 (also reproduced inline below).

### (a) cross-IPC-namespace, single ECU

```bash
# Prereqs: agnocast kmod loaded; workspace built; AGNOCAST_BRIDGE_MODE=Standard (default).

# Shell A: alpha NS (talker)
sudo -E unshare --ipc bash -c '
  source /opt/ros/humble/setup.bash && source install/setup.bash
  ros2 launch agnocast_sample_application talker.launch.xml & sleep 60; wait
'

# Shell B: beta NS (listener)
sudo -E unshare --ipc bash -c '
  source /opt/ros/humble/setup.bash && source install/setup.bash
  ros2 launch agnocast_sample_application listener.launch.xml & sleep 60; wait
'
```

Expected within ~5 seconds:

- Shell B starts logging received messages from `/my_topic`.
- Each bridge_manager log shows three "Listening on MQ" lines (primary + daemon-bridge + factory-register) followed by "Registered factory for type 'agnocast_sample_interfaces/msg/DynamicSizeArray' from library '...'". The library path is the talker binary on the talker side and `libagnocast_listener_component.so` on the listener side.
- `cat /dev/shm/agnocast_type_registry/<ns_inode>/*.txt` (from any host shell — `/dev/shm` is shared across IPC namespaces) shows talker + listener entries with a non-zero `bridge_manager_pid` in the 5th tab field.
- `ros2 topic info_agnocast /my_topic` (host NS) shows the gossip-aggregated count: `Agnocast Publisher count: 1` (talker) and `Agnocast Subscription count: 1` (listener). Bridge endpoints (`is_bridge=true`) are filtered out by the CLI.
- Per-IPC-NS `/dev/mqueue` lists three MQs per bridge_manager (`agnocast_bridge_manager@<bm_pid>`, `agnocast_daemon_bridge@<bm_pid>`, `agnocast_factory_register@<bm_pid>`). Inspect via `sudo nsenter -t <agent_pid> --ipc -- ls /dev/mqueue/`.

> **Caveats**
> - `sudo -E` (not just `sudo`) is required so the inner shell inherits `RMW_IMPLEMENTATION`. Mixed RMWs discover via RTPS UDP but data delivery is unreliable.
> - Run `ros2 daemon stop && sleep 1 && ros2 daemon start && sleep 3` in the host shell once after sourcing, so the ros2 daemon picks up `ros2agnocast_discovery_msgs` in its `PYTHONPATH`.

### (b) cross-ECU, same `ROS_DOMAIN_ID`

Replace shells A/B above with two separate ECUs (or two VMs on the same network) sharing `ROS_DOMAIN_ID`. No `unshare -i` needed. Same expectations.

### (c) bridge cleanup on endpoint loss

```bash
pkill -f "agnocast_sample_application.*listener"
sleep 10
ros2 topic info_agnocast /my_topic
# Expect: no is_bridge=true endpoints; ROS 2 pub/sub counts back to zero.
```

### Liveness check (operator-facing)

```bash
ros2 agnocast discovery_daemon_status   # exit 0 = all OK
```

## Version Update Label (Required)

- `need-patch-update`

Python only (`ros2agnocast_discovery_agent`, `ros2agnocast`) plus one bash e2e. No `agnocastlib` / kmod / ABI changes.




