### PR TITLE
refactor(agnocastlib): rename bridge "request" APIs to "registration"

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -80,7 +80,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRegistrationPolicy>>(
     node, topic_name, qos, options);
 }
 
@@ -101,7 +101,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRequestPolicy>>(
+  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRegistrationPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 
@@ -124,7 +124,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
     node, topic_name, qos, std::forward<Func>(callback), options);
 }
 
@@ -147,7 +147,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRequestPolicy>>(
+  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
     std::forward<Func>(callback), options);
 }
@@ -167,7 +167,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRequestPolicy>>(
+  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
 }
 
@@ -186,7 +186,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRequestPolicy>>(
+  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
     node, topic_name, qos);
 }
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -24,7 +24,7 @@
 namespace agnocast
 {
 
-struct NoBridgeRequestPolicy;
+struct NoBridgeRegistrationPolicy;
 
 bool service_is_ready_core(const std::string & service_name);
 bool wait_for_service_nanoseconds(
@@ -98,8 +98,8 @@ private:
     }
   };
 
-  using ServiceRequestPublisher = BasicPublisher<RequestT, NoBridgeRequestPolicy>;
-  using ServiceResponseSubscriber = BasicSubscription<ResponseT, NoBridgeRequestPolicy>;
+  using ServiceRequestPublisher = BasicPublisher<RequestT, NoBridgeRegistrationPolicy>;
+  using ServiceResponseSubscriber = BasicSubscription<ResponseT, NoBridgeRegistrationPolicy>;
 
   std::atomic<int64_t> next_sequence_number_;
   std::mutex seqno2_response_call_info_mtx_;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -60,7 +60,7 @@ struct PublisherOptions
 };
 
 // Internal implementation — users should use agnocast::Publisher<MessageT> instead.
-template <typename MessageT, typename BridgeRequestPolicy>
+template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicPublisher
 {
   topic_local_id_t id_ = -1;
@@ -127,13 +127,13 @@ class BasicPublisher
     }
     id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
     generate_gid();
-    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
 
     return actual_qos;
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicPublisher<MessageT, BridgeRequestPolicy>>;
+  using SharedPtr = std::shared_ptr<BasicPublisher<MessageT, BridgeRegistrationPolicy>>;
 
   BasicPublisher(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
@@ -269,7 +269,7 @@ public:
   const char * get_topic_name() const { return topic_name_.c_str(); }
 };
 
-struct AgnocastToRosPubsubRequestPolicy;
+struct AgnocastToRosPubsubRegistrationPolicy;
 
 /**
  * @brief The user-facing Agnocast publisher type.
@@ -279,6 +279,7 @@ struct AgnocastToRosPubsubRequestPolicy;
  */
 AGNOCAST_PUBLIC
 template <typename MessageT>
-using Publisher = agnocast::BasicPublisher<MessageT, agnocast::AgnocastToRosPubsubRequestPolicy>;
+using Publisher =
+  agnocast::BasicPublisher<MessageT, agnocast::AgnocastToRosPubsubRegistrationPolicy>;
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -18,9 +18,9 @@ namespace agnocast
 {
 
 // Internal implementation - users should use agnocast::Service<ServiceT> instead.
-template <typename ServiceT, typename BridgeRequestPolicy>
+template <typename ServiceT, typename BridgeRegistrationPolicy>
 class BasicService
-: public std::enable_shared_from_this<BasicService<ServiceT, BridgeRequestPolicy>>
+: public std::enable_shared_from_this<BasicService<ServiceT, BridgeRegistrationPolicy>>
 {
 private:
   // TODO(bdm-k): Consider supporting callbacks that take lvalue references.
@@ -33,7 +33,7 @@ private:
   template <typename Func>
   struct is_deferred_cb
   : std::bool_constant<std::is_invocable_v<
-      std::decay_t<Func>, std::shared_ptr<BasicService<ServiceT, BridgeRequestPolicy>>,
+      std::decay_t<Func>, std::shared_ptr<BasicService<ServiceT, BridgeRegistrationPolicy>>,
       ipc_shared_ptr<typename ServiceT::Request> &&>>
   {
   };
@@ -49,8 +49,8 @@ private:
     int64_t _sequence_number;
   };
 
-  using ServiceResponsePublisher = BasicPublisher<ResponseT, NoBridgeRequestPolicy>;
-  using ServiceRequestSubscriber = BasicSubscription<RequestT, NoBridgeRequestPolicy>;
+  using ServiceResponsePublisher = BasicPublisher<ResponseT, NoBridgeRegistrationPolicy>;
+  using ServiceRequestSubscriber = BasicSubscription<RequestT, NoBridgeRegistrationPolicy>;
 
   const std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string service_name_;
@@ -140,11 +140,11 @@ private:
         wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), options);
     }
 
-    BridgeRequestPolicy::template request_bridge<NodeT, ServiceT>(node, service_name_);
+    BridgeRegistrationPolicy::template register_bridge<NodeT, ServiceT>(node, service_name_);
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicService<ServiceT, BridgeRequestPolicy>>;
+  using SharedPtr = std::shared_ptr<BasicService<ServiceT, BridgeRegistrationPolicy>>;
 
   template <typename Func>
   BasicService(
@@ -208,7 +208,7 @@ public:
   }
 };
 
-struct RosToAgnocastServiceRequestPolicy;
+struct RosToAgnocastServiceRegistrationPolicy;
 
 /**
  * @brief The user-facing Agnocast service server.
@@ -218,6 +218,6 @@ struct RosToAgnocastServiceRequestPolicy;
  */
 AGNOCAST_PUBLIC
 template <typename ServiceT>
-using Service = BasicService<ServiceT, RosToAgnocastServiceRequestPolicy>;
+using Service = BasicService<ServiceT, RosToAgnocastServiceRegistrationPolicy>;
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -41,7 +41,7 @@ extern int agnocast_fd;
 constexpr int64_t ENTRY_ID_NOT_ASSIGNED = -1;
 
 // Forward declaration for friend access
-template <typename MessageT, typename BridgeRequestPolicy>
+template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicPublisher;
 
 namespace detail
@@ -102,7 +102,7 @@ template <typename T>
 class ipc_shared_ptr
 {
   // Allow BasicPublisher to call invalidate_all_references()
-  template <typename MessageT, typename BridgeRequestPolicy>
+  template <typename MessageT, typename BridgeRegistrationPolicy>
   friend class BasicPublisher;
 
   // Allow converting constructors to access private members of ipc_shared_ptr<U>

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -113,7 +113,7 @@ public:
 };
 
 // Internal implementation — users should use agnocast::Subscription<MessageT> instead.
-template <typename MessageT, typename BridgeRequestPolicy>
+template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicSubscription : public SubscriptionBase
 {
   std::pair<mqd_t, std::string> mq_subscription_;
@@ -148,7 +148,7 @@ class BasicSubscription : public SubscriptionBase
       actual_qos, false, options.ignore_local_publications, is_bridge, node_name, type_name);
 
     id_ = add_subscriber_args.ret_id;
-    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
@@ -161,7 +161,7 @@ class BasicSubscription : public SubscriptionBase
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicSubscription<MessageT, BridgeRequestPolicy>>;
+  using SharedPtr = std::shared_ptr<BasicSubscription<MessageT, BridgeRegistrationPolicy>>;
 
   template <typename Func>
   BasicSubscription(
@@ -228,7 +228,7 @@ public:
 };
 
 // Internal implementation — users should use agnocast::TakeSubscription<MessageT> instead.
-template <typename MessageT, typename BridgeRequestPolicy>
+template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicTakeSubscription : public SubscriptionBase
 {
 private:
@@ -265,13 +265,13 @@ private:
       initialize(actual_qos, true, options.ignore_local_publications, false, node_name, type_name);
 
     id_ = add_subscriber_args.ret_id;
-    BridgeRequestPolicy::template request_bridge<MessageT>(topic_name_, id_);
+    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
 
     return actual_qos;
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicTakeSubscription<MessageT, BridgeRequestPolicy>>;
+  using SharedPtr = std::shared_ptr<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>;
 
   BasicTakeSubscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
@@ -386,19 +386,19 @@ public:
 };
 
 // Internal implementation — users should use agnocast::PollingSubscriber<MessageT> instead.
-template <typename MessageT, typename BridgeRequestPolicy>
+template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicPollingSubscriber
 {
-  typename BasicTakeSubscription<MessageT, BridgeRequestPolicy>::SharedPtr subscriber_;
+  typename BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>::SharedPtr subscriber_;
 
 public:
-  using SharedPtr = std::shared_ptr<BasicPollingSubscriber<MessageT, BridgeRequestPolicy>>;
+  using SharedPtr = std::shared_ptr<BasicPollingSubscriber<MessageT, BridgeRegistrationPolicy>>;
 
   explicit BasicPollingSubscriber(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1},
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
   {
-    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRequestPolicy>>(
+    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>(
       node, topic_name, qos, options);
   };
 
@@ -406,7 +406,7 @@ public:
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1},
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
   {
-    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRequestPolicy>>(
+    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>(
       node, topic_name, qos, options);
   };
 
@@ -419,7 +419,7 @@ public:
   const agnocast::ipc_shared_ptr<const MessageT> take_data() { return subscriber_->take(true); };
 };
 
-struct RosToAgnocastPubsubRequestPolicy;
+struct RosToAgnocastPubsubRegistrationPolicy;
 
 /// @brief The user-facing event-driven subscription type.
 /// Alias for `BasicSubscription<MessageT>`. Use this type (not BasicSubscription directly) when
@@ -427,7 +427,7 @@ struct RosToAgnocastPubsubRequestPolicy;
 AGNOCAST_PUBLIC
 template <typename MessageT>
 using Subscription =
-  agnocast::BasicSubscription<MessageT, agnocast::RosToAgnocastPubsubRequestPolicy>;
+  agnocast::BasicSubscription<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
 
 /// @brief The user-facing polling take-subscription type.
 /// Alias for `BasicTakeSubscription<MessageT>`. Use this type (not BasicTakeSubscription directly)
@@ -435,7 +435,7 @@ using Subscription =
 AGNOCAST_PUBLIC
 template <typename MessageT>
 using TakeSubscription =
-  agnocast::BasicTakeSubscription<MessageT, agnocast::RosToAgnocastPubsubRequestPolicy>;
+  agnocast::BasicTakeSubscription<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
 
 /// @brief The user-facing polling subscriber type.
 /// Alias for `BasicPollingSubscriber<MessageT>`. Use this type (not BasicPollingSubscriber
@@ -443,6 +443,6 @@ using TakeSubscription =
 AGNOCAST_PUBLIC
 template <typename MessageT>
 using PollingSubscriber =
-  agnocast::BasicPollingSubscriber<MessageT, agnocast::RosToAgnocastPubsubRequestPolicy>;
+  agnocast::BasicPollingSubscriber<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -31,100 +31,101 @@ namespace agnocast
 static constexpr size_t DEFAULT_QOS_DEPTH = 10;
 
 template <typename MessageT>
-void send_standard_pubsub_bridge_request(
+void send_standard_pubsub_bridge_registration(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
 template <typename ServiceT>
-void send_standard_service_bridge_request(
+void send_standard_service_bridge_registration(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity);
 template <typename MessageT>
-void send_performance_pubsub_bridge_request(
+void send_performance_pubsub_bridge_registration(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
 template <typename ServiceT>
-void send_performance_service_bridge_request(
+void send_performance_service_bridge_registration(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity);
 
 template <typename MessageT>
-void request_pubsub_bridge_core(
+void register_pubsub_bridge_core(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
 {
   auto bridge_mode = get_bridge_mode();
   if (bridge_mode == BridgeMode::Standard) {
-    send_standard_pubsub_bridge_request<MessageT>(topic_name, id, direction);
+    send_standard_pubsub_bridge_registration<MessageT>(topic_name, id, direction);
   } else if (bridge_mode == BridgeMode::Performance) {
-    send_performance_pubsub_bridge_request<MessageT>(topic_name, id, direction);
+    send_performance_pubsub_bridge_registration<MessageT>(topic_name, id, direction);
   }
 }
 
 template <typename ServiceT>
-void request_service_bridge_core(
+void register_service_bridge_core(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity)
 {
   auto bridge_mode = get_bridge_mode();
   if (bridge_mode == BridgeMode::Standard) {
-    send_standard_service_bridge_request<ServiceT>(service_name, direction, shadow_node_identity);
+    send_standard_service_bridge_registration<ServiceT>(
+      service_name, direction, shadow_node_identity);
   } else if (bridge_mode == BridgeMode::Performance) {
-    send_performance_service_bridge_request<ServiceT>(
+    send_performance_service_bridge_registration<ServiceT>(
       service_name, direction, shadow_node_identity);
   }
 }
 
 // Policy for agnocast::Subscription.
-// Requests a bridge that forwards messages from ROS 2 to Agnocast (R2A).
-struct RosToAgnocastPubsubRequestPolicy
+// Registers a bridge that forwards messages from ROS 2 to Agnocast (R2A).
+struct RosToAgnocastPubsubRegistrationPolicy
 {
   template <typename MessageT>
-  static void request_bridge(const std::string & topic_name, topic_local_id_t id)
+  static void register_bridge(const std::string & topic_name, topic_local_id_t id)
   {
-    request_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::ROS2_TO_AGNOCAST);
+    register_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::ROS2_TO_AGNOCAST);
   }
 };
 
 // Policy for agnocast::Publisher.
-// Requests a bridge that forwards messages from Agnocast to ROS 2 (A2R).
-struct AgnocastToRosPubsubRequestPolicy
+// Registers a bridge that forwards messages from Agnocast to ROS 2 (A2R).
+struct AgnocastToRosPubsubRegistrationPolicy
 {
   template <typename MessageT>
-  static void request_bridge(const std::string & topic_name, topic_local_id_t id)
+  static void register_bridge(const std::string & topic_name, topic_local_id_t id)
   {
-    request_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::AGNOCAST_TO_ROS2);
+    register_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::AGNOCAST_TO_ROS2);
   }
 };
 
 // Policy for agnocast::Service.
-// Requests a bridge that forwards requests from ROS 2 to Agnocast (R2A).
-struct RosToAgnocastServiceRequestPolicy
+// Registers a bridge that forwards requests from ROS 2 to Agnocast (R2A).
+struct RosToAgnocastServiceRegistrationPolicy
 {
   template <typename NodeT, typename ServiceT>
-  static void request_bridge(NodeT * node, const std::string & service_name)
+  static void register_bridge(NodeT * node, const std::string & service_name)
   {
     std::optional<std::pair<std::string, std::string>> shadow_node_identity{std::nullopt};
     if constexpr (std::is_same_v<std::remove_cv_t<NodeT>, agnocast::Node>) {
       shadow_node_identity =
         std::make_pair(std::string(node->get_namespace()), std::string(node->get_name()));
     }
-    request_service_bridge_core<ServiceT>(
+    register_service_bridge_core<ServiceT>(
       service_name, BridgeDirection::ROS2_TO_AGNOCAST, shadow_node_identity);
   }
 };
 
 // Dummy policy to avoid circular header dependencies.
-// Used internally by BridgeNode, Service, and Client where bridge requests
+// Used internally by BridgeNode, Service, and Client where bridge registrations
 // are not needed and would cause include cycles.
-struct NoBridgeRequestPolicy
+struct NoBridgeRegistrationPolicy
 {
   template <typename T, typename... Args>
-  static void request_bridge(Args &&... args)
+  static void register_bridge(Args &&... args)
   {
-    request_bridge_impl(std::forward<Args>(args)...);
+    register_bridge_impl(std::forward<Args>(args)...);
   }
 
 private:
-  static void request_bridge_impl(const std::string &, topic_local_id_t) {}
+  static void register_bridge_impl(const std::string &, topic_local_id_t) {}
   template <typename NodeT>
-  static void request_bridge_impl(NodeT *, const std::string &)
+  static void register_bridge_impl(NodeT *, const std::string &)
   {
   }
 };
@@ -132,7 +133,7 @@ private:
 template <typename MessageT>
 class RosToAgnocastPubsubBridge : public PubsubBridgeBase
 {
-  using AgnoPub = agnocast::BasicPublisher<MessageT, NoBridgeRequestPolicy>;
+  using AgnoPub = agnocast::BasicPublisher<MessageT, NoBridgeRegistrationPolicy>;
   typename AgnoPub::SharedPtr agnocast_pub_;
   typename rclcpp::Subscription<MessageT>::SharedPtr ros_sub_;
   rclcpp::CallbackGroup::SharedPtr ros_cb_group_;
@@ -182,7 +183,7 @@ public:
 template <typename MessageT>
 class AgnocastToRosPubsubBridge : public PubsubBridgeBase
 {
-  using AgnoSub = agnocast::BasicSubscription<MessageT, NoBridgeRequestPolicy>;
+  using AgnoSub = agnocast::BasicSubscription<MessageT, NoBridgeRegistrationPolicy>;
   typename rclcpp::Publisher<MessageT>::SharedPtr ros_pub_;
   typename AgnoSub::SharedPtr agnocast_sub_;
   rclcpp::CallbackGroup::SharedPtr agno_cb_group_;
@@ -345,23 +346,24 @@ void send_mq_message(
 }
 
 template <typename MessageT>
-void send_standard_pubsub_bridge_request(
+void send_standard_pubsub_bridge_registration(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_bridge_requester");
+  static const auto logger = rclcpp::get_logger("agnocast_bridge_registrar");
 
   auto fn_r2a = reinterpret_cast<uintptr_t>(&start_r2a_pubsub_node<MessageT>);
   auto fn_a2r = reinterpret_cast<uintptr_t>(&start_a2r_pubsub_node<MessageT>);
 
-  auto [msg, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Standard, logger)
-                         .set_direction(direction)
-                         .set_is_service(false)
-                         .set_pubsub_target_id(id)
-                         .set_topic_name(topic_name.c_str())
-                         .set_factory(fn_r2a, fn_a2r)
-                         .build_standard_message();
+  auto [msg, reason] =
+    BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Standard, logger)
+      .set_direction(direction)
+      .set_is_service(false)
+      .set_pubsub_target_id(id)
+      .set_topic_name(topic_name.c_str())
+      .set_factory(fn_r2a, fn_a2r)
+      .build_standard_message();
   if (!reason.empty()) {
-    RCLCPP_ERROR(logger, "Failed to build standard pubsub bridge request: %s", reason.c_str());
+    RCLCPP_ERROR(logger, "Failed to build standard pubsub bridge registration: %s", reason.c_str());
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
@@ -371,26 +373,28 @@ void send_standard_pubsub_bridge_request(
 }
 
 template <typename ServiceT>
-void send_standard_service_bridge_request(
+void send_standard_service_bridge_registration(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_service_bridge_requester");
+  static const auto logger = rclcpp::get_logger("agnocast_service_bridge_registrar");
 
   auto fn_r2a = reinterpret_cast<uintptr_t>(&start_r2a_service_node<ServiceT>);
   // TODO(bdm-k): Specify `start_a2r_service_node` once it's implemented.
   // Service bridges currently support only the ROS2 -> Agnocast direction.
   auto fn_a2r = fn_r2a;  // dummy value
 
-  auto [msg, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Standard, logger)
-                         .set_direction(direction)
-                         .set_is_service(true)
-                         .set_service_name(service_name.c_str())
-                         .set_shadow_node_identity(shadow_node_identity)
-                         .set_factory(fn_r2a, fn_a2r)
-                         .build_standard_message();
+  auto [msg, reason] =
+    BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Standard, logger)
+      .set_direction(direction)
+      .set_is_service(true)
+      .set_service_name(service_name.c_str())
+      .set_shadow_node_identity(shadow_node_identity)
+      .set_factory(fn_r2a, fn_a2r)
+      .build_standard_message();
   if (!reason.empty()) {
-    RCLCPP_ERROR(logger, "Failed to build standard service bridge request: %s", reason.c_str());
+    RCLCPP_ERROR(
+      logger, "Failed to build standard service bridge registration: %s", reason.c_str());
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
@@ -400,22 +404,24 @@ void send_standard_service_bridge_request(
 }
 
 template <typename MessageT>
-void send_performance_pubsub_bridge_request(
+void send_performance_pubsub_bridge_registration(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_performance_bridge_requester");
+  static const auto logger = rclcpp::get_logger("agnocast_performance_bridge_registrar");
 
   const std::string message_type_name = rosidl_generator_traits::name<MessageT>();
 
-  auto [msg, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Performance, logger)
-                         .set_direction(direction)
-                         .set_is_service(false)
-                         .set_message_type(message_type_name.c_str())
-                         .set_topic_name(topic_name.c_str())
-                         .set_pubsub_target_id(id)
-                         .build_performance_message();
+  auto [msg, reason] =
+    BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Performance, logger)
+      .set_direction(direction)
+      .set_is_service(false)
+      .set_message_type(message_type_name.c_str())
+      .set_topic_name(topic_name.c_str())
+      .set_pubsub_target_id(id)
+      .build_performance_message();
   if (!reason.empty()) {
-    RCLCPP_ERROR(logger, "Failed to build performance pubsub bridge request: %s", reason.c_str());
+    RCLCPP_ERROR(
+      logger, "Failed to build performance pubsub bridge registration: %s", reason.c_str());
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
@@ -425,23 +431,25 @@ void send_performance_pubsub_bridge_request(
 }
 
 template <typename ServiceT>
-void send_performance_service_bridge_request(
+void send_performance_service_bridge_registration(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_performance_service_bridge_requester");
+  static const auto logger = rclcpp::get_logger("agnocast_performance_service_bridge_registrar");
 
   const std::string service_type_name = rosidl_generator_traits::name<ServiceT>();
 
-  auto [msg, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Performance, logger)
-                         .set_direction(direction)
-                         .set_is_service(true)
-                         .set_service_type(service_type_name.c_str())
-                         .set_service_name(service_name.c_str())
-                         .set_shadow_node_identity(shadow_node_identity)
-                         .build_performance_message();
+  auto [msg, reason] =
+    BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Performance, logger)
+      .set_direction(direction)
+      .set_is_service(true)
+      .set_service_type(service_type_name.c_str())
+      .set_service_name(service_name.c_str())
+      .set_shadow_node_identity(shadow_node_identity)
+      .build_performance_message();
   if (!reason.empty()) {
-    RCLCPP_ERROR(logger, "Failed to build performance service bridge request: %s", reason.c_str());
+    RCLCPP_ERROR(
+      logger, "Failed to build performance service bridge registration: %s", reason.c_str());
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -69,20 +69,20 @@ bool has_external_ros2_subscriber(const rclcpp::Node * node, const std::string &
 rclcpp::QoS get_service_qos(const std::string & service_name);
 bool is_agnocast_service_alive(const std::string & service_name, std::string & reason);
 
-/// @brief A builder class for creating bridge request messages.
+/// @brief A builder class for creating bridge registration messages.
 ///
 /// It handles errors such as setting non-existent fields or invalid values for each field, and the
 /// `build_*` member functions return an error reason. However, it does not check whether the
 /// computed message as a whole is valid. It's the caller's responsibility to invoke a correct
 /// set of setters to build a valid message.
-class BridgeRequestMsgBuilder
+class BridgeRegistrationMsgBuilder
 {
   std::variant<MqMsgBridge, MqMsgPerformanceBridge> msg_;
   rclcpp::Logger logger_;
   bool failed_;
   std::string reason_;
 
-  BridgeRequestMsgBuilder & fail(const char * format, ...);
+  BridgeRegistrationMsgBuilder & fail(const char * format, ...);
   int checked_snprintf(
     const std::string & member, char * buffer, size_t size, const char * format, ...);
 
@@ -92,17 +92,17 @@ public:
     Performance,
   };
 
-  explicit BridgeRequestMsgBuilder(Mode mode, const rclcpp::Logger & logger);
+  explicit BridgeRegistrationMsgBuilder(Mode mode, const rclcpp::Logger & logger);
 
-  BridgeRequestMsgBuilder & set_direction(BridgeDirection direction);
-  BridgeRequestMsgBuilder & set_is_service(bool is_service);
-  BridgeRequestMsgBuilder & set_factory(uintptr_t fn_r2a, uintptr_t fn_a2r);
-  BridgeRequestMsgBuilder & set_message_type(const char * message_type);
-  BridgeRequestMsgBuilder & set_topic_name(const char * topic_name);
-  BridgeRequestMsgBuilder & set_pubsub_target_id(topic_local_id_t target_id);
-  BridgeRequestMsgBuilder & set_service_type(const char * service_type);
-  BridgeRequestMsgBuilder & set_service_name(const char * service_name);
-  BridgeRequestMsgBuilder & set_shadow_node_identity(
+  BridgeRegistrationMsgBuilder & set_direction(BridgeDirection direction);
+  BridgeRegistrationMsgBuilder & set_is_service(bool is_service);
+  BridgeRegistrationMsgBuilder & set_factory(uintptr_t fn_r2a, uintptr_t fn_a2r);
+  BridgeRegistrationMsgBuilder & set_message_type(const char * message_type);
+  BridgeRegistrationMsgBuilder & set_topic_name(const char * topic_name);
+  BridgeRegistrationMsgBuilder & set_pubsub_target_id(topic_local_id_t target_id);
+  BridgeRegistrationMsgBuilder & set_service_type(const char * service_type);
+  BridgeRegistrationMsgBuilder & set_service_name(const char * service_name);
+  BridgeRegistrationMsgBuilder & set_shadow_node_identity(
     const std::optional<std::pair<std::string, std::string>> & shadow_node_identity);
 
   std::pair<MqMsgBridge, std::string> build_standard_message();

--- a/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
+++ b/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
@@ -276,7 +276,7 @@ public:
       topic_ = topic;
       qos_ = qos;
       options_ = options;
-      sub_ = std::make_shared<BasicSubscription<M, RosToAgnocastPubsubRequestPolicy>>(
+      sub_ = std::make_shared<BasicSubscription<M, RosToAgnocastPubsubRegistrationPolicy>>(
         node, topic, detail::to_rclcpp_qos(qos),
         [this](ipc_shared_ptr<M> msg) { this->cb(std::move(msg)); }, options);
       node_raw_ = node;

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -236,7 +236,7 @@ bool is_agnocast_service_alive(const std::string & service_name, std::string & r
   }
 }
 
-BridgeRequestMsgBuilder::BridgeRequestMsgBuilder(Mode mode, const rclcpp::Logger & logger)
+BridgeRegistrationMsgBuilder::BridgeRegistrationMsgBuilder(Mode mode, const rclcpp::Logger & logger)
 : logger_(logger), failed_(false)
 {
   if (mode == Mode::Standard) {
@@ -248,7 +248,7 @@ BridgeRequestMsgBuilder::BridgeRequestMsgBuilder(Mode mode, const rclcpp::Logger
 
 // NOLINTBEGIN(cert-dcl50-cpp, cppcoreguidelines-pro-bounds-array-to-pointer-decay,
 // hicpp-no-array-decay)
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::fail(const char * format, ...)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::fail(const char * format, ...)
 {
   va_list args;
   va_start(args, format);
@@ -273,7 +273,7 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::fail(const char * format, ...
   return *this;
 }
 
-int BridgeRequestMsgBuilder::checked_snprintf(
+int BridgeRegistrationMsgBuilder::checked_snprintf(
   const std::string & member, char * buffer, size_t size, const char * format, ...)
 {
   if (failed_) return -1;
@@ -296,19 +296,21 @@ int BridgeRequestMsgBuilder::checked_snprintf(
 // NOLINTEND(cert-dcl50-cpp, cppcoreguidelines-pro-bounds-array-to-pointer-decay,
 // hicpp-no-array-decay)
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_direction(BridgeDirection direction)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_direction(
+  BridgeDirection direction)
 {
   std::visit([direction](auto && msg) { msg.direction = direction; }, msg_);
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_is_service(bool is_service)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_is_service(bool is_service)
 {
   std::visit([is_service](auto && msg) { msg.is_service = is_service; }, msg_);
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_factory(uintptr_t fn_r2a, uintptr_t fn_a2r)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_factory(
+  uintptr_t fn_r2a, uintptr_t fn_a2r)
 {
   if (!std::holds_alternative<MqMsgBridge>(msg_)) {
     return fail("'factory' is only for standard bridges");
@@ -349,7 +351,8 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_factory(uintptr_t fn_r2a,
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_message_type(const char * message_type)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_message_type(
+  const char * message_type)
 {
   std::visit(
     [this, message_type](auto && msg) {
@@ -365,7 +368,7 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_message_type(const char *
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_topic_name(const char * topic_name)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_topic_name(const char * topic_name)
 {
   std::visit(
     [this, topic_name](auto && msg) {
@@ -377,13 +380,15 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_topic_name(const char * t
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_pubsub_target_id(topic_local_id_t target_id)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_pubsub_target_id(
+  topic_local_id_t target_id)
 {
   std::visit([target_id](auto && msg) { msg.pubsub_target.target_id = target_id; }, msg_);
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_service_type(const char * service_type)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_service_type(
+  const char * service_type)
 {
   std::visit(
     [this, service_type](auto && msg) {
@@ -399,7 +404,8 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_service_type(const char *
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_service_name(const char * service_name)
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_service_name(
+  const char * service_name)
 {
   std::visit(
     [this, service_name](auto && msg) {
@@ -411,7 +417,7 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_service_name(const char *
   return *this;
 }
 
-BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_shadow_node_identity(
+BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_shadow_node_identity(
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity)
 {
   std::visit(
@@ -434,7 +440,7 @@ BridgeRequestMsgBuilder & BridgeRequestMsgBuilder::set_shadow_node_identity(
   return *this;
 }
 
-std::pair<MqMsgBridge, std::string> BridgeRequestMsgBuilder::build_standard_message()
+std::pair<MqMsgBridge, std::string> BridgeRegistrationMsgBuilder::build_standard_message()
 {
   assert(std::holds_alternative<MqMsgBridge>(msg_));
 
@@ -442,7 +448,8 @@ std::pair<MqMsgBridge, std::string> BridgeRequestMsgBuilder::build_standard_mess
   return {msg, failed_ ? std::move(reason_) : std::string{}};
 }
 
-std::pair<MqMsgPerformanceBridge, std::string> BridgeRequestMsgBuilder::build_performance_message()
+std::pair<MqMsgPerformanceBridge, std::string>
+BridgeRegistrationMsgBuilder::build_performance_message()
 {
   assert(std::holds_alternative<MqMsgPerformanceBridge>(msg_));
 

--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -307,12 +307,13 @@ void StandardBridgeManager::send_pubsub_delegation(
   const topic_local_id_t target_id =
     (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? entry.target_id_r2a : entry.target_id_a2r;
 
-  auto [req, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Standard, logger_)
-                         .set_direction(direction)
-                         .set_is_service(false)
-                         .set_topic_name(topic_name.c_str())
-                         .set_pubsub_target_id(target_id)
-                         .build_standard_message();
+  auto [req, reason] =
+    BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Standard, logger_)
+      .set_direction(direction)
+      .set_is_service(false)
+      .set_topic_name(topic_name.c_str())
+      .set_pubsub_target_id(target_id)
+      .build_standard_message();
   // req.factory can be left zeroed because it is not going to be used.
 
   if (!reason.empty()) {

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -20,7 +20,7 @@ extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge_@(snake_type_n
   const rclcpp::QoS & sub_qos)
 {
   using MsgT = @(cpp_type);
-  using AgnoPub = agnocast::BasicPublisher<MsgT, agnocast::NoBridgeRequestPolicy>;
+  using AgnoPub = agnocast::BasicPublisher<MsgT, agnocast::NoBridgeRegistrationPolicy>;
 
   auto agno_pub = std::make_shared<AgnoPub>(
     node.get(),
@@ -79,7 +79,7 @@ extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge_@(snake_type_n
   sub_opts.ignore_local_publications = true;
   sub_opts.callback_group = cb_group;
 
-  using AgnoSub = agnocast::BasicSubscription<MsgT, agnocast::NoBridgeRequestPolicy>;
+  using AgnoSub = agnocast::BasicSubscription<MsgT, agnocast::NoBridgeRegistrationPolicy>;
   auto agno_sub = std::make_shared<AgnoSub>(
     node.get(),
     topic_name,


### PR DESCRIPTION
## Description

**Pure rename — no behavior, logic, or ABI change.**

A `Publisher` / `Subscription` / `Service` constructor does not create a bridge — it registers its bridge factory / message-type info with the `bridge_manager`. The old `request_*` naming implied "create a bridge now". Renamed to `register_*` to match what the call does (and the manager-side `register_*` handlers):

The `bridge_manager` owns the creation timing: pub/sub bridges are created on demand once a DDS counterpart appears, while service bridges are created eagerly so ROS 2 clients can reach the service.

- `request_bridge` → `register_bridge`
- `*RequestPolicy` → `*RegistrationPolicy`
- `request_{pubsub,service}_bridge_core` → `register_{pubsub,service}_bridge_core`
- `send_*_bridge_request` → `send_*_bridge_registration`
- `BridgeRequestMsgBuilder` → `BridgeRegistrationMsgBuilder`

This makes the code more readable and following changes (#1389, #1390) easier. 

Untouched: the kmod ABI name `ioctl_check_and_request_bridge_shutdown_args` and genuine service-request terminology.

## How was this PR tested?
- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A, kmod untouched
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] `colcon build` + `agnocastlib` unit tests (531) pass, regenerated/built a bridge plugin to confirm the plugin template still compiles, and `pre-commit` (clang-format) is clean.

## Version Update Label (Required)

- `need-patch-update`
