### PR TITLE
feat(agnocastlib): handle daemon cross-NS bridge requests in performance mode

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -5,6 +5,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -24,6 +25,12 @@ inline constexpr std::string_view SUFFIX_SERVICE_A2R = "_S_A2R";
 
 inline constexpr size_t SUFFIX_LEN = 6;
 static_assert(SUFFIX_PUBSUB_R2A.length() == SUFFIX_LEN);
+
+// How long a daemon cross-NS bridge request keeps a bridge forced after the last
+// request. Must exceed the daemon's publish interval (1 s) so a few missed ticks
+// don't tear down a healthy cross-NS bridge, yet stay short so a vanished remote
+// endpoint stops being forced promptly. Shared by both bridge manager modes.
+inline constexpr std::chrono::seconds DAEMON_FORCE_TTL{5};
 static_assert(SUFFIX_PUBSUB_A2R.length() == SUFFIX_LEN);
 static_assert(SUFFIX_SERVICE_R2A.length() == SUFFIX_LEN);
 static_assert(SUFFIX_SERVICE_A2R.length() == SUFFIX_LEN);
@@ -60,6 +67,10 @@ struct PublisherCountResult
 BridgeMode get_bridge_mode();
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id);
 rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t publisher_id);
+// Rebuild a QoS profile from the fields a daemon cross-NS request carries. The
+// daemon has no local endpoint to query, so reliability / durability / depth are
+// reconstructed from the request rather than from the kernel.
+rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req);
 PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name);
 SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_name);
 bool update_ros2_subscriber_num(const rclcpp::Node * node, const std::string & topic_name);

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -7,6 +7,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -26,6 +27,18 @@ public:
 
 private:
   using RequestMap = std::unordered_map<topic_local_id_t, MqMsgPerformanceBridge>;
+
+  // A cross-NS bridge request from the per-NS daemon. Unlike an intra-NS request,
+  // there is no local endpoint to resolve the plugin / QoS from, so the type and
+  // QoS travel in the request itself. While unexpired, the bridge is created
+  // without a same-graph DDS counterpart (the peer NS's bridge creates it) and is
+  // shielded from demand-based teardown.
+  struct DaemonForcedRequest
+  {
+    std::string message_type;
+    rclcpp::QoS qos;
+    std::chrono::steady_clock::time_point forced_until;
+  };
 
   struct R2AServiceBridgeItem
   {
@@ -54,13 +67,25 @@ private:
   std::unordered_map<std::string, PerformancePubsubBridgeResult> active_pubsub_a2r_bridges_;
   std::unordered_map<std::string, RequestMap> request_cache_;
 
+  // Daemon-forced cross-NS requests, keyed by topic, split by direction.
+  std::unordered_map<std::string, DaemonForcedRequest> daemon_forced_r2a_;
+  std::unordered_map<std::string, DaemonForcedRequest> daemon_forced_a2r_;
+
   std::unordered_map<std::string, R2AServiceBridgeItem> active_r2a_service_bridges_;
 
   void start_ros_execution();
 
   void on_mq_request(int fd);
+  void on_daemon_mq_request(int fd);
   void on_signal();
   std::string on_socket_request() const;
+
+  void register_daemon_pubsub_request(const MqMsgDaemonBridge & req);
+  bool is_daemon_forced(const std::string & topic_name, BridgeDirection direction) const;
+  void create_daemon_forced_bridges();
+  void activate_daemon_forced_bridge(
+    const std::string & topic_name, const std::string & message_type, const rclcpp::QoS & qos,
+    bool is_r2a);
 
   void check_and_create_pubsub_bridges();
   void check_and_remove_pubsub_bridges();

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -81,6 +81,17 @@ rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t p
                                                     : rclcpp::DurabilityPolicy::Volatile);
 }
 
+rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req)
+{
+  return rclcpp::QoS(req.qos_depth)
+    .durability(
+      req.qos_is_transient_local ? rclcpp::DurabilityPolicy::TransientLocal
+                                 : rclcpp::DurabilityPolicy::Volatile)
+    .reliability(
+      req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                          : rclcpp::ReliabilityPolicy::BestEffort);
+}
+
 SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_name)
 {
   union ioctl_get_subscriber_num_args args = {};

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -58,6 +58,11 @@ void PerformanceBridgeManager::run()
   event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
+  // Performance mode runs one bridge manager per IPC namespace, so the daemon
+  // request MQ is per-NS too (not keyed by pid like standard mode).
+  event_loop_.register_aux_mq(
+    create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID), DAEMON_BRIDGE_MQ_MAX_MESSAGES,
+    DAEMON_BRIDGE_MQ_MESSAGE_SIZE, [this](int fd) { this->on_daemon_mq_request(fd); });
 
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
@@ -66,6 +71,7 @@ void PerformanceBridgeManager::run()
     }
 
     check_and_create_pubsub_bridges();
+    create_daemon_forced_bridges();
     check_and_remove_pubsub_bridges();
     check_and_remove_service_bridges();
     check_and_remove_request_cache();
@@ -122,6 +128,99 @@ void PerformanceBridgeManager::on_mq_request(int fd)
 
     create_pubsub_bridge_if_needed(
       topic_name, request_cache_[topic_name], message_type, msg.direction);
+  }
+}
+
+void PerformanceBridgeManager::on_daemon_mq_request(int fd)
+{
+  MqMsgDaemonBridge req{};
+  while (mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr) > 0) {
+    if (shutdown_requested_) {
+      break;
+    }
+    register_daemon_pubsub_request(req);
+  }
+}
+
+void PerformanceBridgeManager::register_daemon_pubsub_request(const MqMsgDaemonBridge & req)
+{
+  const std::string topic_name = static_cast<const char *>(req.topic_name);
+  const std::string message_type = static_cast<const char *>(req.type_name);
+
+  const auto forced_until = std::chrono::steady_clock::now() + DAEMON_FORCE_TTL;
+  auto & forced =
+    (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? daemon_forced_r2a_ : daemon_forced_a2r_;
+  forced.insert_or_assign(
+    topic_name, DaemonForcedRequest{message_type, daemon_request_qos(req), forced_until});
+}
+
+bool PerformanceBridgeManager::is_daemon_forced(
+  const std::string & topic_name, BridgeDirection direction) const
+{
+  const auto & forced =
+    (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? daemon_forced_r2a_ : daemon_forced_a2r_;
+  const auto it = forced.find(topic_name);
+  return it != forced.end() && std::chrono::steady_clock::now() < it->second.forced_until;
+}
+
+void PerformanceBridgeManager::create_daemon_forced_bridges()
+{
+  for (const bool is_r2a : {true, false}) {
+    auto & forced = is_r2a ? daemon_forced_r2a_ : daemon_forced_a2r_;
+    for (auto it = forced.begin(); it != forced.end();) {
+      const std::string & topic_name = it->first;
+
+      // Lease expired: drop the force and let the normal on-demand lifecycle resume.
+      if (std::chrono::steady_clock::now() >= it->second.forced_until) {
+        it = forced.erase(it);
+        continue;
+      }
+
+      const bool already_active = is_r2a ? active_pubsub_r2a_bridges_.count(topic_name) > 0
+                                         : active_pubsub_a2r_bridges_.count(topic_name) > 0;
+      // The same-graph DDS counterpart check is skipped while forced, but a live
+      // local Agnocast endpoint is still required for the bridge to carry traffic.
+      const auto count = is_r2a ? get_agnocast_subscriber_count(topic_name).count
+                                : get_agnocast_publisher_count(topic_name).count;
+      if (!already_active && count > 0) {
+        activate_daemon_forced_bridge(topic_name, it->second.message_type, it->second.qos, is_r2a);
+      }
+      ++it;
+    }
+  }
+}
+
+void PerformanceBridgeManager::activate_daemon_forced_bridge(
+  const std::string & topic_name, const std::string & message_type, const rclcpp::QoS & qos,
+  bool is_r2a)
+{
+  try {
+    PerformancePubsubBridgeResult result =
+      is_r2a ? loader_.create_r2a_pubsub_bridge(container_node_, topic_name, message_type, qos)
+             : loader_.create_a2r_pubsub_bridge(container_node_, topic_name, message_type, qos);
+    if (!result.entity_handle) {
+      return;
+    }
+
+    if (is_r2a) {
+      if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_r2a_bridges_[topic_name] = result;
+    } else {
+      if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_a2r_bridges_[topic_name] = result;
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      logger_, "Failed to create daemon-forced bridge for '%s': %s", topic_name.c_str(), e.what());
+  } catch (...) {
+    RCLCPP_WARN(
+      logger_, "Unknown error creating daemon-forced bridge for '%s'", topic_name.c_str());
   }
 }
 
@@ -187,7 +286,10 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
       return;
     }
 
-    if (result.count <= 0 || !is_demanded_by_ros2) {
+    // A daemon-forced cross-NS bridge is kept alive without a same-graph DDS
+    // counterpart; only a vanished local Agnocast endpoint (count <= 0) removes it.
+    const bool keep_forced = is_daemon_forced(topic_name, BridgeDirection::ROS2_TO_AGNOCAST);
+    if (result.count <= 0 || (!is_demanded_by_ros2 && !keep_forced)) {
       if (r2a_it->second.callback_group) {
         executor_->stop_callback_group(r2a_it->second.callback_group);
       }
@@ -217,7 +319,8 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
       return;
     }
 
-    if (result.count <= 0 || !is_demanded_by_ros2) {
+    const bool keep_forced = is_daemon_forced(topic_name, BridgeDirection::AGNOCAST_TO_ROS2);
+    if (result.count <= 0 || (!is_demanded_by_ros2 && !keep_forced)) {
       if (a2r_it->second.callback_group) {
         executor_->stop_callback_group(a2r_it->second.callback_group);
       }

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -18,11 +18,6 @@
 namespace agnocast
 {
 
-// Longer than the daemon's publish interval (1 s) so a few missed daemon
-// ticks don't tear down a healthy cross-NS bridge, short enough that a
-// genuinely vanished remote endpoint stops being forced promptly.
-constexpr std::chrono::seconds DAEMON_FORCE_TTL{5};
-
 StandardBridgeManager::StandardBridgeManager(pid_t target_pid)
 : target_pid_(target_pid),
   logger_(rclcpp::get_logger("agnocast_standard_bridge_manager")),

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -1,5 +1,6 @@
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <gtest/gtest.h>
 
@@ -41,4 +42,32 @@ TEST(DaemonBridgeMqTest, PerformanceMqNameAppendsDomainId)
     agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
     "/agnocast_daemon_bridge_perf_d7");
   unsetenv("ROS_DOMAIN_ID");
+}
+
+// Performance-mode daemon bridges have no local endpoint to query, so the QoS
+// must be rebuilt faithfully from the request's explicit fields.
+TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
+{
+  agnocast::MqMsgDaemonBridge req{};
+  req.qos_depth = 10;
+  req.qos_is_reliable = true;
+  req.qos_is_transient_local = true;
+
+  const rclcpp::QoS qos = agnocast::daemon_request_qos(req);
+  EXPECT_EQ(qos.depth(), 10u);
+  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+}
+
+TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
+{
+  agnocast::MqMsgDaemonBridge req{};
+  req.qos_depth = 1;
+  req.qos_is_reliable = false;
+  req.qos_is_transient_local = false;
+
+  const rclcpp::QoS qos = agnocast::daemon_request_qos(req);
+  EXPECT_EQ(qos.depth(), 1u);
+  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::BestEffort);
+  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
 }


### PR DESCRIPTION
## Description

Auto-generate cross-IPC-namespace (and cross-ECU) bridges under **performance mode** too. The per-namespace discovery daemon already dispatches `MqMsgDaemonBridge` to the per-NS performance MQ (#1372); this PR makes the performance `bridge_manager` act on it.

Changes:

- **agnocastlib**: the performance `bridge_manager` listens on the per-NS daemon MQ (`/agnocast_daemon_bridge_perf`, one per IPC namespace — not keyed by pid like standard mode). While a request is unexpired it creates the bridge **without** a same-graph DDS counterpart and shields it from demand-based teardown; that counterpart cannot exist until the peer namespace's bridge is also up (chicken-and-egg). The force expires shortly after the daemon stops asserting, restoring the normal on-demand lifecycle.
- Unlike standard mode — which reuses the process-local factory cached from its own intra-NS requests — performance mode has no such factory, so the bridge is resolved from the request's **message type** (plugin) and its QoS is rebuilt from the request's explicit fields (`daemon_request_qos`). This is the asymmetry already documented on `MqMsgDaemonBridge`.
- `DAEMON_FORCE_TTL` moves into the shared `bridge_utils` header so both managers share one source of truth for the force-lease duration (it must stay longer than the daemon's publish interval).

No agent-side changes — the decider already targets the per-NS performance MQ (#1372). Additive only; no existing ABI changes.

## Related links

- Cross-namespace bridge design (TIER IV internal link): https://tier4.atlassian.net/wiki/x/2YFtNwE
- Architecture overview (TIER IV internal link): https://tier4.atlassian.net/wiki/x/fIDcMwE
- Standard-mode counterpart: #1372

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) — standard mode
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) — standard mode
- [ ] kunit tests (required when modifying the kernel module) — N/A, kmod untouched
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **Unit tests** (`test_unit_agnocastlib`, `DaemonBridgeMqTest`): the existing `MqMsgDaemonBridge` wire-layout / MQ-naming cases, plus two new cases pinning `daemon_request_qos` — the performance-mode QoS rebuilt from the request's explicit depth / reliability / durability fields.
- **Manual cross-NS test** (performance mode) — **confirmed PASS**: listener in IPC ns B received the talker (IPC ns A) via the auto-generated performance bridge. Performance mode needs a one-time setup step first — it does not work by default (see [#1386](https://github.com/autowarefoundation/agnocast/issues/1386)): generate the bridge plugin for the topic's type, then run talker/listener in separate IPC namespaces:

  ```bash
  # source this workspace first; local_setup.bash avoids pulling in other overlays (e.g. autoware)
  source /opt/ros/humble/setup.bash && source install/local_setup.bash
  ros2 agnocast generate-bridge-plugins --message-types agnocast_sample_interfaces/msg/DynamicSizeArray
  colcon build --packages-select agnocast_bridge_plugins && source install/local_setup.bash

  # talker (ns A) and listener (ns B), each in its own shell:
  sudo unshare --ipc bash -c 'sysctl -w fs.mqueue.msg_max=1024 >/dev/null; source install/setup.bash; \
    AGNOCAST_BRIDGE_MODE=performance ros2 launch agnocast_sample_application talker.launch.xml discovery_agent:=true'
  sudo unshare --ipc bash -c 'sysctl -w fs.mqueue.msg_max=1024 >/dev/null; source install/setup.bash; \
    AGNOCAST_BRIDGE_MODE=performance ros2 launch agnocast_sample_application listener.launch.xml discovery_agent:=true'
  ```

  Expected: within a few seconds the listener prints `subscribe message: id=N` (with `discovery_agent:=false`, nothing).

## Notes for reviewers

- Stacked on #1372 — review/merge that first. The diff here is the performance-manager half plus the shared `DAEMON_FORCE_TTL` relocation.
- The force-lease / teardown-shield behavior mirrors standard mode and is exercised by the manual cross-NS test above; the unit tests cover the one piece of new pure logic (QoS reconstruction), matching the test depth of #1372.
- The kmod is untouched: type names still come from the tmpfs type registry (#1356); moving that to a kmod ioctl is deferred to the planned refactor and is independent of this change.

## Version Update Label (Required)

- `need-patch-update`
