### PR TITLE
ci(agnocast_kmod): add KUnit gcov coverage job

### DIFF
--- a/.github/actions/prepare-agnocast-kunit/action.yml
+++ b/.github/actions/prepare-agnocast-kunit/action.yml
@@ -1,0 +1,93 @@
+name: Prepare Agnocast KUnit kernel
+description: >
+  Install build deps, cache/clone the pinned Linux source, cache the build dir,
+  and stage the Agnocast sources into the kernel tree. Shared by the kunit and
+  kunit-coverage workflows. The caller must check out the repo first.
+
+inputs:
+  linux-ref:
+    description: Linux git tag to build against.
+    required: true
+  linux-repo:
+    description: Linux git repository URL.
+    required: true
+  build-dir:
+    description: kunit.py build dir (kept outside the source tree).
+    required: true
+  cache-key:
+    description: Exact cache key for the build dir.
+    required: true
+  restore-key:
+    description: restore-keys prefix for the build dir.
+    required: true
+  gcov:
+    description: If 'true', instrument the Agnocast objects for gcov.
+    default: 'false'
+  extra-packages:
+    description: Extra apt packages to install (space-separated).
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential flex bison libelf-dev libssl-dev bc python3 \
+          qemu-system-x86 ${{ inputs.extra-packages }}
+
+    # Cache the Linux source tree. Keyed on the ref only — safe for an immutable
+    # tag; add a SHA/date if it ever points at a moving branch.
+    - name: Cache Linux source tree
+      id: linux-src-cache
+      uses: actions/cache@v4
+      with:
+        path: linux
+        key: linux-src-${{ inputs.linux-ref }}
+
+    - name: Shallow clone Linux ${{ inputs.linux-ref }}
+      if: steps.linux-src-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: git clone --depth 1 --branch "${{ inputs.linux-ref }}" "${{ inputs.linux-repo }}" linux
+
+    # Build dir lives outside the source tree so the source cache above doesn't
+    # absorb build artifacts; restore-keys reuses a previous dir for incremental
+    # rebuilds.
+    - name: Cache build dir
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.build-dir }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: ${{ inputs.restore-key }}
+
+    # A restored build dir from a different source checkout can reference paths
+    # the fresh clone lacks; drop it so the build is clean.
+    - name: Drop stale build dir if source was re-cloned
+      if: steps.linux-src-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: rm -rf "${{ inputs.build-dir }}"
+
+    # Layout mirrors agnocast_kmod/ so the tests' "../agnocast.h" includes
+    # resolve; .github/kunit/Kbuild is dropped in as the in-tree Makefile.
+    - name: Stage Agnocast sources into the kernel tree
+      shell: bash
+      run: |
+        set -euo pipefail
+        dst=linux/drivers/agnocast
+        rm -rf "${dst}"
+        mkdir -p "${dst}/agnocast_kunit"
+        cp agnocast_kmod/*.c agnocast_kmod/*.h "${dst}/"
+        cp agnocast_kmod/agnocast_kunit/*.c \
+           agnocast_kmod/agnocast_kunit/*.h \
+           agnocast_kmod/agnocast_kunit/Makefile.inc \
+           "${dst}/agnocast_kunit/"
+        cp .github/kunit/Kbuild "${dst}/Makefile"
+        if [ "${{ inputs.gcov }}" = "true" ]; then
+          echo 'GCOV_PROFILE := y' >> "${dst}/Makefile"
+        fi
+        if ! grep -q 'drivers/agnocast' linux/drivers/Makefile; then
+          echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
+        fi

--- a/.github/kunit/coverage.config
+++ b/.github/kunit/coverage.config
@@ -1,0 +1,17 @@
+# Extra kconfig for the coverage job (.github/workflows/kunit-coverage.yaml),
+# merged on top of kunitconfig. Adds gcov plus the virtio-9p / serial /
+# initramfs support the coverage initramfs needs to boot and copy data out.
+CONFIG_GCOV_KERNEL=y
+CONFIG_DEBUG_FS=y
+CONFIG_BLK_DEV_INITRD=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_PCI=y
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_NET=y
+CONFIG_NET_9P=y
+CONFIG_NET_9P_VIRTIO=y
+CONFIG_9P_FS=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y

--- a/.github/workflows/kunit-coverage.yaml
+++ b/.github/workflows/kunit-coverage.yaml
@@ -1,0 +1,173 @@
+name: kunit-coverage
+
+# Measures gcov line/function coverage for the Agnocast KUnit suite.
+#
+# The plain `kunit` workflow runs the suite for pass/fail; it can't report
+# coverage because that flow boots a kernel with no userspace and halts, so the
+# gcov data in /sys/kernel/debug/gcov is never exported. This job builds a
+# GCOV-instrumented kernel, boots it under QEMU with a tiny BusyBox initramfs
+# that copies /sys/kernel/debug/gcov out over a virtio-9p share, then runs lcov
+# on the host. Results go to the job summary and an HTML artifact.
+#
+# Shared setup (deps, kernel cache/clone, gcov-instrumented staging) lives in
+# the .github/actions/prepare-agnocast-kunit composite action.
+
+on:
+  pull_request:
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
+      - '.github/workflows/kunit-coverage.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
+      - '.github/workflows/kunit-coverage.yaml'
+
+concurrency:
+  group: kunit-coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  LINUX_REF: v6.12
+  LINUX_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+
+jobs:
+  agnocast-kunit-coverage:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare kernel and stage Agnocast sources (gcov-instrumented)
+        uses: ./.github/actions/prepare-agnocast-kunit
+        with:
+          linux-ref: ${{ env.LINUX_REF }}
+          linux-repo: ${{ env.LINUX_REPO }}
+          build-dir: kunit-build-cov
+          cache-key: kunit-cov-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/actions/prepare-agnocast-kunit/**', '.github/workflows/kunit-coverage.yaml') }}
+          restore-key: kunit-cov-${{ runner.os }}-${{ env.LINUX_REF }}-
+          gcov: 'true'
+          extra-packages: busybox-static cpio lcov
+
+      # Build the GCOV kernel. We boot it ourselves (below) rather than via
+      # `kunit.py run`, so we can attach an initramfs that exports the gcov data.
+      - name: Build GCOV-instrumented kernel
+        working-directory: linux
+        run: |
+          set -euo pipefail
+          ./tools/testing/kunit/kunit.py build \
+            --kunitconfig="${GITHUB_WORKSPACE}/.github/kunit/kunitconfig" \
+            --kunitconfig="${GITHUB_WORKSPACE}/.github/kunit/coverage.config" \
+            --arch=x86_64 \
+            --build_dir="${GITHUB_WORKSPACE}/kunit-build-cov" \
+            --jobs="$(nproc)"
+
+      # Minimal BusyBox initramfs whose /init mounts debugfs + a 9p share, copies
+      # the gcov tree out, and powers off. KUnit runs at boot (kunit.enable=1),
+      # before /init, so the gcov data is already populated. Build /init via echo
+      # (not a heredoc) so YAML indentation can't leak in and break the shebang.
+      - name: Build initramfs
+        run: |
+          set -euo pipefail
+          ir="${GITHUB_WORKSPACE}/initramfs"
+          rm -rf "${ir}"; mkdir -p "${ir}"/{bin,proc,sys,mnt,dev}
+          cp /bin/busybox "${ir}/bin/"
+          for a in sh mount cp dmesg poweroff sync; do ln -sf busybox "${ir}/bin/${a}"; done
+          {
+            echo '#!/bin/sh'
+            echo 'mount -t proc none /proc'
+            echo 'mount -t sysfs none /sys'
+            echo 'mount -t debugfs none /sys/kernel/debug'
+            echo 'mount -t 9p -o trans=virtio,version=9p2000.L hostshare /mnt'
+            echo 'cp -r /sys/kernel/debug/gcov /mnt/gcov'
+            echo 'dmesg > /mnt/dmesg.txt'
+            echo 'sync'
+            echo 'poweroff -f'
+          } > "${ir}/init"
+          chmod +x "${ir}/init"
+          ( cd "${ir}" && find . | cpio -o -H newc 2>/dev/null | gzip > "${GITHUB_WORKSPACE}/initramfs.cpio.gz" )
+
+      - name: Run suite under QEMU and collect gcov
+        run: |
+          set -euo pipefail
+          share="${GITHUB_WORKSPACE}/cov-share"
+          rm -rf "${share}"; mkdir -p "${share}"
+          timeout 300 qemu-system-x86_64 \
+            -kernel kunit-build-cov/arch/x86/boot/bzImage \
+            -initrd initramfs.cpio.gz \
+            -append "console=ttyS0 kunit.enable=1 rdinit=/init" \
+            -fsdev local,id=fs0,path="${share}",security_model=none \
+            -device virtio-9p-pci,fsdev=fs0,mount_tag=hostshare \
+            -no-reboot -nographic -m 2G | tee qemu-console.log
+          if grep -q '^not ok' qemu-console.log; then
+            echo "::error::A KUnit test failed; see the console log."
+            exit 1
+          fi
+          n=$(find "${share}/gcov" -name '*.gcda' -path '*drivers/agnocast*' 2>/dev/null | wc -l)
+          echo "agnocast .gcda files captured: ${n}"
+          if [ "${n}" -lt 1 ]; then
+            echo "::error::No agnocast gcov data captured."
+            exit 1
+          fi
+
+      - name: Build coverage report
+        run: |
+          set -euo pipefail
+          build="${GITHUB_WORKSPACE}/kunit-build-cov"
+          share="${GITHUB_WORKSPACE}/cov-share"
+          # The debugfs tree mirrors the absolute build path. Copy only the .gcda
+          # files next to their .gcno in the build dir (the tree's .gcno are
+          # symlinks back into the build dir, so copying them would self-collide).
+          while IFS= read -r f; do
+            cp "${f}" "${f#${share}/gcov}"
+          done < <(find "${share}/gcov${build}" -name '*.gcda')
+          # geninfo_unexecuted_blocks=1 keeps gcov/gcc version skew from
+          # mis-counting (the "unexecuted block ... non-zero hit count" warning).
+          lcov --capture --quiet --rc geninfo_unexecuted_blocks=1 \
+            --directory "${build}/drivers/agnocast" -o coverage.info
+          # Keep only Agnocast production .c (drop the KUnit test code).
+          lcov --quiet --extract coverage.info '*/drivers/agnocast/*.c' -o coverage.info
+          lcov --quiet --remove coverage.info '*/agnocast_kunit/*' '*/agnocast_kunit_main.c' -o coverage.info
+          genhtml --quiet coverage.info --output-directory coverage-html
+          # Build the per-file table straight from the lcov tracefile
+          # (LH/LF lines, FNH/FNF functions) rather than `lcov --list`, which
+          # mis-renders the rates under lcov 2.x (shows ~0% functions). These
+          # numbers are the same ones genhtml puts in the uploaded HTML report.
+          table=$(awk '
+            /^SF:/  { sf = $0; sub(/.*\//, "", sf) }
+            /^LF:/  { lf = substr($0, 4) }
+            /^LH:/  { lh = substr($0, 4) }
+            /^FNF:/ { ff = substr($0, 5) }
+            /^FNH:/ { fh = substr($0, 5) }
+            /^end_of_record/ {
+              printf "| %s | %.1f%% (%d/%d) | %.1f%% (%d/%d) |\n", \
+                sf, (lf ? 100*lh/lf : 0), lh, lf, (ff ? 100*fh/ff : 0), fh, ff
+              TLF += lf; TLH += lh; TFF += ff; TFH += fh
+            }
+            END {
+              printf "| **Total** | **%.1f%% (%d/%d)** | **%.1f%% (%d/%d)** |\n", \
+                (TLF ? 100*TLH/TLF : 0), TLH, TLF, (TFF ? 100*TFH/TFF : 0), TFH, TFF
+            }' coverage.info)
+          echo "${table}"
+          {
+            echo '## Agnocast kmod KUnit coverage (production .c only)'
+            echo ''
+            echo '| File | Lines | Functions |'
+            echo '|---|---|---|'
+            echo "${table}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agnocast-kunit-coverage-${{ github.run_id }}
+          path: coverage-html
+          if-no-files-found: ignore

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -15,18 +15,23 @@ name: kunit
 #
 # Future: an --arch=arm64 matrix axis (qemu-system-aarch64) could be added to
 # catch arch-specific regressions.
+#
+# Shared setup (deps, kernel cache/clone, staging) lives in the
+# .github/actions/prepare-agnocast-kunit composite action.
 
 on:
   pull_request:
     paths:
       - 'agnocast_kmod/**'
       - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
       - '.github/workflows/kunit.yaml'
   push:
     branches: [main]
     paths:
       - 'agnocast_kmod/**'
       - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
       - '.github/workflows/kunit.yaml'
 
 # Cancel superseded runs on the same ref so concurrent pushes don't fight over
@@ -55,67 +60,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install kunit.py prerequisites
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential flex bison libelf-dev libssl-dev bc python3 \
-            qemu-system-x86
-
-      # Cache the Linux source tree. Keyed on LINUX_REF only — safe for an
-      # immutable tag. If LINUX_REF is ever pointed at a moving branch, add a
-      # commit SHA or date to the key.
-      - name: Cache Linux source tree
-        id: linux-src-cache
-        uses: actions/cache@v4
+      - name: Prepare kernel and stage Agnocast sources
+        uses: ./.github/actions/prepare-agnocast-kunit
         with:
-          path: linux
-          key: linux-src-${{ env.LINUX_REF }}
-
-      - name: Shallow clone Linux ${{ env.LINUX_REF }}
-        if: steps.linux-src-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch "${LINUX_REF}" "${LINUX_REPO}" linux
-
-      # Cache kunit.py's build dir, kept outside the source tree so the cache
-      # above doesn't absorb build artifacts. restore-keys reuses a previous
-      # build dir, so only the changed Agnocast objects recompile.
-      - name: Cache KUnit build dir
-        id: kunit-build-cache
-        uses: actions/cache@v4
-        with:
-          path: kunit-build
-          key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/workflows/kunit.yaml') }}
-          restore-keys: |
-            kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-
-
-      # If the source tree was just re-cloned but restore-keys brought back a
-      # build dir from a previous run, that dir may reference object paths the
-      # fresh tree lacks. Drop it so kunit.py does a clean build.
-      - name: Drop stale build dir if source was re-cloned
-        if: steps.linux-src-cache.outputs.cache-hit != 'true'
-        run: rm -rf kunit-build
-
-      # Stage the Agnocast sources into the kernel tree and hand kbuild our
-      # in-tree Makefile (.github/kunit/Kbuild). The layout mirrors agnocast_kmod/
-      # so the tests' "../agnocast.h" includes resolve.
-      - name: Stage Agnocast sources into Linux tree
-        run: |
-          set -euo pipefail
-          dst=linux/drivers/agnocast
-          rm -rf "${dst}"
-          mkdir -p "${dst}/agnocast_kunit"
-          cp agnocast_kmod/*.c agnocast_kmod/*.h "${dst}/"
-          cp agnocast_kmod/agnocast_kunit/*.c \
-             agnocast_kmod/agnocast_kunit/*.h \
-             agnocast_kmod/agnocast_kunit/Makefile.inc \
-             "${dst}/agnocast_kunit/"
-          cp .github/kunit/Kbuild "${dst}/Makefile"
-          if ! grep -q 'drivers/agnocast' linux/drivers/Makefile; then
-            echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
-          fi
+          linux-ref: ${{ env.LINUX_REF }}
+          linux-repo: ${{ env.LINUX_REPO }}
+          build-dir: kunit-build
+          cache-key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/actions/prepare-agnocast-kunit/**', '.github/workflows/kunit.yaml') }}
+          restore-key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-
 
       # Build the suite into a kernel, boot it under QEMU, run the tests.
       - name: Run Agnocast KUnit suite under QEMU


### PR DESCRIPTION
## Description

Adds a `kunit-coverage` workflow that reports gcov line/function coverage for the Agnocast KUnit suite.

The `kunit` workflow runs the suite for pass/fail but can't report coverage: that flow boots a kernel with no userspace and halts, so the gcov data in `/sys/kernel/debug/gcov` is never exported. This job instead:

1. builds a **GCOV-instrumented** kernel (`GCOV_PROFILE := y` on the Agnocast objects only),
2. boots it under QEMU with a tiny **BusyBox initramfs** that mounts `debugfs` + a **virtio-9p** share, copies the gcov tree out, and powers off (KUnit runs at boot, before `/init`, so the data is already populated),
3. runs `lcov` on the host, filtered to the Agnocast production `.c` files.

Results go to the **job summary** and an uploaded **HTML artifact**. Same path-based trigger as the `kunit` job.

The kernel prep and source staging are shared with the `kunit` job, so they're extracted into a composite action that both workflows call — the coverage job passing `gcov: 'true'` plus its extra packages. `kunit.yaml`'s only change is switching onto that action (no behavior change to the pass/fail job).

## Files

- `.github/workflows/kunit-coverage.yaml` — the coverage job.
- `.github/kunit/coverage.config` — extra kconfig (gcov + virtio-9p + serial + initramfs), merged on top of `kunitconfig`.
- `.github/actions/prepare-agnocast-kunit/action.yml` — composite action holding the setup shared by both jobs (deps, kernel cache/clone, source staging). `GCOV_PROFILE := y` is appended to the staged Makefile only when `gcov: 'true'`, so the fast pass/fail job stays uninstrumented.

## Notes for reviewers

- Coverage is filtered to `*/drivers/agnocast/*.c` minus the KUnit test code, so it reflects the production kmod only.
- The coverage build is GCOV-instrumented with its own cache/build dir, separate from the `kunit` job, so it doesn't slow the fast pass/fail gate.
- The per-file summary table is parsed straight from `coverage.info` (`LH/LF`, `FNH/FNF`) rather than `lcov --list`, which mis-renders the rates under lcov 2.x on `ubuntu-24.04` (reports ~0% functions) even though the captured data is correct.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

CI-only change; the `kunit-coverage` job runs the suite under QEMU on this PR — see its run **Summary** for the per-file table and the `agnocast-kunit-coverage-<run_id>` HTML artifact.

## Version Update Label (Required)

`need-patch-update` — CI-only change, no API or compatibility impact.
