### PR TITLE
perf(ros2agnocast): return from gossip collection once all publishers report

### DIFF
--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -77,10 +77,19 @@ def collect_announcements(
     sub = spin_node.create_subscription(
         AgnocastDaemonState, GOSSIP_TOPIC, on_msg, gossip_qos())
     try:
-        # TODO: break early once each visible publisher has reported.
         deadline = time.monotonic() + timeout_sec
         while time.monotonic() < deadline:
             rclpy.spin_once(spin_node, timeout_sec=0.05)
+            try:
+                publishers = spin_node.get_publishers_info_by_topic(GOSSIP_TOPIC)
+            except Exception:
+                publishers = []
+            # Return as soon as every visible publisher has reported, rather
+            # than waiting out timeout_sec (now just an upper bound).
+            # One agent = one publisher = one (host_uuid, ipc_ns_inode) snapshot,
+            # so the publisher count is how many snapshots to expect.
+            if publishers and len(snapshots) >= len(publishers):
+                break
     finally:
         spin_node.destroy_subscription(sub)
 


### PR DESCRIPTION
## Description

Make the `/_agnocast_discovery` gossip collection (`discovery.py: collect_announcements`) **return as soon as every visible publisher (one per daemon) has reported**, instead of always waiting out `timeout_sec`.

Background: every `ros2agnocast` CLI verb that reads gossip (`ros2 topic|node {list,info,hz,echo,delay}_agnocast`) paid a flat ~2 s wait, even when all agents had already responded. The timeout now serves only as an upper bound (slow discovery / no agent → ioctl fallback, unchanged).

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` — N/A: no change to the pub / sub path.
- [ ] `bash scripts/test/e2e_test_2to2.bash` — N/A: same reason.
- [ ] kunit tests — N/A: kmod untouched.
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` — N/A.
- [ ] sample application
- [x] `colcon test --packages-select ros2agnocast` passes.
- [x] Manual latency check — the fixed ~2 s wait is gone when an agent is up:

```bash
source /opt/ros/humble/setup.bash && source install/setup.bash

time ros2 topic list_agnocast                 # no agent  -> ~3.0 s (timeout + ioctl fallback)

ros2 run ros2agnocast_discovery_agent discovery_agent >/dev/null 2>&1 &
sleep 3
time ros2 topic list_agnocast                 # agent up  -> ~1.0 s (early return)
kill %1
```

Measured: ~2.98 s (no agent) vs ~0.96 s (agent up). Same code in both, so the gap is the eliminated fixed wait.

## Notes for reviewers

- Relies on the invariant *one publisher = one `(host_uuid, ipc_ns_inode)` snapshot*; `>=` (not `==`) absorbs discovery lag and a publisher leaving after it has delivered, so it never returns early-wrong.
- `--gossip-timeout` (hidden) and `DEFAULT_COLLECT_TIMEOUT_SEC` are kept as the upper bound; fully removing them is out of scope.

## Version Update Label (Required)

- `need-patch-update` — CLI latency only; no API / ABI / wire change.
