### PR TITLE
feat(agnocastlib): make perf bridge independent from bridge plugins

### DIFF
--- a/scripts/test/e2e_test_2to2.bash
+++ b/scripts/test/e2e_test_2to2.bash
@@ -81,17 +81,6 @@ CURRENT_BRIDGE_DISPLAY=${LOWER_BRIDGE_MODE:-"standard (default)"}
 echo "Bridge mode: $CURRENT_BRIDGE_DISPLAY" | sudo tee /dev/kmsg
 
 if [ "$LOWER_BRIDGE_MODE" = "performance" ] || [ "$LOWER_BRIDGE_MODE" = "2" ]; then
-    if [ -d "agnocast_bridge_plugins" ]; then
-        echo "Skip generating bridge plugins: agnocast_bridge_plugins directory already exists" | sudo tee /dev/kmsg
-    else
-        ros2 agnocast generate-bridge-plugins --all
-    fi
-    if ! colcon build --packages-select agnocast_bridge_plugins; then
-        echo "ERROR: colcon build failed for agnocast_bridge_plugins" | sudo tee /dev/kmsg
-        exit 1
-    fi
-    source install/setup.bash
-
     echo "Performance mode cleanup: checking agno_pbr_* processes" | sudo tee /dev/kmsg
     # Kill stale performance bridge processes directly by PID.
     mapfile -t AGNO_PBR_PIDS < <(ps -eo pid=,comm= | awk '$2 ~ /^agno_pbr_/ {print $1}')

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
@@ -47,7 +47,7 @@ private:
 
   static std::string convert_type_to_snake_case(const std::string & message_type);
   static std::vector<std::string> generate_library_paths();
-  void * load_library_from_paths(const std::vector<std::string> & paths);
+  void * load_library_from_paths(const std::vector<std::string> & paths, std::string & last_error);
   void * get_bridge_factory_symbol(
     const std::string & type_name, const std::string & symbol_name_prefix, bool is_service);
 };

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp
@@ -37,6 +37,14 @@ private:
   // path -> handle
   std::unordered_map<std::string, void *> loaded_libraries_;
 
+  static PerformancePubsubBridgeResult create_r2a_pubsub_bridge_generic(
+    const rclcpp::Node::SharedPtr & node, const std::string & topic_name,
+    const std::string & message_type, const rclcpp::QoS & qos);
+
+  static PerformancePubsubBridgeResult create_a2r_pubsub_bridge_generic(
+    const rclcpp::Node::SharedPtr & node, const std::string & topic_name,
+    const std::string & message_type, const rclcpp::QoS & qos);
+
   static std::string convert_type_to_snake_case(const std::string & message_type);
   static std::vector<std::string> generate_library_paths();
   void * load_library_from_paths(const std::vector<std::string> & paths);

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -34,7 +34,7 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_r2a_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
-    RCLCPP_INFO_ONCE(
+    RCLCPP_INFO(
       logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
       topic_name.c_str(), message_type.c_str());
     return create_r2a_pubsub_bridge_generic(node, topic_name, message_type, qos);
@@ -51,7 +51,7 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_a2r_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
-    RCLCPP_INFO_ONCE(
+    RCLCPP_INFO(
       logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
       topic_name.c_str(), message_type.c_str());
     return create_a2r_pubsub_bridge_generic(node, topic_name, message_type, qos);
@@ -118,6 +118,8 @@ std::vector<std::string> PerformanceBridgeLoader::generate_library_paths()
 void * PerformanceBridgeLoader::load_library_from_paths(
   const std::vector<std::string> & paths, std::string & last_error)
 {
+  last_error.clear();
+
   if (paths.empty()) {
     return nullptr;
   }
@@ -154,20 +156,30 @@ void * PerformanceBridgeLoader::get_bridge_factory_symbol(
   std::string last_dlopen_error;
   void * handle = load_library_from_paths(lib_paths, last_dlopen_error);
   if (handle == nullptr) {
-    if (is_service) {
-      if (lib_paths.empty()) {
+    if (lib_paths.empty()) {
+      if (is_service) {
         RCLCPP_ERROR(
           logger_,
-          "No plugin paths available. Have you generated bridge plugins? "
-          "Bridge plugins are required for service bridge.");
+          "No plugin paths available for service bridge. Have you generated bridge plugins?");
+      }
+    } else {
+      std::string tried_paths;
+      for (const auto & path : lib_paths) {
+        tried_paths += "\n  - " + path;
+      }
+      if (is_service) {
+        RCLCPP_ERROR(
+          logger_,
+          "Failed to load plugin for service type '%s'.\n"
+          "Tried paths:%s\n"
+          "Last error: %s",
+          type_name.c_str(), tried_paths.c_str(), last_dlopen_error.c_str());
       } else {
-        std::string tried_paths;
-        for (const auto & path : lib_paths) {
-          tried_paths += "\n  - " + path;
-        }
-        RCLCPP_ERROR(
+        RCLCPP_WARN(
           logger_,
-          "Failed to load plugin library for service type '%s'. Tried paths:%s\nLast error: %s",
+          "Failed to load plugin for message type '%s'. Falling back to generic bridge.\n"
+          "Tried paths:%s\n"
+          "Last error: %s",
           type_name.c_str(), tried_paths.c_str(), last_dlopen_error.c_str());
       }
     }

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -34,7 +34,7 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_r2a_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
-    RCLCPP_INFO(
+    RCLCPP_DEBUG(
       logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
       topic_name.c_str(), message_type.c_str());
     return create_r2a_pubsub_bridge_generic(node, topic_name, message_type, qos);
@@ -51,7 +51,7 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_a2r_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
-    RCLCPP_INFO(
+    RCLCPP_DEBUG(
       logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
       topic_name.c_str(), message_type.c_str());
     return create_a2r_pubsub_bridge_generic(node, topic_name, message_type, qos);

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -1,5 +1,7 @@
 #include "agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp"
 
+#include "agnocast/bridge/agnocast_bridge_node.hpp"
+
 #include <ament_index_cpp/get_package_prefix.hpp>
 
 #include <dlfcn.h>
@@ -31,7 +33,8 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge(
 {
   void * symbol = get_bridge_factory_symbol(message_type, "create_r2a_pubsub_bridge", false);
   if (symbol == nullptr) {
-    return {nullptr, nullptr};
+    // Fall back to the generic bridge, which is independent of plugins.
+    return create_r2a_pubsub_bridge_generic(node, topic_name, message_type, qos);
   }
 
   auto factory = reinterpret_cast<R2APubsubBridgeFactory>(symbol);
@@ -44,7 +47,8 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge(
 {
   void * symbol = get_bridge_factory_symbol(message_type, "create_a2r_pubsub_bridge", false);
   if (symbol == nullptr) {
-    return {nullptr, nullptr};
+    // Fall back to the generic bridge, which is independent of plugins.
+    return create_a2r_pubsub_bridge_generic(node, topic_name, message_type, qos);
   }
 
   auto factory = reinterpret_cast<A2RPubsubBridgeFactory>(symbol);
@@ -108,7 +112,6 @@ std::vector<std::string> PerformanceBridgeLoader::generate_library_paths()
 void * PerformanceBridgeLoader::load_library_from_paths(const std::vector<std::string> & paths)
 {
   if (paths.empty()) {
-    RCLCPP_ERROR(logger_, "No plugin paths available. Have you generated bridge plugins?");
     return nullptr;
   }
 
@@ -126,14 +129,6 @@ void * PerformanceBridgeLoader::load_library_from_paths(const std::vector<std::s
     }
   }
 
-  // All paths failed - log the error
-  std::string tried_paths;
-  for (const auto & path : paths) {
-    tried_paths += "\n  - " + path;
-  }
-  RCLCPP_ERROR(
-    logger_, "Failed to load plugin. Tried paths:%s\nLast error: %s", tried_paths.c_str(),
-    dlerror());
   return nullptr;
 }
 
@@ -146,6 +141,22 @@ void * PerformanceBridgeLoader::get_bridge_factory_symbol(
 
   void * handle = load_library_from_paths(lib_paths);
   if (handle == nullptr) {
+    if (is_service) {
+      if (lib_paths.empty()) {
+        RCLCPP_ERROR(
+          logger_,
+          "No plugin paths available. Have you generated bridge plugins? "
+          "Bridge plugins are required for service bridge.");
+      } else {
+        std::string tried_paths;
+        for (const auto & path : lib_paths) {
+          tried_paths += "\n  - " + path;
+        }
+        RCLCPP_ERROR(
+          logger_, "Failed to load plugin library for service type '%s'. Tried paths:%s",
+          type_name.c_str(), tried_paths.c_str());
+      }
+    }
     return nullptr;
   }
 
@@ -156,22 +167,73 @@ void * PerformanceBridgeLoader::get_bridge_factory_symbol(
 
   const char * dlsym_error = dlerror();
   if (dlsym_error != nullptr) {
-    RCLCPP_ERROR(
-      logger_, "Failed to find symbol '%s' for %s type '%s': %s", symbol_name.c_str(), type_label,
-      type_name.c_str(), dlsym_error);
+    if (is_service) {
+      RCLCPP_ERROR(
+        logger_, "Failed to find symbol '%s' for %s type '%s': %s", symbol_name.c_str(), type_label,
+        type_name.c_str(), dlsym_error);
+    }
     return nullptr;
   }
 
   if (symbol == nullptr) {
-    RCLCPP_ERROR(
-      logger_,
-      "Symbol '%s' was found for %s type '%s' but returned NULL, which is invalid for a factory "
-      "function.",
-      symbol_name.c_str(), type_label, type_name.c_str());
+    if (is_service) {
+      RCLCPP_ERROR(
+        logger_,
+        "Symbol '%s' was found for %s type '%s' but returned NULL, which is invalid for a factory "
+        "function.",
+        symbol_name.c_str(), type_label, type_name.c_str());
+    }
     return nullptr;
   }
 
   return symbol;
+}
+
+PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge_generic(
+  const rclcpp::Node::SharedPtr & node, const std::string & topic_name,
+  const std::string & message_type, const rclcpp::QoS & qos)
+{
+  auto agno_pub = std::make_shared<agnocast::GenericPublisher>(
+    node.get(), topic_name, message_type,
+    rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).transient_local(), agnocast::PublisherOptions{},
+    agnocast::PublisherRole::BridgeInternal);
+
+  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  rclcpp::SubscriptionOptions opts;
+  opts.ignore_local_publications = true;
+  opts.callback_group = cb_group;
+
+  auto sub = node->create_generic_subscription(
+    topic_name, message_type, qos,
+    [agno_pub](const rclcpp::SerializedMessage & serialized_msg) {
+      agno_pub->publish(serialized_msg);
+    },
+    opts);
+
+  return {sub, cb_group};
+}
+
+PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge_generic(
+  const rclcpp::Node::SharedPtr & node, const std::string & topic_name,
+  const std::string & message_type, const rclcpp::QoS & qos)
+{
+  auto ros_pub = node->create_generic_publisher(
+    topic_name, message_type,
+    rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).reliable().transient_local());
+
+  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  agnocast::SubscriptionOptions sub_opts;
+  sub_opts.ignore_local_publications = true;
+  sub_opts.callback_group = cb_group;
+
+  auto agno_sub = std::make_shared<agnocast::GenericSubscription>(
+    node.get(), topic_name, message_type, qos,
+    [ros_pub](const rclcpp::SerializedMessage & serialized_msg) {
+      ros_pub->publish(serialized_msg);
+    },
+    sub_opts, agnocast::SubscriptionRole::BridgeInternal);
+
+  return {agno_sub, cb_group};
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/bridge/performance/agnocast_performance_bridge_loader.hpp"
 
 #include "agnocast/bridge/agnocast_bridge_node.hpp"
+#include "rclcpp/version.h"
 
 #include <ament_index_cpp/get_package_prefix.hpp>
 
@@ -229,14 +230,28 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge_
   opts.ignore_local_publications = true;
   opts.callback_group = cb_group;
 
+  // Compatibility note:
+  // - Humble expects the callback taking std::shared_ptr<SerializedMessage>.
+  // - Jazzy treats the callback as AnySubscriptionCallback, but if we receive the message as
+  //   std::shared_ptr<SerializedMessage>, rclcpp deep-copies the message.
+  // Keep the Humble/Jazzy split here for performance optimization.
   auto sub = node->create_generic_subscription(
     topic_name, message_type, qos,
+#if RCLCPP_VERSION_MAJOR >= 28
     [agno_pub](const rclcpp::SerializedMessage & serialized_msg) {
       agno_pub->publish(serialized_msg);
     },
+#else
+    [agno_pub](const std::shared_ptr<rclcpp::SerializedMessage> & serialized_msg) {
+      agno_pub->publish(*serialized_msg);
+    },
+#endif
     opts);
 
-  return {sub, cb_group};
+  PerformancePubsubBridgeResult result;
+  result.entity_handle = sub;
+  result.callback_group = cb_group;
+  return result;
 }
 
 PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge_generic(

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -34,6 +34,9 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_r2a_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_r2a_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
+    RCLCPP_INFO_ONCE(
+      logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
+      topic_name.c_str(), message_type.c_str());
     return create_r2a_pubsub_bridge_generic(node, topic_name, message_type, qos);
   }
 
@@ -48,6 +51,9 @@ PerformancePubsubBridgeResult PerformanceBridgeLoader::create_a2r_pubsub_bridge(
   void * symbol = get_bridge_factory_symbol(message_type, "create_a2r_pubsub_bridge", false);
   if (symbol == nullptr) {
     // Fall back to the generic bridge, which is independent of plugins.
+    RCLCPP_INFO_ONCE(
+      logger_, "No plugin found for topic '%s' (type: %s). Using generic bridge.",
+      topic_name.c_str(), message_type.c_str());
     return create_a2r_pubsub_bridge_generic(node, topic_name, message_type, qos);
   }
 
@@ -109,7 +115,8 @@ std::vector<std::string> PerformanceBridgeLoader::generate_library_paths()
   return paths;
 }
 
-void * PerformanceBridgeLoader::load_library_from_paths(const std::vector<std::string> & paths)
+void * PerformanceBridgeLoader::load_library_from_paths(
+  const std::vector<std::string> & paths, std::string & last_error)
 {
   if (paths.empty()) {
     return nullptr;
@@ -127,6 +134,11 @@ void * PerformanceBridgeLoader::load_library_from_paths(const std::vector<std::s
       loaded_libraries_[path] = handle;
       return handle;
     }
+    // Capture error immediately before any subsequent call clears it.
+    const char * err = dlerror();
+    if (err != nullptr) {
+      last_error = err;
+    }
   }
 
   return nullptr;
@@ -139,7 +151,8 @@ void * PerformanceBridgeLoader::get_bridge_factory_symbol(
   std::string snake_type = convert_type_to_snake_case(type_name);
   std::vector<std::string> lib_paths = generate_library_paths();
 
-  void * handle = load_library_from_paths(lib_paths);
+  std::string last_dlopen_error;
+  void * handle = load_library_from_paths(lib_paths, last_dlopen_error);
   if (handle == nullptr) {
     if (is_service) {
       if (lib_paths.empty()) {
@@ -153,8 +166,9 @@ void * PerformanceBridgeLoader::get_bridge_factory_symbol(
           tried_paths += "\n  - " + path;
         }
         RCLCPP_ERROR(
-          logger_, "Failed to load plugin library for service type '%s'. Tried paths:%s",
-          type_name.c_str(), tried_paths.c_str());
+          logger_,
+          "Failed to load plugin library for service type '%s'. Tried paths:%s\nLast error: %s",
+          type_name.c_str(), tried_paths.c_str(), last_dlopen_error.c_str());
       }
     }
     return nullptr;


### PR DESCRIPTION
## Description

This PR adds generic R2A and A2R pub/sub bridges to the performance bridge. This removes the dependency on the `agnocast_bridge_plugins` shared library. The performance bridge can now run without it.

### How it works

* **Generic Bridge:** Uses the newly added `GenericPublisher` and `GenericSubscription`. It creates pub/sub bridges without knowing the exact message types at compile time.
* **Performance Optimization:** The existing `agnocast_bridge_plugins` approach is kept for better performance. 
* **Fallback Logic:** The system tries to use a bridge plugin first. If one is not found, it falls back to the generic bridge.

### Log message strategy

* **Pub/Sub Bridges:** Missing plugins are no longer treated as errors. The old error messages are removed. Instead, an info message is logged when the fallback occurs.
* **Service Bridges:** The generic fallback is **not** supported for services. The error messages for service bridges are kept.

### Changes to e2e test

* Removed the step that auto-generates and builds `agnocast_bridge_plugins` in `e2e_test_2to2.bash`, because the bridge now works without it.

## Related links

* https://github.com/autowarefoundation/agnocast/pull/1393
* https://github.com/autowarefoundation/agnocast/pull/1395

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
  * *Note: Run with the `-b performance` option and without the `agnocast_bridge_plugins` package.*
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

`need-patch-update`