### PR TITLE
feat(ros2agnocast): add `ros2 bag record_agnocast` CLI verb

### DIFF
--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -107,19 +107,23 @@ class A2rBridgeActivator:
         """Timer callback: warn if A2R bridge publishers have not appeared within the timeout."""
         now = time.monotonic()
         with self._lock:
-            to_remove = []
-            for topic_name, created_at in self._awaiting_bridge_topics.items():
-                if self._node.count_publishers(topic_name) > 0:
-                    to_remove.append(topic_name)
-                elif now - created_at >= self.BRIDGE_SPAWN_TIMEOUT:
-                    self._node.get_logger().warning(
-                        "A2R bridge has not been created for topic '%s' "
-                        "(%d seconds elapsed since subscription was created)"
-                        % (topic_name, int(now - created_at))
-                    )
-                    to_remove.append(topic_name)
+            candidates = list(self._awaiting_bridge_topics.items())
+
+        to_remove = []
+        for topic_name, created_at in candidates:
+            if self._node.count_publishers(topic_name) > 0:
+                to_remove.append(topic_name)
+            elif now - created_at >= self.BRIDGE_SPAWN_TIMEOUT:
+                self._node.get_logger().warning(
+                    "A2R bridge has not been created for topic '%s' "
+                    "(%d seconds elapsed since subscription was created)"
+                    % (topic_name, int(now - created_at))
+                )
+                to_remove.append(topic_name)
+
+        with self._lock:
             for topic_name in to_remove:
-                del self._awaiting_bridge_topics[topic_name]
+                self._awaiting_bridge_topics.pop(topic_name, None)
 
     def stop(self) -> None:
         """Shut down the gossip spin thread and release resources."""

--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -1,0 +1,106 @@
+import os
+import threading
+
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.logging import LoggingSeverity
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+
+from ros2agnocast.discovery import GOSSIP_TOPIC, gossip_qos
+from ros2agnocast.verb._bridged_ros2cli import load_msg_class
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+
+
+class A2rBridgeActivator:
+    """Watch /_agnocast_discovery and spawn dummy ROS2 subscriptions to activate A2R bridges.
+
+    One dummy subscription per unique topic_name is created on first discovery and kept
+    alive for the lifetime of this object, so that:
+
+    - The A2R bridge for each Agnocast publisher topic is started immediately on discovery.
+    - Subscriptions survive publisher restarts (e.g. bag recording is not interrupted).
+
+    Uses a private rclpy context to avoid interfering with the caller's default context.
+
+    Usage::
+
+        with A2rBridgeActivator() as activator:
+            # ... record or otherwise consume Agnocast topics via ROS2 ...
+    """
+
+    def __init__(self, log_level: str = 'info') -> None:
+        self._ctx = rclpy.Context()
+        self._node = None
+        self._thread = None
+        self._lock = threading.Lock()
+        self._active_subs: dict = {}  # topic_name -> Subscription
+        self._log_level = log_level
+
+    def start(self) -> None:
+        """Initialize rclpy context, create node, subscribe to gossip, and start spin thread."""
+        rclpy.init(context=self._ctx)
+        self._node = rclpy.create_node(
+            '_ros2agnocast_a2r_activator_%d' % os.getpid(),
+            context=self._ctx,
+        )
+        severity = LoggingSeverity[self._log_level.upper()]
+        self._node.get_logger().set_level(severity)
+        self._node.create_subscription(
+            AgnocastDaemonState,
+            GOSSIP_TOPIC,
+            self._on_discovery,
+            gossip_qos(),
+        )
+        self._thread = threading.Thread(
+            target=self._spin,
+            daemon=True,
+            name='a2r_bridge_activator',
+        )
+        self._thread.start()
+
+    def _spin(self) -> None:
+        executor = SingleThreadedExecutor(context=self._ctx)
+        executor.add_node(self._node)
+        try:
+            executor.spin()
+        except Exception:
+            pass
+        finally:
+            executor.remove_node(self._node)
+            try:
+                self._node.destroy_node()
+            except Exception:
+                pass
+
+    def _on_discovery(self, msg: AgnocastDaemonState) -> None:
+        with self._lock:
+            for topic in msg.topics:
+                if topic.publishers and topic.topic_name not in self._active_subs:
+                    self._spawn_subscription(topic.topic_name, topic.type_name)
+
+    def _spawn_subscription(self, topic_name: str, type_name: str) -> None:
+        """Create a dummy ROS2 subscription to trigger the A2R bridge. Called with _lock held."""
+        msg_type = load_msg_class(type_name)
+        if msg_type is None:
+            return
+        qos = QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        sub = self._node.create_subscription(msg_type, topic_name, lambda _msg: None, qos)
+        self._active_subs[topic_name] = sub
+        self._node.get_logger().debug("A2R bridge activated: '%s' (%s)" % (topic_name, type_name))
+
+    def stop(self) -> None:
+        """Shut down the gossip spin thread and release resources."""
+        rclpy.try_shutdown(context=self._ctx)
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *_):
+        self.stop()

--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -29,6 +29,8 @@ class A2rBridgeActivator:
     """
 
     def __init__(self, log_level: str = 'info') -> None:
+        # TODO: Accept a topic filter (e.g. an explicit list, type filter, or regex) so that
+        #       A2R bridges are only activated for the topics the caller actually needs.
         self._ctx = rclpy.Context()
         self._node = None
         self._thread = None
@@ -75,6 +77,8 @@ class A2rBridgeActivator:
     def _on_discovery(self, msg: AgnocastDaemonState) -> None:
         with self._lock:
             for topic in msg.topics:
+                if topic.topic_name.startswith('/AGNOCAST_SRV_'):
+                    continue
                 if topic.publishers and topic.topic_name not in self._active_subs:
                     self._spawn_subscription(topic.topic_name, topic.type_name)
 

--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import threading
 import time
 
@@ -38,7 +39,6 @@ class A2rBridgeActivator:
         self._ctx = rclpy.Context()
         self._node = None
         self._thread = None
-        self._lock = threading.Lock()
         self._gossip_sub = None
         self._timer = None
         self._active_subs: dict = {}             # topic_name -> Subscription
@@ -85,15 +85,16 @@ class A2rBridgeActivator:
                 pass
 
     def _on_discovery(self, msg: AgnocastDaemonState) -> None:
-        with self._lock:
-            for topic in msg.topics:
-                if topic.topic_name.startswith('/AGNOCAST_SRV_'):
-                    continue
-                if topic.publishers and topic.topic_name not in self._active_subs:
-                    self._spawn_subscription(topic.topic_name, topic.type_name)
+        # No lock needed: both _on_discovery and _check_bridges are called from the same
+        # SingleThreadedExecutor spin thread, so they never execute concurrently.
+        for topic in msg.topics:
+            if topic.topic_name.startswith('/AGNOCAST_SRV_'):
+                continue
+            if topic.publishers and topic.topic_name not in self._active_subs:
+                self._spawn_subscription(topic.topic_name, topic.type_name)
 
     def _spawn_subscription(self, topic_name: str, type_name: str) -> None:
-        """Create a dummy ROS2 subscription to trigger the A2R bridge. Called with _lock held."""
+        """Create a dummy ROS2 subscription to trigger the A2R bridge."""
         msg_type = load_msg_class(type_name)
         if msg_type is None:
             return
@@ -105,16 +106,13 @@ class A2rBridgeActivator:
         sub = self._node.create_subscription(msg_type, topic_name, lambda _msg: None, qos)
         self._active_subs[topic_name] = sub
         self._awaiting_bridge_topics[topic_name] = time.monotonic()
-        self._node.get_logger().debug("A2R bridge activated: '%s' (%s)" % (topic_name, type_name))
+        self._node.get_logger().debug("A2R bridge requested: '%s' (%s)" % (topic_name, type_name))
 
     def _check_bridges(self) -> None:
         """Timer callback: warn if A2R bridge publishers have not appeared within the timeout."""
         now = time.monotonic()
-        with self._lock:
-            candidates = list(self._awaiting_bridge_topics.items())
-
         to_remove = []
-        for topic_name, created_at in candidates:
+        for topic_name, created_at in self._awaiting_bridge_topics.items():
             if self._node.count_publishers(topic_name) > 0:
                 to_remove.append(topic_name)
             elif now - created_at >= self.BRIDGE_SPAWN_TIMEOUT:
@@ -125,15 +123,19 @@ class A2rBridgeActivator:
                 )
                 to_remove.append(topic_name)
 
-        with self._lock:
-            for topic_name in to_remove:
-                self._awaiting_bridge_topics.pop(topic_name, None)
+        for topic_name in to_remove:
+            self._awaiting_bridge_topics.pop(topic_name, None)
 
     def stop(self) -> None:
         """Shut down the gossip spin thread and release resources."""
         rclpy.try_shutdown(context=self._ctx)
         if self._thread is not None:
             self._thread.join(timeout=5.0)
+            if self._thread.is_alive():
+                print(
+                    '[WARN] [ros2agnocast]: A2rBridgeActivator spin thread did not stop within 5 seconds',
+                    file=sys.stderr,
+                )
 
     def __enter__(self):
         self.start()

--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -39,6 +39,8 @@ class A2rBridgeActivator:
         self._node = None
         self._thread = None
         self._lock = threading.Lock()
+        self._gossip_sub = None
+        self._timer = None
         self._active_subs: dict = {}             # topic_name -> Subscription
         self._awaiting_bridge_topics: dict = {}   # topic_name -> monotonic time, until confirmed or timed out
         self._log_level = log_level
@@ -50,15 +52,15 @@ class A2rBridgeActivator:
             '_ros2agnocast_a2r_activator_%d' % os.getpid(),
             context=self._ctx,
         )
-        severity = LoggingSeverity[self._log_level.upper()]
+        severity = getattr(LoggingSeverity, self._log_level.upper(), LoggingSeverity.INFO)
         self._node.get_logger().set_level(severity)
-        self._node.create_subscription(
+        self._gossip_sub = self._node.create_subscription(
             AgnocastDaemonState,
             GOSSIP_TOPIC,
             self._on_discovery,
             gossip_qos(),
         )
-        self._node.create_timer(self.BRIDGE_CHECK_INTERVAL, self._check_bridges)
+        self._timer = self._node.create_timer(self.BRIDGE_CHECK_INTERVAL, self._check_bridges)
         self._thread = threading.Thread(
             target=self._spin,
             daemon=True,
@@ -71,8 +73,10 @@ class A2rBridgeActivator:
         executor.add_node(self._node)
         try:
             executor.spin()
-        except Exception:
-            pass
+        except Exception as e:
+            if rclpy.ok(context=self._ctx):
+                self._node.get_logger().error(
+                    f'A2rBridgeActivator spin thread exited with error: {e}')
         finally:
             executor.remove_node(self._node)
             try:

--- a/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
+++ b/src/ros2agnocast/ros2agnocast/verb/_a2r_bridge_activator.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import time
 
 import rclpy
 from rclpy.executors import SingleThreadedExecutor
@@ -28,6 +29,9 @@ class A2rBridgeActivator:
             # ... record or otherwise consume Agnocast topics via ROS2 ...
     """
 
+    BRIDGE_CHECK_INTERVAL = 2.0   # seconds between diagnostic checks
+    BRIDGE_SPAWN_TIMEOUT = 5.0    # seconds to wait before warning about missing bridge
+
     def __init__(self, log_level: str = 'info') -> None:
         # TODO: Accept a topic filter (e.g. an explicit list, type filter, or regex) so that
         #       A2R bridges are only activated for the topics the caller actually needs.
@@ -35,7 +39,8 @@ class A2rBridgeActivator:
         self._node = None
         self._thread = None
         self._lock = threading.Lock()
-        self._active_subs: dict = {}  # topic_name -> Subscription
+        self._active_subs: dict = {}             # topic_name -> Subscription
+        self._awaiting_bridge_topics: dict = {}   # topic_name -> monotonic time, until confirmed or timed out
         self._log_level = log_level
 
     def start(self) -> None:
@@ -53,6 +58,7 @@ class A2rBridgeActivator:
             self._on_discovery,
             gossip_qos(),
         )
+        self._node.create_timer(self.BRIDGE_CHECK_INTERVAL, self._check_bridges)
         self._thread = threading.Thread(
             target=self._spin,
             daemon=True,
@@ -94,7 +100,26 @@ class A2rBridgeActivator:
         )
         sub = self._node.create_subscription(msg_type, topic_name, lambda _msg: None, qos)
         self._active_subs[topic_name] = sub
+        self._awaiting_bridge_topics[topic_name] = time.monotonic()
         self._node.get_logger().debug("A2R bridge activated: '%s' (%s)" % (topic_name, type_name))
+
+    def _check_bridges(self) -> None:
+        """Timer callback: warn if A2R bridge publishers have not appeared within the timeout."""
+        now = time.monotonic()
+        with self._lock:
+            to_remove = []
+            for topic_name, created_at in self._awaiting_bridge_topics.items():
+                if self._node.count_publishers(topic_name) > 0:
+                    to_remove.append(topic_name)
+                elif now - created_at >= self.BRIDGE_SPAWN_TIMEOUT:
+                    self._node.get_logger().warning(
+                        "A2R bridge has not been created for topic '%s' "
+                        "(%d seconds elapsed since subscription was created)"
+                        % (topic_name, int(now - created_at))
+                    )
+                    to_remove.append(topic_name)
+            for topic_name in to_remove:
+                del self._awaiting_bridge_topics[topic_name]
 
     def stop(self) -> None:
         """Shut down the gossip spin thread and release resources."""

--- a/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
@@ -13,4 +13,4 @@ class BagRecordAgnocastVerb(RecordVerb):
         #         --all-services, --services, --exclude-services
         # NOTE: Agnocast service is not-supported.
         with A2rBridgeActivator(log_level=args.log_level):
-            return RecordVerb.main(self, args=args)
+            return super().main(args=args)

--- a/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
@@ -6,5 +6,11 @@ class BagRecordAgnocastVerb(RecordVerb):
     """Record ROS data to a bag, with automatic A2R bridge activation for Agnocast topics."""
 
     def main(self, *, args):
+        # TODO: Pass a topic filter to A2rBridgeActivator so that bridges are only activated
+        #       for the topics being recorded. The filter used by the ros2 bag record verb is as follows:
+        #         -a / --all, --all-topics, [Topic ...] (positional), --topics, --topic-types,
+        #         -e / --regex, --exclude-topics, --exclude-topic-types, --exclude-regex,
+        #         --all-services, --services, --exclude-services
+        # NOTE: Agnocast service is not-supported.
         with A2rBridgeActivator(log_level=args.log_level):
             return RecordVerb.main(self, args=args)

--- a/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/bag_record_agnocast.py
@@ -1,0 +1,10 @@
+from ros2bag.verb.record import RecordVerb
+from ros2agnocast.verb._a2r_bridge_activator import A2rBridgeActivator
+
+
+class BagRecordAgnocastVerb(RecordVerb):
+    """Record ROS data to a bag, with automatic A2R bridge activation for Agnocast topics."""
+
+    def main(self, *, args):
+        with A2rBridgeActivator(log_level=args.log_level):
+            return RecordVerb.main(self, args=args)

--- a/src/ros2agnocast/setup.py
+++ b/src/ros2agnocast/setup.py
@@ -41,5 +41,8 @@ setup(
             'list_agnocast = ros2agnocast.verb.node_list_agnocast:ListAgnocastVerb',
             'info_agnocast = ros2agnocast.verb.node_info_agnocast:NodeInfoAgnocastVerb',
         ],
+        'ros2bag.verb': [
+            'record_agnocast = ros2agnocast.verb.bag_record_agnocast:BagRecordAgnocastVerb',
+        ],
     },
 )

--- a/src/ros2agnocast/test/test_a2r_bridge_activator.py
+++ b/src/ros2agnocast/test/test_a2r_bridge_activator.py
@@ -1,0 +1,163 @@
+"""Unit tests for A2rBridgeActivator bridge-diagnostic logic.
+
+These tests exercise _on_discovery and _check_bridges without starting
+rclpy or DDS.  The rclpy node is replaced by a MagicMock so that the
+logic under test can be driven in pure Python.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from ros2agnocast.verb._a2r_bridge_activator import A2rBridgeActivator
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState, AgnocastEndpoint, AgnocastTopic
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_activator() -> A2rBridgeActivator:
+    """Return an A2rBridgeActivator with a mock node (no rclpy required)."""
+    act = A2rBridgeActivator()
+    act._node = MagicMock()
+    return act
+
+
+def _endpoint(node_name: str = '/pub') -> AgnocastEndpoint:
+    ep = AgnocastEndpoint()
+    ep.node_name = node_name
+    ep.pid = 1
+    ep.qos_depth = 1
+    ep.qos_is_transient_local = False
+    ep.qos_is_reliable = False
+    ep.is_bridge = False
+    return ep
+
+
+def _topic(topic_name: str, *, pubs=None, type_name: str = 'std_msgs/msg/String') -> AgnocastTopic:
+    t = AgnocastTopic()
+    t.topic_name = topic_name
+    t.type_name = type_name
+    t.domain_id = 0
+    t.publishers = pubs if pubs is not None else []
+    t.subscribers = []
+    return t
+
+
+def _state(*topics: AgnocastTopic) -> AgnocastDaemonState:
+    msg = AgnocastDaemonState()
+    msg.schema_version = 1
+    msg.agnocast_version = ''
+    msg.host_uuid = 'test'
+    msg.host_hostname = 'test'
+    msg.ipc_ns_inode = 0
+    msg.topics = list(topics)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# _on_discovery tests
+# ---------------------------------------------------------------------------
+
+def test_on_discovery_adds_topic_to_awaiting():
+    act = _make_activator()
+    with patch('ros2agnocast.verb._a2r_bridge_activator.load_msg_class', return_value=MagicMock()):
+        act._on_discovery(_state(_topic('/chatter', pubs=[_endpoint()])))
+    assert '/chatter' in act._awaiting_bridge_topics
+
+
+def test_on_discovery_skips_agnocast_srv_topics():
+    act = _make_activator()
+    with patch('ros2agnocast.verb._a2r_bridge_activator.load_msg_class', return_value=MagicMock()):
+        act._on_discovery(_state(_topic('/AGNOCAST_SRV_foo', pubs=[_endpoint()])))
+    assert '/AGNOCAST_SRV_foo' not in act._awaiting_bridge_topics
+
+
+def test_on_discovery_skips_topics_without_publishers():
+    act = _make_activator()
+    with patch('ros2agnocast.verb._a2r_bridge_activator.load_msg_class', return_value=MagicMock()):
+        act._on_discovery(_state(_topic('/chatter', pubs=[])))
+    assert '/chatter' not in act._awaiting_bridge_topics
+
+
+def test_on_discovery_does_not_duplicate_subscription():
+    act = _make_activator()
+    with patch('ros2agnocast.verb._a2r_bridge_activator.load_msg_class', return_value=MagicMock()):
+        act._on_discovery(_state(_topic('/chatter', pubs=[_endpoint()])))
+        act._on_discovery(_state(_topic('/chatter', pubs=[_endpoint()])))
+    assert act._node.create_subscription.call_count == 1
+
+
+def test_on_discovery_skips_when_load_msg_class_returns_none():
+    act = _make_activator()
+    with patch('ros2agnocast.verb._a2r_bridge_activator.load_msg_class', return_value=None):
+        act._on_discovery(_state(_topic('/chatter', pubs=[_endpoint()])))
+    assert '/chatter' not in act._awaiting_bridge_topics
+
+
+# ---------------------------------------------------------------------------
+# _check_bridges tests
+# ---------------------------------------------------------------------------
+
+def test_check_bridges_removes_confirmed_topic_silently():
+    act = _make_activator()
+    act._awaiting_bridge_topics['/chatter'] = 0.0  # created long ago
+    act._node.count_publishers.return_value = 1
+
+    with patch('ros2agnocast.verb._a2r_bridge_activator.time') as mock_time:
+        mock_time.monotonic.return_value = act.BRIDGE_SPAWN_TIMEOUT + 1.0
+        act._check_bridges()
+
+    assert '/chatter' not in act._awaiting_bridge_topics
+    act._node.get_logger.return_value.warning.assert_not_called()
+
+
+def test_check_bridges_warns_and_removes_timed_out_topic():
+    act = _make_activator()
+    act._awaiting_bridge_topics['/chatter'] = 0.0
+    act._node.count_publishers.return_value = 0
+
+    with patch('ros2agnocast.verb._a2r_bridge_activator.time') as mock_time:
+        mock_time.monotonic.return_value = act.BRIDGE_SPAWN_TIMEOUT + 1.0
+        act._check_bridges()
+
+    assert '/chatter' not in act._awaiting_bridge_topics
+    act._node.get_logger.return_value.warning.assert_called_once()
+    warning_msg = act._node.get_logger.return_value.warning.call_args[0][0]
+    assert '/chatter' in warning_msg
+
+
+def test_check_bridges_does_not_warn_before_timeout():
+    act = _make_activator()
+    act._awaiting_bridge_topics['/chatter'] = 0.0
+    act._node.count_publishers.return_value = 0
+
+    with patch('ros2agnocast.verb._a2r_bridge_activator.time') as mock_time:
+        mock_time.monotonic.return_value = act.BRIDGE_SPAWN_TIMEOUT - 1.0
+        act._check_bridges()
+
+    assert '/chatter' in act._awaiting_bridge_topics
+    act._node.get_logger.return_value.warning.assert_not_called()
+
+
+def test_check_bridges_handles_multiple_topics_independently():
+    act = _make_activator()
+    act._awaiting_bridge_topics['/ok'] = 0.0
+    act._awaiting_bridge_topics['/missing'] = 0.0
+    act._awaiting_bridge_topics['/pending'] = 999.0  # created "recently"
+
+    def count_publishers(topic_name):
+        return 1 if topic_name == '/ok' else 0
+
+    act._node.count_publishers.side_effect = count_publishers
+
+    with patch('ros2agnocast.verb._a2r_bridge_activator.time') as mock_time:
+        mock_time.monotonic.return_value = 1000.0
+        act._check_bridges()
+
+    assert '/ok' not in act._awaiting_bridge_topics       # confirmed -> removed
+    assert '/missing' not in act._awaiting_bridge_topics  # timed out -> removed with warning
+    assert '/pending' in act._awaiting_bridge_topics      # still within timeout -> kept
+
+    warning_msg = act._node.get_logger.return_value.warning.call_args[0][0]
+    assert '/missing' in warning_msg
+    assert act._node.get_logger.return_value.warning.call_count == 1


### PR DESCRIPTION
## Description

Adds `ros2 bag record_agnocast` CLI verb that wraps `ros2 bag record` with automatic A2R (Agnocast-to-ROS2) bridge activation.

### Background

`ros2 bag record` subscribes to ROS2 topics, but Agnocast topics are only bridged to ROS2 when a ROS2 subscriber appears.  
Without explicit bridge activation, agnocast-only topics aren't recorded.

### What this PR does

- Adds `BagRecordAgnocastVerb` (`ros2 bag record_agnocast`) that inherits from `ros2bag`'s `RecordVerb` and wraps `main()` with an `A2rBridgeActivator` context manager. `ros2 bag record_agnocast` inherits all CLI arguments defined in `ros2 bag record`.
- Adds `A2rBridgeActivator`, a background helper that:
  - Subscribes to `/_agnocast_discovery` (gossip topic) in a private rclpy context.
  - On each discovery message, creates a dummy ROS2 subscription for every Agnocast publisher topic (except internal `AGNOCAST_SRV_*` topics), triggering the A2R bridge.
  - Keeps subscriptions alive for the lifetime of the recording so bridges survive publisher restarts.
  - Emits a warning if an A2R bridge publisher has not appeared within 5 seconds of subscription creation.
- Registers the new verb via the `ros2bag.verb` entry point in `setup.py`.
- Adds unit tests for `A2rBridgeActivator._on_discovery` and `_check_bridges` (pure-Python, no DDS required).

### Known limitations / TODOs

- Topic filtering is not yet implemented: A2R bridges are activated for **all** discovered Agnocast publisher topics regardless of the `--topics` / `--regex` / etc. flags passed to `ros2 bag record_agnocast`. This is noted with TODO comments in the code.
- Agnocast services are not supported.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

- Topic filtering is deferred to a follow-up PR (TODO comments are in place).

### Demo

When an Agnocast-only topic publisher is running, `ros2 bag record` does not record any messages.

**Terminal 1:**
```
$ ros2 launch agnocast_sample_application talker.launch.xml discovery_agent:=true
```

**Terminal 2:**
```
$ ros2 bag record --topics /my_topic
[...]
[INFO] [...] [rosbag2_recorder]: Starting recording to 'rosbag2_2026_06_04-11_31_12'
[...]
$ ros2 bag info rosbag2_2026_06_04-11_31_12

Files:             rosbag2_2026_06_04-11_31_12_0.mcap
Bag size:          1.9 KiB
Storage id:        mcap
ROS Distro:        jazzy
Duration:          0.000000000s
Start:             Apr 12 2262 08:47:16.854775807 (9223372036.854775807)
End:               Apr 12 2262 08:47:16.854775807 (9223372036.854775807)
Messages:          0
Topic information: 
Service:           0
Service information: 
```

Using `record_agnocast` instead of `record` activates the A2R bridge automatically, and messages are recorded correctly.

**Terminal 2:**
```
$ ros2 bag record_agnocast --topics /my_topic
[...]
[INFO] [...] [rosbag2_recorder]: Starting recording to 'rosbag2_2026_06_04-11_34_16'
[...]
$ ros2 bag info rosbag2_2026_06_04-11_34_16

Files:             rosbag2_2026_06_04-11_34_16_0.mcap
Bag size:          399.5 MiB
Storage id:        mcap
ROS Distro:        jazzy
Duration:          40.766594264s
Start:             Jun  4 2026 11:34:16.619195036 (1780540456.619195036)
End:               Jun  4 2026 11:34:57.385789300 (1780540497.385789300)
Messages:          409
Topic information: Topic: /my_topic | Type: agnocast_sample_interfaces/msg/DynamicSizeArray | Count: 409 | Serialization Format: cdr
Service:           0
Service information: 
```

The recorded bag can be played back with `ros2 bag play` as usual. Note that playback publishes via a ROS2 publisher, not a Agnocast publisher.

## Version Update Label (Required)

`need-patch-update`: Bug fixes and other changes