### PR TITLE
fix(ros2agnocast_discovery_agent): exit duplicate agent cleanly instead of signal.pause()

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -9,9 +9,11 @@ One daemon process is intended to run per IPC namespace. To make duplicate
 launches (e.g. one node spawning the agent and another ``ros2 launch``
 session also trying to spawn one) safe, the agent acquires an
 ``flock(2)``-based singleton lock on a per-IPC-namespace file before
-starting; subsequent instances detect the held lock and stay idle on
-``signal.pause()`` until terminated, so they don't disturb the launch
-tree they belong to.
+starting; subsequent instances detect the held lock and exit cleanly
+(code 0), leaving exactly one live agent per namespace. Emitting a single
+agent per launch tree is the launch side's responsibility; this lock is
+the cross-invocation safety net for when separate launches target the
+same namespace.
 """
 
 import ctypes
@@ -21,7 +23,6 @@ import fcntl
 import importlib.metadata
 import logging
 import os
-import signal
 import socket
 import sys
 from typing import IO
@@ -380,26 +381,19 @@ class DiscoveryAgent(Node):
 
 
 def main(argv=None) -> int:
-    # Singleton check before DDS / ioctl bring-up so duplicate launches stay
-    # passive instead of polluting the gossip topic or hammering the kmod.
+    # Take the per-IPC-namespace singleton lock before any DDS / ioctl work.
+    # If another agent holds it, exit cleanly (0).
     #
-    # Duplicates DO NOT exit early: launch supervisors (especially
-    # `launch_test` running parallel sample-app tests) treat a Node exit as a
-    # process-died event and propagate teardown to the rest of the launch
-    # tree. So when the lock is held, we sit idle on `signal.pause()` —
-    # SIGINT / SIGTERM still tears the duplicate down cleanly with the rest
-    # of its parent launch.
+    # A duplicate that exits early *could* make launch_test treat it as a
+    # crashed node and tear down the launch tree. That's not a risk here: the
+    # launch emits one agent per tree, so a held lock always means a separate
+    # launch/run — never a same-tree sibling — which exiting can't affect.
     ipc_ns_inode = _read_ipc_ns_inode()
     lock_attempt = _try_acquire_singleton_lock(ipc_ns_inode)
     if lock_attempt.status == LockStatus.HELD:
         sys.stderr.write(
-            f'agnocast_discovery_agent: another instance is already running in this '
-            f'IPC namespace (inode={ipc_ns_inode}); staying idle.\n')
-        try:
-            while True:
-                signal.pause()
-        except KeyboardInterrupt:
-            pass
+            'agnocast_discovery_agent: another instance is already running in this '
+            f'IPC namespace (inode={ipc_ns_inode}); exiting.\n')
         return 0
     if lock_attempt.status == LockStatus.ERROR:
         # Don't masquerade as "already running" — propagate failure so

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -5,6 +5,7 @@ helpers directly with a mock ctypes library.
 """
 
 import ctypes
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -263,3 +264,28 @@ def test_acquire_singleton_lock_reports_error_on_unwritable_dir(monkeypatch):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/nonexistent_path_for_agnocast_test')
     from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
     assert _try_acquire_singleton_lock(789).status == LockStatus.ERROR
+
+
+def test_main_exits_promptly_when_another_agent_holds_the_lock(monkeypatch, tmp_path):
+    """A duplicate (lock already held) returns 0 promptly instead of idling.
+
+    Runs main() in a thread so a regression to the old ``signal.pause()``
+    (which would block forever here) is caught as a non-returning thread
+    rather than hanging the whole test run. main() returns before any DDS /
+    ioctl bring-up, so this needs neither the kmod nor rclpy.
+    """
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import (
+        LockStatus, _read_ipc_ns_inode, _try_acquire_singleton_lock, main)
+
+    holder = _try_acquire_singleton_lock(_read_ipc_ns_inode())
+    assert holder.status == LockStatus.ACQUIRED
+    try:
+        result = {}
+        t = threading.Thread(target=lambda: result.__setitem__('rc', main(argv=[])))
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), 'main() did not return (regressed to signal.pause()?)'
+        assert result['rc'] == 0
+    finally:
+        holder.file.close()


### PR DESCRIPTION
## Description

A duplicate discovery agent (one that loses the per-IPC-namespace `flock(2)` singleton lock) now exits cleanly with code 0 instead of idling on `signal.pause()`.

Emitting a single agent per launch tree is the launch side's responsibility; this lock is just the cross-invocation safety net.

## Related links

- Related launch-side dedup (Autoware): autowarefoundation/autoware_core#1084

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (`-p 22`)
- [x] `bash scripts/test/e2e_test_2to2.bash`
- [ ] kunit tests (kmod not modified)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash`
- [ ] sample application
- Added a pytest (`test_main_exits_promptly_when_another_agent_holds_the_lock`)
  asserting `main()` returns 0 promptly when the lock is held.

## Notes for reviewers

Exiting is safe under `launch_test`: a held lock always means a *separate*
launch/run (the launch emits one agent per tree), so there is no same-tree
sibling whose early exit `launch_test` could mistake for a crash.

## Version Update Label (Required)

- `need-patch-update`
