### PR TITLE
refactor(bridge): fixed performance node name

### DIFF
--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -75,7 +75,7 @@ void PerformanceBridgeManager::run()
 
 void PerformanceBridgeManager::start_ros_execution()
 {
-  std::string node_name = "agnocast_bridge_node_" + std::to_string(getpid());
+  std::string node_name = "agnocast_bridge_node_performance";
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges


### PR DESCRIPTION
## Description
In the callback isolated executor, since the mechanism first performs a pre-run and then restarts to apply configuration, node names must be known in advance. A mechanism where node names are determined randomly at runtime is therefore problematic.
Since only one performance bridge is instantiated, its node name will be fixed rather than PID-dependent. Note that for the standard bridge, real-time performance is not strictly required, and there is a plan to consolidate it to a single instance in the future, so no action will be taken on this for now.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
