### PR TITLE
fix(ros2agnocast,ci): unskip ros2agnocast in colcon test

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -171,8 +171,7 @@ jobs:
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
         source install/setup.bash
-        # --packages-skip ros2agnocast: skip Python package with no tests (pytest fails on empty test suite)
-        colcon test --merge-install --packages-skip ros2agnocast --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -LE "requires_kernel_module|requires_heaphook"
+        colcon test --merge-install --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -LE "requires_kernel_module|requires_heaphook"
 
     - name: Generate coverage report
       if: github.event_name == 'pull_request' && steps.check_diff.outputs.cpp_changed == 'true'
@@ -258,8 +257,7 @@ jobs:
       run: |
         source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
         source install/setup.bash
-        # --packages-skip ros2agnocast: skip Python package with no tests (pytest fails on empty test suite)
-        colcon test --merge-install --packages-skip ros2agnocast --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_integration_agnocast_heaphook"
+        colcon test --merge-install --event-handlers console_direct+ --return-code-on-test-failure --ctest-args -R "test_integration_agnocast_heaphook"
 
   # Summary job that provides a single status check for branch protection rules.
   # Matrix jobs report status as "job-name (matrix-value)", but branch protection

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -20,6 +20,7 @@ setup(
             '*.cpp',
         ],
     },
+    extras_require={'test': ['pytest']},
     entry_points={
         'ros2cli.command': [
             'agnocast = ros2agnocast.command.agnocast:AgnocastCommand',

--- a/src/ros2agnocast/test/test_verb_helpers.py
+++ b/src/ros2agnocast/test/test_verb_helpers.py
@@ -1,0 +1,24 @@
+"""Unit tests for pure verb helpers."""
+
+from ros2agnocast.verb.node_info_agnocast import (
+    service_name_from_request_topic,
+    service_name_from_response_topic,
+)
+
+
+def test_service_name_from_request_topic_strips_prefix():
+    assert service_name_from_request_topic(
+        '/AGNOCAST_SRV_REQUEST/add_two_ints') == '/add_two_ints'
+
+
+def test_service_name_from_request_topic_returns_none_for_non_service():
+    assert service_name_from_request_topic('/regular_topic') is None
+
+
+def test_service_name_from_response_topic_strips_prefix_and_sep_suffix():
+    assert service_name_from_response_topic(
+        '/AGNOCAST_SRV_RESPONSE/add_two_ints_SEP_42') == '/add_two_ints'
+
+
+def test_service_name_from_response_topic_returns_none_for_non_service():
+    assert service_name_from_response_topic('/regular_topic') is None


### PR DESCRIPTION
## Description

`ros2agnocast` is currently passed to `colcon test` as `--packages-skip`, since "pytest fails on empty test suite". Real tests are about to land in a follow-up PR (cross-NS CLI, #1351), so lift the exclusion now to unblock those tests.

The lift requires two changes alongside the workflow:

- declare `extras_require={'test': ['pytest']}` in `setup.py` so the `ament_python` test runner invokes pytest;
- seed `test/test_verb_helpers.py` with a small unit test of two pure helpers (`service_name_from_*_topic`) so pytest finds a non-empty test suite today (Jazzy treats zero collected tests as an error).

## Related links

- Follow-up that adds the real test suite: #1351

## How was this PR tested?

- [ ] Autoware
- [ ] \`bash scripts/test/e2e_test_1to1.bash\` (required)
- [ ] \`bash scripts/test/e2e_test_2to2.bash\` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] \`bash scripts/test/run_requires_kernel_module_tests.bash\` (required) — skipped: no kmod / agnocastlib changes in this PR
- [ ] sample application

Additional checks run locally:

- \`colcon test --packages-select ros2agnocast\` → 4 pytest cases collected and passing.

## Notes for reviewers

## Version Update Label (Required)

- \`need-patch-update\` (CI / test-config only; no API or behavior change).