### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   assign:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Assign author to assignee on PR
         uses: technote-space/assign-author@v1

--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - ros_distro: humble
-            os: ubuntu-24.04
+            os: ubuntu-22.04
           - ros_distro: jazzy
             os: ubuntu-24.04
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - ros_distro: humble
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - ros_distro: jazzy
             os: ubuntu-24.04
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-kmod.yaml
+++ b/.github/workflows/build-kmod.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-kmod:
     if: ${{ github.event.label.name == 'run-build-test' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Set PR fetch depth

--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   checkpatch:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set PR fetch depth

--- a/.github/workflows/run-pre-commit.yaml
+++ b/.github/workflows/run-pre-commit.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sparse-check.yaml
+++ b/.github/workflows/sparse-check.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sparse-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Update GitHub Actions `runs-on` runners from `ubuntu-22.04` to `ubuntu-24.04`
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows pass on ubuntu-24.04 runners

Made with [Cursor](https://cursor.com)