### PR TITLE
feat(agnocast_kmod, agnocastlib)[need-minor-update]: isolate topics by ROS_DOMAIN_ID

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -39,6 +39,7 @@ union ioctl_add_process_args {
   struct
   {
     bool is_performance_bridge_manager;
+    uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct
   {
@@ -400,7 +401,7 @@ int agnocast_ioctl_take_msg(
 
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_performance_bridge_manager,
-  union ioctl_add_process_args * ioctl_ret);
+  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret);
 
 int agnocast_ioctl_get_subscriber_num(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const pid_t pid,

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -66,6 +66,9 @@ struct process_info
   pid_t local_pid;
   struct mempool_entry * mempool_entry;
   const struct ipc_namespace * ipc_ns;
+  // The process's ROS_DOMAIN_ID (0 if unset), fixed for the process's lifetime.
+  // Used as the domain component of the topic key for this process's operations.
+  uint32_t domain_id;
   struct list_head exit_subscription_list;
   uint32_t exit_subscription_count;
   struct hlist_node node;
@@ -127,6 +130,9 @@ struct topic_wrapper
 {
   const struct ipc_namespace *
     ipc_ns;  // For use in separating topic namespaces when using containers.
+  // Part of the topic identity: topics with the same name/ipc_ns but different
+  // ROS_DOMAIN_ID are distinct wrappers and do not match (ROS 2 domain isolation).
+  uint32_t domain_id;
   char * key;
   struct rw_semaphore
     topic_rwsem;  // Per-topic rwsem: read for read-only ops, write for publish/receive/modify

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -36,23 +36,49 @@ static unsigned long get_topic_hash(const char * str)
 }
 
 static struct topic_wrapper * find_topic(
-  const char * topic_name, const struct ipc_namespace * ipc_ns)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
   struct topic_wrapper * entry;
   unsigned long hash_val = get_topic_hash(topic_name);
 
   hash_for_each_possible(topic_hashtable, entry, node, hash_val)
   {
-    if (ipc_eq(entry->ipc_ns, ipc_ns) && strcmp(entry->key, topic_name) == 0) return entry;
+    if (
+      ipc_eq(entry->ipc_ns, ipc_ns) && entry->domain_id == domain_id &&
+      strcmp(entry->key, topic_name) == 0)
+      return entry;
   }
 
   return NULL;
 }
 
-static int add_topic(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, struct topic_wrapper ** wrapper)
+// A process operates in exactly one ROS_DOMAIN_ID, recorded in its process_info.
+// Returns the default domain 0 if the process is not registered.
+// Caller must hold global_htables_rwsem (same as agnocast_find_process_info).
+static uint32_t get_process_domain_id(pid_t pid)
 {
-  *wrapper = find_topic(topic_name, ipc_ns);
+  struct process_info * proc_info = agnocast_find_process_info(pid);
+  return proc_info ? proc_info->domain_id : 0;
+}
+
+static uint32_t get_current_domain_id(void)
+{
+  return get_process_domain_id(current->tgid);
+}
+
+// find_topic variant for operations on behalf of the calling process: matches in
+// the caller's own domain. Caller holds global_htables_rwsem.
+static struct topic_wrapper * find_topic_for_current(
+  const char * topic_name, const struct ipc_namespace * ipc_ns)
+{
+  return find_topic(topic_name, ipc_ns, get_current_domain_id());
+}
+
+static int add_topic(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id,
+  struct topic_wrapper ** wrapper)
+{
+  *wrapper = find_topic(topic_name, ipc_ns, domain_id);
   if (*wrapper) {
     return 0;
   }
@@ -66,6 +92,7 @@ static int add_topic(
   }
 
   (*wrapper)->ipc_ns = ipc_ns;
+  (*wrapper)->domain_id = domain_id;
   (*wrapper)->key = kstrdup(topic_name, GFP_KERNEL);
   if (!(*wrapper)->key) {
     dev_warn(
@@ -352,7 +379,7 @@ int agnocast_ioctl_release_message_entry_reference(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -543,7 +570,7 @@ static bool has_alive_performance_bridge_manager(const struct ipc_namespace * ip
 
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_performance_bridge_manager,
-  union ioctl_add_process_args * ioctl_ret)
+  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret)
 {
   int ret = 0;
 
@@ -586,6 +613,7 @@ int agnocast_ioctl_add_process(
   }
 
   new_proc_info->ipc_ns = ipc_ns;
+  new_proc_info->domain_id = domain_id;
 
   INIT_HLIST_NODE(&new_proc_info->node);
   uint32_t hash_val = hash_min(new_proc_info->global_pid, PROC_INFO_HASH_BITS);
@@ -610,7 +638,7 @@ int agnocast_ioctl_add_subscriber(
   down_write(&global_htables_rwsem);
 
   struct topic_wrapper * wrapper;
-  ret = add_topic(topic_name, ipc_ns, &wrapper);
+  ret = add_topic(topic_name, ipc_ns, get_process_domain_id(subscriber_pid), &wrapper);
   if (ret < 0) {
     goto unlock;
   }
@@ -640,7 +668,7 @@ int agnocast_ioctl_add_publisher(
   down_write(&global_htables_rwsem);
 
   struct topic_wrapper * wrapper;
-  ret = add_topic(topic_name, ipc_ns, &wrapper);
+  ret = add_topic(topic_name, ipc_ns, get_process_domain_id(publisher_pid), &wrapper);
   if (ret < 0) {
     goto unlock;
   }
@@ -768,7 +796,7 @@ int agnocast_ioctl_publish_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -927,7 +955,7 @@ int agnocast_ioctl_receive_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -984,7 +1012,7 @@ int agnocast_ioctl_take_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1104,7 +1132,7 @@ int agnocast_ioctl_get_subscriber_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
 
   if (!wrapper) {
     up_read(&global_htables_rwsem);
@@ -1157,7 +1185,7 @@ int agnocast_ioctl_set_ros2_subscriber_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (wrapper) {
     down_write(&wrapper->topic_rwsem);
     wrapper->topic.ros2_subscriber_num = count;
@@ -1177,7 +1205,7 @@ int agnocast_ioctl_set_ros2_publisher_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (wrapper) {
     down_write(&wrapper->topic_rwsem);
     wrapper->topic.ros2_publisher_num = count;
@@ -1201,7 +1229,7 @@ int agnocast_ioctl_get_publisher_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
 
   if (!wrapper) {
     up_read(&global_htables_rwsem);
@@ -1532,7 +1560,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1618,7 +1646,7 @@ int agnocast_ioctl_get_topic_publisher_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1703,7 +1731,7 @@ int agnocast_ioctl_get_subscriber_qos(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_dbg(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1742,7 +1770,7 @@ int agnocast_ioctl_get_publisher_qos(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_dbg(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1779,7 +1807,7 @@ int agnocast_ioctl_remove_subscriber(
 
   down_write(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     ret = -EINVAL;
     goto unlock;
@@ -1874,7 +1902,7 @@ int agnocast_ioctl_remove_publisher(
 
   down_write(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     ret = -EINVAL;
     goto unlock;
@@ -2154,7 +2182,9 @@ static long add_process_cmd(union ioctl_add_process_args __user * arg)
   union ioctl_add_process_args add_process_args;
   if (copy_from_user(&add_process_args, arg, sizeof(add_process_args))) return -EFAULT;
   bool is_performance_bridge_manager = add_process_args.is_performance_bridge_manager;
-  ret = agnocast_ioctl_add_process(pid, ipc_ns, is_performance_bridge_manager, &add_process_args);
+  uint32_t domain_id = add_process_args.domain_id;
+  ret = agnocast_ioctl_add_process(
+    pid, ipc_ns, is_performance_bridge_manager, domain_id, &add_process_args);
   if (ret == 0) {
     if (copy_to_user(arg, &add_process_args, sizeof(add_process_args))) return -EFAULT;
   }
@@ -2808,7 +2838,7 @@ int agnocast_increment_message_entry_rc(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(
       agnocast_device, "Topic (topic_name=%s) not found. (increment_message_entry_rc)\n",
@@ -2887,7 +2917,7 @@ bool agnocast_is_proc_exited(const pid_t pid)
 
 int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return 0;
   }
@@ -2904,7 +2934,7 @@ int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_nam
 bool agnocast_is_in_topic_entries(
   const char * topic_name, const struct ipc_namespace * ipc_ns, int64_t entry_id)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -2922,7 +2952,7 @@ int agnocast_get_entry_rc(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const int64_t entry_id,
   const topic_local_id_t pubsub_id)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return -1;
   }
@@ -2943,7 +2973,7 @@ int64_t agnocast_get_latest_received_entry_id(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t subscriber_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return -1;
   }
@@ -2959,7 +2989,7 @@ bool agnocast_is_in_subscriber_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t subscriber_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -2973,7 +3003,7 @@ bool agnocast_is_in_subscriber_htable(
 bool agnocast_is_in_publisher_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -3000,7 +3030,7 @@ int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns)
 
 bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns)
 {
-  return find_topic(topic_name, ipc_ns) != NULL;
+  return find_topic_for_current(topic_name, ipc_ns) != NULL;
 }
 
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -13,7 +13,7 @@ void test_case_add_process_normal(struct kunit * test)
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
@@ -31,12 +31,12 @@ void test_case_add_process_many(struct kunit * test)
   for (int i = 0; i < mempool_num - 1; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
   }
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   // ================================================
   // Assert
@@ -54,8 +54,8 @@ void test_case_add_process_twice(struct kunit * test)
 
   pid_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret1 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
-  int ret2 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret1 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret2 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, ret2, -EINVAL);
@@ -73,11 +73,11 @@ void test_case_add_process_too_many(struct kunit * test)
   for (int i = 0; i < mempool_num; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
   }
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   // ================================================
   // Assert

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -17,8 +17,60 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static int add_pubsub_pair(
+  struct kunit * test, const pid_t pub_pid, const pid_t sub_pid, const uint32_t qos_depth)
+{
+  union ioctl_add_publisher_args add_publisher_args;
+  int ret = agnocast_ioctl_add_publisher(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
+    IS_BRIDGE, &add_publisher_args);
+  if (ret < 0) return ret;
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  return agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, sub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
+    QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+}
+
+// A publisher and subscriber with the same topic name but different ROS_DOMAIN_ID
+// must produce two distinct topic wrappers (ROS 2 domain isolation).
+void test_case_add_subscriber_domain_isolation(struct kunit * test)
+{
+  const pid_t pub_pid = 2000;
+  const pid_t sub_pid = 2001;
+  setup_process_domain(test, pub_pid, 0);
+  setup_process_domain(test, sub_pid, 1);
+
+  KUNIT_ASSERT_EQ(test, add_pubsub_pair(test, pub_pid, sub_pid, 1), 0);
+
+  // Two wrappers: (TOPIC_NAME, ipc_ns, domain=0) and (TOPIC_NAME, ipc_ns, domain=1).
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 2);
+}
+
+// A publisher and subscriber in the same domain on the same topic share one
+// wrapper (unchanged behavior).
+void test_case_add_subscriber_same_domain_shared(struct kunit * test)
+{
+  const pid_t pub_pid = 2002;
+  const pid_t sub_pid = 2003;
+  setup_process_domain(test, pub_pid, 0);
+  setup_process_domain(test, sub_pid, 0);
+
+  KUNIT_ASSERT_EQ(test, add_pubsub_pair(test, pub_pid, sub_pid, 1), 0);
+
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 1);
 }
 
 void test_case_add_subscriber_normal(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
@@ -2,9 +2,13 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_ADD_SUBSCRIBER              \
-  KUNIT_CASE(test_case_add_subscriber_normal), \
-    KUNIT_CASE(test_case_add_subscriber_too_many_subscribers)
+#define TEST_CASES_ADD_SUBSCRIBER                              \
+  KUNIT_CASE(test_case_add_subscriber_normal),                 \
+    KUNIT_CASE(test_case_add_subscriber_too_many_subscribers), \
+    KUNIT_CASE(test_case_add_subscriber_domain_isolation),     \
+    KUNIT_CASE(test_case_add_subscriber_same_domain_shared)
 
 void test_case_add_subscriber_normal(struct kunit * test);
 void test_case_add_subscriber_too_many_subscribers(struct kunit * test);
+void test_case_add_subscriber_domain_isolation(struct kunit * test);
+void test_case_add_subscriber_same_domain_shared(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
@@ -14,13 +14,13 @@ void test_case_bridge_manager_flag_set_on_registration(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Verify the flag was set by checking a new process sees it
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -32,13 +32,13 @@ void test_case_bridge_manager_detected_by_new_process(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register normal process - should see bridge manager exists
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -50,7 +50,7 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Notify shutdown
@@ -59,7 +59,7 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   // Register normal process - should see no bridge manager
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_performance_bridge_daemon_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -14,7 +14,7 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   // Register bridge manager only
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - only bridge manager exists (process_num == 1)
@@ -27,7 +27,7 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   // Verify is_performance_bridge_manager was cleared - new process should not see bridge manager
   pid_t normal_pid = pid_carbs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -39,13 +39,13 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   // Register bridge manager
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register another process
   pid_t other_pid = pid_carbs++;
   union ioctl_add_process_args other_args = {};
-  ret = agnocast_ioctl_add_process(other_pid, current->nsproxy->ipc_ns, false, &other_args);
+  ret = agnocast_ioctl_add_process(other_pid, current->nsproxy->ipc_ns, false, 0, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - other process exists (process_num > 1)
@@ -58,7 +58,7 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   // Verify is_performance_bridge_manager is still set - new process should see bridge manager
   pid_t new_pid = pid_carbs++;
   union ioctl_add_process_args new_args = {};
-  ret = agnocast_ioctl_add_process(new_pid, current->nsproxy->ipc_ns, false, &new_args);
+  ret = agnocast_ioctl_add_process(new_pid, current->nsproxy->ipc_ns, false, 0, &new_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, new_args.ret_performance_bridge_daemon_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -27,7 +27,7 @@ static void setup_processes(struct kunit * test, const int process_num)
   union ioctl_add_process_args ioctl_ret;
   for (int i = 0; i < process_num; i++) {
     const pid_t pid = PID_BASE + i;
-    int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+    int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));
   }
@@ -37,7 +37,7 @@ static void setup_processes(struct kunit * test, const int process_num)
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -15,7 +15,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -15,7 +15,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -18,8 +18,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -36,8 +36,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -53,8 +53,8 @@ static void setup_one_publisher_with_bridge(struct kunit * test, char * topic_na
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -183,8 +183,8 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -18,8 +18,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -36,8 +36,8 @@ static void setup_one_subscriber_with_bridge(struct kunit * test, char * topic_n
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -54,8 +54,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -72,7 +72,7 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 =
-    agnocast_ioctl_add_process(intra_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+    agnocast_ioctl_add_process(intra_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -44,8 +44,8 @@ static void setup_one_publisher(
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -66,7 +66,7 @@ static void setup_pub_sub_same_process(
 
   union ioctl_add_process_args add_process_args;
   int ret_proc =
-    agnocast_ioctl_add_process(common_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+    agnocast_ioctl_add_process(common_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   if (ret_addr) {
     *ret_addr = add_process_args.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   topic_local_id_t * subscriber_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -42,8 +42,8 @@ static void setup_one_publisher(
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -676,7 +676,7 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -718,8 +718,8 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -756,8 +756,8 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -984,7 +984,7 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1027,7 +1027,7 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -24,8 +24,8 @@ static void setup_one_publisher(
   const pid_t PUBLISHER_PID = 2000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(PUBLISHER_PID, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    PUBLISHER_PID, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH,
@@ -106,8 +106,8 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
 
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
-  int ret2 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret2 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -156,7 +156,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid1 = 1000;
   union ioctl_add_process_args add_process_args1;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid1, current->nsproxy->ipc_ns, false, &add_process_args1);
+    subscriber_pid1, current->nsproxy->ipc_ns, false, 0, &add_process_args1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -175,7 +175,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid2 = 1001;
   union ioctl_add_process_args add_process_args2;
   int ret5 = agnocast_ioctl_add_process(
-    subscriber_pid2, current->nsproxy->ipc_ns, false, &add_process_args2);
+    subscriber_pid2, current->nsproxy->ipc_ns, false, 0, &add_process_args2);
   KUNIT_ASSERT_EQ(test, ret5, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
@@ -232,8 +232,8 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
 
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
-  int ret2 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret2 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -22,7 +22,7 @@ static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -22,7 +22,7 @@ static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -14,8 +14,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -17,8 +17,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   topic_local_id_t * subscriber_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -42,8 +42,8 @@ static void setup_one_publisher(
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -772,7 +772,7 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   // Arrange
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -817,8 +817,8 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth1 = 10;
@@ -859,8 +859,8 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   // Arrange
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -1021,7 +1021,7 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1066,7 +1066,7 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -55,6 +55,7 @@ union ioctl_add_process_args {
   struct
   {
     bool is_performance_bridge_manager;
+    uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct
   {

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -77,6 +77,10 @@ inline void validate_subscription_qos(const rclcpp::QoS & qos)
 }
 
 void validate_ld_preload();
+// Return the calling process's ROS_DOMAIN_ID parsed from the env var (0 if unset
+// or unparsable), matching ROS 2's default. Registered with the kmod so topics
+// in different domains are isolated.
+uint32_t get_ros_domain_id();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -157,6 +157,7 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge()
 {
   union ioctl_add_process_args add_process_args = {};
   add_process_args.is_performance_bridge_manager = true;
+  add_process_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     throw std::runtime_error(std::string("AGNOCAST_ADD_PROCESS_CMD failed: ") + strerror(errno));
   }
@@ -463,6 +464,7 @@ struct initialize_agnocast_result initialize_agnocast(
   }
 
   union ioctl_add_process_args add_process_args = {};
+  add_process_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_PROCESS_CMD failed: %s", strerror(errno));
     close(agnocast_fd);

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -91,6 +91,20 @@ static std::string performance_domain_suffix()
   return "_d" + std::string(domain_id);
 }
 
+uint32_t get_ros_domain_id()
+{
+  const char * domain_id_env = getenv("ROS_DOMAIN_ID");
+  if (domain_id_env == nullptr || *domain_id_env == '\0') {
+    return 0;
+  }
+  char * end = nullptr;
+  const uint64_t value = std::strtoul(domain_id_env, &end, 10);
+  if (*end != '\0') {
+    return 0;  // Unparsable: fall back to the default domain.
+  }
+  return static_cast<uint32_t>(value);
+}
+
 std::string create_mq_name_for_bridge(const pid_t pid)
 {
   std::string name = "/agnocast_bridge_manager@" + std::to_string(pid);

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <system_error>
 
 namespace agnocast
@@ -98,9 +99,12 @@ uint32_t get_ros_domain_id()
     return 0;
   }
   char * end = nullptr;
+  errno = 0;
   const uint64_t value = std::strtoul(domain_id_env, &end, 10);
-  if (*end != '\0') {
-    return 0;  // Unparsable: fall back to the default domain.
+  // Out-of-range values would silently wrap into an unintended domain (e.g. 0),
+  // breaking isolation, so reject them rather than truncate.
+  if (*end != '\0' || errno != 0 || value > std::numeric_limits<uint32_t>::max()) {
+    return 0;
   }
   return static_cast<uint32_t>(value);
 }


### PR DESCRIPTION
## Description

Extend the kmod topic identity from `(topic_name, ipc_ns)` to `(topic_name, ipc_ns, domain_id)`, so publishers and subscribers in different `ROS_DOMAIN_ID`s no longer match. Currently every Agnocast publisher/subscriber in one IPC namespace connects regardless of `ROS_DOMAIN_ID`; this brings Agnocast in line with ROS 2's domain isolation. An unset `ROS_DOMAIN_ID` maps to domain 0 (ROS 2's default), so single-domain setups are unchanged.

Changes:

- **agnocast_kmod**: `topic_wrapper` and `process_info` gain a `domain_id`, and `find_topic` compares it (the single isolation point; the hash stays keyed on the name, like `ipc_ns`). The process's `ROS_DOMAIN_ID` is carried in the `add_process` ioctl and stored in `process_info`; `add_publisher` / `add_subscriber` tag the wrapper with the registering process's domain, and other per-process operations resolve the caller's domain via `find_topic_for_current`.
- **agnocastlib**: `agnocast::init` passes the parsed `ROS_DOMAIN_ID` (`get_ros_domain_id`) in the `add_process` ioctl.

Scope: kmod-level isolation only. Follow-up PRs make the discovery agent and `ros2 agnocast` CLI domain-aware, and add opt-in cross-domain relaying for selected topics (a ROS 2 `domain_bridge` equivalent).

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1390

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **kunit (added)**: the same topic name in different `ROS_DOMAIN_ID`s produces two distinct wrappers; the same domain shares one.
- **Manual**: in one IPC namespace, a listener on a different `ROS_DOMAIN_ID` than the talker no longer receives over Agnocast; the same domain still does.

  ```bash
  # talker on domain 0
  ROS_DOMAIN_ID=0 ros2 launch agnocast_sample_application talker.launch.xml
  # listener on a different domain -> receives nothing (isolated)
  ROS_DOMAIN_ID=1 ros2 launch agnocast_sample_application listener.launch.xml
  # listener on the same domain -> receives
  ROS_DOMAIN_ID=0 ros2 launch agnocast_sample_application listener.launch.xml
  ```

## Version Update Label (Required)

- `need-minor-update` (kmod struct + `add_process` ioctl ABI change)
