### PR TITLE
feat(agnocastlib): add `agnocast::GenericPublisher`

### DIFF
--- a/scripts/sample_application/run_generic_talker.bash
+++ b/scripts/sample_application/run_generic_talker.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source install/setup.bash
+ros2 launch agnocast_sample_application generic_talker.launch.xml

--- a/src/agnocast_sample_application/CMakeLists.txt
+++ b/src/agnocast_sample_application/CMakeLists.txt
@@ -20,6 +20,12 @@ target_include_directories(talker PRIVATE
   ${agnocastlib_INCLUDE_DIRS}
 )
 
+add_executable(generic_talker src/minimal_generic_publisher.cpp)
+ament_target_dependencies(generic_talker rclcpp agnocastlib agnocast_sample_interfaces)
+target_include_directories(generic_talker PRIVATE
+  ${agnocastlib_INCLUDE_DIRS}
+)
+
 add_executable(cie_tutorial_node src/cie_tutorial_node.cpp)
 ament_target_dependencies(cie_tutorial_node rclcpp agnocastlib)
 
@@ -143,6 +149,9 @@ install(TARGETS agnocast_cie_listener_component
 )
 
 install(TARGETS talker
+  DESTINATION lib/${PROJECT_NAME})
+
+install(TARGETS generic_talker
   DESTINATION lib/${PROJECT_NAME})
 
 install(TARGETS cie_talker

--- a/src/agnocast_sample_application/launch/generic_talker.launch.xml
+++ b/src/agnocast_sample_application/launch/generic_talker.launch.xml
@@ -1,0 +1,15 @@
+<launch>
+    <!--
+      `discovery_agent` arg controls whether the per-IPC-namespace Agnocast
+      discovery agent is spawned alongside the generic talker. Exactly one daemon
+      should run per IPC namespace; set this to false when including this
+      launch from another launch that already spawns the daemon.
+    -->
+    <arg name="discovery_agent" default="false"/>
+    <include file="$(find-pkg-share ros2agnocast_discovery_agent)/launch/discovery_agent.launch.xml"
+             if="$(var discovery_agent)"/>
+
+    <node pkg="agnocast_sample_application" exec="generic_talker" name="generic_talker_node" output="screen">
+        <env name="LD_PRELOAD" value="libagnocast_heaphook.so:$(env LD_PRELOAD '')" />
+    </node>
+</launch>

--- a/src/agnocast_sample_application/src/minimal_generic_publisher.cpp
+++ b/src/agnocast_sample_application/src/minimal_generic_publisher.cpp
@@ -1,0 +1,58 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/msg/dynamic_size_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+
+using namespace std::chrono_literals;
+const long long MESSAGE_SIZE = 1000ll * 1024;
+
+class MinimalGenericPublisher : public rclcpp::Node
+{
+  int64_t count_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  agnocast::GenericPublisher::SharedPtr publisher_;
+
+  void timer_callback()
+  {
+    agnocast_sample_interfaces::msg::DynamicSizeArray message;
+    message.id = count_;
+    message.data.reserve(MESSAGE_SIZE / sizeof(uint64_t));
+    for (size_t i = 0; i < MESSAGE_SIZE / sizeof(uint64_t); i++) {
+      message.data.push_back(i + count_);
+    }
+
+    rclcpp::Serialization<agnocast_sample_interfaces::msg::DynamicSizeArray> serializer;
+    rclcpp::SerializedMessage serialized;
+    serializer.serialize_message(&message, &serialized);
+
+    publisher_->publish(serialized);
+    RCLCPP_INFO(this->get_logger(), "publish message: id=%ld", count_++);
+  }
+
+public:
+  MinimalGenericPublisher() : Node("minimal_generic_publisher")
+  {
+    count_ = 0;
+
+    publisher_ = agnocast::create_generic_publisher(
+      this, "/my_topic", "agnocast_sample_interfaces/msg/DynamicSizeArray", 1);
+
+    timer_ =
+      this->create_wall_timer(100ms, std::bind(&MinimalGenericPublisher::timer_callback, this));
+  }
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  agnocast::SingleThreadedAgnocastExecutor executor;
+  auto node = std::make_shared<MinimalGenericPublisher>();
+  executor.add_node(node);
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(glog REQUIRED)
+find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
 add_library(agnocast SHARED
   src/agnocast.cpp src/agnocast_utils.cpp src/agnocast_publisher.cpp src/agnocast_subscription.cpp
@@ -55,7 +56,7 @@ add_library(agnocast SHARED
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
   src/node/diagnostic_updater/diagnostic_updater.cpp)
 
-ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater)
+ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_introspection_cpp)
 
 target_link_libraries(agnocast
   ${rcl_yaml_param_parser_LIBRARIES}
@@ -154,7 +155,8 @@ if(BUILD_TESTING)
     test/unit/test_agnocast_context.cpp
     test/unit/test_diagnostic_updater.cpp
     test/unit/test_type_registry_writer.cpp
-    test/unit/test_agnocast_generic_callback.cpp)
+    test/unit/test_agnocast_generic_callback.cpp
+    test/unit/test_agnocast_generic_publisher.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)
@@ -306,6 +308,19 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_integration_generic_subscription_${PROJECT_NAME}
     std_msgs rosidl_typesupport_cpp)
   set_tests_properties(test_integration_generic_subscription_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
+  # GenericPublisher integration test (requires kernel module, no mock)
+  ament_add_gmock(test_integration_generic_publisher_${PROJECT_NAME}
+    test/integration/test_agnocast_generic_publisher.cpp)
+  target_include_directories(test_integration_generic_publisher_${PROJECT_NAME} PRIVATE include)
+  target_link_libraries(test_integration_generic_publisher_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_generic_publisher_${PROJECT_NAME}
+    std_msgs rosidl_typesupport_cpp)
+  set_tests_properties(test_integration_generic_publisher_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
     TIMEOUT 60
     LABELS "requires_kernel_module;requires_heaphook"

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -105,6 +105,47 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 
+/// @brief Create an Agnocast generic publisher (Stage 1 free function, QoS overload).
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param topic_type Message type string.
+/// @param qos Quality of service profile.
+/// @param options Publisher options.
+/// @return Shared pointer to the created generic publisher.
+AGNOCAST_PUBLIC
+template <typename NodeT>
+GenericPublisher::SharedPtr create_generic_publisher(
+  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, agnocast::PublisherOptions options = agnocast::PublisherOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<GenericPublisher>(node, topic_name, topic_type, qos, options);
+}
+
+/// @brief Create an Agnocast generic publisher (Stage 1 free function, history-depth overload).
+/// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
+/// @param node Pointer to the node.
+/// @param topic_name Topic name.
+/// @param topic_type Message type string.
+/// @param qos_history_depth History depth for the QoS profile.
+/// @param options Publisher options.
+/// @return Shared pointer to the created generic publisher.
+AGNOCAST_PUBLIC
+template <typename NodeT>
+GenericPublisher::SharedPtr create_generic_publisher(
+  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+  const size_t qos_history_depth, agnocast::PublisherOptions options = agnocast::PublisherOptions{})
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<GenericPublisher>(
+    node, topic_name, topic_type, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
+}
+
 /// @brief Create an Agnocast subscription (Stage 1 free function, QoS overload).
 /// @tparam MessageT ROS message type.
 /// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -8,6 +8,8 @@
 #include "agnocast/agnocast_utils.hpp"
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/serialized_message.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
 
 #include <fcntl.h>
 #include <mqueue.h>
@@ -57,6 +59,31 @@ struct PublisherOptions
   bool do_always_ros2_publish = false;
   /// QoS parameter override options (same semantics as rclcpp).
   rclcpp::QosOverridingOptions qos_overriding_options{};
+};
+
+/**
+ * @brief Role of a publisher with respect to the Agnocast<->ROS bridge.
+ *
+ * Encodes two properties of a publisher:
+ *   - whether it is used by the bridge implementation itself
+ *   - whether it should issue an A2R bridge request on construction
+ *
+ *   | Role            | kmod `is_bridge` | bridge request issued |
+ *   |-----------------|------------------|-----------------------|
+ *   | Default         | false            | yes (A2R)             |
+ *   | AgnocastOnly    | false            | no                    |
+ *   | BridgeInternal  | true             | no                    |
+ */
+enum class PublisherRole : uint8_t {
+  /// User-created publisher; issues an A2R bridge request.
+  Default,
+  /// Used internally; no bridge request is issued.
+  /// Not intended for direct use by application code.
+  AgnocastOnly,
+  /// Used by the bridge implementation itself; marked as bridge in kmod and
+  /// issues no bridge request.
+  /// Not intended for direct use by application code.
+  BridgeInternal,
 };
 
 // Base class for Agnocast publishers. This class handles the common operations
@@ -244,6 +271,60 @@ public:
 
     message.reset();
   }
+};
+
+/**
+ * @brief Mirrors `rclcpp::GenericPublisher` semantics: the topic type is supplied as a
+ * runtime string (e.g. "std_msgs/msg/String") rather than a compile-time
+ * template argument. The typesupport library is loaded eagerly in the
+ * constructor and held for the publisher's lifetime.
+ *
+ * Messages are passed to `publish()` as `rclcpp::SerializedMessage` objects
+ * and are deserialized into Agnocast shared memory within the `publish()` call.
+ *
+ * NOTE: Standard bridge mode is not supported for this publisher type.
+ * When standard bridge is used, no bridge request is issued, so no bridge is
+ * created and communication with ROS 2 subscribers is not possible. This is
+ * by design, as standard bridge support is planned for removal.
+ */
+AGNOCAST_PUBLIC
+class GenericPublisher : public PublisherBase
+{
+  // Keeps the dynamically loaded typesupport and introspection shared libraries
+  // (.so) alongside their handles for the lifetime of the publisher.
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
+  const rosidl_message_type_support_t * type_support_handle_{nullptr};
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * members_{nullptr};
+
+  template <typename NodeT>
+  rclcpp::QoS constructor_impl(
+    NodeT * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, PublisherRole role);
+
+public:
+  using SharedPtr = std::shared_ptr<GenericPublisher>;
+
+  AGNOCAST_PUBLIC
+  GenericPublisher(
+    rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, agnocast::PublisherOptions options = agnocast::PublisherOptions{},
+    PublisherRole role = PublisherRole::Default);
+
+  AGNOCAST_PUBLIC
+  GenericPublisher(
+    agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, agnocast::PublisherOptions options = agnocast::PublisherOptions{},
+    PublisherRole role = PublisherRole::Default);
+
+  /**
+   * @brief Deserialize a serialized message into Agnocast shared memory and
+   * publish it via zero-copy IPC.
+   *
+   * @param serialized_msg Serialized ROS 2 message to deserialize and publish.
+   */
+  AGNOCAST_PUBLIC
+  void publish(const rclcpp::SerializedMessage & serialized_msg);
 };
 
 struct AgnocastToRosPubsubRegistrationPolicy;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -300,7 +300,7 @@ class GenericPublisher : public PublisherBase
   template <typename NodeT>
   rclcpp::QoS constructor_impl(
     NodeT * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, PublisherRole role);
+    const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role);
 
 public:
   using SharedPtr = std::shared_ptr<GenericPublisher>;
@@ -308,13 +308,13 @@ public:
   AGNOCAST_PUBLIC
   GenericPublisher(
     rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, agnocast::PublisherOptions options = agnocast::PublisherOptions{},
+    const rclcpp::QoS & qos, const PublisherOptions & options = PublisherOptions{},
     PublisherRole role = PublisherRole::Default);
 
   AGNOCAST_PUBLIC
   GenericPublisher(
     agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, agnocast::PublisherOptions options = agnocast::PublisherOptions{},
+    const rclcpp::QoS & qos, const PublisherOptions & options = PublisherOptions{},
     PublisherRole role = PublisherRole::Default);
 
   /**

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -69,7 +69,7 @@ inline void register_pubsub_bridge_by_type_name(
     static const auto logger = rclcpp::get_logger("agnocast_bridge_registrar");
     RCLCPP_WARN_ONCE(
       logger,
-      "GenericSubscription does not support standard-mode bridge. "
+      "GenericSubscription and GenericPublisher do not support standard-mode bridge. "
       "Set AGNOCAST_BRIDGE_MODE=performance to enable bridging.");
   } else if (bridge_mode == BridgeMode::Performance) {
     send_performance_pubsub_bridge_registration_by_type_name(

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -30,6 +30,7 @@
   <depend>rcpputils</depend>
   <depend>rmw</depend>
   <depend>rosgraph_msgs</depend>
+  <depend>rosidl_typesupport_introspection_cpp</depend>
   <depend>tracetools</depend>
 
   <depend>agnocast_cie_config_msgs</depend>

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -300,7 +300,7 @@ rclcpp::QoS GenericPublisher::constructor_impl(
 
 GenericPublisher::GenericPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
-  const rclcpp::QoS & qos, agnocast::PublisherOptions options, PublisherRole role)
+  const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
 {
   const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
 
@@ -312,7 +312,7 @@ GenericPublisher::GenericPublisher(
 
 GenericPublisher::GenericPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
-  const rclcpp::QoS & qos, agnocast::PublisherOptions options, PublisherRole role)
+  const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
 {
   const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -1,11 +1,19 @@
 #include "agnocast/agnocast_publisher.hpp"
 
+#include "agnocast/bridge/agnocast_bridge_node.hpp"
 #include "agnocast/internal/type_registry_writer.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
+#include <rclcpp/typesupport_helpers.hpp>
+#include <rosidl_runtime_cpp/message_initialization.hpp>
+
+#include <rcutils/allocator.h>
+#include <rmw/rmw.h>
+#include <rmw/serialized_message.h>
 #include <sys/types.h>
 
 #include <array>
+#include <new>
 
 namespace agnocast
 {
@@ -248,6 +256,128 @@ PublisherBase::~PublisherBase()
     if (ioctl(agnocast_fd, AGNOCAST_REMOVE_PUBLISHER_CMD, &remove_publisher_args) < 0) {
       RCLCPP_WARN(logger, "Failed to remove publisher (id=%d) from kernel.", id_);
     }
+  }
+}
+
+template <typename NodeT>
+rclcpp::QoS GenericPublisher::constructor_impl(
+  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
+{
+  // The typesupport functions may throw exceptions if the shared libraries
+  // fail to load or an invalid message type name is provided. These
+  // exceptions are not handled here, causing the constructor to exit
+  // immediately.
+  ts_lib_ = rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_cpp");
+  ts_lib_introspection_ =
+    rclcpp::get_typesupport_library(topic_type, "rosidl_typesupport_introspection_cpp");
+#if RCLCPP_VERSION_MAJOR >= 28
+  type_support_handle_ =
+    rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib_);
+  const rosidl_message_type_support_t * introspection_handle =
+    rclcpp::get_message_typesupport_handle(
+      topic_type, "rosidl_typesupport_introspection_cpp", *ts_lib_introspection_);
+#else
+  type_support_handle_ =
+    rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib_);
+  const rosidl_message_type_support_t * introspection_handle = rclcpp::get_typesupport_handle(
+    topic_type, "rosidl_typesupport_introspection_cpp", *ts_lib_introspection_);
+#endif
+  members_ = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+    introspection_handle->data);
+
+  const bool is_bridge = (role == PublisherRole::BridgeInternal);
+  const rclcpp::QoS actual_qos =
+    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
+
+  if (role == PublisherRole::Default) {
+    register_pubsub_bridge_by_type_name(
+      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
+  }
+
+  return actual_qos;
+}
+
+GenericPublisher::GenericPublisher(
+  rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, agnocast::PublisherOptions options, PublisherRole role)
+{
+  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
+    topic_name_.c_str(), actual_qos.depth());
+}
+
+GenericPublisher::GenericPublisher(
+  agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, agnocast::PublisherOptions options, PublisherRole role)
+{
+  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
+    actual_qos.depth());
+}
+
+void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
+{
+  // Mirror the pre-conditions checked by rclcpp::SerializationBase::deserialize_message
+  // to avoid a SIGSEGV inside rmw_deserialize on malformed input.
+  if (serialized_msg.capacity() == 0) {
+    RCLCPP_ERROR(
+      logger,
+      "GenericPublisher::publish: serialized message has capacity of zero; dropping message");
+    return;
+  }
+  if (serialized_msg.size() == 0) {
+    RCLCPP_ERROR(
+      logger, "GenericPublisher::publish: serialized message has size of zero; dropping message");
+    return;
+  }
+
+  increment_borrowed_publisher_num();
+  void * ptr = ::operator new(members_->size_of_);
+
+  // Invoke the constructor of the message type at ptr.
+  // Type-specific initialization is unnecessary because the message object
+  // will be immediately populated with data by rmw_deserialize.
+  // Perform minimal initialization only.
+  members_->init_function(ptr, rosidl_runtime_cpp::MessageInitialization::SKIP);
+
+  const rmw_ret_t ret =
+    rmw_deserialize(&serialized_msg.get_rcl_serialized_message(), type_support_handle_, ptr);
+
+  if (ret != RMW_RET_OK) {
+    members_->fini_function(ptr);
+    ::operator delete(ptr);
+    decrement_borrowed_publisher_num();
+    RCLCPP_ERROR(
+      logger, "rmw_deserialize failed in GenericPublisher (rmw_ret=%d); dropping message",
+      static_cast<int>(ret));
+    return;
+  }
+
+  const auto va = reinterpret_cast<uint64_t>(ptr);
+  union ioctl_publish_msg_args publish_msg_args {
+  };
+  {
+    std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
+    publish_msg_args = publish_core(this, topic_name_, id_, va, opened_mqs_);
+  }
+
+  decrement_borrowed_publisher_num();
+
+  // Release entries that all subscribers have finished reading.
+  // Only the addresses previously passed to the kernel by this publisher are returned here.
+  // Therefore, the message type is guaranteed to match members_ and it's safe to call
+  // fini_function on the pointer.
+  for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
+    void * rptr = reinterpret_cast<void *>(publish_msg_args.ret_released_addrs[i]);
+    members_->fini_function(rptr);
+    ::operator delete(rptr);
   }
 }
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -350,10 +350,11 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
   const rmw_ret_t ret =
     rmw_deserialize(&serialized_msg.get_rcl_serialized_message(), type_support_handle_, ptr);
 
+  decrement_borrowed_publisher_num();
+
   if (ret != RMW_RET_OK) {
     members_->fini_function(ptr);
     ::operator delete(ptr);
-    decrement_borrowed_publisher_num();
     RCLCPP_ERROR(
       logger, "rmw_deserialize failed in GenericPublisher (rmw_ret=%d); dropping message",
       static_cast<int>(ret));
@@ -367,8 +368,6 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
     std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
     publish_msg_args = publish_core(this, topic_name_, id_, va, opened_mqs_);
   }
-
-  decrement_borrowed_publisher_num();
 
   // Release entries that all subscribers have finished reading.
   // Only the addresses previously passed to the kernel by this publisher are returned here.

--- a/src/agnocastlib/test/integration/test_agnocast_generic_publisher.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_generic_publisher.cpp
@@ -1,0 +1,274 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_single_threaded_executor.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/agnocast_only_single_threaded_executor.hpp"
+#include "rclcpp/serialization.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+using StringMsg = std_msgs::msg::String;
+
+namespace
+{
+
+// Polls `pred` until it returns true or `timeout` elapses.
+template <typename Pred>
+bool wait_for(Pred pred, std::chrono::milliseconds timeout = 5000ms)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) return true;
+    std::this_thread::sleep_for(10ms);
+  }
+  return pred();
+}
+
+}  // namespace
+
+class GenericPublisherTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_generic_pub");
+    executor_ = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    node_.reset();
+    executor_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<agnocast::SingleThreadedAgnocastExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+// ---------------------------------------------------------------------------
+// Round-trip: serialized message is delivered to a typed Subscription.
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherTest, round_trip_to_typed_subscription)
+{
+  const std::string topic = "/test_generic_pub_to_typed_sub";
+  const std::string type = "std_msgs/msg/String";
+  const std::string expected_data = "hello from generic publisher";
+  rclcpp::QoS qos{1};
+
+  auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions sub_opts;
+  sub_opts.callback_group = cbg;
+
+  std::shared_ptr<const StringMsg> received;
+  std::mutex mtx;
+
+  auto sub = agnocast::create_subscription<StringMsg>(
+    node_.get(), topic, qos,
+    [&received, &mtx](agnocast::ipc_shared_ptr<const StringMsg> msg) {
+      auto copy = std::make_shared<StringMsg>(*msg);
+      std::lock_guard<std::mutex> lock(mtx);
+      received = std::move(copy);
+    },
+    sub_opts);
+
+  auto pub = agnocast::create_generic_publisher(node_.get(), topic, type, qos);
+
+  StringMsg out_msg;
+  out_msg.data = expected_data;
+  rclcpp::Serialization<StringMsg> serializer;
+  rclcpp::SerializedMessage serialized;
+  serializer.serialize_message(&out_msg, &serialized);
+  pub->publish(serialized);
+
+  const bool delivered = wait_for([&] {
+    std::lock_guard<std::mutex> lock(mtx);
+    return received != nullptr;
+  });
+
+  ASSERT_TRUE(delivered) << "Timed out waiting for typed subscription callback";
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    EXPECT_EQ(received->data, expected_data);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: serialized message is delivered to a GenericSubscription.
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherTest, round_trip_to_generic_subscription)
+{
+  const std::string topic = "/test_generic_pub_to_generic_sub";
+  const std::string type = "std_msgs/msg/String";
+  const std::string expected_data = "hello via generic subscription";
+  rclcpp::QoS qos{1};
+
+  auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions sub_opts;
+  sub_opts.callback_group = cbg;
+
+  std::shared_ptr<rclcpp::SerializedMessage> received;
+  std::mutex mtx;
+  auto sub = agnocast::create_generic_subscription(
+    node_.get(), topic, type, qos,
+    [&received, &mtx](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+      std::lock_guard<std::mutex> lock(mtx);
+      received = std::move(msg);
+    },
+    sub_opts);
+
+  auto pub = agnocast::create_generic_publisher(node_.get(), topic, type, qos);
+
+  StringMsg out_msg;
+  out_msg.data = expected_data;
+  rclcpp::Serialization<StringMsg> serializer;
+  rclcpp::SerializedMessage serialized;
+  serializer.serialize_message(&out_msg, &serialized);
+  pub->publish(serialized);
+
+  const bool delivered = wait_for([&] {
+    std::lock_guard<std::mutex> lock(mtx);
+    return received != nullptr;
+  });
+
+  ASSERT_TRUE(delivered) << "Timed out waiting for GenericSubscription callback";
+
+  rclcpp::Serialization<StringMsg> deser;
+  StringMsg decoded;
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    deser.deserialize_message(received.get(), &decoded);
+  }
+  EXPECT_EQ(decoded.data, expected_data);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: constructor registers the publisher; topic name and GID are populated.
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherTest, lifecycle_registers_publisher)
+{
+  const std::string topic = "/test_generic_pub_lifecycle";
+  const std::string type = "std_msgs/msg/String";
+  rclcpp::QoS qos{1};
+
+  {
+    auto pub = agnocast::create_generic_publisher(node_.get(), topic, type, qos);
+
+    EXPECT_STRNE(pub->get_topic_name(), "");
+
+    const rmw_gid_t & gid = pub->get_gid();
+    EXPECT_EQ(gid.data[0], static_cast<uint8_t>('A'));
+    EXPECT_EQ(gid.data[1], static_cast<uint8_t>('G'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor error: unknown topic type throws std::runtime_error before any IPC.
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherTest, typesupport_error_unknown_type)
+{
+  const std::string unknown_type = "totally_fake_package/msg/DoesNotExist";
+
+  EXPECT_THROW(
+    agnocast::GenericPublisher(node_.get(), "/test_topic", unknown_type, rclcpp::QoS{1}),
+    std::runtime_error);
+}
+
+// =========================================
+// agnocast::Node tests
+// =========================================
+
+class AgnocastNodeGenericPublisherTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    node_ = std::make_shared<agnocast::Node>("test_generic_pub_agnocast_node");
+    executor_ = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    node_.reset();
+    executor_.reset();
+    agnocast::shutdown();
+  }
+
+  std::shared_ptr<agnocast::Node> node_;
+  std::shared_ptr<agnocast::AgnocastOnlySingleThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+// ---------------------------------------------------------------------------
+// Round-trip: GenericPublisher works correctly with agnocast::Node.
+// ---------------------------------------------------------------------------
+TEST_F(AgnocastNodeGenericPublisherTest, round_trip_serialization)
+{
+  const std::string topic = "/test_agnocast_node_generic_pub";
+  const std::string type = "std_msgs/msg/String";
+  const std::string expected_data = "hello from agnocast node generic publisher";
+  rclcpp::QoS qos{1};
+
+  auto cbg = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions sub_opts;
+  sub_opts.callback_group = cbg;
+
+  std::shared_ptr<rclcpp::SerializedMessage> received;
+  std::mutex mtx;
+  auto sub = agnocast::create_generic_subscription(
+    node_.get(), topic, type, qos,
+    [&received, &mtx](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+      std::lock_guard<std::mutex> lock(mtx);
+      received = std::move(msg);
+    },
+    sub_opts);
+
+  auto pub = agnocast::create_generic_publisher(node_.get(), topic, type, qos);
+
+  StringMsg out_msg;
+  out_msg.data = expected_data;
+  rclcpp::Serialization<StringMsg> serializer;
+  rclcpp::SerializedMessage serialized;
+  serializer.serialize_message(&out_msg, &serialized);
+  pub->publish(serialized);
+
+  const bool delivered = wait_for([&] {
+    std::lock_guard<std::mutex> lock(mtx);
+    return received != nullptr;
+  });
+
+  ASSERT_TRUE(delivered) << "Timed out waiting for GenericSubscription callback";
+
+  rclcpp::Serialization<StringMsg> deser;
+  StringMsg decoded;
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    deser.deserialize_message(received.get(), &decoded);
+  }
+  EXPECT_EQ(decoded.data, expected_data);
+}

--- a/src/agnocastlib/test/unit/test_agnocast_generic_publisher.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_generic_publisher.cpp
@@ -1,0 +1,135 @@
+#include "agnocast/agnocast_publisher.hpp"
+#include "rclcpp/serialization.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+#include <rcutils/logging.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+// Defined in test_mocked_agnocast.cpp (same compilation unit / test target).
+extern int publish_core_mock_called_count;
+
+namespace
+{
+
+const std::string kKnownType = "std_msgs/msg/String";
+const std::string kUnknownType = "totally_fake_package/msg/DoesNotExist";
+
+std::string g_captured_log;
+
+void log_capture_handler(
+  const rcutils_log_location_t * /*location*/, int /*severity*/, const char * name,
+  rcutils_time_point_value_t /*timestamp*/, const char * format, va_list * args)
+{
+  if (name == nullptr || std::string(name) != "Agnocast") {
+    return;
+  }
+  char buf[1024];
+  va_list args_copy;
+  va_copy(args_copy, *args);
+  vsnprintf(buf, sizeof(buf), format, args_copy);
+  va_end(args_copy);
+  g_captured_log += buf;
+  g_captured_log += '\n';
+}
+
+class LogCapture
+{
+public:
+  LogCapture()
+  {
+    g_captured_log.clear();
+    previous_ = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(log_capture_handler);
+  }
+  ~LogCapture() { rcutils_logging_set_output_handler(previous_); }
+
+private:
+  rcutils_logging_output_handler_t previous_;
+};
+
+}  // namespace
+
+class GenericPublisherUnitTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_generic_pub_node");
+    pub_ = std::make_unique<agnocast::GenericPublisher>(
+      node_.get(), "/test_generic_pub_string", kKnownType, rclcpp::QoS{1});
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  static rclcpp::SerializedMessage make_valid_serialized_message()
+  {
+    std_msgs::msg::String msg;
+    msg.data = "hello from generic publisher unit test";
+    rclcpp::Serialization<std_msgs::msg::String> serializer;
+    rclcpp::SerializedMessage serialized;
+    serializer.serialize_message(&msg, &serialized);
+    return serialized;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::unique_ptr<agnocast::GenericPublisher> pub_;
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: unknown topic type → std::runtime_error in constructor
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherUnitTest, typesupport_error_unknown_type)
+{
+  EXPECT_THROW(
+    agnocast::GenericPublisher(node_.get(), "/test_topic", kUnknownType, rclcpp::QoS{1}),
+    std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: valid serialized message → publish_core is called once
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherUnitTest, publish_calls_publish_core)
+{
+  publish_core_mock_called_count = 0;
+  pub_->publish(make_valid_serialized_message());
+
+  EXPECT_EQ(publish_core_mock_called_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: capacity == 0 → publish_core not called; ERROR is logged
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherUnitTest, publish_zero_capacity_skips_publish_core)
+{
+  publish_core_mock_called_count = 0;
+  LogCapture capture;
+
+  rclcpp::SerializedMessage empty_msg;  // capacity() == 0, size() == 0
+  pub_->publish(empty_msg);
+
+  EXPECT_EQ(publish_core_mock_called_count, 0);
+  EXPECT_NE(g_captured_log.find("capacity of zero"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: capacity > 0 but size == 0 → publish_core not called; ERROR is logged
+// ---------------------------------------------------------------------------
+TEST_F(GenericPublisherUnitTest, publish_zero_size_skips_publish_core)
+{
+  publish_core_mock_called_count = 0;
+  LogCapture capture;
+
+  rclcpp::SerializedMessage msg_with_capacity;  // capacity > 0, size == 0
+  msg_with_capacity.reserve(64);
+  pub_->publish(msg_with_capacity);
+
+  EXPECT_EQ(publish_core_mock_called_count, 0);
+  EXPECT_NE(g_captured_log.find("size of zero"), std::string::npos);
+}


### PR DESCRIPTION
## Description

Add `agnocast::GenericPublisher`, which mirrors `rclcpp::GenericPublisher`.

The topic type is given as a runtime string (e.g. `"std_msgs/msg/String"`) instead of a compile-time template argument. Messages are passed to `publish()` as `rclcpp::SerializedMessage` objects and are deserialized into Agnocast shared memory inside the `publish()` call.

Only the Performance bridge mode is supported; under the Standard bridge mode no bridge request is issued and a warning is logged once.

## How it works

The design keeps all deserialization work inside `GenericPublisher::publish()` and reuses the existing publisher machinery (`PublisherBase`, `publish_core`, the kernel ioctl path) unchanged.

Key points:


- **Dynamic typesupport loading.** Two shared libraries (`rosidl_typesupport_cpp` and `rosidl_typesupport_introspection_cpp`) are loaded eagerly in the constructor and held for the publisher's lifetime.
- **Publish path.** On each `publish()` call, a buffer is heap-allocated, populated by `rmw_deserialize`, and passed to `publish_core` as a virtual address — exactly as a typed `Publisher<T>` would.
- **`PublisherRole` enum.** A small `PublisherRole` enum (`Default` / `AgnocastOnly` / `BridgeInternal`) is introduced to encode bridge-registration behaviour, replacing the template `BridgeRequestPolicy` pattern used by `BasicPublisher`.
- **Free functions.** `create_generic_publisher()` overloads (QoS and history-depth) are added to `agnocast.hpp`, mirroring the existing `create_publisher()` overloads.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

Manual tests using the sample application were run as follows.

**Terminal 1 (talker):**

```bash
export AGNOCAST_BRIDGE_MODE=performance
bash scripts/sample_application/run_generic_talker.bash
```

**Terminal 2 (Case 1: A2A — listener using `GenericSubscription`):**

```bash
export AGNOCAST_BRIDGE_MODE=performance
bash scripts/sample_application/run_generic_listener.bash
```

**Terminal 2 (Case 2: A2R — ROS 2 subscriber):**

```bash
ros2 topic echo_agnocast /my_topic
```

## Notes for reviewers

A few things were intentionally left out of this PR to keep it small and keep reviewer load low. They are written down here so the discussion is not repeated in line comments.

- **`PublisherRole` design difference from `BasicPublisher`.** `BasicPublisher` uses a template `BridgeRequestPolicy`, while `GenericPublisher` uses the new `PublisherRole` enum. The intent is that `BasicPublisher` will adopt the same design in a follow-up refactor PR, so the two will end up consistent. This design difference is therefore out of scope for this PR.

## Version Update Label (Required)

`need-patch-update`