### PR TITLE
fix(agnocastlib): terminate standard bridge_manager when its parent exits

### DIFF
--- a/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/standard/agnocast_standard_bridge_manager.cpp
@@ -72,6 +72,21 @@ void StandardBridgeManager::run()
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
 
+  // The standard bridge_manager exists only to serve its parent Agnocast
+  // process, so it must terminate when that parent exits. Ask the kernel to
+  // deliver SIGTERM when the parent dies; the event loop's signalfd turns that
+  // into a graceful shutdown via on_signal(). Without this the manager is
+  // reparented to init and lingers, leaking its process and POSIX message
+  // queues (which keep consuming the per-user RLIMIT_MSGQUEUE budget).
+  if (prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0) != 0) {
+    RCLCPP_WARN(logger_, "PR_SET_PDEATHSIG failed: %s", strerror(errno));
+  }
+  // Close the fork()/prctl() race: if the parent already exited before the
+  // death signal was armed, PR_SET_PDEATHSIG never fires, so check explicitly.
+  if (kill(target_pid_, 0) != 0) {
+    shutdown_requested_ = true;
+  }
+
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
       break;


### PR DESCRIPTION
## Description

The Agnocast process forks its `bridge_manager` in standard mode. The `bridge_manager` becomes orphaned once it has created any service bridge(s) (e.g. for parameter services): it still holds an active service bridge, and its self-exit check only fires when the parent is gone *and* no bridge is active, so it never exits when the Agnocast process dies.

The orphaned `bridge_manager` keeps holding its POSIX message queues, consuming the per-user RLIMIT_MSGQUEUE budget, which intermittently times out `test_integration_agnocast_node_agnocastlib` (which is the part of `scripts/test/run_requires_kernel_module_tests.bash`).

This PR sets `PR_SET_PDEATHSIG(SIGTERM)` in the standard `bridge_manager` so the kernel signals it when the parent (the Agnocast process) dies; the event loop's signalfd turns that into a graceful shutdown. A `kill(target_pid_, 0)` check covers the `fork()`/`prctl()` race. The performance `bridge_manager` is per-IPC-namespace and intentionally outlives any single process, so it is left unchanged.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A, kmod untouched
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- Before: one `test_integration_agnocast_node_agnocastlib` run leaks 2 orphaned `agno_br_*` processes (reparented to `init`, surviving indefinitely).
- After: the same run leaves **0** orphans, and `run_requires_kernel_module_tests.bash` passes reliably (3/3 clean runs). `agnocastlib` unit tests pass (283/283).

## Version Update Label (Required)

- `need-patch-update`
