### PR TITLE
fix(scripts): fix logic for sucessful installation for `switch_kmod.bash`

### DIFF
--- a/scripts/switch_kmod.bash
+++ b/scripts/switch_kmod.bash
@@ -172,21 +172,18 @@ sudo apt-get install -y "${target_package}"
 
 echo "[5/5] Load agnocast and verify"
 
-# Snapshot dmesg line count so we can isolate messages emitted by THIS
-# modprobe (avoids mistaking a stale 'Agnocast installed!' line from an
-# earlier load for the current one).
-dmesg_before=$(sudo dmesg | wc -l)
-
 sudo modprobe agnocast
 echo "  Loaded."
 
-new_dmesg=$(sudo dmesg | tail -n +$((dmesg_before + 1)))
-install_line=$(echo "$new_dmesg" | grep -E "Agnocast installed! v" | tail -n 1 || true)
+# Steps 1–4 unloaded the old module, purged every agnocast-kmod-v* package,
+# and installed exactly one target package, so the last 'Agnocast installed!'
+# line in dmesg corresponds to the modprobe we just ran.
+install_line=$(sudo dmesg | grep -E "Agnocast installed! v" | tail -n 1 || true)
 
 if [ -z "$install_line" ]; then
-	echo "  Error: did not see 'Agnocast installed! v...' in dmesg after modprobe."
+	echo "  Error: no 'Agnocast installed! v...' line found in dmesg."
 	echo "  Recent agnocast-related kernel messages:"
-	echo "$new_dmesg" | grep -i agnocast || true
+	sudo dmesg | grep -i agnocast | tail -n 20 || true
 	exit 1
 fi
 


### PR DESCRIPTION
## Description
Fix the post-modprobe verification in `switch_kmod.bash` Step 5.

The old logic snapshotted `dmesg | wc -l` before modprobe and used `tail -n +N` to isolate new lines. Steps 1–4 (unload / apt purge / dkms remove / apt install) take ~10s+, during which the kernel ring buffer can roll. When old lines are evicted, the snapshotted absolute line number exceeds the current dmesg length, `tail -n +N` returns empty, and verification fails even though `Agnocast installed! vX` is present.

Since Steps 1–4 unload the old module, purge every `agnocast-kmod-v*` package, and install exactly one target package, the last `Agnocast installed! vX` line in dmesg is guaranteed to be from this modprobe. Replaced the diff with a simple `grep | tail -n 1`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
