### PR TITLE
feat(agnocastlib): handle daemon cross-NS bridge requests in performance mode

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -68,7 +68,11 @@ struct MqMsgDaemonBridge
 };
 
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
-constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 2;
+// The discovery agent bursts one request per (cross-NS topic, direction) each tick,
+// so a shallow queue would throttle startup convergence to a few bridges per second.
+// The bridge_manager already opens the 256-deep performance MQ, so matching it needs
+// no extra fs.mqueue.msg_max headroom.
+constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 256;
 constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
 constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -5,6 +5,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -16,6 +17,28 @@ namespace agnocast
 {
 
 enum class BridgeMode { Off, On };
+
+// How long a daemon cross-NS bridge request keeps a bridge forced after the last
+// request. Must exceed the daemon's publish interval (1 s) so a few missed ticks
+// don't tear down a healthy cross-NS bridge, yet stay short so a vanished remote
+// endpoint stops being forced promptly.
+inline constexpr std::chrono::seconds DAEMON_FORCE_TTL{5};
+
+// A daemon-forced lease registered at `now` lasts until `now + DAEMON_FORCE_TTL`,
+// and is active while the current time is strictly before that deadline — i.e. the
+// half-open window [registered, registered + DAEMON_FORCE_TTL). Factored out of the
+// bridge manager so the lease/TTL boundary is unit-testable with an injected clock.
+inline std::chrono::steady_clock::time_point daemon_force_deadline(
+  const std::chrono::steady_clock::time_point now)
+{
+  return now + DAEMON_FORCE_TTL;
+}
+inline bool is_daemon_force_active(
+  const std::chrono::steady_clock::time_point deadline,
+  const std::chrono::steady_clock::time_point now)
+{
+  return now < deadline;
+}
 
 struct SubscriberCountResult
 {
@@ -32,6 +55,10 @@ struct PublisherCountResult
 BridgeMode get_bridge_mode();
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id);
 rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t publisher_id);
+// Rebuild a QoS profile from the fields a daemon cross-NS request carries. The
+// daemon has no local endpoint to query, so reliability / durability / depth are
+// reconstructed from the request rather than from the kernel.
+rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req);
 PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name);
 SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_name);
 bool update_ros2_subscriber_num(const rclcpp::Node * node, const std::string & topic_name);

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -7,6 +7,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -26,6 +27,18 @@ public:
 
 private:
   using RequestMap = std::unordered_map<topic_local_id_t, MqMsgPerformanceBridge>;
+
+  // A cross-NS bridge request from the per-NS daemon. Unlike an intra-NS request,
+  // there is no local endpoint to resolve the plugin / QoS from, so the type and
+  // QoS travel in the request itself. While unexpired, the bridge is created
+  // without a same-graph DDS counterpart (the peer NS's bridge creates it) and is
+  // shielded from demand-based teardown.
+  struct DaemonForcedRequest
+  {
+    std::string message_type;
+    rclcpp::QoS qos;
+    std::chrono::steady_clock::time_point forced_until;
+  };
 
   struct R2AServiceBridgeItem
   {
@@ -54,13 +67,25 @@ private:
   std::unordered_map<std::string, PerformancePubsubBridgeResult> active_pubsub_a2r_bridges_;
   std::unordered_map<std::string, RequestMap> request_cache_;
 
+  // Daemon-forced cross-NS requests, keyed by topic, split by direction.
+  std::unordered_map<std::string, DaemonForcedRequest> daemon_forced_r2a_;
+  std::unordered_map<std::string, DaemonForcedRequest> daemon_forced_a2r_;
+
   std::unordered_map<std::string, R2AServiceBridgeItem> active_r2a_service_bridges_;
 
   void start_ros_execution();
 
   void on_mq_request(int fd);
+  void on_daemon_mq_request(int fd);
   void on_signal();
   std::string on_socket_request() const;
+
+  void register_daemon_pubsub_request(const MqMsgDaemonBridge & req);
+  bool is_daemon_forced(const std::string & topic_name, BridgeDirection direction) const;
+  void create_daemon_forced_bridges();
+  void activate_daemon_forced_bridge(
+    const std::string & topic_name, const std::string & message_type, const rclcpp::QoS & qos,
+    bool is_r2a);
 
   void check_and_create_pubsub_bridges();
   void check_and_remove_pubsub_bridges();

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -82,6 +82,17 @@ rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t p
                                                     : rclcpp::DurabilityPolicy::Volatile);
 }
 
+rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req)
+{
+  return rclcpp::QoS(req.qos_depth)
+    .durability(
+      req.qos_is_transient_local ? rclcpp::DurabilityPolicy::TransientLocal
+                                 : rclcpp::DurabilityPolicy::Volatile)
+    .reliability(
+      req.qos_is_reliable ? rclcpp::ReliabilityPolicy::Reliable
+                          : rclcpp::ReliabilityPolicy::BestEffort);
+}
+
 SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_name)
 {
   union ioctl_get_subscriber_num_args args = {};

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -58,6 +58,10 @@ void PerformanceBridgeManager::run()
   event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
+  // One bridge manager runs per IPC namespace, so its daemon request MQ is per-NS too.
+  event_loop_.register_aux_mq(
+    create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID), DAEMON_BRIDGE_MQ_MAX_MESSAGES,
+    DAEMON_BRIDGE_MQ_MESSAGE_SIZE, [this](int fd) { this->on_daemon_mq_request(fd); });
 
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
@@ -66,6 +70,7 @@ void PerformanceBridgeManager::run()
     }
 
     check_and_create_pubsub_bridges();
+    create_daemon_forced_bridges();
     check_and_remove_pubsub_bridges();
     check_and_remove_service_bridges();
     check_and_remove_request_cache();
@@ -122,6 +127,107 @@ void PerformanceBridgeManager::on_mq_request(int fd)
 
     create_pubsub_bridge_if_needed(
       topic_name, request_cache_[topic_name], message_type, msg.direction);
+  }
+}
+
+void PerformanceBridgeManager::on_daemon_mq_request(int fd)
+{
+  MqMsgDaemonBridge req{};
+  while (!shutdown_requested_) {
+    ssize_t bytes_read = mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr);
+    if (bytes_read < 0) {
+      // EAGAIN just means the queue is drained; anything else is unexpected and
+      // would otherwise silently drop a daemon bridge request.
+      if (errno != EAGAIN) {
+        RCLCPP_WARN_STREAM(
+          logger_, "mq_receive failed for daemon bridge mq (fd=" << fd << "): " << strerror(errno));
+      }
+      break;
+    }
+    register_daemon_pubsub_request(req);
+  }
+}
+
+void PerformanceBridgeManager::register_daemon_pubsub_request(const MqMsgDaemonBridge & req)
+{
+  const std::string topic_name = static_cast<const char *>(req.topic_name);
+  const std::string message_type = static_cast<const char *>(req.type_name);
+
+  const auto forced_until = daemon_force_deadline(std::chrono::steady_clock::now());
+  auto & forced =
+    (req.direction == BridgeDirection::ROS2_TO_AGNOCAST) ? daemon_forced_r2a_ : daemon_forced_a2r_;
+  forced.insert_or_assign(
+    topic_name, DaemonForcedRequest{message_type, daemon_request_qos(req), forced_until});
+}
+
+bool PerformanceBridgeManager::is_daemon_forced(
+  const std::string & topic_name, BridgeDirection direction) const
+{
+  const auto & forced =
+    (direction == BridgeDirection::ROS2_TO_AGNOCAST) ? daemon_forced_r2a_ : daemon_forced_a2r_;
+  const auto it = forced.find(topic_name);
+  return it != forced.end() &&
+         is_daemon_force_active(it->second.forced_until, std::chrono::steady_clock::now());
+}
+
+void PerformanceBridgeManager::create_daemon_forced_bridges()
+{
+  for (const bool is_r2a : {true, false}) {
+    auto & forced = is_r2a ? daemon_forced_r2a_ : daemon_forced_a2r_;
+    for (auto it = forced.begin(); it != forced.end();) {
+      const std::string & topic_name = it->first;
+
+      // Lease expired: drop the force and let the normal on-demand lifecycle resume.
+      if (std::chrono::steady_clock::now() >= it->second.forced_until) {
+        it = forced.erase(it);
+        continue;
+      }
+
+      const bool already_active = is_r2a ? active_pubsub_r2a_bridges_.count(topic_name) > 0
+                                         : active_pubsub_a2r_bridges_.count(topic_name) > 0;
+      // The same-graph DDS counterpart check is skipped while forced, but a live
+      // local Agnocast endpoint is still required for the bridge to carry traffic.
+      const auto count = is_r2a ? get_agnocast_subscriber_count(topic_name).count
+                                : get_agnocast_publisher_count(topic_name).count;
+      if (!already_active && count > 0) {
+        activate_daemon_forced_bridge(topic_name, it->second.message_type, it->second.qos, is_r2a);
+      }
+      ++it;
+    }
+  }
+}
+
+void PerformanceBridgeManager::activate_daemon_forced_bridge(
+  const std::string & topic_name, const std::string & message_type, const rclcpp::QoS & qos,
+  bool is_r2a)
+{
+  try {
+    PerformancePubsubBridgeResult result =
+      is_r2a ? loader_.create_r2a_pubsub_bridge(container_node_, topic_name, message_type, qos)
+             : loader_.create_a2r_pubsub_bridge(container_node_, topic_name, message_type, qos);
+    if (!result.entity_handle) {
+      return;
+    }
+
+    if (is_r2a) {
+      if (!update_ros2_publisher_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_r2a_bridges_[topic_name] = result;
+    } else {
+      if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
+        RCLCPP_ERROR(
+          logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
+      }
+      active_pubsub_a2r_bridges_[topic_name] = result;
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      logger_, "Failed to create daemon-forced bridge for '%s': %s", topic_name.c_str(), e.what());
+  } catch (...) {
+    RCLCPP_WARN(
+      logger_, "Unknown error creating daemon-forced bridge for '%s'", topic_name.c_str());
   }
 }
 
@@ -187,7 +293,10 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
       return;
     }
 
-    if (result.count <= 0 || !is_demanded_by_ros2) {
+    // A daemon-forced cross-NS bridge is kept alive without a same-graph DDS
+    // counterpart; only a vanished local Agnocast endpoint (count <= 0) removes it.
+    const bool keep_forced = is_daemon_forced(topic_name, BridgeDirection::ROS2_TO_AGNOCAST);
+    if (result.count <= 0 || (!is_demanded_by_ros2 && !keep_forced)) {
       if (r2a_it->second.callback_group) {
         executor_->stop_callback_group(r2a_it->second.callback_group);
       }
@@ -217,7 +326,8 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
       return;
     }
 
-    if (result.count <= 0 || !is_demanded_by_ros2) {
+    const bool keep_forced = is_daemon_forced(topic_name, BridgeDirection::AGNOCAST_TO_ROS2);
+    if (result.count <= 0 || (!is_demanded_by_ros2 && !keep_forced)) {
       if (a2r_it->second.callback_group) {
         executor_->stop_callback_group(a2r_it->second.callback_group);
       }

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -1,8 +1,10 @@
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdlib>
 #include <string>
@@ -87,4 +89,65 @@ TEST(DaemonBridgeMqTest, PerformanceMqNameEmptyDomainIdHasNoSuffix)
   EXPECT_EQ(
     agnocast::create_mq_name_for_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
     "/agnocast_bridge_manager@" + std::to_string(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID));
+}
+
+// Performance-mode daemon bridges have no local endpoint to query, so the QoS
+// must be rebuilt faithfully from the request's explicit fields.
+TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
+{
+  agnocast::MqMsgDaemonBridge req{};
+  req.qos_depth = 10;
+  req.qos_is_reliable = true;
+  req.qos_is_transient_local = true;
+
+  const rclcpp::QoS qos = agnocast::daemon_request_qos(req);
+  EXPECT_EQ(qos.depth(), 10u);
+  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+}
+
+TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
+{
+  agnocast::MqMsgDaemonBridge req{};
+  req.qos_depth = 1;
+  req.qos_is_reliable = false;
+  req.qos_is_transient_local = false;
+
+  const rclcpp::QoS qos = agnocast::daemon_request_qos(req);
+  EXPECT_EQ(qos.depth(), 1u);
+  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::BestEffort);
+  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+}
+
+// The daemon-forced lease (used by the performance bridge_manager to keep a
+// cross-NS bridge alive without a same-graph DDS counterpart) is active for the
+// half-open window [registered, registered + DAEMON_FORCE_TTL).
+TEST(DaemonBridgeMqTest, DaemonForceLeaseWindowIsHalfOpen)
+{
+  const std::chrono::steady_clock::time_point t0{};
+  const auto deadline = agnocast::daemon_force_deadline(t0);
+
+  // The lease lasts exactly DAEMON_FORCE_TTL.
+  EXPECT_EQ(deadline - t0, agnocast::DAEMON_FORCE_TTL);
+
+  EXPECT_TRUE(agnocast::is_daemon_force_active(deadline, t0));  // just registered
+  EXPECT_TRUE(agnocast::is_daemon_force_active(
+    deadline, t0 + agnocast::DAEMON_FORCE_TTL - std::chrono::milliseconds(1)));  // within
+  // Boundary: the window is half-open, so the exact deadline is already expired.
+  EXPECT_FALSE(agnocast::is_daemon_force_active(deadline, t0 + agnocast::DAEMON_FORCE_TTL));
+  EXPECT_FALSE(agnocast::is_daemon_force_active(
+    deadline, t0 + agnocast::DAEMON_FORCE_TTL + std::chrono::seconds(1)));  // after
+}
+
+// Re-asserting the request (the daemon does so every tick) pushes the deadline
+// out, so a continuously-requested bridge never lapses.
+TEST(DaemonBridgeMqTest, DaemonForceLeaseRenewalExtendsDeadline)
+{
+  const std::chrono::steady_clock::time_point t0{};
+  const auto first = agnocast::daemon_force_deadline(t0);
+  const auto renewed = agnocast::daemon_force_deadline(t0 + std::chrono::seconds(1));
+
+  EXPECT_GT(renewed, first);
+  // Still active at the original deadline because it was renewed before lapsing.
+  EXPECT_TRUE(agnocast::is_daemon_force_active(renewed, first));
 }


### PR DESCRIPTION
## Description

Make the `bridge_manager` (one per IPC namespace) act on the cross-NS bridge requests dispatched by the discovery agent. With this, cross-NS (and cross-ECU) bridges are auto-generated.

Changes:

- **agnocastlib**: the `bridge_manager` now also listens on its per-NS daemon MQ (`/agnocast_daemon_bridge_perf`) for `MqMsgDaemonBridge` requests.
  - **What `bridge_manager` already does:** it builds and keeps a bridge for a topic only when it sees a *local* DDS counterpart — i.e. demand-driven from what's visible in its own namespace.
  - **When the agent sends a request to `bridge_manager`:** the agent does so when it sees the counterpart outside its namespace — e.g. NS-A (namespace-A) has an Agnocast subscriber and NS-B an Agnocast publisher. (Without this PR, no bridge will be created in this case.) The local counterpart can't exist until the peer namespace's bridge is up too (chicken-and-egg), so while a request keeps coming the `bridge_manager` creates and keeps the bridge *without* one. It keeps the bridge as long as the agent keeps sending the request, and drops it shortly after the agent stops (after `DAEMON_FORCE_TTL`, which must outlast the agent's publish interval).
  - The `bridge_manager` has no process-local factory, so it resolves the bridge from the request's **message type** (plugin) and rebuilds its QoS from the request's explicit fields (`daemon_request_qos`).
  - Sizes the daemon request MQ (`DAEMON_BRIDGE_MQ_MAX_MESSAGES = 256`, matching the performance MQ) so a startup burst of requests is absorbed in one tick instead of trickling in at the queue depth per second.

Additive only; no existing ABI changes, kmod untouched.

## Related links

- Cross-namespace bridge design (TIER IV internal link): https://tier4.atlassian.net/wiki/x/2YFtNwE
- Architecture overview (TIER IV internal link): https://tier4.atlassian.net/wiki/x/fIDcMwE

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A, kmod untouched
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **Unit tests** (`agnocastlib` gtest, incl. the `MqMsgDaemonBridge` wire-layout cases plus two new cases pinning `daemon_request_qos` — the QoS rebuilt from the request's explicit depth / reliability / durability fields). All pass.
- **Manual cross-NS test** — **confirmed PASS**: listener in IPC ns B received the talker (IPC ns A) via the auto-generated bridge. The bridge needs a one-time setup step first — it does not work by default (see [#1386](https://github.com/autowarefoundation/agnocast/issues/1386)): generate the bridge plugin for the topic's type, then run talker/listener in separate IPC namespaces:

  ```bash
  # source this workspace first; local_setup.bash avoids pulling in other overlays (e.g. autoware)
  source /opt/ros/humble/setup.bash && source install/local_setup.bash
  ros2 agnocast generate-bridge-plugins --message-types agnocast_sample_interfaces/msg/DynamicSizeArray
  colcon build --packages-select agnocast_bridge_plugins && source install/local_setup.bash

  # talker (ns A) and listener (ns B), each in its own shell:
  sudo unshare --ipc bash -c 'sysctl -w fs.mqueue.msg_max=1024 >/dev/null; source install/setup.bash; \
    ros2 launch agnocast_sample_application talker.launch.xml discovery_agent:=true'
  sudo unshare --ipc bash -c 'sysctl -w fs.mqueue.msg_max=1024 >/dev/null; source install/setup.bash; \
    ros2 launch agnocast_sample_application listener.launch.xml discovery_agent:=true'
  ```

  Expected: within a few seconds the listener prints `subscribe message: id=N` (with `discovery_agent:=false`, nothing).

## Version Update Label (Required)

- `need-patch-update`
