### PR TITLE
fix(agnocastlib): make SignalHandler chain previously registered handlers

### DIFF
--- a/src/agnocastlib/src/node/agnocast_signal_handler.cpp
+++ b/src/agnocastlib/src/node/agnocast_signal_handler.cpp
@@ -75,8 +75,8 @@ void SignalHandler::install()
   {
   };
   sigemptyset(&sa.sa_mask);
-  sa.sa_flags = 0;
-  sa.sa_handler = &SignalHandler::signal_handler;
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = &SignalHandler::signal_handler;
 
   if (sigaction(SIGINT, &sa, &old_sigint_action_) != 0) {
     RCLCPP_ERROR(logger, "Failed to install SIGINT handler: %s", strerror(errno));
@@ -249,11 +249,23 @@ void SignalHandler::wait_for_signal_eventfd()
   }
 }
 
-void SignalHandler::signal_handler(int signum)
+void SignalHandler::signal_handler(int signum, siginfo_t * siginfo, void * context)
 {
-  (void)signum;
-
   int saved_errno = errno;
+
+  const struct sigaction & old_action =
+    (signum == SIGINT) ? old_sigint_action_ : old_sigterm_action_;
+  if (old_action.sa_flags & SA_SIGINFO) {
+    if (old_action.sa_sigaction != nullptr) {
+      old_action.sa_sigaction(signum, siginfo, context);
+    }
+  } else {
+    if (
+      old_action.sa_handler != nullptr && old_action.sa_handler != SIG_DFL &&
+      old_action.sa_handler != SIG_IGN) {
+      old_action.sa_handler(signum);
+    }
+  }
 
   handler_inflight_count_.fetch_add(1);
   signal_received_.store(true);

--- a/src/agnocastlib/src/node/agnocast_signal_handler.hpp
+++ b/src/agnocastlib/src/node/agnocast_signal_handler.hpp
@@ -70,7 +70,7 @@ private:
   static void notify_signal_eventfd();
   static void wait_for_signal_eventfd();
   static void signal_processing_loop();
-  static void signal_handler(int signum);
+  static void signal_handler(int signum, siginfo_t * siginfo, void * context);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
@@ -99,6 +99,43 @@ struct sigaction get_current_sigaction(int signum)
   return action;
 }
 
+template <typename Pred>
+bool wait_for_condition(Pred pred, int timeout_ms = TIMEOUT_MS_DEFAULT)
+{
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  while (!pred() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+  return pred();
+}
+
+static_assert(
+  std::atomic<int>::is_always_lock_free,
+  "std::atomic<int> is not lock-free on this target architecture!");
+
+// Global atomics for signal argument capture in old-handler stub functions.
+std::atomic<int> g_sa_handler_signum{-1};
+
+void old_sa_handler_stub(int signum)
+{
+  g_sa_handler_signum.store(signum);
+}
+
+std::atomic<int> g_sa_sigaction_signum{-1};
+std::atomic<int> g_sa_sigaction_si_signo{-1};
+std::atomic<int> g_sa_sigaction_si_code{-1};
+std::atomic<int> g_sa_sigaction_si_pid{-1};
+
+void old_sa_sigaction_stub(int signum, siginfo_t * siginfo, void * /* context */)
+{
+  g_sa_sigaction_signum.store(signum);
+  if (siginfo != nullptr) {
+    g_sa_sigaction_si_signo.store(siginfo->si_signo);
+    g_sa_sigaction_si_code.store(siginfo->si_code);
+    g_sa_sigaction_si_pid.store(static_cast<int>(siginfo->si_pid));
+  }
+}
+
 }  // namespace
 
 class SignalHandlerTest : public ::testing::Test
@@ -138,15 +175,15 @@ TEST_F(SignalHandlerTest, InstallAndUninstallRestoreSigintAndSigtermHandlers)
 
   const auto sigint_installed = get_current_sigaction(SIGINT);
   const auto sigterm_installed = get_current_sigaction(SIGTERM);
-  EXPECT_NE(sigint_installed.sa_handler, sigint_before.sa_handler);
-  EXPECT_NE(sigterm_installed.sa_handler, sigterm_before.sa_handler);
+  EXPECT_NE(sigint_installed.sa_sigaction, sigint_before.sa_sigaction);
+  EXPECT_NE(sigterm_installed.sa_sigaction, sigterm_before.sa_sigaction);
 
   agnocast::SignalHandler::uninstall();
 
   const auto sigint_after = get_current_sigaction(SIGINT);
   const auto sigterm_after = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after.sa_handler, sigint_before.sa_handler);
-  EXPECT_EQ(sigterm_after.sa_handler, sigterm_before.sa_handler);
+  EXPECT_EQ(sigint_after.sa_sigaction, sigint_before.sa_sigaction);
+  EXPECT_EQ(sigterm_after.sa_sigaction, sigterm_before.sa_sigaction);
 }
 
 TEST_F(SignalHandlerTest, InstallAndUninstallAreIdempotent)
@@ -157,26 +194,27 @@ TEST_F(SignalHandlerTest, InstallAndUninstallAreIdempotent)
   agnocast::SignalHandler::install();
   const auto sigint_after_first_install = get_current_sigaction(SIGINT);
   const auto sigterm_after_first_install = get_current_sigaction(SIGTERM);
-  EXPECT_NE(sigint_after_first_install.sa_handler, sigint_before.sa_handler);
-  EXPECT_NE(sigterm_after_first_install.sa_handler, sigterm_before.sa_handler);
+  EXPECT_NE(sigint_after_first_install.sa_sigaction, sigint_before.sa_sigaction);
+  EXPECT_NE(sigterm_after_first_install.sa_sigaction, sigterm_before.sa_sigaction);
 
   agnocast::SignalHandler::install();
   const auto sigint_after_second_install = get_current_sigaction(SIGINT);
   const auto sigterm_after_second_install = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_second_install.sa_handler, sigint_after_first_install.sa_handler);
-  EXPECT_EQ(sigterm_after_second_install.sa_handler, sigterm_after_first_install.sa_handler);
+  EXPECT_EQ(sigint_after_second_install.sa_sigaction, sigint_after_first_install.sa_sigaction);
+  EXPECT_EQ(sigterm_after_second_install.sa_sigaction, sigterm_after_first_install.sa_sigaction);
 
   agnocast::SignalHandler::uninstall();
   const auto sigint_after_first_uninstall = get_current_sigaction(SIGINT);
   const auto sigterm_after_first_uninstall = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_first_uninstall.sa_handler, sigint_before.sa_handler);
-  EXPECT_EQ(sigterm_after_first_uninstall.sa_handler, sigterm_before.sa_handler);
+  EXPECT_EQ(sigint_after_first_uninstall.sa_sigaction, sigint_before.sa_sigaction);
+  EXPECT_EQ(sigterm_after_first_uninstall.sa_sigaction, sigterm_before.sa_sigaction);
 
   agnocast::SignalHandler::uninstall();
   const auto sigint_after_second_uninstall = get_current_sigaction(SIGINT);
   const auto sigterm_after_second_uninstall = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_second_uninstall.sa_handler, sigint_after_first_uninstall.sa_handler);
-  EXPECT_EQ(sigterm_after_second_uninstall.sa_handler, sigterm_after_first_uninstall.sa_handler);
+  EXPECT_EQ(sigint_after_second_uninstall.sa_sigaction, sigint_after_first_uninstall.sa_sigaction);
+  EXPECT_EQ(
+    sigterm_after_second_uninstall.sa_sigaction, sigterm_after_first_uninstall.sa_sigaction);
 }
 
 TEST_F(SignalHandlerTest, SigintNotifiesRegisteredEventfdViaWorkerThread)
@@ -466,4 +504,85 @@ TEST_F(SignalHandlerTest, NotifyAllExecutorsFailsAfterUninstall)
 
   agnocast::SignalHandler::notify_all_executors();
   EXPECT_FALSE(event_fd_has_notification(fd));
+}
+
+TEST_F(SignalHandlerTest, OldSaHandlerIsCalledWithCorrectSigintArgument)
+{
+  g_sa_handler_signum.store(-1);
+
+  struct sigaction old_before
+  {
+  };
+  struct sigaction sa
+  {
+  };
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sa.sa_handler = old_sa_handler_stub;
+  ASSERT_EQ(sigaction(SIGINT, &sa, &old_before), 0);
+
+  agnocast::SignalHandler::install();
+  send_sigint();
+
+  EXPECT_TRUE(wait_for_condition([] { return g_sa_handler_signum.load() != -1; }));
+  EXPECT_EQ(g_sa_handler_signum.load(), SIGINT);
+
+  agnocast::SignalHandler::uninstall();
+  ASSERT_EQ(sigaction(SIGINT, &old_before, nullptr), 0);
+}
+
+TEST_F(SignalHandlerTest, OldSaHandlerIsCalledWithCorrectSigtermArgument)
+{
+  g_sa_handler_signum.store(-1);
+
+  struct sigaction old_before
+  {
+  };
+  struct sigaction sa
+  {
+  };
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sa.sa_handler = old_sa_handler_stub;
+  ASSERT_EQ(sigaction(SIGTERM, &sa, &old_before), 0);
+
+  agnocast::SignalHandler::install();
+  send_sigterm();
+
+  EXPECT_TRUE(wait_for_condition([] { return g_sa_handler_signum.load() != -1; }));
+  EXPECT_EQ(g_sa_handler_signum.load(), SIGTERM);
+
+  agnocast::SignalHandler::uninstall();
+  ASSERT_EQ(sigaction(SIGTERM, &old_before, nullptr), 0);
+}
+
+TEST_F(SignalHandlerTest, OldSaSigactionHandlerIsCalledWithCorrectArguments)
+{
+  g_sa_sigaction_signum.store(-1);
+  g_sa_sigaction_si_signo.store(-1);
+  g_sa_sigaction_si_code.store(-1);
+  g_sa_sigaction_si_pid.store(-1);
+
+  struct sigaction old_before
+  {
+  };
+  struct sigaction sa
+  {
+  };
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = old_sa_sigaction_stub;
+  ASSERT_EQ(sigaction(SIGINT, &sa, &old_before), 0);
+
+  agnocast::SignalHandler::install();
+  send_sigint();
+
+  EXPECT_TRUE(wait_for_condition([] { return g_sa_sigaction_signum.load() != -1; }));
+  EXPECT_EQ(g_sa_sigaction_signum.load(), SIGINT);
+  EXPECT_EQ(g_sa_sigaction_si_signo.load(), SIGINT);
+  EXPECT_EQ(g_sa_sigaction_si_code.load(), SI_USER);
+  EXPECT_EQ(g_sa_sigaction_si_pid.load(), static_cast<int>(getpid()));
+
+  agnocast::SignalHandler::uninstall();
+  ASSERT_EQ(sigaction(SIGINT, &old_before, nullptr), 0);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_signal_handler.cpp
@@ -136,6 +136,17 @@ void old_sa_sigaction_stub(int signum, siginfo_t * siginfo, void * /* context */
   }
 }
 
+bool sigactions_equal(const struct sigaction & a, const struct sigaction & b)
+{
+  if ((a.sa_flags & SA_SIGINFO) != (b.sa_flags & SA_SIGINFO)) {
+    return false;
+  }
+  if (a.sa_flags & SA_SIGINFO) {
+    return a.sa_sigaction == b.sa_sigaction;
+  }
+  return a.sa_handler == b.sa_handler;
+}
+
 }  // namespace
 
 class SignalHandlerTest : public ::testing::Test
@@ -175,15 +186,15 @@ TEST_F(SignalHandlerTest, InstallAndUninstallRestoreSigintAndSigtermHandlers)
 
   const auto sigint_installed = get_current_sigaction(SIGINT);
   const auto sigterm_installed = get_current_sigaction(SIGTERM);
-  EXPECT_NE(sigint_installed.sa_sigaction, sigint_before.sa_sigaction);
-  EXPECT_NE(sigterm_installed.sa_sigaction, sigterm_before.sa_sigaction);
+  EXPECT_FALSE(sigactions_equal(sigint_installed, sigint_before));
+  EXPECT_FALSE(sigactions_equal(sigterm_installed, sigterm_before));
 
   agnocast::SignalHandler::uninstall();
 
   const auto sigint_after = get_current_sigaction(SIGINT);
   const auto sigterm_after = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after.sa_sigaction, sigint_before.sa_sigaction);
-  EXPECT_EQ(sigterm_after.sa_sigaction, sigterm_before.sa_sigaction);
+  EXPECT_TRUE(sigactions_equal(sigint_after, sigint_before));
+  EXPECT_TRUE(sigactions_equal(sigterm_after, sigterm_before));
 }
 
 TEST_F(SignalHandlerTest, InstallAndUninstallAreIdempotent)
@@ -194,27 +205,26 @@ TEST_F(SignalHandlerTest, InstallAndUninstallAreIdempotent)
   agnocast::SignalHandler::install();
   const auto sigint_after_first_install = get_current_sigaction(SIGINT);
   const auto sigterm_after_first_install = get_current_sigaction(SIGTERM);
-  EXPECT_NE(sigint_after_first_install.sa_sigaction, sigint_before.sa_sigaction);
-  EXPECT_NE(sigterm_after_first_install.sa_sigaction, sigterm_before.sa_sigaction);
+  EXPECT_FALSE(sigactions_equal(sigint_after_first_install, sigint_before));
+  EXPECT_FALSE(sigactions_equal(sigterm_after_first_install, sigterm_before));
 
   agnocast::SignalHandler::install();
   const auto sigint_after_second_install = get_current_sigaction(SIGINT);
   const auto sigterm_after_second_install = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_second_install.sa_sigaction, sigint_after_first_install.sa_sigaction);
-  EXPECT_EQ(sigterm_after_second_install.sa_sigaction, sigterm_after_first_install.sa_sigaction);
+  EXPECT_TRUE(sigactions_equal(sigint_after_second_install, sigint_after_first_install));
+  EXPECT_TRUE(sigactions_equal(sigterm_after_second_install, sigterm_after_first_install));
 
   agnocast::SignalHandler::uninstall();
   const auto sigint_after_first_uninstall = get_current_sigaction(SIGINT);
   const auto sigterm_after_first_uninstall = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_first_uninstall.sa_sigaction, sigint_before.sa_sigaction);
-  EXPECT_EQ(sigterm_after_first_uninstall.sa_sigaction, sigterm_before.sa_sigaction);
+  EXPECT_TRUE(sigactions_equal(sigint_after_first_uninstall, sigint_before));
+  EXPECT_TRUE(sigactions_equal(sigterm_after_first_uninstall, sigterm_before));
 
   agnocast::SignalHandler::uninstall();
   const auto sigint_after_second_uninstall = get_current_sigaction(SIGINT);
   const auto sigterm_after_second_uninstall = get_current_sigaction(SIGTERM);
-  EXPECT_EQ(sigint_after_second_uninstall.sa_sigaction, sigint_after_first_uninstall.sa_sigaction);
-  EXPECT_EQ(
-    sigterm_after_second_uninstall.sa_sigaction, sigterm_after_first_uninstall.sa_sigaction);
+  EXPECT_TRUE(sigactions_equal(sigint_after_second_uninstall, sigint_after_first_uninstall));
+  EXPECT_TRUE(sigactions_equal(sigterm_after_second_uninstall, sigterm_after_first_uninstall));
 }
 
 TEST_F(SignalHandlerTest, SigintNotifiesRegisteredEventfdViaWorkerThread)


### PR DESCRIPTION
## Description

### Background
The current `SignalHandler` overwrites previously registered handlers instead of chaining them. As a result, existing handlers are completely ignored while `SignalHandler` is active. 

This causes unexpected issues. For example, `glog` cannot handle `SIGTERM` correctly after `SignalHandler::install()` is called.

### Solution
This PR fixes the issue by chaining the handlers. The newly installed signal handler now safely calls the previously registered handler.

## Related Links
The signal handler implementation in `rclcpp` is helpful for reviewing this PR:
[rclcpp/signal_handler.cpp](https://github.com/ros2/rclcpp/blob/8b8a9183f76c2277d5fb94eabd6a6b628a0a5d6c/rclcpp/src/rclcpp/signal_handler.cpp#L67-L88)

Close https://github.com/autowarefoundation/agnocast/issues/1182

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
