### PR TITLE
feat(agnocastlib, ros2agnocast_discovery_agent): add cross-NS daemon bridge MQ and let the discovery agent dispatch bridge requests

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -156,7 +156,8 @@ if(BUILD_TESTING)
     test/unit/test_diagnostic_updater.cpp
     test/unit/test_type_registry_writer.cpp
     test/unit/test_agnocast_generic_callback.cpp
-    test/unit/test_agnocast_generic_publisher.cpp)
+    test/unit/test_agnocast_generic_publisher.cpp
+    test/unit/test_daemon_bridge_mq.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -86,10 +86,33 @@ struct MqMsgPerformanceBridge
   bool is_service;
 };
 
+// Cross-IPC-namespace bridge request from the per-NS daemon to a same-NS
+// bridge_manager. The daemon holds no process-local factory pointers, so it
+// names the target by topic (standard mode reuses the factory the manager
+// already cached from this process's intra-NS requests) and by type
+// (performance mode resolves a plugin). QoS is sent explicitly since the
+// bridge_manager cannot query the originating endpoint's QoS on its own.
+struct MqMsgDaemonBridge
+{
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
+  BridgeDirection direction;
+  uint32_t qos_depth;
+  bool qos_is_transient_local;
+  bool qos_is_reliable;
+};
+
 constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
+constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 2;
 constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgBridge);
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
+constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;
+
+// Standard mode: one MQ per user process, `/agnocast_daemon_bridge@<pid>`.
+// Performance mode: one MQ per IPC namespace, `/agnocast_daemon_bridge_perf`.
+inline constexpr const char * DAEMON_BRIDGE_MQ_PREFIX = "/agnocast_daemon_bridge";
+inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME = "/agnocast_daemon_bridge_perf";
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -80,6 +80,10 @@ void validate_ld_preload();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);
+// Name of the MQ a per-NS daemon uses to ask a bridge_manager to create a
+// cross-NS bridge. Standard mode keys on the owning user process's pid;
+// performance mode is per-NS (see impl).
+std::string create_mq_name_for_daemon_bridge(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -15,6 +15,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <csignal>
@@ -50,6 +51,13 @@ public:
   void set_signal_handler(SignalCallback cb);
   void set_socket_handler(SocketCallback cb);
 
+  // Register a secondary MQ on this event loop (e.g. the daemon-originated
+  // cross-NS bridge request MQ). Call before `spin_once`; may be called more
+  // than once, each registration keeping its own fd-dispatched handler.
+  // Throws on failure.
+  void register_aux_mq(
+    const std::string & name, long max_messages, long msg_size, EventCallback cb);
+
   const std::string & get_mq_name() const { return mq_name_; }
 
 protected:
@@ -66,6 +74,17 @@ private:
   std::string mq_name_;
 
   long mq_msg_size_;
+
+  // One per `register_aux_mq()` call; matched by fd in `spin_once`.
+  struct AuxMq
+  {
+    mqd_t fd = (mqd_t)-1;
+    std::string name;
+    EventCallback cb;
+  };
+  // Expected to hold only a handful of entries (~5), so a flat vector is both
+  // simpler and faster to scan than a hash map would be at this size.
+  std::vector<AuxMq> aux_mqs_;
 
   EventCallback mq_cb_;
   SignalCallback signal_cb_;
@@ -146,6 +165,12 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
         handle_socket(client_fd);
         close(client_fd);
       }
+    } else {
+      auto it = std::find_if(
+        aux_mqs_.begin(), aux_mqs_.end(), [fd](const AuxMq & aux) { return fd == aux.fd; });
+      if (it != aux_mqs_.end() && it->cb) {
+        it->cb(fd);
+      }
     }
   }
   return true;
@@ -217,6 +242,34 @@ inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
 inline void IpcEventLoopBase::set_socket_handler(SocketCallback cb)
 {
   socket_cb_ = std::move(cb);
+}
+
+inline void IpcEventLoopBase::register_aux_mq(
+  const std::string & name, long max_messages, long msg_size, EventCallback cb)
+{
+  struct mq_attr attr = {};
+  attr.mq_maxmsg = max_messages;
+  attr.mq_msgsize = msg_size;
+
+  mqd_t fd =
+    mq_open(name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
+  if (fd == -1) {
+    throw std::system_error(errno, std::generic_category(), "aux MQ open failed: " + name);
+  }
+
+  try {
+    add_fd_to_epoll(fd, "AuxMQ");
+  } catch (...) {
+    if (mq_close(fd) == -1) {
+      RCLCPP_WARN(logger_, "Failed to close aux mq_fd: %s", strerror(errno));
+    }
+    if (mq_unlink(name.c_str()) == -1 && errno != ENOENT) {
+      RCLCPP_WARN(logger_, "Failed to unlink aux mq: %s", strerror(errno));
+    }
+    throw;
+  }
+
+  aux_mqs_.push_back(AuxMq{fd, name, std::move(cb)});
 }
 
 inline void IpcEventLoopBase::setup_mq()
@@ -408,6 +461,21 @@ inline void IpcEventLoopBase::cleanup_resources()
         logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
     }
   }
+
+  for (auto & aux : aux_mqs_) {
+    if (aux.fd != (mqd_t)-1) {
+      if (mq_close(aux.fd) == -1) {
+        RCLCPP_WARN_STREAM(
+          logger_,
+          "Failed to close aux mq_fd for mq_name='" << aux.name << "': " << strerror(errno));
+      }
+      if (mq_unlink(aux.name.c_str()) == -1 && errno != ENOENT) {
+        RCLCPP_WARN_STREAM(
+          logger_, "Failed to unlink aux mq for mq_name='" << aux.name << "': " << strerror(errno));
+      }
+    }
+  }
+  aux_mqs_.clear();
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -79,16 +79,33 @@ std::string create_mq_name_for_agnocast_publish(
   return create_mq_name("/agnocast", topic_name, id);
 }
 
+// MQ-name suffix that scopes the per-IPC-namespace performance bridge by domain.
+// An unset OR empty ROS_DOMAIN_ID means "no domain" (no suffix), keeping this in
+// sync with the Python discovery agent (bridge_decider._performance_mq_name).
+static std::string performance_domain_suffix()
+{
+  const char * domain_id = getenv("ROS_DOMAIN_ID");
+  if (domain_id == nullptr || *domain_id == '\0') {
+    return "";
+  }
+  return "_d" + std::string(domain_id);
+}
+
 std::string create_mq_name_for_bridge(const pid_t pid)
 {
   std::string name = "/agnocast_bridge_manager@" + std::to_string(pid);
   if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
-    const char * domain_id = getenv("ROS_DOMAIN_ID");
-    if (domain_id != nullptr) {
-      name += "_d" + std::string(domain_id);
-    }
+    name += performance_domain_suffix();
   }
   return name;
+}
+
+std::string create_mq_name_for_daemon_bridge(const pid_t pid)
+{
+  if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
+    return std::string(PERFORMANCE_DAEMON_BRIDGE_MQ_NAME) + performance_domain_suffix();
+  }
+  return std::string(DAEMON_BRIDGE_MQ_PREFIX) + "@" + std::to_string(pid);
 }
 
 uint64_t get_self_ipc_ns_inode()

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -1,0 +1,90 @@
+#include "agnocast/agnocast_mq.hpp"
+#include "agnocast/agnocast_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdlib>
+#include <string>
+
+namespace
+{
+// Restores ROS_DOMAIN_ID to its pre-test value on scope exit, so tests that
+// mutate it don't leak into later tests (the runner may start with it set).
+class ScopedRosDomainId
+{
+public:
+  ScopedRosDomainId()
+  {
+    const char * value = getenv("ROS_DOMAIN_ID");
+    if (value != nullptr) {
+      had_value_ = true;
+      old_value_ = value;
+    }
+  }
+  ~ScopedRosDomainId()
+  {
+    if (had_value_) {
+      setenv("ROS_DOMAIN_ID", old_value_.c_str(), 1);
+    } else {
+      unsetenv("ROS_DOMAIN_ID");
+    }
+  }
+
+private:
+  bool had_value_ = false;
+  std::string old_value_;
+};
+}  // namespace
+
+// The discovery daemon (Python) packs MqMsgDaemonBridge by hand, mirroring
+// this layout. These checks fail loudly if the C++ struct drifts from the
+// daemon's `_MSG_PACK_FORMAT` ('=256s256sIIBB2x', 524 bytes).
+TEST(DaemonBridgeMqTest, WireLayoutMatchesDaemonPackFormat)
+{
+  using agnocast::MqMsgDaemonBridge;
+  EXPECT_EQ(sizeof(MqMsgDaemonBridge), 524u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, topic_name), 0u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, type_name), 256u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, direction), 512u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_depth), 516u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_is_transient_local), 520u);
+  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_is_reliable), 521u);
+}
+
+TEST(DaemonBridgeMqTest, StandardMqNameIsKeyedByPid)
+{
+  EXPECT_EQ(agnocast::create_mq_name_for_daemon_bridge(4242), "/agnocast_daemon_bridge@4242");
+}
+
+TEST(DaemonBridgeMqTest, PerformanceMqNameIsPerNamespace)
+{
+  const ScopedRosDomainId guard;
+  unsetenv("ROS_DOMAIN_ID");
+  EXPECT_EQ(
+    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
+    "/agnocast_daemon_bridge_perf");
+}
+
+TEST(DaemonBridgeMqTest, PerformanceMqNameAppendsDomainId)
+{
+  const ScopedRosDomainId guard;
+  setenv("ROS_DOMAIN_ID", "7", 1);
+  EXPECT_EQ(
+    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
+    "/agnocast_daemon_bridge_perf_d7");
+}
+
+// An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix. Both
+// name builders must agree on this and with the Python agent.
+TEST(DaemonBridgeMqTest, PerformanceMqNameEmptyDomainIdHasNoSuffix)
+{
+  const ScopedRosDomainId guard;
+  setenv("ROS_DOMAIN_ID", "", 1);
+  EXPECT_EQ(
+    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
+    "/agnocast_daemon_bridge_perf");
+  EXPECT_EQ(
+    agnocast::create_mq_name_for_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
+    "/agnocast_bridge_manager@" + std::to_string(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID));
+}

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -42,6 +42,7 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastTopic,
 )
 
+from . import bridge_decider
 from .type_registry import TypeRegistryReader
 
 
@@ -291,8 +292,8 @@ class DiscoveryAgent(Node):
     """rclpy Node that publishes the local Agnocast state every PUBLISH_INTERVAL_SEC.
 
     Also subscribes to its own gossip topic and caches the latest snapshot per
-    ``(host_uuid, ipc_ns_inode)`` — exposed through ``remote_states`` for
-    future consumers (e.g. cross-NS decision logic added in a follow-up PR).
+    ``(host_uuid, ipc_ns_inode)``; each tick the bridge decider diffs that
+    against the local state and issues cross-NS bridge requests.
     """
 
     def __init__(self, registry: TypeRegistryReader | None = None):
@@ -333,7 +334,8 @@ class DiscoveryAgent(Node):
         self._registry.rebuild()
         self._registry.cleanup_dead_pids()
         self._prune_stale_remote_states()
-        self.publish_snapshot()
+        snapshot = self.publish_snapshot()
+        self._dispatch_bridge_requests(snapshot)
 
     def _prune_stale_remote_states(
             self, now_sec: float | None = None,
@@ -353,10 +355,19 @@ class DiscoveryAgent(Node):
         for key in stale_keys:
             del self._remote_states[key]
 
-    def publish_snapshot(self) -> None:
+    def publish_snapshot(self) -> AgnocastDaemonState:
         """Build and publish the current local AgnocastDaemonState."""
         msg = self.build_state()
         self._pub.publish(msg)
+        return msg
+
+    def _dispatch_bridge_requests(self, local_state: AgnocastDaemonState) -> None:
+        if not self._remote_states:
+            return
+        remote_states = {key: msg for key, (msg, _received_at) in self._remote_states.items()}
+        requests = bridge_decider.decide_bridges(local_state, remote_states)
+        if requests:
+            bridge_decider.dispatch_requests(requests, logger=self.get_logger())
 
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -1,0 +1,194 @@
+"""Decide and dispatch cross-namespace bridge requests for the discovery agent.
+
+Each tick the agent compares the local Agnocast state with the remote
+snapshots gathered over gossip. When a topic has an Agnocast endpoint locally
+and the opposite-role endpoint in another namespace, a bridge is needed here
+so the two reach each other through ROS 2 (DDS):
+
+  * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
+  * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
+
+The request is sent as ``MqMsgDaemonBridge`` to the per-namespace bridge_manager
+MQ. The struct layout is mirrored here so the daemon stays decoupled from
+libagnocast's C++ headers; ``agnocast_mq.hpp`` owns the source of truth and a
+test asserts the size stays in sync.
+"""
+
+import ctypes
+from dataclasses import dataclass
+import errno
+import os
+import struct
+from typing import Iterable, Optional
+
+TOPIC_NAME_BUFFER_SIZE = 256
+MESSAGE_TYPE_BUFFER_SIZE = 256
+
+# char topic_name[256]; char type_name[256]; uint32 direction; uint32 qos_depth;
+# bool qos_is_transient_local; bool qos_is_reliable; + 2 bytes tail padding so
+# the total matches sizeof(MqMsgDaemonBridge) == 524 on the C++ side.
+_MSG_PACK_FORMAT = '=256s256sIIBB2x'
+
+DIRECTION_ROS2_TO_AGNOCAST = 0
+DIRECTION_AGNOCAST_TO_ROS2 = 1
+
+# One bridge_manager per IPC namespace listens on this MQ.
+_PERFORMANCE_MQ_NAME = '/agnocast_daemon_bridge_perf'
+
+# librt mq_* loaded lazily to keep the daemon's deps at "rclpy + stdlib".
+_librt = None
+
+
+def _load_librt():
+    global _librt
+    if _librt is not None:
+        return _librt
+    lib = ctypes.CDLL('librt.so.1', use_errno=True)
+    lib.mq_open.argtypes = [ctypes.c_char_p, ctypes.c_int]
+    lib.mq_open.restype = ctypes.c_int
+    lib.mq_send.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint]
+    lib.mq_send.restype = ctypes.c_int
+    lib.mq_close.argtypes = [ctypes.c_int]
+    lib.mq_close.restype = ctypes.c_int
+    _librt = lib
+    return _librt
+
+
+@dataclass(frozen=True)
+class BridgeRequest:
+    topic_name: str
+    type_name: str
+    direction: int
+    qos_depth: int
+    qos_is_transient_local: bool
+    qos_is_reliable: bool
+
+
+def serialize_request(req: BridgeRequest) -> bytes:
+    topic = req.topic_name.encode('utf-8')[: TOPIC_NAME_BUFFER_SIZE - 1]
+    type_name = req.type_name.encode('utf-8')[: MESSAGE_TYPE_BUFFER_SIZE - 1]
+    return struct.pack(
+        _MSG_PACK_FORMAT,
+        topic,
+        type_name,
+        req.direction,
+        req.qos_depth,
+        1 if req.qos_is_transient_local else 0,
+        1 if req.qos_is_reliable else 0,
+    )
+
+
+def _resolve_types(local_state, remote_states) -> dict:
+    """Resolve each topic's message type, preferring local then any remote.
+
+    A bridge is deduped per ``(topic, direction)``, so its type must be resolved
+    per-topic across local + *all* remotes: the remote that supplies the
+    opposite-role endpoint may lack the type while another snapshot has it.
+    """
+    types = {t.topic_name: t.type_name for t in local_state.topics if t.type_name}
+    for remote in remote_states.values():
+        for t in remote.topics:
+            if t.type_name:
+                types.setdefault(t.topic_name, t.type_name)
+    return types
+
+
+def decide_bridges(local_state, remote_states) -> list:
+    """Return the bridge requests this namespace should issue this tick.
+
+    ``remote_states`` maps ``(host_uuid, ipc_ns_inode)`` to AgnocastDaemonState.
+    Requests are collapsed to one per ``(topic, direction)``.
+    """
+    requests = {}
+
+    local_by_topic = {t.topic_name: t for t in local_state.topics}
+    types = _resolve_types(local_state, remote_states)
+
+    for (host_uuid, ipc_ns_inode), remote in remote_states.items():
+        if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
+            continue
+        for remote_topic in remote.topics:
+            local_topic = local_by_topic.get(remote_topic.topic_name)
+            if local_topic is None:
+                continue
+
+            local_pubs = [p for p in local_topic.publishers if not p.is_bridge]
+            local_subs = [s for s in local_topic.subscribers if not s.is_bridge]
+            remote_pubs = [p for p in remote_topic.publishers if not p.is_bridge]
+            remote_subs = [s for s in remote_topic.subscribers if not s.is_bridge]
+
+            type_name = types.get(local_topic.topic_name)
+            if not type_name:
+                continue
+
+            if local_pubs and remote_subs:
+                pub = local_pubs[0]
+                key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
+                requests.setdefault(key, BridgeRequest(
+                    topic_name=local_topic.topic_name,
+                    type_name=type_name,
+                    direction=DIRECTION_AGNOCAST_TO_ROS2,
+                    qos_depth=pub.qos_depth,
+                    qos_is_transient_local=pub.qos_is_transient_local,
+                    qos_is_reliable=pub.qos_is_reliable,
+                ))
+
+            if local_subs and remote_pubs:
+                sub = local_subs[0]
+                key = (local_topic.topic_name, DIRECTION_ROS2_TO_AGNOCAST)
+                requests.setdefault(key, BridgeRequest(
+                    topic_name=local_topic.topic_name,
+                    type_name=type_name,
+                    direction=DIRECTION_ROS2_TO_AGNOCAST,
+                    qos_depth=sub.qos_depth,
+                    qos_is_transient_local=sub.qos_is_transient_local,
+                    qos_is_reliable=sub.qos_is_reliable,
+                ))
+
+    return list(requests.values())
+
+
+def _performance_mq_name() -> str:
+    name = _PERFORMANCE_MQ_NAME
+    domain_id = os.environ.get('ROS_DOMAIN_ID')
+    if domain_id:
+        name += '_d' + domain_id
+    return name
+
+
+def send_request(mq_name: str, payload: bytes) -> Optional[str]:
+    """Send ``payload`` to ``mq_name``; return an error string or None.
+
+    O_NONBLOCK keeps a full or absent queue from stalling the daemon: the
+    request is re-issued idempotently next tick.
+    """
+    lib = _load_librt()
+    fd = lib.mq_open(mq_name.encode('utf-8'), os.O_WRONLY | os.O_NONBLOCK)
+    if fd == -1:
+        err = ctypes.get_errno()
+        if err == errno.ENOENT:
+            return None
+        return f'mq_open({mq_name}): {os.strerror(err)}'
+    try:
+        if lib.mq_send(fd, payload, len(payload), 0) == -1:
+            err = ctypes.get_errno()
+            if err == errno.EAGAIN:
+                return None
+            return f'mq_send({mq_name}): {os.strerror(err)}'
+    finally:
+        lib.mq_close(fd)
+    return None
+
+
+def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
+    """Deliver each request to the per-namespace bridge_manager MQ.
+
+    The MQ is absent until a bridge_manager is up; ``send_request`` skips
+    ENOENT/EAGAIN so a missing or full queue never stalls the daemon, and the
+    request is re-issued idempotently next tick.
+    """
+    perf_mq = _performance_mq_name()
+    for req in requests:
+        err = send_request(perf_mq, serialize_request(req))
+        if err is not None and logger is not None:
+            logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -1,0 +1,184 @@
+"""Unit tests for the bridge decider.
+
+These need neither the kmod, DDS, nor a POSIX MQ: ``decide_bridges`` is pure
+logic, and the wire format is checked against the hand-built byte layout that
+mirrors ``sizeof(MqMsgDaemonBridge) == 524`` in ``agnocast_mq.hpp``.
+"""
+
+import struct
+
+from ros2agnocast_discovery_agent.bridge_decider import (
+    BridgeRequest,
+    decide_bridges,
+    DIRECTION_AGNOCAST_TO_ROS2,
+    DIRECTION_ROS2_TO_AGNOCAST,
+    dispatch_requests,
+    serialize_request,
+)
+from ros2agnocast_discovery_msgs.msg import (
+    AgnocastDaemonState,
+    AgnocastEndpoint,
+    AgnocastTopic,
+)
+
+
+def _endpoint(node, depth=10, transient=False, reliable=True, is_bridge=False):
+    ep = AgnocastEndpoint()
+    ep.node_name = node
+    ep.qos_depth = depth
+    ep.qos_is_transient_local = transient
+    ep.qos_is_reliable = reliable
+    ep.is_bridge = is_bridge
+    return ep
+
+
+def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None):
+    t = AgnocastTopic()
+    t.topic_name = name
+    t.type_name = type_name
+    t.domain_id = 0
+    t.publishers = pubs or []
+    t.subscribers = subs or []
+    return t
+
+
+def _state(host_uuid='HOST', ipc_ns=111, topics=None):
+    s = AgnocastDaemonState()
+    s.schema_version = 1
+    s.host_uuid = host_uuid
+    s.ipc_ns_inode = ipc_ns
+    s.topics = topics or []
+    return s
+
+
+def test_decide_emits_a2r_when_local_pub_remote_sub():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/pub')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/sub')])])
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].topic_name == '/x'
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].type_name == 'std_msgs/msg/Int32'
+
+
+def test_decide_emits_r2a_when_local_sub_remote_pub():
+    local = _state(topics=[_topic('/x', subs=[_endpoint('/sub')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', pubs=[_endpoint('/pub')])])
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_ROS2_TO_AGNOCAST
+
+
+def test_decide_emits_both_directions_when_both_sides_have_both():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], subs=[_endpoint('/ls')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', pubs=[_endpoint('/rp')], subs=[_endpoint('/rs')])])
+
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    directions = sorted(r.direction for r in reqs)
+    assert directions == sorted([DIRECTION_ROS2_TO_AGNOCAST, DIRECTION_AGNOCAST_TO_ROS2])
+
+
+def test_decide_skips_bridge_only_endpoints():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp', is_bridge=True)])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/rs')])])
+
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_skips_self_namespace():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], subs=[_endpoint('/ls')])])
+    assert decide_bridges(local, {('HOST', 111): local}) == []
+
+
+def test_decide_skips_when_no_topic_overlap():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/y', subs=[_endpoint('/rs')])])
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_skips_when_type_unknown_on_both_sides():
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', type_name='', subs=[_endpoint('/rs')])])
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_uses_remote_type_when_local_missing():
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', type_name='std_msgs/msg/String',
+                                   subs=[_endpoint('/rs')])])
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].type_name == 'std_msgs/msg/String'
+
+
+def test_decide_uses_type_from_other_remote_when_matching_remote_missing():
+    # The remote that supplies the opposite-role endpoint (sub) has no type,
+    # but another remote snapshot for the same topic does -> still bridged.
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')])])
+    remote_sub = _state(host_uuid='A', ipc_ns=1,
+                        topics=[_topic('/x', type_name='', subs=[_endpoint('/rs')])])
+    remote_type = _state(host_uuid='B', ipc_ns=2,
+                         topics=[_topic('/x', type_name='std_msgs/msg/String')])
+
+    reqs = decide_bridges(local, {('A', 1): remote_sub, ('B', 2): remote_type})
+    assert len(reqs) == 1
+    assert reqs[0].type_name == 'std_msgs/msg/String'
+
+
+def test_decide_skips_when_only_same_role_present():
+    # Topic matches but the opposite-role peer is absent (both sides only
+    # publish, no subscriber anywhere) -> nothing to bridge.
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', pubs=[_endpoint('/rp')])])
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_collapses_duplicates_across_remotes():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
+    remote_a = _state(host_uuid='A', ipc_ns=1, topics=[_topic('/x', subs=[_endpoint('/sa')])])
+    remote_b = _state(host_uuid='B', ipc_ns=2, topics=[_topic('/x', subs=[_endpoint('/sb')])])
+
+    reqs = decide_bridges(local, {('A', 1): remote_a, ('B', 2): remote_b})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+
+
+def test_serialize_matches_cpp_struct_size():
+    req = BridgeRequest('/x', 'std_msgs/msg/Int32', DIRECTION_AGNOCAST_TO_ROS2,
+                        10, False, True)
+    assert len(serialize_request(req)) == 524
+
+
+def test_serialize_nul_terminates_truncated_topic():
+    req = BridgeRequest('/' + 'a' * 1000, 'T', DIRECTION_AGNOCAST_TO_ROS2, 10, False, True)
+    assert serialize_request(req)[255] == 0
+
+
+def test_serialize_packs_direction_qos_at_expected_offsets():
+    req = BridgeRequest('/x', 'T', DIRECTION_ROS2_TO_AGNOCAST, 7, True, True)
+    payload = serialize_request(req)
+    direction, depth = struct.unpack_from('=II', payload, 512)
+    transient, reliable = struct.unpack_from('=BB', payload, 520)
+    assert (direction, depth, transient, reliable) == (DIRECTION_ROS2_TO_AGNOCAST, 7, 1, 1)
+
+
+def test_dispatch_targets_per_namespace_mq(monkeypatch):
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+
+    req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
+    dispatch_requests([req])
+
+    assert all(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
+    assert len(sent) == 1


### PR DESCRIPTION
## Description

Auto-generate bridges between Agnocast endpoints that live in different **IPC namespaces** (or ECUs). This PR adds the shared plumbing plus the discovery agent that drives it (how it decides whether to make a request and how it sends it); the per-NS `bridge_manager` that acts on the requests is in the stacked PR.

Each per-NS discovery agent compares its local Agnocast state against the remote gossip snapshots. When a topic has a local endpoint whose opposite-role peer lives in another namespace, the agent asks the `bridge_manager` in its namespace to build the matching half of the relay:

- local **publisher** + remote **subscriber** → an **A2R** bridge (Agnocast → DDS)
- local **subscriber** + remote **publisher** → an **R2A** bridge (DDS → Agnocast)

Each namespace builds only its own half; the halves connect over DDS (e.g. NS-A's A2R → DDS → NS-B's R2A), so the two endpoints reach each other.

Changes:

- **agnocastlib**: a new agent→manager request `MqMsgDaemonBridge` on its own MQ (`create_mq_name_for_daemon_bridge`), which the bridge event loop can also listen on (`register_aux_mq`).
- **ros2agnocast_discovery_agent**: `bridge_decider` computes the needed requests each tick and dispatches `MqMsgDaemonBridge` to the per-NS `bridge_manager` MQ.

**Scope:** the request path targets the per-NS (performance) `bridge_manager`. The standard `bridge_manager` is intentionally not wired: the standard bridge is planned to be unified into the per-NS (performance) bridge. See the design link below.

This reuses the existing factory mechanism; additive only — no existing ABI changes, kmod untouched.

## Related links

- Cross-namespace bridge design (TIER IV internal link): https://tier4.atlassian.net/wiki/x/2YFtNwE
- Architecture overview (TIER IV internal link): https://tier4.atlassian.net/wiki/x/fIDcMwE
- Preceded by #1388 (bridge `request`→`registration` rename, merged into main)

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A, kmod untouched
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **Unit tests**: `bridge_decider` pytest (direction/role logic, dedup, type fallback, wire format, per-NS MQ dispatch) and a C++ test pinning the `MqMsgDaemonBridge` wire layout (`sizeof == 524`, field offsets) to the agent's Python `struct` format. `agnocastlib` gtest and the discovery-agent pytest pass.
- The end-to-end cross-NS behavior is exercised together with the stacked performance-manager PR.

## Version Update Label (Required)

- `need-patch-update`
