### PR TITLE
receive msg optimization

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2270,14 +2270,6 @@ static long receive_msg_cmd(union ioctl_receive_msg_args __user * arg)
   }
   kfree(pub_shm_infos);
 
-  // Function Replacement Target
-  /*
-  if (ret == 0) {
-    if (copy_to_user(arg, &receive_msg_args, sizeof(receive_msg_args))) return -EFAULT;
-  }
-  return ret;
-  */
-
   size_t n = receive_msg_args.ret_entry_num;
 
   if (n > MAX_RECEIVE_NUM) n = MAX_RECEIVE_NUM;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2270,9 +2270,45 @@ static long receive_msg_cmd(union ioctl_receive_msg_args __user * arg)
   }
   kfree(pub_shm_infos);
 
+  // Function Replacement Target
+  /*
   if (ret == 0) {
     if (copy_to_user(arg, &receive_msg_args, sizeof(receive_msg_args))) return -EFAULT;
   }
+  return ret;
+  */
+
+  size_t n = receive_msg_args.ret_entry_num;
+
+  if (n > MAX_RECEIVE_NUM) n = MAX_RECEIVE_NUM;
+
+  /* scalar fields */
+  if (copy_to_user(
+        &arg->ret_entry_num, &receive_msg_args.ret_entry_num,
+        sizeof(receive_msg_args.ret_entry_num)))
+    return -EFAULT;
+
+  if (copy_to_user(
+        &arg->ret_call_again, &receive_msg_args.ret_call_again,
+        sizeof(receive_msg_args.ret_call_again)))
+    return -EFAULT;
+
+  if (copy_to_user(
+        &arg->ret_pub_shm_num, &receive_msg_args.ret_pub_shm_num,
+        sizeof(receive_msg_args.ret_pub_shm_num)))
+    return -EFAULT;
+
+  /* arrays (only valid prefix) */
+  if (copy_to_user(
+        arg->ret_entry_ids, receive_msg_args.ret_entry_ids,
+        n * sizeof(receive_msg_args.ret_entry_ids[0])))
+    return -EFAULT;
+
+  if (copy_to_user(
+        arg->ret_entry_addrs, receive_msg_args.ret_entry_addrs,
+        n * sizeof(receive_msg_args.ret_entry_addrs[0])))
+    return -EFAULT;
+
   return ret;
 }
 


### PR DESCRIPTION
## Description
After this change, instead of copying the full fixed-size buffer (`MAX_RECEIVE_NUM`),
we only copy the valid prefix (`ret_entry_num`) of `ret_entry_ids` and `ret_entry_addrs`.

This avoids unnecessary kernel-to-userspace copies while preserving the existing contract
that only indices in the range `[0, ret_entry_num - 1]` are valid.

This change does not affect ABI semantics, as userspace already relies on `ret_entry_num`
to determine the number of valid entries.

## Related links
Related to #943 
## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers
This change does not modify ioctl fields or semantics.

`ret_entry_num` continues to define the valid range for `ret_entry_ids` and `ret_entry_addrs`.

The unused array elements are intentionally not copied to userspace.

Existing userspace already iterates only up to `ret_entry_num`.
## Version Update Label (Required)

`need-patch-update`
