### PR TITLE
fix(scripts): handle multi-path COLCON_PREFIX_PATH when locating heaphook

### DIFF
--- a/scripts/test/run_requires_kernel_module_tests.bash
+++ b/scripts/test/run_requires_kernel_module_tests.bash
@@ -13,11 +13,28 @@ source /opt/ros/${ROS_DISTRO}/setup.bash
 colcon build --packages-up-to agnocast_e2e_test --cmake-args -DBUILD_TESTING=ON
 source install/setup.bash
 
-# Pre-flight check: heaphook library must exist
-HEAPHOOK_PATH="${COLCON_PREFIX_PATH}/agnocastlib/lib/libagnocast_heaphook.so"
-if [ ! -f "${HEAPHOOK_PATH}" ]; then
-  echo "ERROR: ${HEAPHOOK_PATH} not found." >&2
-  echo "Build agnocast_heaphook first: cd agnocast_heaphook && cargo build --release && cp target/release/libagnocast_heaphook.so ${COLCON_PREFIX_PATH}/lib/" >&2
+# Pre-flight check: heaphook library must exist somewhere on COLCON_PREFIX_PATH.
+# COLCON_PREFIX_PATH is colon-separated when multiple workspaces are sourced
+# (e.g. an Autoware underlay plus this Agnocast overlay), so we have to walk
+# the list instead of dereferencing it as a single path — otherwise the test
+# fails out before colcon even runs, with an ERROR pointing at a path that
+# literally contains a `:`.
+HEAPHOOK_RELATIVE="agnocastlib/lib/libagnocast_heaphook.so"
+HEAPHOOK_PATH=""
+IFS=':' read -r -a _PREFIX_ENTRIES <<< "${COLCON_PREFIX_PATH}"
+for _prefix in "${_PREFIX_ENTRIES[@]}"; do
+  candidate="${_prefix}/${HEAPHOOK_RELATIVE}"
+  if [ -f "${candidate}" ]; then
+    HEAPHOOK_PATH="${candidate}"
+    break
+  fi
+done
+if [ -z "${HEAPHOOK_PATH}" ]; then
+  echo "ERROR: ${HEAPHOOK_RELATIVE} not found under any COLCON_PREFIX_PATH entry:" >&2
+  for _prefix in "${_PREFIX_ENTRIES[@]}"; do
+    echo "  - ${_prefix}/${HEAPHOOK_RELATIVE}" >&2
+  done
+  echo "Build agnocast_heaphook first: cd agnocast_heaphook && cargo build --release && cp target/release/libagnocast_heaphook.so install/agnocastlib/lib/" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Description

`run_requires_kernel_module_tests.bash` dereferenced `${COLCON_PREFIX_PATH}` as a single path when checking for `libagnocast_heaphook.so`. In dev environments that source both an Autoware underlay and this Agnocast overlay — a common setup — `COLCON_PREFIX_PATH` is colon-separated, so the pre-flight check fails out with an ERROR pointing at a synthetic path containing a literal `:`, *before colcon ever runs*:

```text
ERROR: /home/<user>/agnocast/install:/home/<user>/autoware/install/agnocastlib/lib/libagnocast_heaphook.so not found.
```

This fix walks the colon-separated entries and picks the first one that hosts the heaphook. The failure message also enumerates the searched prefixes so it is obvious which workspaces were checked.

## Related links

- Affected since: #1222 (PR that introduced the pre-flight check, 2026-04-07).
- Independent of the cross-IPC-NS bridge feature stack (#1350 → #1351 → #1352 → #1353).

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) — N/A: this PR only touches `run_requires_kernel_module_tests.bash`.
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) — N/A: same reason.
- [ ] kunit tests (required when modifying the kernel module) — N/A: kmod untouched.
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) — verified the pre-flight check now finds heaphook in a multi-workspace shell (Autoware underlay + Agnocast overlay sourced), and prints a per-prefix diagnostic when none is present.
- [ ] sample application
- [x] Standalone logic check with a synthetic `COLCON_PREFIX_PATH=/nonexistent:<real-prefix>` confirms the loop falls through to the real prefix.

## Notes for reviewers

Pure script fix; no library or kmod changes.

## Version Update Label (Required)

- `need-patch-update`