### PR TITLE
chore(agnocastlib): mark service/client API as officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ This reflects the current status, and support is expected to expand in the futur
 | Linux Distribution | Ubuntu 22.04 (Jammy) / Ubuntu 24.04 (Noble)                 |
 | Linux Kernel       | 5.x / 6.x series (detailed version matrix not yet available) |
 
-> **Warning**: Agnocast service/client is not officially supported yet and the API may change in the future. Use at your own risk.
-
 ---
 
 ## For Users

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -147,8 +147,6 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 
 **Purpose**: Service and Client management
 
-> **Warning**: Agnocast service/client is not officially supported yet and the API may change in the future. Use at your own risk.
-
 | Feature | agnocast::Node | Support Level | Planned | Notes |
 |---------|----------------|---------------|---------|-------|
 | `add_client()` | ✗ | **Throws Exception** | No | Use `agnocast::create_client()` or `agnocast::Node::create_client()` |
@@ -306,8 +304,8 @@ The following tables compare methods that are **directly defined** in each class
 |-----|:------------:|:--------------:|-------|
 | `create_wall_timer()` | ✓ | ✓ | Return type differs (`uint32_t` timer_id vs `rclcpp::TimerBase::SharedPtr`) |
 | `create_timer()` | ✓ | ✓ | Supports ROS_TIME (simulation time). Return type differs (`agnocast::TimerBase::SharedPtr` vs `rclcpp::TimerBase::SharedPtr`). Note: dynamic deactivation of ROS time (`use_sim_time` changed from `true` to `false` at runtime) is not yet supported. |
-| `create_client<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Client vs. agnocast::Client). **Not officially supported yet; API may change.** |
-| `create_service<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Service vs. agnocast::Service). **Not officially supported yet; API may change.** |
+| `create_client<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Client vs. agnocast::Client). |
+| `create_service<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Service vs. agnocast::Service). |
 
 #### Graph API (ROS Network Discovery)
 

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -198,7 +198,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
 /// @param qos Quality of service profile. Defaults to `rclcpp::ServicesQoS()`.
 /// @param group Callback group. Defaults to `nullptr` (default callback group).
 /// @return Shared pointer to the created client.
-// AGNOCAST_PUBLIC
+AGNOCAST_PUBLIC
 template <typename ServiceT, typename NodeT>
 typename Client<ServiceT>::SharedPtr create_client(
   NodeT * node, const std::string & service_name, const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
@@ -207,11 +207,6 @@ typename Client<ServiceT>::SharedPtr create_client(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  RCLCPP_WARN(
-    node->get_logger(),
-    "Agnocast service/client is not officially supported yet and the API may change in the "
-    "future: %s",
-    node->get_node_services_interface()->resolve_service_name(service_name).c_str());
   return std::make_shared<Client<ServiceT>>(node, service_name, qos, group);
 }
 
@@ -226,7 +221,7 @@ typename Client<ServiceT>::SharedPtr create_client(
 /// @param qos Quality of service profile. Defaults to `rclcpp::ServicesQoS()`.
 /// @param group Callback group. Defaults to `nullptr` (default callback group).
 /// @return Shared pointer to the created service.
-// AGNOCAST_PUBLIC
+AGNOCAST_PUBLIC
 template <typename ServiceT, typename NodeT, typename Func>
 typename Service<ServiceT>::SharedPtr create_service(
   NodeT * node, const std::string & service_name, Func && callback,
@@ -235,11 +230,6 @@ typename Service<ServiceT>::SharedPtr create_service(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  RCLCPP_WARN(
-    node->get_logger(),
-    "Agnocast service/client is not officially supported yet and the API may change in the "
-    "future: %s",
-    node->get_node_services_interface()->resolve_service_name(service_name).c_str());
   return std::make_shared<Service<ServiceT>>(
     node, service_name, std::forward<Func>(callback), qos, group);
 }

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -34,11 +34,10 @@ bool wait_for_service_nanoseconds(
 extern int agnocast_fd;
 
 /**
- * @brief Service client for zero-copy Agnocast service communication. The service/client API is
- * experimental and may change in future versions.
+ * @brief Service client for zero-copy Agnocast service communication.
  * @tparam ServiceT The ROS service type (e.g., std_srvs::srv::SetBool).
  */
-// AGNOCAST_PUBLIC
+AGNOCAST_PUBLIC
 template <typename ServiceT>
 class Client
 {
@@ -47,27 +46,27 @@ public:
 
   /// Future that resolves to the service response. Returned by async_send_request() (no-callback
   /// overload).
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   using Future = std::future<ipc_shared_ptr<typename ServiceT::Response>>;
   /// Shared future that resolves to the service response. Passed to the callback in
   /// async_send_request().
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   using SharedFuture = std::shared_future<ipc_shared_ptr<typename ServiceT::Response>>;
 
   /// Return type of async_send_request() (no-callback overload). Contains a Future and the request
   /// ID. Access the future via the `future` member and the request ID via `request_id`.
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   struct FutureAndRequestId : rclcpp::detail::FutureAndRequestId<Future>
   {
     using rclcpp::detail::FutureAndRequestId<Future>::FutureAndRequestId;
     /// Convert to a SharedFutureAndRequestId by sharing the underlying future.
-    // AGNOCAST_PUBLIC
+    AGNOCAST_PUBLIC
     SharedFuture share() noexcept { return this->future.share(); }
   };
   /// Return type of async_send_request() (callback overload). Contains a SharedFuture and the
   /// request ID. Access the shared future via the `future` member and the request ID via
   /// `request_id`.
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   struct SharedFutureAndRequestId : rclcpp::detail::FutureAndRequestId<SharedFuture>
   {
     using rclcpp::detail::FutureAndRequestId<SharedFuture>::FutureAndRequestId;
@@ -171,7 +170,7 @@ public:
 
   /** @brief Allocate a request message in shared memory.
    *  @return Owned pointer to the request message in shared memory. */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   ipc_shared_ptr<typename ServiceT::Request> borrow_loaned_request()
   {
     auto request = publisher_->borrow_loaned_message();
@@ -182,18 +181,18 @@ public:
 
   /** @brief Return the resolved service name.
    *  @return Null-terminated service name string. */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   const char * get_service_name() const { return service_name_.c_str(); }
 
   /** @brief Check if the service server is available.
    *  @return True if the service server is available. */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   bool service_is_ready() const { return service_is_ready_core(service_name_); }
 
   /** @brief Block until the service is available or the timeout expires.
    *  @param timeout Maximum duration to wait (-1 = wait forever).
    *  @return True if service became available, false on timeout. */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   template <typename RepT, typename RatioT>
   bool wait_for_service(
     std::chrono::duration<RepT, RatioT> timeout = std::chrono::nanoseconds(-1)) const
@@ -209,7 +208,7 @@ public:
    * obtain the response.
    *  @return A SharedFutureAndRequestId containing the shared future (`.future`) and a sequence
    * number (`.request_id`). */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   SharedFutureAndRequestId async_send_request(
     ipc_shared_ptr<typename ServiceT::Request> && request,
     std::function<void(SharedFuture)> callback)
@@ -232,7 +231,7 @@ public:
    *  @param request Request from borrow_loaned_request(). Must be moved in.
    *  @return A FutureAndRequestId containing the future (`.future`) and a sequence number
    * (`.request_id`). Call `.future.get()` to block until the response arrives. */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   FutureAndRequestId async_send_request(ipc_shared_ptr<typename ServiceT::Request> && request)
   {
     Future future;

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -175,7 +175,7 @@ public:
    * @param request The request that initiated the service call.
    * @param response The response to send. Must be acquired by calling borrow_loaned_response().
    */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   void send_response(
     ipc_shared_ptr<typename ServiceT::Request> && request,
     ipc_shared_ptr<typename ServiceT::Response> && response)
@@ -196,7 +196,7 @@ public:
    * @param request The request that initiated the service call.
    * @return Owned pointer to the response message in shared memory.
    */
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   ipc_shared_ptr<typename ServiceT::Response> borrow_loaned_response(
     const ipc_shared_ptr<typename ServiceT::Request> & request)
   {
@@ -214,10 +214,9 @@ struct RosToAgnocastServiceRequestPolicy;
  * @brief The user-facing Agnocast service server.
  * Alias for `BasicService<ServiceT>`. Use this type (not BasicService directly) when declaring
  * service server variables.
- * The service/client API is experimental and may change in future versions.
  * @tparam ServiceT The ROS service type (e.g., std_srvs::srv::SetBool).
  */
-// AGNOCAST_PUBLIC
+AGNOCAST_PUBLIC
 template <typename ServiceT>
 using Service = BasicService<ServiceT, RosToAgnocastServiceRequestPolicy>;
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -587,17 +587,12 @@ public:
   /// @param qos Quality of service profile. Defaults to `rclcpp::ServicesQoS()`.
   /// @param group Callback group. Defaults to `nullptr` (default callback group).
   /// @return Shared pointer to the created client.
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   template <typename ServiceT>
   typename agnocast::Client<ServiceT>::SharedPtr create_client(
     const std::string & service_name, const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    RCLCPP_WARN(
-      get_logger(),
-      "Agnocast service/client is not officially supported yet and the API may change in the "
-      "future: %s",
-      get_node_services_interface()->resolve_service_name(service_name).c_str());
     return std::make_shared<Client<ServiceT>>(this, service_name, qos, group);
   }
 
@@ -610,18 +605,13 @@ public:
   /// @param qos Quality of service profile. Defaults to `rclcpp::ServicesQoS()`.
   /// @param group Callback group. Defaults to `nullptr` (default callback group).
   /// @return Shared pointer to the created service.
-  // AGNOCAST_PUBLIC
+  AGNOCAST_PUBLIC
   template <typename ServiceT, typename Func>
   typename agnocast::Service<ServiceT>::SharedPtr create_service(
     const std::string & service_name, Func && callback,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    RCLCPP_WARN(
-      get_logger(),
-      "Agnocast service/client is not officially supported yet and the API may change in the "
-      "future: %s",
-      get_node_services_interface()->resolve_service_name(service_name).c_str());
     return std::make_shared<Service<ServiceT>>(
       this, service_name, std::forward<Func>(callback), qos, group);
   }


### PR DESCRIPTION
## Description

This PR removes experimental warnings and uncomment `AGNOCAST_PUBLIC` for service and client symbols.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

