### PR TITLE
feat(ros2agnocast): add discovery_daemon_status verb for daemon liveness

### DIFF
--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -5,17 +5,20 @@ for cross-namespace observability. If the agent is not running (or
 running in a different IPC namespace), that observability silently stops
 working — this verb gives the operator a single place to confirm liveness.
 
+This command only inspects the **current** IPC namespace (the one the
+command itself runs in); run it inside the namespace you want to check.
+
 Checks performed (each prints OK / NG with detail):
 
-  * **process** — any `ros2agnocast_discovery_agent` process is running
-    in **this** IPC namespace (matched by `/proc/<pid>/ns/ipc`).
-  * **gossip** — `/_agnocast_discovery` has at least one DDS publisher
-    on the current `ROS_DOMAIN_ID` and a snapshot is received within
-    the timeout.
+  * **process** — any ``ros2agnocast_discovery_agent`` process is running
+    in **this** IPC namespace (matched by ``/proc/<pid>/ns/ipc``).
+  * **gossip** — a snapshot from **this** IPC namespace is received on
+    ``/_agnocast_discovery`` within the timeout (snapshots from other
+    namespaces sharing the topic don't count).
   * **type_registry** — the tmpfs directory
-    `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/` exists and contains
-    at least one ``<pid>.txt`` (proves at least one Agnocast process has
-    registered).
+    ``${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/``
+    holds at least one ``<pid>.txt`` whose process is still alive (proves
+    a live Agnocast process has registered).
 
 Exit code:
 
@@ -24,20 +27,20 @@ Exit code:
 """
 
 import os
-import time
 
-import rclpy
 from ros2cli.node.strategy import NodeStrategy
 from ros2cli.verb import VerbExtension
 
-from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
-
-
-_GOSSIP_TOPIC = '/_agnocast_discovery'
+from ros2agnocast.discovery import (
+    add_gossip_timeout_arg,
+    collect_announcements,
+    GOSSIP_TOPIC,
+    warn_if_gossip_timeout_overridden,
+)
 
 
 def _type_registry_base() -> str:
-    """Resolve the tmpfs root, honoring `AGNOCAST_TMPFS_DIR` like the writer."""
+    """Resolve the tmpfs root, honoring ``AGNOCAST_TMPFS_DIR`` like the writer."""
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
     return os.path.join(root, 'agnocast_type_registry')
 
@@ -52,6 +55,7 @@ def _check_daemon_process(my_ns_inode):
     for pid_str in os.listdir('/proc'):
         if not pid_str.isdigit():
             continue
+
         pid = int(pid_str)
         # The discovery agent runs as a python script — its ``comm`` is the
         # python interpreter — so match on cmdline instead.
@@ -60,6 +64,7 @@ def _check_daemon_process(my_ns_inode):
                 cmdline = fp.read().replace(b'\0', b' ').decode('utf-8', errors='replace')
         except (FileNotFoundError, PermissionError):
             continue
+
         # Match the actual agent binary path so we don't also pick up
         # ``ros2 run ros2agnocast_discovery_agent discovery_agent``
         # wrapper processes (whose cmdline contains the same package name
@@ -67,78 +72,104 @@ def _check_daemon_process(my_ns_inode):
         if '/ros2agnocast_discovery_agent/lib/ros2agnocast_discovery_agent/discovery_agent' \
                 not in cmdline:
             continue
+
         # Must be in the same IPC namespace as the caller.
         try:
-            their_ns = os.stat(f'/proc/{pid}/ns/ipc').st_ino
+            their_ns_inode = os.stat(f'/proc/{pid}/ns/ipc').st_ino
         except (FileNotFoundError, PermissionError):
             continue
-        if their_ns != my_ns_inode:
+
+        if their_ns_inode != my_ns_inode:
             continue
+
         found_pids.append(pid)
 
     if not found_pids:
         return False, 'no discovery_agent process found in this IPC namespace'
+
     if len(found_pids) > 1:
         return True, f'pid(s)={found_pids} (warning: multiple daemons running in this NS)'
+
     return True, f'pid={found_pids[0]}'
 
 
-def _check_gossip(timeout_sec=2.0):
+def _check_gossip(my_ns_inode, timeout_sec):
     """Return (ok, detail) for the gossip-subscription check.
 
-    ``NodeStrategy`` initializes rclpy itself; do not call ``rclpy.init``
-    here or the second call raises ``Context.init() must only be called once``.
+    ``collect_announcements`` aggregates every namespace publishing on the
+    shared gossip topic, so we filter for a snapshot tagged with our own
+    ``ipc_ns_inode`` — a snapshot from another namespace must not pass this
+    check. ``NodeStrategy`` initializes rclpy itself; do not call
+    ``rclpy.init`` here or the second call raises ``Context.init() must
+    only be called once``.
     """
     with NodeStrategy(None) as node:
-        from ros2agnocast.discovery import gossip_qos
-        received = []
+        snapshots = collect_announcements(node, timeout_sec)
 
-        def cb(msg: AgnocastDaemonState) -> None:
-            received.append(msg)
+    seen_my_ns = any(s.ipc_ns_inode == my_ns_inode for s in snapshots)
+    if seen_my_ns:
+        return True, f'received a snapshot from this IPC namespace on {GOSSIP_TOPIC}'
 
-        sub = node.create_subscription(
-            AgnocastDaemonState, _GOSSIP_TOPIC, cb, gossip_qos())
-        try:
-            deadline = time.monotonic() + timeout_sec
-            while time.monotonic() < deadline and not received:
-                rclpy.spin_once(node, timeout_sec=0.05)
-        finally:
-            node.destroy_subscription(sub)
+    if snapshots:
+        return False, (
+            f'no snapshot from this IPC namespace (inode={my_ns_inode}) within '
+            f'{timeout_sec}s; saw {len(snapshots)} from other namespace(s)')
 
-        if not received:
-            return False, (
-                f'no AgnocastDaemonState received on {_GOSSIP_TOPIC} within '
-                f'{timeout_sec}s')
-        return True, f'received {len(received)} snapshot(s) on {_GOSSIP_TOPIC}'
+    return False, f'no AgnocastDaemonState received on {GOSSIP_TOPIC} within {timeout_sec}s'
 
 
 def _check_type_registry(my_ns_inode):
-    """Return (ok, detail) for the tmpfs type registry check."""
+    """Return (ok, detail) for the tmpfs type registry check.
+
+    A ``<pid>.txt`` file alone isn't enough — a process that died without
+    cleaning up leaves a stale file. We require at least one file whose
+    name is a PID with a live ``/proc/<pid>`` entry, matching the writer's
+    "one live process has registered" contract.
+    """
     ns_dir = os.path.join(_type_registry_base(), str(my_ns_inode))
     if not os.path.isdir(ns_dir):
         return False, f'directory missing: {ns_dir}'
-    files = [f for f in os.listdir(ns_dir) if f.endswith('.txt')]
-    if not files:
-        return False, f'{ns_dir} contains no <pid>.txt registrations'
-    return True, f'{ns_dir} has {len(files)} registration file(s)'
+
+    live = 0
+    stale = 0
+    for name in os.listdir(ns_dir):
+        if not name.endswith('.txt'):
+            continue
+
+        pid_str = name[:-len('.txt')]
+        if not pid_str.isdigit():
+            continue
+
+        if os.path.exists(f'/proc/{pid_str}'):
+            live += 1
+        else:
+            stale += 1
+
+    if live:
+        return True, f'{ns_dir} has {live} live registration file(s)'
+
+    detail = f'{ns_dir} has no registration from a live process'
+    if stale:
+        detail += f' ({stale} stale <pid>.txt awaiting daemon cleanup)'
+    return False, detail
 
 
 class DiscoveryDaemonStatusVerb(VerbExtension):
-    """Check the per-IPC-namespace Agnocast discovery agent's liveness."""
+    """Check the current IPC namespace's Agnocast discovery agent liveness."""
 
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
-            '--gossip-timeout', type=float, default=2.0,
-            help='Seconds to wait for a /_agnocast_discovery snapshot (default: 2.0)')
+        add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
+        warn_if_gossip_timeout_overridden(args)
+
         my_ns_inode = _self_ipc_ns_inode()
         print(f'IPC namespace inode: {my_ns_inode}')
 
         any_ng = False
         for name, fn in [
             ('process       ', lambda: _check_daemon_process(my_ns_inode)),
-            ('gossip        ', lambda: _check_gossip(args.gossip_timeout)),
+            ('gossip        ', lambda: _check_gossip(my_ns_inode, args.gossip_timeout)),
             ('type_registry ', lambda: _check_type_registry(my_ns_inode)),
         ]:
             ok, detail = fn()

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -10,15 +10,19 @@ command itself runs in); run it inside the namespace you want to check.
 
 Checks performed (each prints OK / NG with detail):
 
-  * **process** — any ``ros2agnocast_discovery_agent`` process is running
-    in **this** IPC namespace (matched by ``/proc/<pid>/ns/ipc``).
+  * **process** — the discovery agent for **this** IPC namespace is alive,
+    detected by probing the exclusive ``flock(2)`` it holds on its per-NS
+    singleton lock file for its whole lifetime. The lock path already encodes
+    the IPC namespace, so this needs no executable-path matching. (NG if the
+    lock is free or its file is absent.)
   * **gossip** — a snapshot from **this** IPC namespace is received on
     ``/_agnocast_discovery`` within the timeout (snapshots from other
     namespaces sharing the topic don't count).
-  * **type_registry** — the tmpfs directory
-    ``${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/``
-    holds at least one ``<pid>.txt`` whose process is still alive (proves
-    a live Agnocast process has registered).
+  * **type_registry** — *informational only.* Reports how many live Agnocast
+    processes have registered in this namespace under
+    ``${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/``.
+    An empty or absent registry just means nothing has registered yet, so this
+    never counts as NG.
 
 Exit code:
 
@@ -26,6 +30,7 @@ Exit code:
   * 1 — at least one NG (operator should investigate)
 """
 
+import fcntl
 import os
 
 from ros2cli.node.strategy import NodeStrategy
@@ -49,48 +54,47 @@ def _self_ipc_ns_inode():
     return os.stat('/proc/self/ns/ipc').st_ino
 
 
+def _singleton_lock_path(my_ns_inode) -> str:
+    """Path of the agent's per-IPC-namespace singleton lock.
+
+    Must match ``_singleton_lock_path`` in
+    ``ros2agnocast_discovery_agent.agent``, including the ``AGNOCAST_TMPFS_DIR``
+    override, so this verb probes the same file the agent locks.
+    """
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, f'agnocast_discovery_agent_{my_ns_inode}.lock')
+
+
 def _check_daemon_process(my_ns_inode):
-    """Return (ok, detail) for the daemon-process check."""
-    found_pids = []
-    for pid_str in os.listdir('/proc'):
-        if not pid_str.isdigit():
-            continue
+    """Return (ok, detail) for the daemon-liveness check.
 
-        pid = int(pid_str)
-        # The discovery agent runs as a python script — its ``comm`` is the
-        # python interpreter — so match on cmdline instead.
-        try:
-            with open(f'/proc/{pid}/cmdline', 'rb') as fp:
-                cmdline = fp.read().replace(b'\0', b' ').decode('utf-8', errors='replace')
-        except (FileNotFoundError, PermissionError):
-            continue
+    The agent holds an exclusive ``flock(2)`` on its per-NS lock file for its
+    whole lifetime. We probe that lock with a non-blocking ``LOCK_EX``: if we
+    cannot take it, a live agent in this namespace is holding it. This is more
+    robust than matching the agent's executable path, and the lock path already
+    encodes the IPC namespace. (Closing our fd drops any lock we did take, so a
+    successful probe leaves no lock behind.)
+    """
+    lock_path = _singleton_lock_path(my_ns_inode)
+    if not os.path.exists(lock_path):
+        return False, f'no agent lock at {lock_path}; agent never started in this NS'
 
-        # Match the actual agent binary path so we don't also pick up
-        # ``ros2 run ros2agnocast_discovery_agent discovery_agent``
-        # wrapper processes (whose cmdline contains the same package name
-        # as an argv slot rather than as the executable path).
-        if '/ros2agnocast_discovery_agent/lib/ros2agnocast_discovery_agent/discovery_agent' \
-                not in cmdline:
-            continue
+    try:
+        fd = os.open(lock_path, os.O_RDONLY | os.O_CLOEXEC)
+    except OSError as e:
+        return False, f'cannot open agent lock {lock_path}: {e}'
 
-        # Must be in the same IPC namespace as the caller.
-        try:
-            their_ns_inode = os.stat(f'/proc/{pid}/ns/ipc').st_ino
-        except (FileNotFoundError, PermissionError):
-            continue
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return True, f'agent holds the singleton lock ({lock_path})'
+    except OSError as e:
+        return False, f'cannot probe agent lock {lock_path}: {e}'
+    finally:
+        os.close(fd)
 
-        if their_ns_inode != my_ns_inode:
-            continue
-
-        found_pids.append(pid)
-
-    if not found_pids:
-        return False, 'no discovery_agent process found in this IPC namespace'
-
-    if len(found_pids) > 1:
-        return True, f'pid(s)={found_pids} (warning: multiple daemons running in this NS)'
-
-    return True, f'pid={found_pids[0]}'
+    # We acquired (and, via close above, released) the lock — nobody held it.
+    return False, f'agent lock is free ({lock_path}); no live agent in this NS'
 
 
 def _check_gossip(my_ns_inode, timeout_sec):
@@ -118,17 +122,19 @@ def _check_gossip(my_ns_inode, timeout_sec):
     return False, f'no AgnocastDaemonState received on {GOSSIP_TOPIC} within {timeout_sec}s'
 
 
-def _check_type_registry(my_ns_inode):
-    """Return (ok, detail) for the tmpfs type registry check.
+def _describe_type_registry(my_ns_inode) -> str:
+    """Return a one-line description of the tmpfs type registry.
 
-    A ``<pid>.txt`` file alone isn't enough — a process that died without
-    cleaning up leaves a stale file. We require at least one file whose
-    name is a PID with a live ``/proc/<pid>`` entry, matching the writer's
-    "one live process has registered" contract.
+    This is *informational*, not a liveness signal: an empty or absent
+    registry just means no Agnocast publisher/subscriber has registered in
+    this namespace yet, which is normal and not an agent fault. So it returns
+    a plain description (no OK/NG) of how many live registrations exist. Stale
+    ``<pid>.txt`` files (process gone) are counted separately and don't count
+    as live.
     """
     ns_dir = os.path.join(_type_registry_base(), str(my_ns_inode))
     if not os.path.isdir(ns_dir):
-        return False, f'directory missing: {ns_dir}'
+        return f'no Agnocast process has registered yet ({ns_dir} absent)'
 
     live = 0
     stale = 0
@@ -146,12 +152,12 @@ def _check_type_registry(my_ns_inode):
             stale += 1
 
     if live:
-        return True, f'{ns_dir} has {live} live registration file(s)'
-
-    detail = f'{ns_dir} has no registration from a live process'
+        detail = f'{live} live registration(s) in {ns_dir}'
+    else:
+        detail = f'no Agnocast process has registered yet in {ns_dir}'
     if stale:
         detail += f' ({stale} stale <pid>.txt awaiting daemon cleanup)'
-    return False, detail
+    return detail
 
 
 class DiscoveryDaemonStatusVerb(VerbExtension):
@@ -168,14 +174,16 @@ class DiscoveryDaemonStatusVerb(VerbExtension):
 
         any_ng = False
         for name, fn in [
-            ('process       ', lambda: _check_daemon_process(my_ns_inode)),
-            ('gossip        ', lambda: _check_gossip(my_ns_inode, args.gossip_timeout)),
-            ('type_registry ', lambda: _check_type_registry(my_ns_inode)),
+            ('process', lambda: _check_daemon_process(my_ns_inode)),
+            ('gossip', lambda: _check_gossip(my_ns_inode, args.gossip_timeout)),
         ]:
             ok, detail = fn()
             status = 'OK' if ok else 'NG'
-            print(f'  {name}{status}: {detail}')
+            print(f'  {name:<14}{status}: {detail}')
             if not ok:
                 any_ng = True
+
+        # Informational only — does not affect the exit code.
+        print(f'  {"type_registry":<14}INFO: {_describe_type_registry(my_ns_inode)}')
 
         return 1 if any_ng else 0

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -8,26 +8,32 @@ working — this verb gives the operator a single place to confirm liveness.
 This command only inspects the **current** IPC namespace (the one the
 command itself runs in); run it inside the namespace you want to check.
 
-Checks performed (each prints OK / NG with detail):
+Default output is a single one-line verdict — nothing else:
 
-  * **process** — the discovery agent for **this** IPC namespace is alive,
-    detected by probing the exclusive ``flock(2)`` it holds on its per-NS
-    singleton lock file for its whole lifetime. The lock path already encodes
-    the IPC namespace, so this needs no executable-path matching. (NG if the
-    lock is free or its file is absent.)
-  * **gossip** — a snapshot from **this** IPC namespace is received on
-    ``/_agnocast_discovery`` within the timeout (snapshots from other
-    namespaces sharing the topic don't count).
-  * **type_registry** — *informational only.* Reports how many live Agnocast
-    processes have registered in this namespace under
-    ``${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/``.
-    An empty or absent registry just means nothing has registered yet, so this
-    never counts as NG.
+  * ``OK. The discovery agent is running.``
+  * ``NG. The discovery agent is not running.``
+  * ``NG. The discovery agent is running but not publishing.``
 
-Exit code:
+(``--verbose`` adds the reason behind the verdict; see below.)
 
-  * 0 — all OK
-  * 1 — at least one NG (operator should investigate)
+The verdict is driven by two internal checks:
+
+  * **process** — the agent holds an exclusive ``flock(2)`` on its per-NS
+    singleton lock file for its whole lifetime, so we probe that lock. The
+    lock path encodes the IPC namespace, so this needs no executable-path
+    matching.
+  * **gossip** — a snapshot from this IPC namespace is received on
+    ``/_agnocast_discovery`` within the timeout. ``gossip`` OK implies
+    ``process`` OK (an agent that publishes is alive), so it is the primary,
+    end-to-end signal; ``process`` only distinguishes "not running" from
+    "running but not publishing" when ``gossip`` is NG.
+
+``--verbose`` additionally prints the IPC namespace inode, each check's
+result, and a ``type_registry`` line (how many live Agnocast processes have
+registered). None of those affect the exit code — they are context, not part
+of the verdict.
+
+Exit code: 0 when the agent is running (gossip OK), 1 otherwise.
 """
 
 import fcntl
@@ -66,39 +72,40 @@ def _singleton_lock_path(my_ns_inode) -> str:
 
 
 def _check_daemon_process(my_ns_inode):
-    """Return (ok, detail) for the daemon-liveness check.
+    """Return (ok, reason) for the daemon-liveness check.
 
     The agent holds an exclusive ``flock(2)`` on its per-NS lock file for its
     whole lifetime. We probe that lock with a non-blocking ``LOCK_EX``: if we
-    cannot take it, a live agent in this namespace is holding it. This is more
-    robust than matching the agent's executable path, and the lock path already
-    encodes the IPC namespace. (Closing our fd drops any lock we did take, so a
-    successful probe leaves no lock behind.)
+    cannot take it, a live agent in this namespace is holding it. The kernel
+    releases the lock when the holder dies, so a lock we *can* take (or a
+    missing file) means no live agent. ``reason`` is a short phrase for the
+    verdict breakdown, not a full sentence.
     """
     lock_path = _singleton_lock_path(my_ns_inode)
     if not os.path.exists(lock_path):
-        return False, f'no agent lock at {lock_path}; agent never started in this NS'
+        return False, f'no singleton lock file ({lock_path})'
 
     try:
         fd = os.open(lock_path, os.O_RDONLY | os.O_CLOEXEC)
     except OSError as e:
-        return False, f'cannot open agent lock {lock_path}: {e}'
+        return False, f'cannot open lock {lock_path}: {e}'
 
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError:
-        return True, f'agent holds the singleton lock ({lock_path})'
+        # Could NOT take the lock -> a live agent is holding it.
+        return True, f'holds the singleton lock ({lock_path})'
     except OSError as e:
-        return False, f'cannot probe agent lock {lock_path}: {e}'
+        return False, f'cannot probe lock {lock_path}: {e}'
     finally:
         os.close(fd)
 
-    # We acquired (and, via close above, released) the lock — nobody held it.
-    return False, f'agent lock is free ({lock_path}); no live agent in this NS'
+    # We took the lock (closing the fd above released it) -> nobody held it.
+    return False, f'singleton lock is free ({lock_path})'
 
 
 def _check_gossip(my_ns_inode, timeout_sec):
-    """Return (ok, detail) for the gossip-subscription check.
+    """Return (ok, reason) for the gossip-subscription check.
 
     ``collect_announcements`` aggregates every namespace publishing on the
     shared gossip topic, so we filter for a snapshot tagged with our own
@@ -112,14 +119,14 @@ def _check_gossip(my_ns_inode, timeout_sec):
 
     seen_my_ns = any(s.ipc_ns_inode == my_ns_inode for s in snapshots)
     if seen_my_ns:
-        return True, f'received a snapshot from this IPC namespace on {GOSSIP_TOPIC}'
+        return True, f'snapshot received on {GOSSIP_TOPIC}'
 
     if snapshots:
         return False, (
-            f'no snapshot from this IPC namespace (inode={my_ns_inode}) within '
-            f'{timeout_sec}s; saw {len(snapshots)} from other namespace(s)')
+            f'no snapshot from this namespace within {timeout_sec}s '
+            f'({len(snapshots)} from other namespace(s))')
 
-    return False, f'no AgnocastDaemonState received on {GOSSIP_TOPIC} within {timeout_sec}s'
+    return False, f'no snapshot on {GOSSIP_TOPIC} within {timeout_sec}s'
 
 
 def _describe_type_registry(my_ns_inode) -> str:
@@ -165,25 +172,43 @@ class DiscoveryDaemonStatusVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):
         add_gossip_timeout_arg(parser)
+        parser.add_argument(
+            '-v', '--verbose', action='store_true',
+            help='also print the IPC namespace inode, each internal check, and '
+                 'the type_registry info line (none affect the exit code)')
 
     def main(self, *, args):
         warn_if_gossip_timeout_overridden(args)
 
         my_ns_inode = _self_ipc_ns_inode()
-        print(f'IPC namespace inode: {my_ns_inode}')
 
-        any_ng = False
-        for name, fn in [
-            ('process', lambda: _check_daemon_process(my_ns_inode)),
-            ('gossip', lambda: _check_gossip(my_ns_inode, args.gossip_timeout)),
-        ]:
-            ok, detail = fn()
-            status = 'OK' if ok else 'NG'
-            print(f'  {name:<14}{status}: {detail}')
-            if not ok:
-                any_ng = True
+        proc_ok, proc_reason = _check_daemon_process(my_ns_inode)
+        # gossip is the end-to-end signal, but it only matters if a process is
+        # up; skip its timeout wait when the agent clearly isn't running.
+        if proc_ok:
+            gossip_ok, gossip_reason = _check_gossip(my_ns_inode, args.gossip_timeout)
+        else:
+            gossip_ok, gossip_reason = None, None
 
-        # Informational only — does not affect the exit code.
-        print(f'  {"type_registry":<14}INFO: {_describe_type_registry(my_ns_inode)}')
+        if args.verbose:
+            print(f'IPC namespace inode: {my_ns_inode}')
+            print(f'  process:       {"OK" if proc_ok else "NG"} ({proc_reason})')
+            if gossip_ok is None:
+                print('  gossip:        skipped (agent not running)')
+            else:
+                print(f'  gossip:        {"OK" if gossip_ok else "NG"} ({gossip_reason})')
+            print(f'  type_registry: {_describe_type_registry(my_ns_inode)}')
+            print('')
 
-        return 1 if any_ng else 0
+        # Default output is the verdict only — the per-check reasons are
+        # diagnostic detail, available via --verbose above.
+        if proc_ok and gossip_ok:
+            print('OK. The discovery agent is running.')
+            return 0
+
+        if not proc_ok:
+            print('NG. The discovery agent is not running.')
+            return 1
+
+        print('NG. The discovery agent is running but not publishing.')
+        return 1

--- a/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/discovery_daemon_status.py
@@ -1,0 +1,150 @@
+"""Check that the per-IPC-namespace Agnocast discovery agent is alive.
+
+The agent publishes the local Agnocast state on ``/_agnocast_discovery``
+for cross-namespace observability. If the agent is not running (or
+running in a different IPC namespace), that observability silently stops
+working — this verb gives the operator a single place to confirm liveness.
+
+Checks performed (each prints OK / NG with detail):
+
+  * **process** — any `ros2agnocast_discovery_agent` process is running
+    in **this** IPC namespace (matched by `/proc/<pid>/ns/ipc`).
+  * **gossip** — `/_agnocast_discovery` has at least one DDS publisher
+    on the current `ROS_DOMAIN_ID` and a snapshot is received within
+    the timeout.
+  * **type_registry** — the tmpfs directory
+    `/dev/shm/agnocast_type_registry/<ipc_ns_inode>/` exists and contains
+    at least one ``<pid>.txt`` (proves at least one Agnocast process has
+    registered).
+
+Exit code:
+
+  * 0 — all OK
+  * 1 — at least one NG (operator should investigate)
+"""
+
+import os
+import time
+
+import rclpy
+from ros2cli.node.strategy import NodeStrategy
+from ros2cli.verb import VerbExtension
+
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+
+
+_GOSSIP_TOPIC = '/_agnocast_discovery'
+
+
+def _type_registry_base() -> str:
+    """Resolve the tmpfs root, honoring `AGNOCAST_TMPFS_DIR` like the writer."""
+    root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
+    return os.path.join(root, 'agnocast_type_registry')
+
+
+def _self_ipc_ns_inode():
+    return os.stat('/proc/self/ns/ipc').st_ino
+
+
+def _check_daemon_process(my_ns_inode):
+    """Return (ok, detail) for the daemon-process check."""
+    found_pids = []
+    for pid_str in os.listdir('/proc'):
+        if not pid_str.isdigit():
+            continue
+        pid = int(pid_str)
+        # The discovery agent runs as a python script — its ``comm`` is the
+        # python interpreter — so match on cmdline instead.
+        try:
+            with open(f'/proc/{pid}/cmdline', 'rb') as fp:
+                cmdline = fp.read().replace(b'\0', b' ').decode('utf-8', errors='replace')
+        except (FileNotFoundError, PermissionError):
+            continue
+        # Match the actual agent binary path so we don't also pick up
+        # ``ros2 run ros2agnocast_discovery_agent discovery_agent``
+        # wrapper processes (whose cmdline contains the same package name
+        # as an argv slot rather than as the executable path).
+        if '/ros2agnocast_discovery_agent/lib/ros2agnocast_discovery_agent/discovery_agent' \
+                not in cmdline:
+            continue
+        # Must be in the same IPC namespace as the caller.
+        try:
+            their_ns = os.stat(f'/proc/{pid}/ns/ipc').st_ino
+        except (FileNotFoundError, PermissionError):
+            continue
+        if their_ns != my_ns_inode:
+            continue
+        found_pids.append(pid)
+
+    if not found_pids:
+        return False, 'no discovery_agent process found in this IPC namespace'
+    if len(found_pids) > 1:
+        return True, f'pid(s)={found_pids} (warning: multiple daemons running in this NS)'
+    return True, f'pid={found_pids[0]}'
+
+
+def _check_gossip(timeout_sec=2.0):
+    """Return (ok, detail) for the gossip-subscription check.
+
+    ``NodeStrategy`` initializes rclpy itself; do not call ``rclpy.init``
+    here or the second call raises ``Context.init() must only be called once``.
+    """
+    with NodeStrategy(None) as node:
+        from ros2agnocast.discovery import gossip_qos
+        received = []
+
+        def cb(msg: AgnocastDaemonState) -> None:
+            received.append(msg)
+
+        sub = node.create_subscription(
+            AgnocastDaemonState, _GOSSIP_TOPIC, cb, gossip_qos())
+        try:
+            deadline = time.monotonic() + timeout_sec
+            while time.monotonic() < deadline and not received:
+                rclpy.spin_once(node, timeout_sec=0.05)
+        finally:
+            node.destroy_subscription(sub)
+
+        if not received:
+            return False, (
+                f'no AgnocastDaemonState received on {_GOSSIP_TOPIC} within '
+                f'{timeout_sec}s')
+        return True, f'received {len(received)} snapshot(s) on {_GOSSIP_TOPIC}'
+
+
+def _check_type_registry(my_ns_inode):
+    """Return (ok, detail) for the tmpfs type registry check."""
+    ns_dir = os.path.join(_type_registry_base(), str(my_ns_inode))
+    if not os.path.isdir(ns_dir):
+        return False, f'directory missing: {ns_dir}'
+    files = [f for f in os.listdir(ns_dir) if f.endswith('.txt')]
+    if not files:
+        return False, f'{ns_dir} contains no <pid>.txt registrations'
+    return True, f'{ns_dir} has {len(files)} registration file(s)'
+
+
+class DiscoveryDaemonStatusVerb(VerbExtension):
+    """Check the per-IPC-namespace Agnocast discovery agent's liveness."""
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '--gossip-timeout', type=float, default=2.0,
+            help='Seconds to wait for a /_agnocast_discovery snapshot (default: 2.0)')
+
+    def main(self, *, args):
+        my_ns_inode = _self_ipc_ns_inode()
+        print(f'IPC namespace inode: {my_ns_inode}')
+
+        any_ng = False
+        for name, fn in [
+            ('process       ', lambda: _check_daemon_process(my_ns_inode)),
+            ('gossip        ', lambda: _check_gossip(args.gossip_timeout)),
+            ('type_registry ', lambda: _check_type_registry(my_ns_inode)),
+        ]:
+            ok, detail = fn()
+            status = 'OK' if ok else 'NG'
+            print(f'  {name}{status}: {detail}')
+            if not ok:
+                any_ng = True
+
+        return 1 if any_ng else 0

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -28,7 +28,7 @@ setup(
         'ros2agnocast.verb': [
             'generate-bridge-plugins = ros2agnocast.verb.generate_bridge_plugins:GenerateBridgePluginsVerb',
             'version = ros2agnocast.verb.version:VersionVerb',
-            'discovery_daemon_status = ros2agnocast.verb.discovery_daemon_status:DiscoveryDaemonStatusVerb',
+            'discovery-daemon-status = ros2agnocast.verb.discovery_daemon_status:DiscoveryDaemonStatusVerb',
         ],
         'ros2topic.verb': [
             'list_agnocast = ros2agnocast.verb.list_agnocast:ListAgnocastVerb',

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -28,6 +28,7 @@ setup(
         'ros2agnocast.verb': [
             'generate-bridge-plugins = ros2agnocast.verb.generate_bridge_plugins:GenerateBridgePluginsVerb',
             'version = ros2agnocast.verb.version:VersionVerb',
+            'discovery_daemon_status = ros2agnocast.verb.discovery_daemon_status:DiscoveryDaemonStatusVerb',
         ],
         'ros2topic.verb': [
             'list_agnocast = ros2agnocast.verb.list_agnocast:ListAgnocastVerb',

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,9 +1,10 @@
 """Pure-logic tests for the discovery_daemon_status verb.
 
-The verb itself talks to /proc and DDS, but the small helpers are
-exercised here with a tmp directory in place of `/dev/shm/agnocast_type_registry`.
+The verb itself talks to /proc and DDS, but the small helpers are exercised
+here with a tmp directory in place of `/dev/shm`.
 """
 
+import fcntl
 import os
 import tempfile
 from unittest.mock import patch
@@ -11,25 +12,25 @@ from unittest.mock import patch
 from ros2agnocast.verb import discovery_daemon_status as ds
 
 
-def test_check_type_registry_missing_dir_returns_ng():
+# --- type_registry: informational description (no OK/NG) --------------------
+
+def test_describe_type_registry_missing_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
-            ok, detail = ds._check_type_registry(999999)
-        assert ok is False
-        assert 'missing' in detail
+            detail = ds._describe_type_registry(999999)
+        assert 'no Agnocast process has registered yet' in detail
 
 
-def test_check_type_registry_empty_dir_returns_ng():
+def test_describe_type_registry_empty_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 12345
         os.makedirs(os.path.join(tmpdir, str(ns_inode)))
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
-            ok, detail = ds._check_type_registry(ns_inode)
-        assert ok is False
-        assert 'no registration from a live process' in detail
+            detail = ds._describe_type_registry(ns_inode)
+        assert 'no Agnocast process has registered yet' in detail
 
 
-def test_check_type_registry_with_live_pid_returns_ok():
+def test_describe_type_registry_with_live_pid_reports_count():
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 12345
         ns_dir = os.path.join(tmpdir, str(ns_inode))
@@ -38,13 +39,12 @@ def test_check_type_registry_with_live_pid_returns_ok():
         with open(os.path.join(ns_dir, f'{os.getpid()}.txt'), 'w') as fp:
             fp.write('/topic\ttype\tpub\t/node\n')
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
-            ok, detail = ds._check_type_registry(ns_inode)
-        assert ok is True
+            detail = ds._describe_type_registry(ns_inode)
         assert '1 live registration' in detail
 
 
-def test_check_type_registry_stale_pid_returns_ng():
-    """A <pid>.txt whose process is gone must not pass the check."""
+def test_describe_type_registry_stale_pid_noted():
+    """A <pid>.txt whose process is gone is noted as stale, not live."""
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 12345
         ns_dir = os.path.join(tmpdir, str(ns_inode))
@@ -53,26 +53,54 @@ def test_check_type_registry_stale_pid_returns_ng():
         with open(os.path.join(ns_dir, '999999999.txt'), 'w') as fp:
             fp.write('/topic\ttype\tpub\t/node\n')
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
-            ok, detail = ds._check_type_registry(ns_inode)
-        assert ok is False
+            detail = ds._describe_type_registry(ns_inode)
         assert 'stale' in detail
+        assert 'no Agnocast process has registered yet' in detail
 
 
-def test_check_daemon_process_self_ns_no_match():
-    """When no discovery_agent is running in this NS, returns NG.
+# --- daemon process: probe the agent's singleton flock ----------------------
 
-    This test runs in the pytest process's own IPC NS, where no
-    discovery_agent should be present unless the test runner happens to
-    overlap with one — extremely unlikely under normal CI.
-    """
-    my_ns_inode = ds._self_ipc_ns_inode()
-    ok, detail = ds._check_daemon_process(my_ns_inode)
-    # Either no daemon (most cases) or one is genuinely running. Both
-    # are valid outputs; we just assert the function returns the
-    # expected tuple shape and detail string is non-empty.
-    assert isinstance(ok, bool)
-    assert isinstance(detail, str)
-    assert detail
+def test_check_daemon_process_missing_lock_is_ng():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
+            ok, detail = ds._check_daemon_process(424242)
+        assert ok is False
+        assert 'no agent lock' in detail
+
+
+def test_check_daemon_process_free_lock_is_ng():
+    """Lock file exists but nobody holds it -> no live agent."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 424242
+        open(os.path.join(tmpdir, f'agnocast_discovery_agent_{ns_inode}.lock'), 'w').close()
+        with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
+            ok, detail = ds._check_daemon_process(ns_inode)
+        assert ok is False
+        assert 'free' in detail
+
+
+def test_check_daemon_process_held_lock_is_ok():
+    """A held flock (as the real agent holds it) -> OK."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 424242
+        lock_path = os.path.join(tmpdir, f'agnocast_discovery_agent_{ns_inode}.lock')
+        holder = open(lock_path, 'w')
+        try:
+            fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
+                ok, detail = ds._check_daemon_process(ns_inode)
+            assert ok is True
+            assert 'holds the singleton lock' in detail
+        finally:
+            holder.close()
+
+
+def test_singleton_lock_path_honors_agnocast_tmpfs_dir(monkeypatch):
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
+    assert ds._singleton_lock_path(7) == '/run/custom/agnocast_discovery_agent_7.lock'
+
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    assert ds._singleton_lock_path(7) == '/dev/shm/agnocast_discovery_agent_7.lock'
 
 
 def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,0 +1,68 @@
+"""Pure-logic tests for the discovery_daemon_status verb.
+
+The verb itself talks to /proc and DDS, but the small helpers are
+exercised here with a tmp directory in place of `/run/agnocast`.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from ros2agnocast.verb import discovery_daemon_status as ds
+
+
+def test_check_type_registry_missing_dir_returns_ng():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
+            ok, detail = ds._check_type_registry(999999)
+        assert ok is False
+        assert 'missing' in detail
+
+
+def test_check_type_registry_empty_dir_returns_ng():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 12345
+        os.makedirs(os.path.join(tmpdir, str(ns_inode)))
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
+            ok, detail = ds._check_type_registry(ns_inode)
+        assert ok is False
+        assert 'no <pid>.txt' in detail
+
+
+def test_check_type_registry_with_files_returns_ok():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 12345
+        ns_dir = os.path.join(tmpdir, str(ns_inode))
+        os.makedirs(ns_dir)
+        with open(os.path.join(ns_dir, '4242.txt'), 'w') as fp:
+            fp.write('/topic\ttype\tpub\t/node\n')
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
+            ok, detail = ds._check_type_registry(ns_inode)
+        assert ok is True
+        assert '1' in detail
+
+
+def test_check_daemon_process_self_ns_no_match():
+    """When no discovery_agent is running in this NS, returns NG.
+
+    This test runs in the pytest process's own IPC NS, where no
+    discovery_agent should be present unless the test runner happens to
+    overlap with one — extremely unlikely under normal CI.
+    """
+    my_ns_inode = ds._self_ipc_ns_inode()
+    ok, detail = ds._check_daemon_process(my_ns_inode)
+    # Either no daemon (most cases) or one is genuinely running. Both
+    # are valid outputs; we just assert the function returns the
+    # expected tuple shape and detail string is non-empty.
+    assert isinstance(ok, bool)
+    assert isinstance(detail, str)
+    assert detail
+
+
+def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):
+    """`AGNOCAST_TMPFS_DIR` overrides the `/dev/shm` default consistently with the writer."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
+    assert ds._type_registry_base() == '/run/custom/agnocast_type_registry'
+
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    assert ds._type_registry_base() == '/dev/shm/agnocast_type_registry'

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,7 +1,7 @@
 """Pure-logic tests for the discovery_daemon_status verb.
 
 The verb itself talks to /proc and DDS, but the small helpers are
-exercised here with a tmp directory in place of `/run/agnocast`.
+exercised here with a tmp directory in place of `/dev/shm/agnocast_type_registry`.
 """
 
 import os
@@ -26,20 +26,36 @@ def test_check_type_registry_empty_dir_returns_ng():
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
             ok, detail = ds._check_type_registry(ns_inode)
         assert ok is False
-        assert 'no <pid>.txt' in detail
+        assert 'no registration from a live process' in detail
 
 
-def test_check_type_registry_with_files_returns_ok():
+def test_check_type_registry_with_live_pid_returns_ok():
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 12345
         ns_dir = os.path.join(tmpdir, str(ns_inode))
         os.makedirs(ns_dir)
-        with open(os.path.join(ns_dir, '4242.txt'), 'w') as fp:
+        # Name the file after our own PID so /proc/<pid> is guaranteed live.
+        with open(os.path.join(ns_dir, f'{os.getpid()}.txt'), 'w') as fp:
             fp.write('/topic\ttype\tpub\t/node\n')
         with patch.object(ds, '_type_registry_base', return_value=tmpdir):
             ok, detail = ds._check_type_registry(ns_inode)
         assert ok is True
-        assert '1' in detail
+        assert '1 live registration' in detail
+
+
+def test_check_type_registry_stale_pid_returns_ng():
+    """A <pid>.txt whose process is gone must not pass the check."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ns_inode = 12345
+        ns_dir = os.path.join(tmpdir, str(ns_inode))
+        os.makedirs(ns_dir)
+        # PID 999999999 is unlikely to be alive.
+        with open(os.path.join(ns_dir, '999999999.txt'), 'w') as fp:
+            fp.write('/topic\ttype\tpub\t/node\n')
+        with patch.object(ds, '_type_registry_base', return_value=tmpdir):
+            ok, detail = ds._check_type_registry(ns_inode)
+        assert ok is False
+        assert 'stale' in detail
 
 
 def test_check_daemon_process_self_ns_no_match():

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -1,12 +1,13 @@
 """Pure-logic tests for the discovery_daemon_status verb.
 
-The verb itself talks to /proc and DDS, but the small helpers are exercised
-here with a tmp directory in place of `/dev/shm`.
+The verb itself talks to /proc and DDS, but the small helpers and the verdict
+logic are exercised here with tmp dirs and patched checks.
 """
 
 import fcntl
 import os
 import tempfile
+from argparse import Namespace
 from unittest.mock import patch
 
 from ros2agnocast.verb import discovery_daemon_status as ds
@@ -63,9 +64,9 @@ def test_describe_type_registry_stale_pid_noted():
 def test_check_daemon_process_missing_lock_is_ng():
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-            ok, detail = ds._check_daemon_process(424242)
+            ok, reason = ds._check_daemon_process(424242)
         assert ok is False
-        assert 'no agent lock' in detail
+        assert 'no singleton lock file' in reason
 
 
 def test_check_daemon_process_free_lock_is_ng():
@@ -74,9 +75,9 @@ def test_check_daemon_process_free_lock_is_ng():
         ns_inode = 424242
         open(os.path.join(tmpdir, f'agnocast_discovery_agent_{ns_inode}.lock'), 'w').close()
         with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-            ok, detail = ds._check_daemon_process(ns_inode)
+            ok, reason = ds._check_daemon_process(ns_inode)
         assert ok is False
-        assert 'free' in detail
+        assert 'free' in reason
 
 
 def test_check_daemon_process_held_lock_is_ok():
@@ -88,12 +89,14 @@ def test_check_daemon_process_held_lock_is_ok():
         try:
             fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-                ok, detail = ds._check_daemon_process(ns_inode)
+                ok, reason = ds._check_daemon_process(ns_inode)
             assert ok is True
-            assert 'holds the singleton lock' in detail
+            assert 'holds the singleton lock' in reason
         finally:
             holder.close()
 
+
+# --- path helpers -----------------------------------------------------------
 
 def test_singleton_lock_path_honors_agnocast_tmpfs_dir(monkeypatch):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
@@ -110,3 +113,69 @@ def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):
 
     monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
     assert ds._type_registry_base() == '/dev/shm/agnocast_type_registry'
+
+
+# --- verdict (main) ---------------------------------------------------------
+
+def _run_main(proc, gossip, verbose=False):
+    """Run the verb's main() with the checks patched. ``gossip=None`` asserts
+    the gossip check is never invoked (process down)."""
+    verb = ds.DiscoveryDaemonStatusVerb()
+    args = Namespace(gossip_timeout=3.0, verbose=verbose)
+    with patch.object(ds, 'warn_if_gossip_timeout_overridden', lambda a: None), \
+            patch.object(ds, '_self_ipc_ns_inode', return_value=4026531839), \
+            patch.object(ds, '_check_daemon_process', return_value=proc), \
+            patch.object(ds, '_describe_type_registry', return_value='2 live registration(s) in /x'):
+        if gossip is None:
+            with patch.object(ds, '_check_gossip') as gossip_mock:
+                rc = verb.main(args=args)
+                gossip_mock.assert_not_called()
+        else:
+            with patch.object(ds, '_check_gossip', return_value=gossip):
+                rc = verb.main(args=args)
+    return rc
+
+
+def test_verdict_running(capsys):
+    rc = _run_main(proc=(True, 'holds the singleton lock (/x.lock)'),
+                   gossip=(True, 'snapshot received on /_agnocast_discovery'))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert 'OK. The discovery agent is running.' in out
+
+
+def test_verdict_not_running_skips_gossip(capsys):
+    rc = _run_main(proc=(False, 'singleton lock is free (/x.lock)'), gossip=None)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert 'NG. The discovery agent is not running.' in out
+    # The per-check reason is diagnostic detail, not shown by default.
+    assert 'singleton lock is free' not in out
+
+
+def test_verdict_running_but_not_publishing(capsys):
+    rc = _run_main(proc=(True, 'holds the singleton lock (/x.lock)'),
+                   gossip=(False, 'no snapshot on /_agnocast_discovery within 3.0s'))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert 'running but not publishing' in out
+    assert 'no snapshot' not in out  # reason is --verbose only
+
+
+def test_default_output_is_verdict_only(capsys):
+    """Default output carries no inode header, type_registry, or per-check reason."""
+    _run_main(proc=(True, 'holds the singleton lock (/x.lock)'),
+              gossip=(True, 'snapshot received on /_agnocast_discovery'))
+    out = capsys.readouterr().out
+    assert out.strip() == 'OK. The discovery agent is running.'
+
+
+def test_verbose_shows_inode_checks_and_type_registry(capsys):
+    rc = _run_main(proc=(True, 'holds the singleton lock (/x.lock)'),
+                   gossip=(True, 'snapshot received on /_agnocast_discovery'), verbose=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert 'IPC namespace inode: 4026531839' in out
+    assert 'type_registry: 2 live registration(s)' in out
+    assert 'holds the singleton lock' in out  # per-check reason shown in --verbose
+    assert 'OK. The discovery agent is running.' in out


### PR DESCRIPTION
## Description

### Background
#1350 added the *discovery agent*, one rclpy process per IPC namespace (NS) that publishes the local Agnocast state on `/_agnocast_discovery`. When the agent isn't running (or is running in a different NS than the operator expects), cross-NS observability silently stops working — `ros2agnocast` CLI verbs that subscribe to the gossip simply see fewer endpoints, with no error.

### What's added
Adds `ros2 agnocast discovery-daemon-status`, a liveness check for the **current** IPC namespace:

| verdict (exit) | default | `--verbose` |
|---|---|---|
| **OK** — running (0) | `OK. The discovery agent is running.` | `IPC namespace inode: <inode>`<br>`  process:       OK (holds the singleton lock)`<br>`  gossip:        OK (snapshot received on /_agnocast_discovery)`<br>`  type_registry: 1 live registration(s) …`<br>_(blank)_<br>`OK. The discovery agent is running.` |
| **NG** — not running (1) | `NG. The discovery agent is not running.` | `IPC namespace inode: <inode>`<br>`  process:       NG (singleton lock is free …)`<br>`  gossip:        skipped (agent not running)`<br>`  type_registry: no … registered yet … (1 stale …)`<br>_(blank)_<br>`NG. The discovery agent is not running.` |
| **NG** — running but not publishing (1) | `NG. The discovery agent is running but not publishing.` | `IPC namespace inode: <inode>`<br>`  process:       OK (holds the singleton lock …)`<br>`  gossip:        NG (no snapshot within 3.0s)`<br>`  type_registry: …`<br>_(blank)_<br>`NG. The discovery agent is running but not publishing.` |

The verdict comes from two internal checks:

| Check | What it asserts |
|---|---|
| **process** | the agent is alive — it holds an exclusive `flock(2)` on its per-NS singleton lock (`${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_discovery_agent_<ipc_ns_inode>.lock`) for its whole lifetime, so we probe that lock. |
| **gossip** | an `AgnocastDaemonState` tagged with **this** namespace's `ipc_ns_inode` is received on `/_agnocast_discovery` within the timeout (snapshots from other namespaces sharing the topic don't count). `gossip` OK implies `process` OK, so it is the primary signal; `process` only distinguishes "not running" from "running but not publishing". |
| **type_registry** (info, `--verbose` only) | how many live Agnocast processes have registered under `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/`. Informational — an empty registry just means nothing has registered yet, and never fails. |

The verb is intentionally per-NS — it inspects only the IPC namespace it runs in, so operators run it inside the namespace they want to interrogate.

## Related links

- Jira: T4DEV-51976 (TIER IV internal)
- Builds on (already merged):
  - **#1356** — adds the tmpfs type registry. The verb's `type_registry` line looks for files the writer in `#1356` creates.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` — N/A: no change to the pub / sub path.
- [ ] `bash scripts/test/e2e_test_2to2.bash` — N/A: same reason.
- [ ] kunit tests — N/A: kmod untouched.
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` — N/A.
- [ ] sample application
- [x] Added automated tests, all pass locally (`colcon test --packages-select ros2agnocast`). The new test file covers the flock-probe liveness check (held / free / missing lock), the informational `type_registry` description (live / stale / empty / missing), the path helpers, and the verdict logic (running / not running / running-but-not-publishing, default vs `--verbose`).

## Notes for reviewers — manual liveness test

Manual run-through, all on one host:

```bash
cd ~/agnocast
source /opt/ros/humble/setup.bash && source install/setup.bash

# --- Happy path: a talker (so type_registry has a writer) + a discovery
#     agent, both in the current IPC namespace ------------------------------
ros2 launch agnocast_sample_application talker.launch.xml discovery_agent:=true \
    > /dev/null 2>&1 &
sleep 6
ros2 agnocast discovery-daemon-status            # default: single verdict
ros2 agnocast discovery-daemon-status --verbose  # + inode / per-check / type_registry

# --- Agent down: stop the launch tree (its discovery agent dies with it) ---
kill %1 && wait %1 2>/dev/null
sleep 2
ros2 agnocast discovery-daemon-status            # default: single verdict
ros2 agnocast discovery-daemon-status --verbose  # + inode / per-check / type_registry
```

Observed output:

```
# Happy path — default
OK. The discovery agent is running.

# Happy path — --verbose
IPC namespace inode: 4026531839
  process:       OK (holds the singleton lock (/dev/shm/agnocast_discovery_agent_4026531839.lock))
  gossip:        OK (snapshot received on /_agnocast_discovery)
  type_registry: 1 live registration(s) in /dev/shm/agnocast_type_registry/4026531839

OK. The discovery agent is running.

# Agent down — default
NG. The discovery agent is not running.

# Agent down — --verbose
IPC namespace inode: 4026531839
  process:       NG (singleton lock is free (/dev/shm/agnocast_discovery_agent_4026531839.lock))
  gossip:        skipped (agent not running)
  type_registry: no Agnocast process has registered yet in /dev/shm/agnocast_type_registry/4026531839 (1 stale <pid>.txt awaiting daemon cleanup)

NG. The discovery agent is not running.
```

Cross-NS variant: run the talker inside `sudo -E unshare --ipc bash -c '...'` and observe that `ros2 agnocast discovery-daemon-status` run *outside* that NS reports `NG` (the agent's singleton lock for the host NS is free / absent).

## Version Update Label (Required)

- `need-patch-update`

Additions only — one new verb file, one new test file, one entry-point line in `setup.py`. No changes to kmod ABI, existing ioctls, public `agnocastlib` API, or wire structs.
