### PR TITLE
feat(agnocastlib): add `agnocast::GenericSubscription`

### DIFF
--- a/scripts/sample_application/run_generic_listener.bash
+++ b/scripts/sample_application/run_generic_listener.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source install/setup.bash
+ros2 launch agnocast_sample_application generic_listener.launch.xml

--- a/src/agnocast_sample_application/CMakeLists.txt
+++ b/src/agnocast_sample_application/CMakeLists.txt
@@ -116,6 +116,24 @@ install(TARGETS agnocast_listener_component
         RUNTIME DESTINATION bin
 )
 
+add_library(agnocast_generic_listener_component SHARED src/minimal_generic_subscriber.cpp)
+ament_target_dependencies(agnocast_generic_listener_component rclcpp rclcpp_components agnocastlib agnocast_sample_interfaces)
+target_include_directories(agnocast_generic_listener_component PRIVATE ${agnocastlib_INCLUDE_DIRS})
+
+agnocast_components_register_node(
+  agnocast_generic_listener_component
+  PLUGIN "MinimalGenericSubscriber"
+  EXECUTABLE generic_listener
+)
+
+ament_export_targets(export_agnocast_generic_listener_component)
+install(TARGETS agnocast_generic_listener_component
+        EXPORT export_agnocast_generic_listener_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+)
+
 ament_export_targets(export_agnocast_cie_listener_component)
 install(TARGETS agnocast_cie_listener_component
         EXPORT export_agnocast_cie_listener_component

--- a/src/agnocast_sample_application/launch/generic_listener.launch.xml
+++ b/src/agnocast_sample_application/launch/generic_listener.launch.xml
@@ -1,0 +1,18 @@
+<launch>
+    <!--
+      `discovery_agent` arg controls whether the per-IPC-namespace Agnocast
+      discovery agent is spawned alongside the listener. Exactly one daemon
+      should run per IPC namespace; set this to false when including this
+      launch from another launch that already spawns the daemon.
+    -->
+    <arg name="discovery_agent" default="false"/>
+    <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
+             if="$(var discovery_agent)"/>
+
+    <node_container pkg="agnocast_components" exec="agnocast_component_container" name="generic_listener_container" namespace="" output="screen">
+      <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
+
+      <composable_node pkg="agnocast_sample_application" plugin="MinimalGenericSubscriber" name="generic_listener_node" namespace="">
+      </composable_node>
+    </node_container>
+</launch>

--- a/src/agnocast_sample_application/src/minimal_generic_subscriber.cpp
+++ b/src/agnocast_sample_application/src/minimal_generic_subscriber.cpp
@@ -1,0 +1,39 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/msg/dynamic_size_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+
+using std::placeholders::_1;
+
+class MinimalGenericSubscriber : public rclcpp::Node
+{
+  agnocast::GenericSubscription::SharedPtr sub_;
+
+  void callback(std::shared_ptr<rclcpp::SerializedMessage> serialized_msg)
+  {
+    rclcpp::Serialization<agnocast_sample_interfaces::msg::DynamicSizeArray> serializer;
+    agnocast_sample_interfaces::msg::DynamicSizeArray msg;
+    serializer.deserialize_message(serialized_msg.get(), &msg);
+
+    RCLCPP_INFO(this->get_logger(), "subscribe message: id=%ld", msg.id);
+  }
+
+public:
+  explicit MinimalGenericSubscriber(const rclcpp::NodeOptions & options)
+  : Node("minimal_generic_subscriber", options)
+  {
+    rclcpp::CallbackGroup::SharedPtr group =
+      create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    agnocast::SubscriptionOptions agnocast_options;
+    agnocast_options.callback_group = group;
+
+    sub_ = agnocast::create_generic_subscription(
+      this, "/my_topic", "agnocast_sample_interfaces/msg/DynamicSizeArray", 1,
+      std::bind(&MinimalGenericSubscriber::callback, this, _1), agnocast_options);
+  }
+};
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(MinimalGenericSubscriber)

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rmw REQUIRED)
 find_package(tracetools REQUIRED)
 find_package(LTTngUST REQUIRED)
 find_package(agnocast_cie_config_msgs REQUIRED)
@@ -53,7 +55,7 @@ add_library(agnocast SHARED
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
   src/node/diagnostic_updater/diagnostic_updater.cpp)
 
-ament_target_dependencies(agnocast rclcpp agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater)
+ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater)
 
 target_link_libraries(agnocast
   ${rcl_yaml_param_parser_LIBRARIES}

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -134,6 +134,7 @@ if(BUILD_TESTING)
   find_package(std_msgs REQUIRED)
 
   # Unit tests
+  find_package(rosidl_typesupport_cpp REQUIRED)
   ament_add_gmock(test_unit_${PROJECT_NAME}
     test/unit/test_agnocast_utils.cpp
     test/unit/test_agnocast_subscription.cpp
@@ -150,10 +151,11 @@ if(BUILD_TESTING)
     test/unit/test_cie_client_utils.cpp
     test/unit/test_agnocast_context.cpp
     test/unit/test_diagnostic_updater.cpp
-    test/unit/test_type_registry_writer.cpp)
+    test/unit/test_type_registry_writer.cpp
+    test/unit/test_agnocast_generic_callback.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
-  ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater)
+  ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)
   set_tests_properties(test_unit_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )
@@ -291,6 +293,19 @@ if(BUILD_TESTING)
   set_tests_properties(test_integration_agnocast_init_ok_shutdown_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
     TIMEOUT 120
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
+  # GenericSubscription integration test (requires kernel module, no mock)
+  ament_add_gmock(test_integration_generic_subscription_${PROJECT_NAME}
+    test/integration/test_agnocast_generic_subscription.cpp)
+  target_include_directories(test_integration_generic_subscription_${PROJECT_NAME} PRIVATE include)
+  target_link_libraries(test_integration_generic_subscription_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_generic_subscription_${PROJECT_NAME}
+    std_msgs rosidl_typesupport_cpp)
+  set_tests_properties(test_integration_generic_subscription_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
     LABELS "requires_kernel_module;requires_heaphook"
   )
 

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -190,6 +190,57 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
     node, topic_name, qos);
 }
 
+/// @brief Create an Agnocast generic subscription (Stage 1 free function, QoS overload).
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @tparam Func Callable accepting a serialized message, e.g. `void(std::shared_ptr<const
+/// rclcpp::SerializedMessage>)`.
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param topic_type Message type string.
+/// @param qos Quality of service profile.
+/// @param callback Callback invoked on each received message.
+/// @param options Subscription options.
+/// @return Shared pointer to the created generic subscription.
+AGNOCAST_PUBLIC
+template <typename NodeT, typename Func>
+GenericSubscription::SharedPtr create_generic_subscription(
+  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, Func && callback,
+  agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<GenericSubscription>(
+    node, topic_name, topic_type, qos, std::forward<Func>(callback), options);
+}
+
+/// @brief Create an Agnocast generic subscription (Stage 1 free function, history-depth overload).
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @tparam Func Callable accepting a serialized message, e.g. `void(std::shared_ptr<const
+/// rclcpp::SerializedMessage>)`.
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param topic_type Message type string.
+/// @param qos_history_depth History depth for the QoS profile.
+/// @param callback Callback invoked on each received message.
+/// @param options Subscription options.
+/// @return Shared pointer to the created generic subscription.
+AGNOCAST_PUBLIC
+template <typename NodeT, typename Func>
+GenericSubscription::SharedPtr create_generic_subscription(
+  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+  const size_t qos_history_depth, Func && callback,
+  agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<GenericSubscription>(
+    node, topic_name, topic_type, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
+    std::forward<Func>(callback), options);
+}
+
 /// @brief Create an Agnocast service client (Stage 1 free function).
 /// @tparam ServiceT ROS service type.
 /// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -111,7 +111,7 @@ TypeErasedCallback get_erased_callback(Func && callback)
   };
 }
 
-// Serialize directly into an existing stack-allocated SerializedMessage to avoid heap allocation.
+// Serialize raw message data into a SerializedMessage.
 // Returns false (and logs an error) on rmw_serialize failure.
 bool generic_serialize_message_in_place(
   const void * raw, const rosidl_message_type_support_t * type_support,
@@ -126,7 +126,7 @@ TypeErasedCallback get_erased_generic_callback(
     std::is_invocable_v<F, std::shared_ptr<rclcpp::SerializedMessage>> ||
       std::is_invocable_v<F, std::unique_ptr<rclcpp::SerializedMessage>> ||
       std::is_invocable_v<F, rclcpp::SerializedMessage &>,
-    "This callback type cannot be handled as a GenericCallback."
+    "This callback type cannot be handled as a GenericCallback. "
     "Callback must be invocable with one of the following arguments "
     "(or any types implicitly convertible from them, e.g., const variants): "
     "std::unique_ptr<rclcpp::SerializedMessage>, "
@@ -161,7 +161,6 @@ TypeErasedCallback get_erased_generic_callback(
       }
       callback(std::move(serialized));
     } else {
-      // Use a stack-allocated SerializedMessage to avoid heap allocation.
       rclcpp::SerializedMessage serialized;
       if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, serialized)) {
         return;

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -4,7 +4,11 @@
 #include "agnocast/agnocast_epoll_update_dispatcher.hpp"
 #include "agnocast/agnocast_smart_pointer.hpp"
 
+#include <rclcpp/serialized_message.hpp>
+
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <type_traits>
 
@@ -40,8 +44,33 @@ public:
   agnocast::ipc_shared_ptr<T> && get() && { return std::move(ptr_); }
 };
 
+// Class for a generic message type used by GenericSubscription.
+class RawMessagePtr : public AnyObject
+{
+  // We use std::byte for ipc_shared_ptr because the exact message type is unknown
+  // at compile time in GenericSubscription.
+  //
+  // This is safe because this pointer purely references a subscribed message.
+  // It does not handle memory allocation or deallocation (no delete is called);
+  // it strictly manages the reference count and releases the reference to the
+  // kernel module. (See ipc_shared_ptr implementation for details).
+  agnocast::ipc_shared_ptr<std::byte> ptr_;
+
+public:
+  explicit RawMessagePtr(agnocast::ipc_shared_ptr<std::byte> p) : ptr_(std::move(p)) {}
+
+  const std::type_info & type() const override { return typeid(RawMessagePtr); }
+
+  agnocast::ipc_shared_ptr<std::byte> && get() && { return std::move(ptr_); }
+};
+
 // Type for type-erased callback function
 using TypeErasedCallback = std::function<void(AnyObject &&)>;
+
+// Type for message creator function that constructs a type-erased message
+// envelope (AnyObject) from a raw shared-memory pointer and its metadata.
+using MessageCreator = std::function<std::unique_ptr<AnyObject>(
+  const void *, const std::string &, const topic_local_id_t, const int64_t)>;
 
 struct CallbackInfo
 {
@@ -51,9 +80,7 @@ struct CallbackInfo
   mqd_t mqdes;
   rclcpp::CallbackGroup::SharedPtr callback_group;
   TypeErasedCallback callback;
-  std::function<std::unique_ptr<AnyObject>(
-    const void *, const std::string &, const topic_local_id_t, const uint64_t)>
-    message_creator;
+  MessageCreator message_creator;
   bool need_epoll_update = true;
 };
 
@@ -84,10 +111,75 @@ TypeErasedCallback get_erased_callback(Func && callback)
   };
 }
 
+// Serialize directly into an existing stack-allocated SerializedMessage to avoid heap allocation.
+// Returns false (and logs an error) on rmw_serialize failure.
+bool generic_serialize_message_in_place(
+  const void * raw, const rosidl_message_type_support_t * type_support,
+  rclcpp::SerializedMessage & out);
+
+template <typename Func>
+TypeErasedCallback get_erased_generic_callback(
+  Func && callback, const rosidl_message_type_support_t * type_support)
+{
+  using F = std::decay_t<Func>;
+  static_assert(
+    std::is_invocable_v<F, std::shared_ptr<rclcpp::SerializedMessage>> ||
+      std::is_invocable_v<F, std::unique_ptr<rclcpp::SerializedMessage>> ||
+      std::is_invocable_v<F, rclcpp::SerializedMessage &>,
+    "This callback type cannot be handled as a GenericCallback."
+    "Callback must be invocable with one of the following arguments "
+    "(or any types implicitly convertible from them, e.g., const variants): "
+    "std::unique_ptr<rclcpp::SerializedMessage>, "
+    "std::shared_ptr<rclcpp::SerializedMessage>, or "
+    "rclcpp::SerializedMessage &.");
+
+  return [callback = std::forward<Func>(callback), type_support](AnyObject && arg) mutable {
+    if (typeid(RawMessagePtr) != arg.type()) {
+      RCLCPP_ERROR(
+        logger, "Agnocast internal implementation error: bad allocation when callback is called");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    agnocast::ipc_shared_ptr<std::byte> raw_ptr =
+      std::move(static_cast<RawMessagePtr &&>(arg)).get();
+    if (!raw_ptr) {
+      RCLCPP_ERROR(logger, "received a null raw message pointer; skipping");
+      return;
+    }
+
+    if constexpr (std::is_invocable_v<F, std::shared_ptr<rclcpp::SerializedMessage>>) {
+      auto serialized = std::make_shared<rclcpp::SerializedMessage>();
+      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
+        return;
+      }
+      callback(std::move(serialized));
+    } else if constexpr (std::is_invocable_v<F, std::unique_ptr<rclcpp::SerializedMessage>>) {
+      auto serialized = std::make_unique<rclcpp::SerializedMessage>();
+      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
+        return;
+      }
+      callback(std::move(serialized));
+    } else {
+      // Use a stack-allocated SerializedMessage to avoid heap allocation.
+      rclcpp::SerializedMessage serialized;
+      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, serialized)) {
+        return;
+      }
+      callback(serialized);
+    }
+  };
+}
+
+uint32_t register_erased_callback(
+  TypeErasedCallback callback, MessageCreator message_creator, const std::string & topic_name,
+  topic_local_id_t subscriber_id, bool is_transient_local, mqd_t mqdes,
+  rclcpp::CallbackGroup::SharedPtr callback_group);
+
 template <typename MessageT, typename Func>
 uint32_t register_callback(
   Func && callback, const std::string & topic_name, const topic_local_id_t subscriber_id,
-  const bool is_transient_local, mqd_t mqdes, const rclcpp::CallbackGroup::SharedPtr callback_group)
+  const bool is_transient_local, mqd_t mqdes, rclcpp::CallbackGroup::SharedPtr callback_group)
 {
   // NOTE: ipc_shared_ptr<MessageT> and ipc_shared_ptr<MessageT>&& make no difference in the
   // assertion expression below, but we go with ipc_shared_ptr<MessageT>&&.
@@ -107,19 +199,14 @@ uint32_t register_callback(
       entry_id));
   };
 
-  uint32_t callback_info_id = allocate_callback_info_id();
-
-  {
-    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-    id2_callback_info[callback_info_id] =
-      CallbackInfo{topic_name,     subscriber_id,   is_transient_local, mqdes,
-                   callback_group, erased_callback, message_creator};
-  }
-
-  EpollUpdateDispatcher::get_instance().request_update_all();
-
-  return callback_info_id;
+  return register_erased_callback(
+    std::move(erased_callback), std::move(message_creator), topic_name, subscriber_id,
+    is_transient_local, mqdes, std::move(callback_group));
 }
+
+uint32_t register_generic_callback(
+  TypeErasedCallback callback, const std::string & topic_name, topic_local_id_t subscriber_id,
+  bool is_transient_local, mqd_t mqdes, rclcpp::CallbackGroup::SharedPtr callback_group);
 
 void receive_and_execute_message(
   uint32_t callback_info_id, pid_t my_pid, const CallbackInfo & callback_info,

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -6,6 +6,8 @@
 
 #include <rclcpp/serialized_message.hpp>
 
+#include <rosidl_runtime_c/message_type_support_struct.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -85,7 +85,7 @@ using TypeErasedCallback = std::function<void(AnyObject &&)>;
 // Type for message creator function that constructs a type-erased message
 // envelope (AnyObject) from a raw shared-memory pointer and its metadata.
 using MessageCreator = std::function<std::unique_ptr<AnyObject>(
-  const void *, const std::string &, const topic_local_id_t, const int64_t)>;
+  void *, const std::string &, const topic_local_id_t, const int64_t)>;
 
 struct CallbackInfo
 {
@@ -208,11 +208,10 @@ uint32_t register_callback(
   TypeErasedCallback erased_callback = get_erased_callback<MessageT>(std::forward<Func>(callback));
 
   auto message_creator = [](
-                           const void * ptr, const std::string & topic_name,
+                           void * ptr, const std::string & topic_name,
                            const topic_local_id_t subscriber_id, const int64_t entry_id) {
     return std::make_unique<TypedMessagePtr<MessageT>>(agnocast::ipc_shared_ptr<MessageT>(
-      const_cast<MessageT *>(static_cast<const MessageT *>(ptr)), topic_name, subscriber_id,
-      entry_id));
+      static_cast<MessageT *>(ptr), topic_name, subscriber_id, entry_id));
   };
 
   return register_erased_callback(

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -14,6 +14,11 @@
 #include <mutex>
 #include <type_traits>
 
+namespace rcpputils
+{
+class SharedLibrary;
+}
+
 namespace agnocast
 {
 
@@ -21,6 +26,14 @@ namespace agnocast
 // atomic wrap-around (overflow back to 0) during concurrent fetch_add calls.
 constexpr uint32_t MAX_CALLBACK_INFO_ID_SAFETY_MARGIN = 1000;
 constexpr uint32_t MAX_CALLBACK_INFO_ID = UINT32_MAX - MAX_CALLBACK_INFO_ID_SAFETY_MARGIN;
+
+/// Bundles the dynamically loaded typesupport library with its message handle.
+/// Keeping both together ensures the handle is never outlived by its library.
+struct TypeSupportBundle
+{
+  std::shared_ptr<rcpputils::SharedLibrary> library;
+  const rosidl_message_type_support_t * handle{nullptr};
+};
 
 struct AgnocastExecutable;
 
@@ -120,8 +133,7 @@ bool serialize_message(
   rclcpp::SerializedMessage & out);
 
 template <typename Func>
-TypeErasedCallback get_erased_generic_callback(
-  Func && callback, const rosidl_message_type_support_t * type_support)
+TypeErasedCallback get_erased_generic_callback(Func && callback, TypeSupportBundle ts)
 {
   using F = std::decay_t<Func>;
   static_assert(
@@ -135,7 +147,7 @@ TypeErasedCallback get_erased_generic_callback(
     "std::shared_ptr<rclcpp::SerializedMessage>, or "
     "rclcpp::SerializedMessage &.");
 
-  return [callback = std::forward<Func>(callback), type_support](AnyObject && arg) mutable {
+  return [callback = std::forward<Func>(callback), ts = std::move(ts)](AnyObject && arg) mutable {
     if (typeid(RawMessagePtr) != arg.type()) {
       RCLCPP_ERROR(
         logger, "Agnocast internal implementation error: bad allocation when callback is called");
@@ -152,21 +164,21 @@ TypeErasedCallback get_erased_generic_callback(
 
     if constexpr (std::is_invocable_v<F, std::shared_ptr<rclcpp::SerializedMessage>>) {
       auto serialized = std::make_shared<rclcpp::SerializedMessage>();
-      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
+      if (!serialize_message(raw_ptr.get(), ts.handle, *serialized)) {
         return;
       }
       raw_ptr.reset();
       callback(std::move(serialized));
     } else if constexpr (std::is_invocable_v<F, std::unique_ptr<rclcpp::SerializedMessage>>) {
       auto serialized = std::make_unique<rclcpp::SerializedMessage>();
-      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
+      if (!serialize_message(raw_ptr.get(), ts.handle, *serialized)) {
         return;
       }
       raw_ptr.reset();
       callback(std::move(serialized));
     } else {
       rclcpp::SerializedMessage serialized;
-      if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, serialized)) {
+      if (!serialize_message(raw_ptr.get(), ts.handle, serialized)) {
         return;
       }
       raw_ptr.reset();

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -115,7 +115,7 @@ TypeErasedCallback get_erased_callback(Func && callback)
 
 // Serialize raw message data into a SerializedMessage.
 // Returns false (and logs an error) on rmw_serialize failure.
-bool generic_serialize_message_in_place(
+bool serialize_message(
   const void * raw, const rosidl_message_type_support_t * type_support,
   rclcpp::SerializedMessage & out);
 

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -153,18 +153,21 @@ TypeErasedCallback get_erased_generic_callback(
       if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
         return;
       }
+      raw_ptr.reset();
       callback(std::move(serialized));
     } else if constexpr (std::is_invocable_v<F, std::unique_ptr<rclcpp::SerializedMessage>>) {
       auto serialized = std::make_unique<rclcpp::SerializedMessage>();
       if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, *serialized)) {
         return;
       }
+      raw_ptr.reset();
       callback(std::move(serialized));
     } else {
       rclcpp::SerializedMessage serialized;
       if (!generic_serialize_message_in_place(raw_ptr.get(), type_support, serialized)) {
         return;
       }
+      raw_ptr.reset();
       callback(serialized);
     }
   };

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -22,9 +22,15 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
+
+namespace rcpputils
+{
+class SharedLibrary;
+}
 
 namespace agnocast
 {
@@ -52,6 +58,31 @@ struct SubscriptionOptions
   bool ignore_local_publications{false};
   /// QoS parameter override options (same semantics as rclcpp).
   rclcpp::QosOverridingOptions qos_overriding_options{};
+};
+
+/**
+ * @brief Role of a subscription with respect to the ROS<->Agnocast bridge.
+ *
+ * Encodes two properties of a subscription:
+ *   - whether it is used by the bridge implementation itself
+ *   - whether it should issue an R2A bridge request on construction
+ *
+ *   | Role            | kmod `is_bridge` | bridge request issued |
+ *   |-----------------|------------------|-----------------------|
+ *   | Default         | false            | yes (R2A)             |
+ *   | AgnocastOnly    | false            | no                    |
+ *   | BridgeInternal  | true             | no                    |
+ */
+enum class SubscriptionRole : uint8_t {
+  /// User-created subscription; issues an R2A bridge request.
+  Default,
+  /// Used internally by the service/client implementation; no bridge request.
+  /// Not intended for direct use by application code.
+  AgnocastOnly,
+  /// Used by the bridge implementation itself; marked as bridge in kmod and
+  /// issues no bridge request.
+  /// Not intended for direct use by application code.
+  BridgeInternal,
 };
 
 // These are cut out of the class for information hiding.
@@ -417,6 +448,108 @@ public:
   /// @return Shared pointer to the latest message.
   AGNOCAST_PUBLIC
   const agnocast::ipc_shared_ptr<const MessageT> take_data() { return subscriber_->take(true); };
+};
+
+/// @brief Mirrors `rclcpp::GenericSubscription` semantics: the topic type is supplied
+/// as a runtime string (e.g. "std_msgs/msg/String") rather than a compile-time
+/// template argument. The typesupport library is loaded eagerly in the
+/// constructor and held for the subscription's lifetime.
+///
+/// Messages are delivered to the callback as serialized data, outside of Agnocast shared memory.
+///
+/// The supported callback signatures are:
+///   - `void(std::shared_ptr<rclcpp::SerializedMessage>)` (and `const` / `const`-T variants)
+///   - `void(std::unique_ptr<rclcpp::SerializedMessage>)` (and `const` / `const`-T variants)
+///   - `void(const rclcpp::SerializedMessage &)` (and `const` variants)
+///
+/// NOTE: Standard bridge mode is not supported for this subscription type.
+/// When standard bridge is used, no bridge request is issued, so no bridge is created and
+/// communication with ROS 2-only publishers is not possible. This is by design,
+/// as standard bridge support is planned for removal.
+AGNOCAST_PUBLIC
+class GenericSubscription : public SubscriptionBase
+{
+  std::pair<mqd_t, std::string> mq_subscription_;
+  uint32_t callback_info_id_{0};
+  /// Keeps the dynamically loaded typesupport .so alive for our lifetime.
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
+  const rosidl_message_type_support_t * type_support_handle_{nullptr};
+
+  void load_typesupport_impl(const std::string & topic_type);
+
+  template <typename NodeT>
+  rclcpp::QoS constructor_impl(
+    NodeT * node, const std::string & topic_type, const rclcpp::QoS & qos,
+    TypeErasedCallback callback, rclcpp::CallbackGroup::SharedPtr callback_group,
+    const agnocast::SubscriptionOptions & options, SubscriptionRole role);
+
+public:
+  using SharedPtr = std::shared_ptr<GenericSubscription>;
+
+  template <typename Func>
+  GenericSubscription(
+    rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, Func && callback,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : SubscriptionBase(node, topic_name)
+  {
+    rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
+
+    const void * callback_addr = static_cast<const void *>(&callback);
+    const char * callback_symbol = tracetools::get_symbol(callback);
+
+    load_typesupport_impl(topic_type);
+    TypeErasedCallback erased =
+      get_erased_generic_callback(std::forward<Func>(callback), type_support_handle_);
+
+    const rclcpp::QoS actual_qos =
+      constructor_impl(node, topic_type, qos, std::move(erased), callback_group, options, role);
+
+    {
+      uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id_;
+      TRACEPOINT(
+        agnocast_subscription_init, static_cast<const void *>(this),
+        static_cast<const void *>(
+          node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
+        callback_addr, static_cast<const void *>(callback_group.get()), callback_symbol,
+        topic_name_.c_str(), actual_qos.depth(), pid_callback_info_id);
+    }
+  }
+
+  template <typename Func>
+  GenericSubscription(
+    agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, Func && callback,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : SubscriptionBase(node, topic_name)
+  {
+    rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
+
+    const void * callback_addr = static_cast<const void *>(&callback);
+    const char * callback_symbol = tracetools::get_symbol(callback);
+
+    load_typesupport_impl(topic_type);
+    TypeErasedCallback erased =
+      get_erased_generic_callback(std::forward<Func>(callback), type_support_handle_);
+
+    const rclcpp::QoS actual_qos =
+      constructor_impl(node, topic_type, qos, std::move(erased), callback_group, options, role);
+
+    {
+      uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id_;
+      TRACEPOINT(
+        agnocast_subscription_init, static_cast<const void *>(this),
+        static_cast<const void *>(get_node_base_address(node)), callback_addr,
+        static_cast<const void *>(callback_group.get()), callback_symbol, topic_name_.c_str(),
+        actual_qos.depth(), pid_callback_info_id);
+    }
+  }
+
+  // Destructor defined in .cpp so that ~shared_ptr<rcpputils::SharedLibrary>
+  // sees the complete SharedLibrary type (forward-declared in this header).
+  ~GenericSubscription();
 };
 
 struct RosToAgnocastPubsubRequestPolicy;

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -27,11 +27,6 @@
 #include <thread>
 #include <vector>
 
-namespace rcpputils
-{
-class SharedLibrary;
-}
-
 namespace agnocast
 {
 class Node;
@@ -473,11 +468,10 @@ class GenericSubscription : public SubscriptionBase
 {
   std::pair<mqd_t, std::string> mq_subscription_;
   uint32_t callback_info_id_;
-  /// Keeps the dynamically loaded typesupport .so alive for our lifetime.
-  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
-  const rosidl_message_type_support_t * type_support_handle_{nullptr};
+  /// Keeps the dynamically loaded typesupport .so and its handle together for our lifetime.
+  TypeSupportBundle type_support_;
 
-  void load_typesupport_impl(const std::string & topic_type);
+  TypeSupportBundle load_typesupport_impl(const std::string & topic_type);
 
   template <typename NodeT>
   rclcpp::QoS constructor_impl(
@@ -501,9 +495,9 @@ public:
     const void * callback_addr = static_cast<const void *>(&callback);
     const char * callback_symbol = tracetools::get_symbol(callback);
 
-    load_typesupport_impl(topic_type);
+    type_support_ = load_typesupport_impl(topic_type);
     TypeErasedCallback erased =
-      get_erased_generic_callback(std::forward<Func>(callback), type_support_handle_);
+      get_erased_generic_callback(std::forward<Func>(callback), type_support_);
 
     const rclcpp::QoS actual_qos =
       constructor_impl(node, topic_type, qos, std::move(erased), callback_group, options, role);
@@ -532,9 +526,9 @@ public:
     const void * callback_addr = static_cast<const void *>(&callback);
     const char * callback_symbol = tracetools::get_symbol(callback);
 
-    load_typesupport_impl(topic_type);
+    type_support_ = load_typesupport_impl(topic_type);
     TypeErasedCallback erased =
-      get_erased_generic_callback(std::forward<Func>(callback), type_support_handle_);
+      get_erased_generic_callback(std::forward<Func>(callback), type_support_);
 
     const rclcpp::QoS actual_qos =
       constructor_impl(node, topic_type, qos, std::move(erased), callback_group, options, role);
@@ -550,7 +544,8 @@ public:
   }
 
   // Destructor defined in .cpp so that ~shared_ptr<rcpputils::SharedLibrary>
-  // sees the complete SharedLibrary type (forward-declared in this header).
+  // (held inside TypeSupportBundle) sees the complete SharedLibrary type
+  // (forward-declared in this header via agnocast_callback_info.hpp).
   ~GenericSubscription();
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -460,7 +460,7 @@ public:
 /// The supported callback signatures are:
 ///   - `void(std::shared_ptr<rclcpp::SerializedMessage>)` (and `const` / `const`-T variants)
 ///   - `void(std::unique_ptr<rclcpp::SerializedMessage>)` (and `const` / `const`-T variants)
-///   - `void(const rclcpp::SerializedMessage &)` (and `const` variants)
+///   - `void(rclcpp::SerializedMessage &)` (and `const` variants)
 ///
 /// NOTE: Standard bridge mode is not supported for this subscription type.
 /// When standard bridge is used, no bridge request is issued, so no bridge is created and
@@ -470,7 +470,7 @@ AGNOCAST_PUBLIC
 class GenericSubscription : public SubscriptionBase
 {
   std::pair<mqd_t, std::string> mq_subscription_;
-  uint32_t callback_info_id_{0};
+  uint32_t callback_info_id_;
   /// Keeps the dynamically loaded typesupport .so alive for our lifetime.
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
   const rosidl_message_type_support_t * type_support_handle_{nullptr};

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -114,7 +114,7 @@ rclcpp::CallbackGroup::SharedPtr get_valid_callback_group(
 class SubscriptionBase
 {
 protected:
-  topic_local_id_t id_;
+  topic_local_id_t id_{-1};
   const std::string topic_name_;
   union ioctl_add_subscriber_args initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
@@ -128,17 +128,19 @@ public:
 
   virtual ~SubscriptionBase()
   {
-    // NOTE: Unmapping memory when a subscriber is destroyed is not implemented. Multiple
-    // subscribers
-    // may share the same mmap region, requiring reference counting in kmod. Since leaving the
-    // memory mapped should not cause any functional issues, this is left as future work.
-    struct ioctl_remove_subscriber_args remove_subscriber_args
-    {
-    };
-    remove_subscriber_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
-    remove_subscriber_args.subscriber_id = id_;
-    if (ioctl(agnocast_fd, AGNOCAST_REMOVE_SUBSCRIBER_CMD, &remove_subscriber_args) < 0) {
-      RCLCPP_WARN(logger, "Failed to remove subscriber (id=%d) from kernel.", id_);
+    if (id_ >= 0) {
+      // NOTE: Unmapping memory when a subscriber is destroyed is not implemented. Multiple
+      // subscribers
+      // may share the same mmap region, requiring reference counting in kmod. Since leaving the
+      // memory mapped should not cause any functional issues, this is left as future work.
+      struct ioctl_remove_subscriber_args remove_subscriber_args
+      {
+      };
+      remove_subscriber_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
+      remove_subscriber_args.subscriber_id = id_;
+      if (ioctl(agnocast_fd, AGNOCAST_REMOVE_SUBSCRIBER_CMD, &remove_subscriber_args) < 0) {
+        RCLCPP_WARN(logger, "Failed to remove subscriber (id=%d) from kernel.", id_);
+      }
     }
   }
 };

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -471,7 +471,7 @@ class GenericSubscription : public SubscriptionBase
   /// Keeps the dynamically loaded typesupport .so and its handle together for our lifetime.
   TypeSupportBundle type_support_;
 
-  TypeSupportBundle load_typesupport_impl(const std::string & topic_type);
+  static TypeSupportBundle load_typesupport_impl(const std::string & topic_type);
 
   template <typename NodeT>
   rclcpp::QoS constructor_impl(

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -436,7 +436,7 @@ inline void send_performance_pubsub_bridge_registration_by_type_name(
   const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
   BridgeDirection direction)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_performance_service_bridge_registrar");
+  static const auto logger = rclcpp::get_logger("agnocast_performance_bridge_registrar");
 
   auto [msg, reason] =
     BridgeRegistrationMsgBuilder(BridgeRegistrationMsgBuilder::Mode::Performance, logger)

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -69,9 +69,8 @@ inline void request_pubsub_bridge_by_type_name(
     static const auto logger = rclcpp::get_logger("agnocast_bridge_requester");
     RCLCPP_WARN_ONCE(
       logger,
-      "GenericSubscription does not yet support standard-mode bridge for topic '%s'. "
-      "Set AGNOCAST_BRIDGE_MODE=performance to enable bridging.",
-      topic_name.c_str());
+      "GenericSubscription does not support standard-mode bridge. "
+      "Set AGNOCAST_BRIDGE_MODE=performance to enable bridging.");
   } else if (bridge_mode == BridgeMode::Performance) {
     send_performance_pubsub_bridge_request_by_type_name(topic_name, id, message_type, direction);
   }

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -40,6 +40,9 @@ void send_standard_service_bridge_request(
 template <typename MessageT>
 void send_performance_pubsub_bridge_request(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
+inline void send_performance_pubsub_bridge_request_by_type_name(
+  const std::string & topic_name, topic_local_id_t id, const std::string & message_type,
+  BridgeDirection direction);
 template <typename ServiceT>
 void send_performance_service_bridge_request(
   const std::string & service_name, BridgeDirection direction,
@@ -54,6 +57,23 @@ void request_pubsub_bridge_core(
     send_standard_pubsub_bridge_request<MessageT>(topic_name, id, direction);
   } else if (bridge_mode == BridgeMode::Performance) {
     send_performance_pubsub_bridge_request<MessageT>(topic_name, id, direction);
+  }
+}
+
+inline void request_pubsub_bridge_by_type_name(
+  const std::string & topic_name, topic_local_id_t id, const std::string & message_type,
+  BridgeDirection direction)
+{
+  auto bridge_mode = get_bridge_mode();
+  if (bridge_mode == BridgeMode::Standard) {
+    static const auto logger = rclcpp::get_logger("agnocast_bridge_requester");
+    RCLCPP_WARN_ONCE(
+      logger,
+      "GenericSubscription does not yet support standard-mode bridge for topic '%s'. "
+      "Set AGNOCAST_BRIDGE_MODE=performance to enable bridging.",
+      topic_name.c_str());
+  } else if (bridge_mode == BridgeMode::Performance) {
+    send_performance_pubsub_bridge_request_by_type_name(topic_name, id, message_type, direction);
   }
 }
 
@@ -403,9 +423,15 @@ template <typename MessageT>
 void send_performance_pubsub_bridge_request(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
 {
-  static const auto logger = rclcpp::get_logger("agnocast_performance_bridge_requester");
-
   const std::string message_type_name = rosidl_generator_traits::name<MessageT>();
+  send_performance_pubsub_bridge_request_by_type_name(topic_name, id, message_type_name, direction);
+}
+
+inline void send_performance_pubsub_bridge_request_by_type_name(
+  const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
+  BridgeDirection direction)
+{
+  static const auto logger = rclcpp::get_logger("agnocast_performance_bridge_requester");
 
   auto [msg, reason] = BridgeRequestMsgBuilder(BridgeRequestMsgBuilder::Mode::Performance, logger)
                          .set_direction(direction)

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -41,7 +41,7 @@ template <typename MessageT>
 void send_performance_pubsub_bridge_registration(
   const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
 inline void send_performance_pubsub_bridge_registration_by_type_name(
-  const std::string & topic_name, topic_local_id_t id, const std::string & message_type,
+  const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
   BridgeDirection direction);
 template <typename ServiceT>
 void send_performance_service_bridge_registration(

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -27,6 +27,8 @@
   <depend>rcl_yaml_param_parser</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rcpputils</depend>
+  <depend>rmw</depend>
   <depend>rosgraph_msgs</depend>
   <depend>tracetools</depend>
 

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -73,11 +73,10 @@ uint32_t register_generic_callback(
   const bool is_transient_local, mqd_t mqdes, rclcpp::CallbackGroup::SharedPtr callback_group)
 {
   auto message_creator = [](
-                           const void * ptr, const std::string & topic_name,
+                           void * ptr, const std::string & topic_name,
                            const topic_local_id_t subscriber_id, const int64_t entry_id) {
     return std::make_unique<RawMessagePtr>(agnocast::ipc_shared_ptr<std::byte>(
-      const_cast<std::byte *>(static_cast<const std::byte *>(ptr)), topic_name, subscriber_id,
-      entry_id));
+      static_cast<std::byte *>(ptr), topic_name, subscriber_id, entry_id));
   };
 
   return register_erased_callback(

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -5,7 +5,6 @@
 #include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_executor.hpp"
 
-#include <rcutils/allocator.h>
 #include <rmw/rmw.h>
 #include <rmw/serialized_message.h>
 #include <rmw/types.h>

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -32,7 +32,7 @@ uint32_t allocate_callback_info_id()
   return callback_info_id;
 }
 
-bool generic_serialize_message_in_place(
+bool serialize_message(
   const void * raw, const rosidl_message_type_support_t * type_support,
   rclcpp::SerializedMessage & out)
 {

--- a/src/agnocastlib/src/agnocast_callback_info.cpp
+++ b/src/agnocastlib/src/agnocast_callback_info.cpp
@@ -5,11 +5,16 @@
 #include "agnocast/agnocast_epoll_event.hpp"
 #include "agnocast/agnocast_executor.hpp"
 
+#include <rcutils/allocator.h>
+#include <rmw/rmw.h>
+#include <rmw/serialized_message.h>
+#include <rmw/types.h>
 #include <sys/epoll.h>
 #include <unistd.h>
 
 #include <array>
 #include <stdexcept>
+#include <utility>
 
 namespace agnocast
 {
@@ -26,6 +31,59 @@ uint32_t allocate_callback_info_id()
     throw std::runtime_error("Callback info ID overflow: too many callbacks registered");
   }
   return callback_info_id;
+}
+
+bool generic_serialize_message_in_place(
+  const void * raw, const rosidl_message_type_support_t * type_support,
+  rclcpp::SerializedMessage & out)
+{
+  const rmw_ret_t ret = rmw_serialize(raw, type_support, &out.get_rcl_serialized_message());
+  if (ret != RMW_RET_OK) {
+    RCLCPP_ERROR(logger, "rmw_serialize failed (rmw_ret=%d); skipping", static_cast<int>(ret));
+    return false;
+  }
+  return true;
+}
+
+uint32_t register_erased_callback(
+  TypeErasedCallback callback, MessageCreator message_creator, const std::string & topic_name,
+  const topic_local_id_t subscriber_id, const bool is_transient_local, mqd_t mqdes,
+  rclcpp::CallbackGroup::SharedPtr callback_group)
+{
+  uint32_t callback_info_id = allocate_callback_info_id();
+
+  {
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+    id2_callback_info[callback_info_id] = CallbackInfo{
+      topic_name,
+      subscriber_id,
+      is_transient_local,
+      mqdes,
+      std::move(callback_group),
+      std::move(callback),
+      std::move(message_creator)};
+  }
+
+  EpollUpdateDispatcher::get_instance().request_update_all();
+
+  return callback_info_id;
+}
+
+uint32_t register_generic_callback(
+  TypeErasedCallback callback, const std::string & topic_name, const topic_local_id_t subscriber_id,
+  const bool is_transient_local, mqd_t mqdes, rclcpp::CallbackGroup::SharedPtr callback_group)
+{
+  auto message_creator = [](
+                           const void * ptr, const std::string & topic_name,
+                           const topic_local_id_t subscriber_id, const int64_t entry_id) {
+    return std::make_unique<RawMessagePtr>(agnocast::ipc_shared_ptr<std::byte>(
+      const_cast<std::byte *>(static_cast<const std::byte *>(ptr)), topic_name, subscriber_id,
+      entry_id));
+  };
+
+  return register_erased_callback(
+    std::move(callback), std::move(message_creator), topic_name, subscriber_id, is_transient_local,
+    mqdes, std::move(callback_group));
 }
 
 void receive_and_execute_message(

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -2,6 +2,7 @@
 #include "agnocast/internal/type_registry_writer.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 #include "rclcpp/typesupport_helpers.hpp"
+#include "rclcpp/version.h"
 #include "rcpputils/shared_library.hpp"
 
 namespace agnocast
@@ -126,8 +127,15 @@ TypeSupportBundle GenericSubscription::load_typesupport_impl(const std::string &
 {
   TypeSupportBundle result;
   result.library = rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp");
+  // rclcpp::get_typesupport_handle() was deprecated in Jazzy (rclcpp 28) in favor of
+  // rclcpp::get_message_typesupport_handle() to distinguish message handles from service handles.
+#if RCLCPP_VERSION_MAJOR >= 28
   result.handle =
     rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *result.library);
+#else
+  result.handle =
+    rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *result.library);
+#endif
   return result;
 }
 

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -145,7 +145,7 @@ rclcpp::QoS GenericSubscription::constructor_impl(
   TypeErasedCallback callback, rclcpp::CallbackGroup::SharedPtr callback_group,
   const agnocast::SubscriptionOptions & options, SubscriptionRole role)
 {
-  const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
+  const bool override_qos = !options.qos_overriding_options.get_policy_kinds().empty();
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
     override_qos ? node->get_node_parameters_interface() : nullptr;
   const rclcpp::QoS actual_qos = override_qos
@@ -174,7 +174,7 @@ rclcpp::QoS GenericSubscription::constructor_impl(
   const bool is_transient_local =
     actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
   callback_info_id_ = agnocast::register_generic_callback(
-    std::move(callback), topic_name_, id_, is_transient_local, mq, callback_group);
+    std::move(callback), topic_name_, id_, is_transient_local, mq, std::move(callback_group));
 
   return actual_qos;
 }

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -1,6 +1,8 @@
 #include "agnocast/agnocast.hpp"
 #include "agnocast/internal/type_registry_writer.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "rclcpp/typesupport_helpers.hpp"
+#include "rcpputils/shared_library.hpp"
 
 namespace agnocast
 {
@@ -119,5 +121,74 @@ rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(agnoc
 {
   return node->get_node_base_interface()->get_default_callback_group();
 }
+
+void GenericSubscription::load_typesupport_impl(const std::string & topic_type)
+{
+  ts_lib_ = rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp");
+  type_support_handle_ =
+    rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib_);
+}
+
+template <typename NodeT>
+rclcpp::QoS GenericSubscription::constructor_impl(
+  NodeT * node, const std::string & topic_type, const rclcpp::QoS & qos,
+  TypeErasedCallback callback, rclcpp::CallbackGroup::SharedPtr callback_group,
+  const agnocast::SubscriptionOptions & options, SubscriptionRole role)
+{
+  const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
+    override_qos ? node->get_node_parameters_interface() : nullptr;
+  const rclcpp::QoS actual_qos = override_qos
+                                   ? rclcpp::detail::declare_qos_parameters(
+                                       options.qos_overriding_options, node_parameters, topic_name_,
+                                       qos, rclcpp::detail::SubscriptionQosParametersTraits{})
+                                   : qos;
+
+  validate_subscription_qos(actual_qos);
+
+  const std::string node_name = node->get_fully_qualified_name();
+
+  const bool is_bridge = (role == SubscriptionRole::BridgeInternal);
+  union ioctl_add_subscriber_args add_subscriber_args = initialize(
+    actual_qos, false, options.ignore_local_publications, is_bridge, node_name, topic_type);
+
+  id_ = add_subscriber_args.ret_id;
+
+  if (role == SubscriptionRole::Default) {
+    request_pubsub_bridge_by_type_name(
+      topic_name_, id_, topic_type, BridgeDirection::ROS2_TO_AGNOCAST);
+  }
+
+  mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
+
+  const bool is_transient_local =
+    actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
+  callback_info_id_ = agnocast::register_generic_callback(
+    std::move(callback), topic_name_, id_, is_transient_local, mq, callback_group);
+
+  return actual_qos;
+}
+
+GenericSubscription::~GenericSubscription()
+{
+  // Remove from callback info map to prevent stale references on re-subscription and to avoid
+  // fd reuse conflicts. When mq_close() is called in remove_mq(), the OS may later reuse the
+  // same fd number for a new subscription. If the old entry remains in id2_callback_info,
+  // adding the new fd to epoll (EPOLL_CTL_ADD) can fail with EEXIST because epoll still
+  // associates that fd number with the stale entry.
+  {
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+    id2_callback_info.erase(callback_info_id_);
+  }
+  remove_mq(mq_subscription_);
+}
+
+template rclcpp::QoS GenericSubscription::constructor_impl<rclcpp::Node>(
+  rclcpp::Node *, const std::string &, const rclcpp::QoS &, TypeErasedCallback,
+  rclcpp::CallbackGroup::SharedPtr, const agnocast::SubscriptionOptions &, SubscriptionRole);
+
+template rclcpp::QoS GenericSubscription::constructor_impl<agnocast::Node>(
+  agnocast::Node *, const std::string &, const rclcpp::QoS &, TypeErasedCallback,
+  rclcpp::CallbackGroup::SharedPtr, const agnocast::SubscriptionOptions &, SubscriptionRole);
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -8,14 +8,14 @@ namespace agnocast
 {
 
 SubscriptionBase::SubscriptionBase(rclcpp::Node * node, const std::string & topic_name)
-: id_(0), topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name))
+: topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name))
 {
   validate_ld_preload();
 }
 
 SubscriptionBase::SubscriptionBase(
   agnocast::Node * node, const std::string & topic_name)  // NOLINT(modernize-pass-by-value)
-: id_(0), topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name))
+: topic_name_(node->get_node_topics_interface()->resolve_topic_name(topic_name))
 {
   validate_ld_preload();
 }

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -122,11 +122,13 @@ rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(agnoc
   return node->get_node_base_interface()->get_default_callback_group();
 }
 
-void GenericSubscription::load_typesupport_impl(const std::string & topic_type)
+TypeSupportBundle GenericSubscription::load_typesupport_impl(const std::string & topic_type)
 {
-  ts_lib_ = rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp");
-  type_support_handle_ =
-    rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib_);
+  TypeSupportBundle result;
+  result.library = rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp");
+  result.handle =
+    rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *result.library);
+  return result;
 }
 
 template <typename NodeT>

--- a/src/agnocastlib/test/integration/test_agnocast_generic_subscription.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_generic_subscription.cpp
@@ -1,0 +1,335 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_callback_info.hpp"
+#include "agnocast/agnocast_single_threaded_executor.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/agnocast_only_single_threaded_executor.hpp"
+#include "rclcpp/serialization.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+using StringMsg = std_msgs::msg::String;
+
+class GenericSubscriptionIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_generic_sub");
+    executor_ = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    node_.reset();
+    executor_.reset();
+    rclcpp::shutdown();
+  }
+
+  template <typename Predicate>
+  bool wait_for(Predicate pred, std::chrono::milliseconds timeout = 3000ms)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (pred()) {
+        return true;
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return pred();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<agnocast::SingleThreadedAgnocastExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+// ------------------------------------------------------------------------------
+// Round-trip test for each supported generic callback signature.
+// ------------------------------------------------------------------------------
+class GenericSubscriptionRoundTripTest : public GenericSubscriptionIntegrationTest
+{
+protected:
+  static std::string decode(const rclcpp::SerializedMessage * msg)
+  {
+    rclcpp::Serialization<StringMsg> serializer;
+    StringMsg decoded;
+    serializer.deserialize_message(msg, &decoded);
+    return decoded.data;
+  }
+
+  template <typename Func>
+  void verify_callback_type(Func && callback)
+  {
+    const std::string topic = "/test_generic_sub";
+    const std::string type = "std_msgs/msg/String";
+    const std::string expected = "hello generic subscription";
+    rclcpp::QoS qos{1};
+
+    auto pub = agnocast::create_publisher<StringMsg>(node_.get(), topic, qos);
+
+    auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    agnocast::SubscriptionOptions opts;
+    opts.callback_group = cbg;
+
+    auto sub = agnocast::create_generic_subscription(
+      node_.get(), topic, type, qos, std::forward<Func>(callback), opts);
+
+    auto loaned = pub->borrow_loaned_message();
+    loaned->data = expected;
+    pub->publish(std::move(loaned));
+
+    const bool delivered = wait_for([this] {
+      std::lock_guard<std::mutex> lock(mtx_);
+      return !received_data_.empty();
+    });
+
+    ASSERT_TRUE(delivered) << "Timed out waiting for GenericSubscription callback";
+    std::lock_guard<std::mutex> lock(mtx_);
+    EXPECT_EQ(received_data_, expected);
+  }
+
+  std::string received_data_;
+  std::mutex mtx_;
+};
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_shared_ptr)
+{
+  verify_callback_type([this](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_const_shared_ptr)
+{
+  verify_callback_type([this](const std::shared_ptr<rclcpp::SerializedMessage> msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_shared_ptr_const_msg)
+{
+  verify_callback_type([this](std::shared_ptr<const rclcpp::SerializedMessage> msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_const_shared_ptr_const_msg)
+{
+  verify_callback_type([this](const std::shared_ptr<const rclcpp::SerializedMessage> msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_const_shared_ptr_ref_msg)
+{
+  verify_callback_type([this](const std::shared_ptr<rclcpp::SerializedMessage> & msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_unique_ptr)
+{
+  verify_callback_type([this](std::unique_ptr<rclcpp::SerializedMessage> msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(msg.get());
+  });
+}
+
+// NOTE: The `const` and `const`-T variants of unique_ptr take the same dispatch
+// branch in get_erased_generic_callback (callback(std::move(serialized))) as the
+// bare std::unique_ptr<rclcpp::SerializedMessage> case above. We omit them here
+// to avoid combinatorial explosion in test cases.
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_serialized_message_ref)
+{
+  verify_callback_type([this](rclcpp::SerializedMessage & msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(&msg);
+  });
+}
+
+TEST_F(GenericSubscriptionRoundTripTest, callback_signature_serialized_message_const_ref)
+{
+  verify_callback_type([this](const rclcpp::SerializedMessage & msg) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    received_data_ = decode(&msg);
+  });
+}
+
+// ------------------------------------------------------------------------------
+// Lifecycle test for GenericSubscription
+// ------------------------------------------------------------------------------
+class GenericSubscriptionLifecycleTest : public GenericSubscriptionIntegrationTest
+{
+};
+
+TEST_F(GenericSubscriptionLifecycleTest, destructor_unregisters_callback_info)
+{
+  const std::string topic = "/test_generic_sub_lifecycle";
+  const std::string type = "std_msgs/msg/String";
+  rclcpp::QoS qos{1};
+
+  const size_t size_before = [&] {
+    std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+    return agnocast::id2_callback_info.size();
+  }();
+
+  {
+    auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    agnocast::SubscriptionOptions sub_opts;
+    sub_opts.callback_group = cbg;
+    auto sub = agnocast::create_generic_subscription(
+      node_.get(), topic, type, qos, [](std::shared_ptr<rclcpp::SerializedMessage>) {}, sub_opts);
+
+    const size_t size_during = [&] {
+      std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+      return agnocast::id2_callback_info.size();
+    }();
+
+    EXPECT_EQ(size_during, size_before + 1)
+      << "GenericSubscription constructor must register one entry in id2_callback_info";
+  }  // sub destroyed here
+
+  const size_t size_after = [&] {
+    std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+    return agnocast::id2_callback_info.size();
+  }();
+
+  EXPECT_EQ(size_after, size_before)
+    << "GenericSubscription destructor must erase its entry from id2_callback_info";
+}
+
+TEST_F(GenericSubscriptionLifecycleTest, invalid_type_name_throws_and_does_not_register)
+{
+  const std::string topic = "/test_generic_sub_invalid_type";
+  const std::string invalid_type = "not_a_valid/type_name";
+  rclcpp::QoS qos{1};
+
+  const size_t size_before = [&] {
+    std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+    return agnocast::id2_callback_info.size();
+  }();
+
+  auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions sub_opts;
+  sub_opts.callback_group = cbg;
+  EXPECT_THROW(
+    agnocast::create_generic_subscription(
+      node_.get(), topic, invalid_type, qos, [](std::shared_ptr<rclcpp::SerializedMessage>) {},
+      sub_opts),
+    std::runtime_error);
+
+  const size_t size_after = [&] {
+    std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+    return agnocast::id2_callback_info.size();
+  }();
+
+  EXPECT_EQ(size_after, size_before)
+    << "A failed constructor must not leave any entry in id2_callback_info";
+}
+
+// ------------------------------------------------------------------------------
+// Verifies that create_generic_subscription works with agnocast::Node (Stage 2).
+// ------------------------------------------------------------------------------
+class AgnocastNodeGenericSubscriptionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    node_ = std::make_shared<agnocast::Node>("test_generic_sub_agnocast_node");
+    executor_ = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    node_.reset();
+    executor_.reset();
+    agnocast::shutdown();
+  }
+
+  template <typename Predicate>
+  bool wait_for(Predicate pred, std::chrono::milliseconds timeout = 3000ms)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (pred()) {
+        return true;
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return pred();
+  }
+
+  std::shared_ptr<agnocast::Node> node_;
+  std::shared_ptr<agnocast::AgnocastOnlySingleThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(AgnocastNodeGenericSubscriptionTest, round_trip_serialization)
+{
+  const std::string topic = "/test_agnocast_node_generic_sub";
+  const std::string type = "std_msgs/msg/String";
+  const std::string expected = "hello agnocast node";
+  rclcpp::QoS qos{1};
+
+  auto pub = agnocast::create_publisher<StringMsg>(node_.get(), topic, qos);
+
+  auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions opts;
+  opts.callback_group = cbg;
+
+  std::string received_data;
+  std::mutex mtx;
+  auto sub = agnocast::create_generic_subscription(
+    node_.get(), topic, type, qos,
+    [&received_data, &mtx](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+      rclcpp::Serialization<StringMsg> serializer;
+      StringMsg decoded;
+      serializer.deserialize_message(msg.get(), &decoded);
+      std::lock_guard<std::mutex> lock(mtx);
+      received_data = decoded.data;
+    },
+    opts);
+
+  auto loaned = pub->borrow_loaned_message();
+  loaned->data = expected;
+  pub->publish(std::move(loaned));
+
+  const bool delivered = wait_for([&] {
+    std::lock_guard<std::mutex> lock(mtx);
+    return !received_data.empty();
+  });
+
+  ASSERT_TRUE(delivered) << "Timed out waiting for GenericSubscription callback";
+  std::lock_guard<std::mutex> lock(mtx);
+  EXPECT_EQ(received_data, expected);
+}

--- a/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
@@ -1,0 +1,132 @@
+// Tests for get_erased_generic_callback and register_generic_callback.
+//
+// These tests verify the serialization path introduced in Commit 1 of
+// the GenericSubscription feature. They run entirely in userspace without the
+// kernel module: ipc_shared_ptr is constructed subscriber-side (entry_id != -1),
+// so the reset() path calls the mocked release_subscriber_reference() instead
+// of delete.
+//
+// The mock for release_subscriber_reference is defined in
+// test_mocked_agnocast.cpp which is compiled into the same test target.
+//
+// Note: rmw_serialize / rmw_deserialize are real RMW calls that require a live
+// RMW implementation.  The tests therefore call rclcpp::init / rclcpp::shutdown
+// to ensure the RMW layer is initialized (following the same pattern used by
+// other unit tests in this target).
+
+#include "agnocast/agnocast_callback_info.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/serialization.hpp"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+using agnocast::get_erased_generic_callback;
+using agnocast::RawMessagePtr;
+using agnocast::TypedMessagePtr;
+using agnocast::TypeErasedCallback;
+
+template <typename T>
+agnocast::ipc_shared_ptr<std::byte> make_subscriber_raw_ptr(
+  T * msg, const std::string & topic_name = "test_topic", agnocast::topic_local_id_t sub_id = 0,
+  int64_t entry_id = 1)
+{
+  return agnocast::ipc_shared_ptr<std::byte>(
+    reinterpret_cast<std::byte *>(msg), topic_name, sub_id, entry_id);
+}
+
+class GenericCallbackTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    ts_ = rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  const rosidl_message_type_support_t * ts_{nullptr};
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: normal path — rmw_serialize round-trip via String
+// ---------------------------------------------------------------------------
+TEST_F(GenericCallbackTest, serialize_round_trips_std_msgs_string)
+{
+  // Arrange
+  const std::string original_data = "hello agnocast";
+  auto msg = std::make_unique<std_msgs::msg::String>();
+  msg->data = original_data;
+
+  auto raw_ptr = make_subscriber_raw_ptr(msg.get());
+  RawMessagePtr envelope{std::move(raw_ptr)};
+
+  std::shared_ptr<rclcpp::SerializedMessage> received;
+  auto user_cb = [&received](std::shared_ptr<rclcpp::SerializedMessage> serialized) {
+    received = std::move(serialized);
+  };
+
+  TypeErasedCallback erased = get_erased_generic_callback(user_cb, ts_);
+
+  // Act
+  erased(std::move(envelope));
+
+  // Assert — user callback was invoked with a non-null SerializedMessage
+  ASSERT_NE(received, nullptr);
+  ASSERT_GT(received->get_rcl_serialized_message().buffer_length, 0u);
+
+  // Round-trip: deserialize back to String and compare
+  rclcpp::Serialization<std_msgs::msg::String> serializer;
+  std_msgs::msg::String decoded;
+  serializer.deserialize_message(received.get(), &decoded);
+  EXPECT_EQ(decoded.data, original_data);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: null raw pointer — callback must be skipped (not called)
+// ---------------------------------------------------------------------------
+TEST_F(GenericCallbackTest, null_raw_pointer_skips_callback)
+{
+  // Arrange: construct an empty ipc_shared_ptr<std::byte> (null)
+  agnocast::ipc_shared_ptr<std::byte> null_ptr;
+  RawMessagePtr envelope{std::move(null_ptr)};
+
+  bool callback_called = false;
+  auto user_cb = [&callback_called](std::shared_ptr<rclcpp::SerializedMessage>) {
+    callback_called = true;
+  };
+
+  TypeErasedCallback erased = get_erased_generic_callback(user_cb, ts_);
+
+  // Act
+  erased(std::move(envelope));
+
+  // Assert — callback must NOT have been called
+  EXPECT_FALSE(callback_called);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: wrong envelope type — must exit with failure
+// ---------------------------------------------------------------------------
+TEST_F(GenericCallbackTest, wrong_envelope_type_exits)
+{
+  // Arrange: pass a TypedMessagePtr<int> to a generic callback
+  int dummy = 42;
+  agnocast::TypedMessagePtr<int> wrong_envelope{
+    agnocast::ipc_shared_ptr<int>(&dummy, "test_topic", 0, /*entry_id=*/1)};
+
+  auto user_cb = [](std::shared_ptr<rclcpp::SerializedMessage>) {};
+
+  TypeErasedCallback erased = get_erased_generic_callback(user_cb, ts_);
+
+  // Act & Assert
+  EXPECT_EXIT(
+    erased(std::move(wrong_envelope)), ::testing::ExitedWithCode(EXIT_FAILURE),
+    "Agnocast internal implementation error: bad allocation when callback is called");
+}

--- a/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
@@ -28,7 +28,6 @@
 
 using agnocast::get_erased_generic_callback;
 using agnocast::RawMessagePtr;
-using agnocast::TypedMessagePtr;
 using agnocast::TypeErasedCallback;
 
 template <typename T>

--- a/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_generic_callback.cpp
@@ -45,12 +45,13 @@ protected:
   void SetUp() override
   {
     rclcpp::init(0, nullptr);
-    ts_ = rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
+    ts_ = agnocast::TypeSupportBundle{
+      nullptr, rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>()};
   }
 
   void TearDown() override { rclcpp::shutdown(); }
 
-  const rosidl_message_type_support_t * ts_{nullptr};
+  agnocast::TypeSupportBundle ts_;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Add `agnocast::GenericSubscription`, which mirrors `rclcpp::GenericSubscription`.

The topic type is given as a runtime string (e.g. `"std_msgs/msg/String"`) instead of a compile-time template argument. Messages are delivered to the user callback as `rclcpp::SerializedMessage` (i.e. serialized bytes), not as the message type itself.

Only the Performance bridge mode is supported; under the Standard bridge mode no bridge request is issued and a warning is logged once.

## How it works

The design tries to reuse the existing subscription machinery (`CallbackInfo`, `register_*_callback`, `receive_and_execute_message`) as much as possible. Only the message envelope and the dispatch lambda are new; the executor / epoll / mq path is unchanged.

Key points:

- **Type-erased envelope.** `CallbackInfo` already dispatches messages through an `AnyObject` envelope (`TypedMessagePtr<T>` for `BasicSubscription`). We add a sibling `RawMessagePtr` that wraps `ipc_shared_ptr<std::byte>`, so the same reference-counting and kernel-release path is reused even though the message type is unknown at compile time.
- **Dispatch.** On each message, the type-erased callback returned by `get_erased_generic_callback` serializes the data into a `rclcpp::SerializedMessage` using `rmw_serialize`. It then releases the SHM reference and invokes the user callback.
- **Registration.** The existing `register_callback` is split into a small `register_erased_callback` core. Both `register_callback` (typed) and the new `register_generic_callback` go through it.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

Manual tests using the sample application were run as follows.

**Terminal 1 (listener, common to both cases):**

```bash
export AGNOCAST_BRIDGE_MODE=performance
bash scripts/sample_application/run_generic_listener.bash
```

**Terminal 2 (Case 1: A2A):**

```bash
export AGNOCAST_BRIDGE_MODE=performance
bash scripts/sample_application/run_talker.bash
```

**Terminal 2 (Case 1: R2A):**

```bash
ros2 topic pub /my_topic agnocast_sample_interfaces/msg/DynamicSizeArray "{ id: 1729, data: [] }"
```

## Notes for reviewers

A few things were intentionally left out of this PR to keep it small and
keep reviewer load low. They are written down here so the discussion is not
repeated in line comments.

- **Code duplication with `BasicSubscription` is left as-is on purpose.**
  `GenericSubscription` and `BasicSubscription` share quite a lot of logic
  (constructor body, QoS override handling, ioctl call, mq setup,
  destructor cleanup). They could be unified, but doing it in this PR
  would make the diff much harder to review. The unification is planned as
  a separate follow-up PR.

- **Different bridge-request design from `BasicSubscription` — please do
  not worry about it in this PR.**
  `BasicSubscription` takes a template type `BridgeRequestPolicy`, but
  `GenericSubscription` adopts a design that does not use
  `BridgeRequestPolicy`. Instead, it introduces a small
  `SubscriptionRole` enum (`Default` / `AgnocastOnly` / `BridgeInternal`)
  to express the same intent without extra templates.
  `BasicSubscription` is intended to adopt this same design in the
  follow-up refactor PR mentioned above, so the two will end up
  consistent. The design difference itself is therefore out of scope for
  this PR.

## Version Update Label (Required)

`need-patch-update`
