### PR TITLE
feat(ros2agnocast): support ros2 topic hz/echo/delay for Agnocast

### DIFF
--- a/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
@@ -4,6 +4,7 @@ import time
 from typing import Callable
 
 import rclpy
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from ros2cli.node.strategy import NodeStrategy
 from ros2agnocast.discovery import (
     DEFAULT_COLLECT_TIMEOUT_SEC,
@@ -124,7 +125,12 @@ def _create_dummy_subscription(topic_name: str, msg_type):
         node = rclpy.create_node(
             '_ros2agnocast_cli_%d' % os.getpid(),
             context=ctx)
-        node.create_subscription(msg_type, topic_name, lambda _msg: None, 10)
+        qos = QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        node.create_subscription(msg_type, topic_name, lambda _msg: None, qos)
         yield node, ctx
     finally:
         if node is not None:

--- a/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
@@ -53,15 +53,15 @@ def wait_for_ros2_publisher(node, topic_name: str, bridge_timeout: float, *, con
     return False
 
 
-def lookup_topic_msg_type(topic_name: str, gossip_timeout: float):
-    """Resolve the ROS message class for topic_name.
+def resolve_type_name(topic_name: str, gossip_timeout: float):
+    """Resolve the ROS type string for topic_name.
 
     First checks the live ROS 2 graph for the topic type.  If the topic is not
     found there, falls back to /_agnocast_discovery gossip to resolve the type
     for Agnocast-only topics.
 
-    Returns the message class on success, or None if the type name cannot be
-    resolved or the message class cannot be loaded (error is printed to stdout).
+    Returns the type string on success, or None if the type name cannot be
+    resolved (error is printed to stdout).
     """
     with NodeStrategy(None) as proxy_node:
         # First, check if the topic already exists in the ROS 2 graph.
@@ -90,6 +90,15 @@ def lookup_topic_msg_type(topic_name: str, gossip_timeout: float):
             % topic_name)
         return None
 
+    return type_name
+
+
+def load_msg_class(type_name: str):
+    """Load and return the ROS message class for type_name.
+
+    Returns the message class on success, or None if the class cannot be
+    loaded (error is printed to stdout).
+    """
     try:
         from rosidl_runtime_py.utilities import get_message
         return get_message(type_name)
@@ -126,9 +135,11 @@ def _create_dummy_subscription(topic_name: str, msg_type):
         rclpy.try_shutdown(context=ctx)
 
 
-def spawn_bridge_and_run(args, topic_name: str, action_fn: Callable) -> int:
+def spawn_bridge_and_run(
+        args, topic_name: str, action_fn: Callable, *, message_type: str | None = None) -> int:
     """Resolve the message type for topic_name, trigger the A2R bridge, and run action_fn(args).
 
+    message_type: if provided, skip discovery and use this type string directly.
     Returns the exit code from action_fn, or 1 on failure.
     """
     warn_if_gossip_timeout_overridden(args)
@@ -136,12 +147,22 @@ def spawn_bridge_and_run(args, topic_name: str, action_fn: Callable) -> int:
         "[*] Triggering A2R bridge for '%s'. "
         'This may take a few seconds...' % topic_name)
 
-    # Phase 1: resolve message type via the ROS 2 graph or /_agnocast_discovery gossip.
-    msg_type = lookup_topic_msg_type(topic_name, args.gossip_timeout)
+    # Phase 1: resolve type name.
+    # If the caller already supplied a type string (e.g. ros2 topic echo_agnocast <topic> <type>),
+    # use it directly; otherwise look it up via the ROS 2 graph or /_agnocast_discovery gossip.
+    if message_type is not None:
+        type_name = message_type
+    else:
+        type_name = resolve_type_name(topic_name, args.gossip_timeout)
+        if type_name is None:
+            return 1
+
+    # Phase 2: load message class from type name.
+    msg_type = load_msg_class(type_name)
     if msg_type is None:
         return 1
 
-    # Phase 2: start dummy subscription and wait for a ROS 2 publisher to appear.
+    # Phase 3: start dummy subscription and wait for a ROS 2 publisher to appear.
     # TODO: Ideally, we should wait until bridges have come up for all Agnocast publishers
     #       across every namespace.  For simplicity, we currently only wait for a single
     #       publisher to appear.

--- a/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
@@ -7,8 +7,10 @@ import rclpy
 from ros2cli.node.strategy import NodeStrategy
 from ros2agnocast.discovery import (
     DEFAULT_COLLECT_TIMEOUT_SEC,
-    collect_announcements,
-    filter_fresh,
+    add_gossip_timeout_arg,
+    collect_announcements_with_fallback,
+    warn_if_gossip_timeout_overridden,
+    warn_if_using_fallback,
 )
 
 DEFAULT_BRIDGE_TIMEOUT = 10.0   # seconds
@@ -35,12 +37,7 @@ def add_bridge_arguments(parser) -> None:
              '(default: %.1f). '
              'If no publisher appears within this time, the topic is assumed to not '
              'exist in Agnocast.' % DEFAULT_BRIDGE_TIMEOUT)
-    parser.add_argument(
-        '--gossip-timeout',
-        type=float,
-        default=DEFAULT_COLLECT_TIMEOUT_SEC,
-        help='Seconds to wait for /_agnocast_discovery gossip from peer '
-             'namespaces / ECUs (default: %(default)ss).')
+    add_gossip_timeout_arg(parser)
 
 
 def wait_for_ros2_publisher(node, topic_name: str, bridge_timeout: float, *, context=None) -> bool:
@@ -76,8 +73,8 @@ def lookup_topic_msg_type(topic_name: str, gossip_timeout: float):
 
         if not type_name:
             # If not found, fall back to /_agnocast_discovery to look up the Agnocast topic.
-            raw_snapshots = collect_announcements(proxy_node, timeout_sec=gossip_timeout)
-            snapshots = filter_fresh(raw_snapshots, node=proxy_node)
+            snapshots, used_fallback = collect_announcements_with_fallback(proxy_node, timeout_sec=gossip_timeout)
+            warn_if_using_fallback(proxy_node, used_fallback, gossip_timeout)
             type_name = next(
                 (topic.type_name
                  for snap in snapshots
@@ -134,6 +131,7 @@ def spawn_bridge_and_run(args, topic_name: str, action_fn: Callable) -> int:
 
     Returns the exit code from action_fn, or 1 on failure.
     """
+    warn_if_gossip_timeout_overridden(args)
     print(
         "[*] Triggering A2R bridge for '%s'. "
         'This may take a few seconds...' % topic_name)

--- a/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_bridged_ros2cli.py
@@ -1,0 +1,164 @@
+import contextlib
+import os
+import time
+from typing import Callable
+
+import rclpy
+from ros2cli.node.strategy import NodeStrategy
+from ros2agnocast.discovery import (
+    DEFAULT_COLLECT_TIMEOUT_SEC,
+    collect_announcements,
+    filter_fresh,
+)
+
+DEFAULT_BRIDGE_TIMEOUT = 10.0   # seconds
+POLL_INTERVAL = 0.2             # seconds between publisher-count checks
+
+_AGNOCAST_BRIDGE_NOTE = (
+    '\n\nnote:\n'
+    '  A dummy ros2 subscriber is first created to trigger the A2R bridge, '
+    'then the standard ros2 topic command begins.'
+)
+
+
+def add_bridge_arguments(parser) -> None:
+    """Add --bridge-timeout argument and append an Agnocast note to parser.description."""
+    if parser.description:
+        parser.description += _AGNOCAST_BRIDGE_NOTE
+    else:
+        parser.description = _AGNOCAST_BRIDGE_NOTE.lstrip()
+    parser.add_argument(
+        '--bridge-timeout',
+        dest='bridge_timeout', type=float, default=DEFAULT_BRIDGE_TIMEOUT,
+        metavar='SEC',
+        help='Seconds to wait for the Agnocast bridge (ROS 2 publisher) to appear '
+             '(default: %.1f). '
+             'If no publisher appears within this time, the topic is assumed to not '
+             'exist in Agnocast.' % DEFAULT_BRIDGE_TIMEOUT)
+    parser.add_argument(
+        '--gossip-timeout',
+        type=float,
+        default=DEFAULT_COLLECT_TIMEOUT_SEC,
+        help='Seconds to wait for /_agnocast_discovery gossip from peer '
+             'namespaces / ECUs (default: %(default)ss).')
+
+
+def wait_for_ros2_publisher(node, topic_name: str, bridge_timeout: float, *, context=None) -> bool:
+    """Poll until a ROS 2 publisher appears on topic_name.
+
+    Returns True if a publisher is detected, False on timeout.
+    """
+    deadline = time.monotonic() + bridge_timeout
+    while rclpy.ok(context=context) and time.monotonic() < deadline:
+        if node.get_publishers_info_by_topic(topic_name):
+            return True
+        time.sleep(POLL_INTERVAL)
+    return False
+
+
+def lookup_topic_msg_type(topic_name: str, gossip_timeout: float):
+    """Resolve the ROS message class for topic_name.
+
+    First checks the live ROS 2 graph for the topic type.  If the topic is not
+    found there, falls back to /_agnocast_discovery gossip to resolve the type
+    for Agnocast-only topics.
+
+    Returns the message class on success, or None if the type name cannot be
+    resolved or the message class cannot be loaded (error is printed to stdout).
+    """
+    with NodeStrategy(None) as proxy_node:
+        # First, check if the topic already exists in the ROS 2 graph.
+        type_name = next(
+            (types[0]
+             for name, types in proxy_node.get_topic_names_and_types()
+             if name == topic_name and types),
+            '')
+
+        if not type_name:
+            # If not found, fall back to /_agnocast_discovery to look up the Agnocast topic.
+            raw_snapshots = collect_announcements(proxy_node, timeout_sec=gossip_timeout)
+            snapshots = filter_fresh(raw_snapshots, node=proxy_node)
+            type_name = next(
+                (topic.type_name
+                 for snap in snapshots
+                 for topic in snap.topics
+                 if topic.topic_name == topic_name and topic.type_name),
+                '')
+
+    if not type_name:
+        print(
+            "ERROR: Could not resolve message type for '%s'. "
+            'The topic was not found in the ROS 2 graph or via /_agnocast_discovery. '
+            'Make sure the topic exists and, for Agnocast topics, the discovery agent is running.'
+            % topic_name)
+        return None
+
+    try:
+        from rosidl_runtime_py.utilities import get_message
+        return get_message(type_name)
+    except Exception as e:
+        print(
+            "ERROR: Could not load message class for type '%s': %s" % (type_name, e))
+        return None
+
+
+@contextlib.contextmanager
+def _create_dummy_subscription(topic_name: str, msg_type):
+    """Context manager that registers a dummy ROS 2 subscriber to trigger the A2R bridge.
+
+    The subscription only needs to exist; no spinning is required to keep it alive.
+    Uses a private rclpy context so the default context remains free for action_fn.
+
+    Yields (node, ctx).
+    """
+    ctx = rclpy.Context()
+    rclpy.init(context=ctx)
+    node = None
+    try:
+        node = rclpy.create_node(
+            '_ros2agnocast_cli_%d' % os.getpid(),
+            context=ctx)
+        node.create_subscription(msg_type, topic_name, lambda _msg: None, 10)
+        yield node, ctx
+    finally:
+        if node is not None:
+            try:
+                node.destroy_node()
+            except Exception:
+                pass
+        rclpy.try_shutdown(context=ctx)
+
+
+def spawn_bridge_and_run(args, topic_name: str, action_fn: Callable) -> int:
+    """Resolve the message type for topic_name, trigger the A2R bridge, and run action_fn(args).
+
+    Returns the exit code from action_fn, or 1 on failure.
+    """
+    print(
+        "[*] Triggering A2R bridge for '%s'. "
+        'This may take a few seconds...' % topic_name)
+
+    # Phase 1: resolve message type via the ROS 2 graph or /_agnocast_discovery gossip.
+    msg_type = lookup_topic_msg_type(topic_name, args.gossip_timeout)
+    if msg_type is None:
+        return 1
+
+    # Phase 2: start dummy subscription and wait for a ROS 2 publisher to appear.
+    # TODO: Ideally, we should wait until bridges have come up for all Agnocast publishers
+    #       across every namespace.  For simplicity, we currently only wait for a single
+    #       publisher to appear.
+    with _create_dummy_subscription(topic_name, msg_type) as (node, ctx):
+        ready = wait_for_ros2_publisher(
+            node, topic_name, args.bridge_timeout, context=ctx)
+
+        if not ready:
+            print(
+                "ERROR: No ROS 2 publisher appeared on '%s' within %.1f s. "
+                'The topic may not exist in Agnocast or the bridge failed to start.'
+                % (topic_name, args.bridge_timeout))
+            return 1
+
+        print('[*] Starting ros2cli command...')
+
+        # The dummy subscription stays alive (via the with block) while action_fn runs.
+        return action_fn(args)

--- a/src/ros2agnocast/ros2agnocast/verb/topic_delay_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_delay_agnocast.py
@@ -1,0 +1,14 @@
+from ros2topic.verb.delay import DelayVerb
+from ros2agnocast.verb._bridged_ros2cli import add_bridge_arguments
+from ros2agnocast.verb._bridged_ros2cli import spawn_bridge_and_run
+
+
+class TopicDelayAgnocastVerb(DelayVerb):
+
+    def add_arguments(self, parser, cli_name):
+        super().add_arguments(parser, cli_name)
+        add_bridge_arguments(parser)
+
+    def main(self, *, args):
+        return spawn_bridge_and_run(
+            args, topic_name=args.topic, action_fn=lambda a: DelayVerb.main(self, args=a))

--- a/src/ros2agnocast/ros2agnocast/verb/topic_echo_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_echo_agnocast.py
@@ -1,0 +1,14 @@
+from ros2topic.verb.echo import EchoVerb
+from ros2agnocast.verb._bridged_ros2cli import add_bridge_arguments
+from ros2agnocast.verb._bridged_ros2cli import spawn_bridge_and_run
+
+
+class TopicEchoAgnocastVerb(EchoVerb):
+
+    def add_arguments(self, parser, cli_name):
+        super().add_arguments(parser, cli_name)
+        add_bridge_arguments(parser)
+
+    def main(self, *, args):
+        return spawn_bridge_and_run(
+            args, topic_name=args.topic_name, action_fn=lambda a: EchoVerb.main(self, args=a))

--- a/src/ros2agnocast/ros2agnocast/verb/topic_echo_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_echo_agnocast.py
@@ -11,4 +11,5 @@ class TopicEchoAgnocastVerb(EchoVerb):
 
     def main(self, *, args):
         return spawn_bridge_and_run(
-            args, topic_name=args.topic_name, action_fn=lambda a: EchoVerb.main(self, args=a))
+            args, topic_name=args.topic_name, action_fn=lambda a: EchoVerb.main(self, args=a),
+            message_type=args.message_type)

--- a/src/ros2agnocast/ros2agnocast/verb/topic_hz_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_hz_agnocast.py
@@ -1,0 +1,14 @@
+from ros2topic.verb.hz import HzVerb
+from ros2agnocast.verb._bridged_ros2cli import add_bridge_arguments
+from ros2agnocast.verb._bridged_ros2cli import spawn_bridge_and_run
+
+
+class TopicHzAgnocastVerb(HzVerb):
+
+    def add_arguments(self, parser, cli_name):
+        super().add_arguments(parser, cli_name)
+        add_bridge_arguments(parser)
+
+    def main(self, *, args):
+        return spawn_bridge_and_run(
+            args, topic_name=args.topic_name, action_fn=lambda a: HzVerb.main(self, args=a))

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -32,6 +32,9 @@ setup(
         'ros2topic.verb': [
             'list_agnocast = ros2agnocast.verb.list_agnocast:ListAgnocastVerb',
             'info_agnocast = ros2agnocast.verb.topic_info_agnocast:TopicInfoAgnocastVerb',
+            'hz_agnocast = ros2agnocast.verb.topic_hz_agnocast:TopicHzAgnocastVerb',
+            'echo_agnocast = ros2agnocast.verb.topic_echo_agnocast:TopicEchoAgnocastVerb',
+            'delay_agnocast = ros2agnocast.verb.topic_delay_agnocast:TopicDelayAgnocastVerb',
         ],
         'ros2node.verb': [
             'list_agnocast = ros2agnocast.verb.node_list_agnocast:ListAgnocastVerb',


### PR DESCRIPTION
## Description

### Summary

**This PR adds support for the debug commands corresponding to `ros2 topic hz/echo/delay` in [ros2cli](https://github.com/ros2/ros2cli)**. These commands support cross-namespace and cross-ECU agnocast topics.

### Background

Previously, these ros2cli subcommands didn't work for agnocast-only topics because they are not initially visible from ROS2 applications. Since standard ros2cli commands immediately exit with an error if no ROS2 publisher is found, they fail to trigger the bridge creation and incorrectly assume the topic does not exist.

This made it difficult for developers to monitor and debug agnocast topics.

### Changes

Adds subcommands `hz_agnocast`/`echo_agnocast`/`delay_agnocast` to the `ros2 topic` verb as an extension for agnocast. `ros2 topic XXX_agnocast` performs the same action as its counterpart, except that it also recognizes agnocast topics.

### How it works

The logic is very straightforward. These commands perform the following steps:

1. Spawn a dummy subscription for the given topic to trigger the agnocast A2R bridge.
2. Wait until a ROS2 publisher appears.
3. Delegate the actual processing to the existing ros2cli command.

Once the dummy subscriber is created, all agnocast bridge managers attempt to create an A2R bridge for every namespace/ECU combination, resulting in all agnocast publishers becoming visible to ROS2.

By adopting this design, we can use all arguments defined in the ros2cli commands (e.g., `--filter`).

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

### Test scripts for manual testing

No automated tests are included because the newly added feature is strongly dependent on the ros2cli implementation, making it difficult to write stable tests. Instead, please test these commands manually.

To make this easier, I have prepared a script ([scripts/test/setup_manual_test_env.bash](https://github.com/autowarefoundation/agnocast/blob/test/ros2agnocast/test-application-and-scripts-for-ros2agnocast/scripts/test/setup_manual_test_env.bash)) in the [test/ros2agnocast/test-application-and-scripts-for-ros2agnocast](https://github.com/autowarefoundation/agnocast/tree/test/ros2agnocast/test-application-and-scripts-for-ros2agnocast) branch. This script allows you to easily set up various test environments, such as spawning agnocast publishers across different namespaces or launching only ROS2 publishers. Please feel free to use it for your manual testing!

### Test Checklists

**Connectivity Checks**
- [ ] Successfully recognizes topics from an agnocast publisher in the same namespace.
- [ ] Successfully recognizes topics from an agnocast publisher in a different namespace.
- [ ] Successfully recognizes topics from a standard ROS2 publisher.
- [ ] Successfully receives published messages from both sources when both agnocast and ROS2 publishers exist simultaneously.
- [ ] Outputs an error when no publisher exists anywhere.
- [ ] Outputs a warning message when a ROS2 topic contains different message types.

**Functional Checks**
- [ ] The `--bridge-timeout` option works correctly.
- [ ] All other existing `ros2cli` command-line arguments work as expected.
- [ ] The help message is displayed correctly.

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
