### PR TITLE
refactor(agnocastlib): split publisher class into PublisherBase and BasicPublisher

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -59,44 +59,23 @@ struct PublisherOptions
   rclcpp::QosOverridingOptions qos_overriding_options{};
 };
 
-// Internal implementation — users should use agnocast::Publisher<MessageT> instead.
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicPublisher
+// Base class for Agnocast publishers. This class handles the common operations
+// shared with all Agnocast publishers, such as kernel registration and message queue management.
+class PublisherBase
 {
+  void generate_gid();
+
+protected:
   topic_local_id_t id_ = -1;
   std::string topic_name_;
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> opened_mqs_;
   std::mutex opened_mqs_mtx_;
   rmw_gid_t gid_;
 
-  void generate_gid()
-  {
-    std::memset(gid_.data, 0, RMW_GID_STORAGE_SIZE);
-
-    // [0-1]: Agnocast identifier
-    gid_.data[0] = 'A';
-    gid_.data[1] = 'G';
-
-    // [2-5]: Process ID
-    pid_t pid = getpid();
-    std::memcpy(gid_.data + 2, &pid, sizeof(pid));
-
-    // [6-11]: topic_name hash (upper 6 bytes)
-    size_t topic_hash = std::hash<std::string>{}(topic_name_);
-    std::memcpy(gid_.data + 6, &topic_hash, 6);
-
-    // [12-15]: publisher id
-    std::memcpy(gid_.data + 12, &id_, sizeof(id_));
-
-    // [16-23]: reserved
-
-    gid_.implementation_identifier = "agnocast";
-  }
-
   template <typename NodeT>
-  rclcpp::QoS constructor_impl(
-    NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    const PublisherOptions & options, const bool is_bridge)
+  rclcpp::QoS init_base(
+    NodeT * node, const std::string & topic_name, const std::string & type_name,
+    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge)
   {
     if (options.do_always_ros2_publish) {
       RCLCPP_ERROR(
@@ -118,6 +97,57 @@ class BasicPublisher
     validate_publisher_qos(actual_qos);
 
     const std::string node_name = node->get_fully_qualified_name();
+    id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
+    generate_gid();
+
+    return actual_qos;
+  }
+
+public:
+  PublisherBase() = default;
+  virtual ~PublisherBase();
+
+  /**
+   * @brief Return the fully-resolved topic name.
+   * @return Null-terminated topic name string.
+   */
+  AGNOCAST_PUBLIC
+  const char * get_topic_name() const { return topic_name_.c_str(); }
+
+  /**
+   * @brief Return the GID of this publisher, unique across both Agnocast and ROS 2.
+   * @return Publisher GID.
+   */
+  AGNOCAST_PUBLIC
+  const rmw_gid_t & get_gid() const { return gid_; }
+
+  /**
+   * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge).
+   * @return Total subscriber count.
+   */
+  AGNOCAST_PUBLIC
+  uint32_t get_subscription_count() const { return get_subscription_count_core(topic_name_); }
+
+  /**
+   * @brief Return the number of Agnocast intra-process subscribers only (excludes ROS 2).
+   * @return Agnocast subscriber count.
+   */
+  AGNOCAST_PUBLIC
+  uint32_t get_intra_subscription_count() const
+  {
+    return get_intra_subscription_count_core(topic_name_);
+  }
+};
+
+// Internal implementation — users should use agnocast::Publisher<MessageT> instead.
+template <typename MessageT, typename BridgeRegistrationPolicy>
+class BasicPublisher : public PublisherBase
+{
+  template <typename NodeT>
+  rclcpp::QoS constructor_impl(
+    NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    const PublisherOptions & options, const bool is_bridge)
+  {
     // Gated to message types only — service types pulled in by
     // BasicService<ServiceT> have no rosidl message name. The empty string
     // signals "skip registry" to initialize_publisher.
@@ -125,8 +155,10 @@ class BasicPublisher
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
-    generate_gid();
+
+    const rclcpp::QoS actual_qos =
+      this->init_base(node, topic_name, type_name, qos, options, is_bridge);
+
     BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
 
     return actual_qos;
@@ -158,30 +190,6 @@ public:
       agnocast_publisher_init, static_cast<const void *>(this),
       static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
       actual_qos.depth());
-  }
-
-  ~BasicPublisher()
-  {
-    for (auto & [_, t] : opened_mqs_) {
-      mqd_t mq = std::get<0>(t);
-      if (mq_close(mq) == -1) {
-        RCLCPP_ERROR_STREAM(
-          logger, "mq_close failed for topic '" << topic_name_ << "': " << strerror(errno));
-      }
-    }
-
-    // NOTE: When a publisher is destroyed, subscribers should unmap its memory, but this is not yet
-    // implemented. Since multiple publishers in the same process share a mempool, process-level
-    // reference counting in kmod is needed. Leaving memory mapped causes no functional issues, so
-    // this is left as future work.
-    struct ioctl_remove_publisher_args remove_publisher_args
-    {
-    };
-    remove_publisher_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
-    remove_publisher_args.publisher_id = id_;
-    if (ioctl(agnocast_fd, AGNOCAST_REMOVE_PUBLISHER_CMD, &remove_publisher_args) < 0) {
-      RCLCPP_WARN(logger, "Failed to remove publisher (id=%d) from kernel.", id_);
-    }
   }
 
   /**
@@ -236,37 +244,6 @@ public:
 
     message.reset();
   }
-
-  /**
-   * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge).
-   * @return Total subscriber count.
-   */
-  AGNOCAST_PUBLIC
-  uint32_t get_subscription_count() const { return get_subscription_count_core(topic_name_); }
-
-  /**
-   * @brief Return the GID of this publisher, unique across both Agnocast and ROS 2.
-   * @return Publisher GID.
-   */
-  AGNOCAST_PUBLIC
-  const rmw_gid_t & get_gid() const { return gid_; }
-
-  /**
-   * @brief Return the number of Agnocast intra-process subscribers only (excludes ROS 2).
-   * @return Agnocast subscriber count.
-   */
-  AGNOCAST_PUBLIC
-  uint32_t get_intra_subscription_count() const
-  {
-    return get_intra_subscription_count_core(topic_name_);
-  }
-
-  /**
-   * @brief Return the fully-resolved topic name.
-   * @return Null-terminated topic name string.
-   */
-  AGNOCAST_PUBLIC
-  const char * get_topic_name() const { return topic_name_.c_str(); }
 };
 
 struct AgnocastToRosPubsubRegistrationPolicy;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -202,11 +202,11 @@ void PublisherBase::generate_gid()
   gid_.data[1] = 'G';
 
   // [2-5]: Process ID
-  pid_t pid = getpid();
+  const auto pid = static_cast<uint32_t>(getpid());
   std::memcpy(gid_.data + 2, &pid, sizeof(pid));
 
   // [6-11]: topic_name hash (upper 6 bytes)
-  size_t topic_hash = std::hash<std::string>{}(topic_name_);
+  const uint64_t topic_hash = static_cast<uint64_t>(std::hash<std::string>{}(topic_name_));
   std::memcpy(gid_.data + 6, &topic_hash, 6);
 
   // [12-15]: publisher id
@@ -219,11 +219,14 @@ void PublisherBase::generate_gid()
 
 PublisherBase::~PublisherBase()
 {
-  for (auto & [_, t] : opened_mqs_) {
-    mqd_t mq = std::get<0>(t);
-    if (mq_close(mq) == -1) {
-      RCLCPP_ERROR_STREAM(
-        logger, "mq_close failed for topic '" << topic_name_ << "': " << strerror(errno));
+  {
+    std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
+    for (auto & [_, t] : opened_mqs_) {
+      mqd_t mq = std::get<0>(t);
+      if (mq_close(mq) == -1) {
+        RCLCPP_ERROR_STREAM(
+          logger, "mq_close failed for topic '" << topic_name_ << "': " << strerror(errno));
+      }
     }
   }
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -195,7 +195,12 @@ uint32_t get_intra_subscription_count_core(const std::string & topic_name)
 
 void PublisherBase::generate_gid()
 {
-  std::memset(gid_.data, 0, RMW_GID_STORAGE_SIZE);
+  constexpr size_t kPidOffset = 2;
+  constexpr size_t kHashOffset = 6;
+  constexpr size_t kHashSize = 6;
+  constexpr size_t kPubIdOffset = 12;
+
+  std::memset(static_cast<void *>(&gid_.data[0]), 0, RMW_GID_STORAGE_SIZE);
 
   // [0-1]: Agnocast identifier
   gid_.data[0] = 'A';
@@ -203,14 +208,14 @@ void PublisherBase::generate_gid()
 
   // [2-5]: Process ID
   const auto pid = static_cast<uint32_t>(getpid());
-  std::memcpy(gid_.data + 2, &pid, sizeof(pid));
+  std::memcpy(static_cast<void *>(&gid_.data[kPidOffset]), &pid, sizeof(pid));
 
   // [6-11]: topic_name hash (upper 6 bytes)
   const uint64_t topic_hash = static_cast<uint64_t>(std::hash<std::string>{}(topic_name_));
-  std::memcpy(gid_.data + 6, &topic_hash, 6);
+  std::memcpy(static_cast<void *>(&gid_.data[kHashOffset]), &topic_hash, kHashSize);
 
   // [12-15]: publisher id
-  std::memcpy(gid_.data + 12, &id_, sizeof(id_));
+  std::memcpy(static_cast<void *>(&gid_.data[kPubIdOffset]), &id_, sizeof(id_));
 
   // [16-23]: reserved
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -193,4 +193,54 @@ uint32_t get_intra_subscription_count_core(const std::string & topic_name)
   return get_subscriber_count_args.ret_same_process_subscriber_num;
 }
 
+void PublisherBase::generate_gid()
+{
+  std::memset(gid_.data, 0, RMW_GID_STORAGE_SIZE);
+
+  // [0-1]: Agnocast identifier
+  gid_.data[0] = 'A';
+  gid_.data[1] = 'G';
+
+  // [2-5]: Process ID
+  pid_t pid = getpid();
+  std::memcpy(gid_.data + 2, &pid, sizeof(pid));
+
+  // [6-11]: topic_name hash (upper 6 bytes)
+  size_t topic_hash = std::hash<std::string>{}(topic_name_);
+  std::memcpy(gid_.data + 6, &topic_hash, 6);
+
+  // [12-15]: publisher id
+  std::memcpy(gid_.data + 12, &id_, sizeof(id_));
+
+  // [16-23]: reserved
+
+  gid_.implementation_identifier = "agnocast";
+}
+
+PublisherBase::~PublisherBase()
+{
+  for (auto & [_, t] : opened_mqs_) {
+    mqd_t mq = std::get<0>(t);
+    if (mq_close(mq) == -1) {
+      RCLCPP_ERROR_STREAM(
+        logger, "mq_close failed for topic '" << topic_name_ << "': " << strerror(errno));
+    }
+  }
+
+  if (id_ >= 0) {
+    // NOTE: When a publisher is destroyed, subscribers should unmap its memory, but this is not yet
+    // implemented. Since multiple publishers in the same process share a mempool, process-level
+    // reference counting in kmod is needed. Leaving memory mapped causes no functional issues, so
+    // this is left as future work.
+    struct ioctl_remove_publisher_args remove_publisher_args
+    {
+    };
+    remove_publisher_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
+    remove_publisher_args.publisher_id = id_;
+    if (ioctl(agnocast_fd, AGNOCAST_REMOVE_PUBLISHER_CMD, &remove_publisher_args) < 0) {
+      RCLCPP_WARN(logger, "Failed to remove publisher (id=%d) from kernel.", id_);
+    }
+  }
+}
+
 }  // namespace agnocast


### PR DESCRIPTION
This PR refactors `BasicPublisher` by extracting its common logic into a new non-templated base class called `PublisherBase`.

### Purpose

This is a preparatory refactor for the upcoming `GenericPublisher`. `GenericPublisher` will be a runtime-typed publisher that accepts a topic type as a string (similar to `rclcpp::GenericPublisher`), rather than a compile-time template argument. `PublisherBase` will serve as the shared foundation for both `BasicPublisher` and `GenericPublisher`. It will manage common tasks for all Agnocast publisher types, such as kernel registration, GID management, and message queue (MQ) lifecycles.

### Changes Made

- **Introduced `PublisherBase`**: Moved the following from `BasicPublisher`:
  - Member variables: `id_`, `topic_name_`, `opened_mqs_`, `opened_mqs_mtx_`, `gid_`.
  - Methods: `generate_gid()` and the destructor (implementations moved to `.cpp`).
  - Accessors: `get_topic_name()`, `get_gid()`, `get_subscription_count()`, `get_intra_subscription_count()`.
- **Updated `BasicPublisher`**: Made it a subclass of `PublisherBase`.
- **Consolidated initialization**: Moved initialization logic into the `init_base()` template method.
- **Added destructor guard**: Added an `id_ >= 0` check in the destructor to be consistent with `SubscriptionBase`.

### What was NOT moved to `PublisherBase`

`publish()` and `borrow_loaned_message()` intentionally remain in `BasicPublisher`.

**Reason:** The upcoming `GenericPublisher` will expose these operations with different signatures (e.g., taking serialized messages instead of typed `ipc_shared_ptr<MessageT>`), or will not use them at all (e.g., `borrow_loaned_message()`). 
If we put them in the base class, we would have to use an undesirable virtual interface or leave unused methods in `GenericPublisher`.


## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

No changes to the user-facing API (`agnocast::Publisher<MessageT>`).

## Version Update Label (Required)

`need-patch-update`