### PR TITLE
[experiment, do not merge] run KUnit CI on the ROS_DOMAIN_ID isolation tests

### DIFF
--- a/.github/actions/prepare-agnocast-kunit/action.yml
+++ b/.github/actions/prepare-agnocast-kunit/action.yml
@@ -1,0 +1,93 @@
+name: Prepare Agnocast KUnit kernel
+description: >
+  Install build deps, cache/clone the pinned Linux source, cache the build dir,
+  and stage the Agnocast sources into the kernel tree. Shared by the kunit and
+  kunit-coverage workflows. The caller must check out the repo first.
+
+inputs:
+  linux-ref:
+    description: Linux git tag to build against.
+    required: true
+  linux-repo:
+    description: Linux git repository URL.
+    required: true
+  build-dir:
+    description: kunit.py build dir (kept outside the source tree).
+    required: true
+  cache-key:
+    description: Exact cache key for the build dir.
+    required: true
+  restore-key:
+    description: restore-keys prefix for the build dir.
+    required: true
+  gcov:
+    description: If 'true', instrument the Agnocast objects for gcov.
+    default: 'false'
+  extra-packages:
+    description: Extra apt packages to install (space-separated).
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential flex bison libelf-dev libssl-dev bc python3 \
+          qemu-system-x86 ${{ inputs.extra-packages }}
+
+    # Cache the Linux source tree. Keyed on the ref only — safe for an immutable
+    # tag; add a SHA/date if it ever points at a moving branch.
+    - name: Cache Linux source tree
+      id: linux-src-cache
+      uses: actions/cache@v4
+      with:
+        path: linux
+        key: linux-src-${{ inputs.linux-ref }}
+
+    - name: Shallow clone Linux ${{ inputs.linux-ref }}
+      if: steps.linux-src-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: git clone --depth 1 --branch "${{ inputs.linux-ref }}" "${{ inputs.linux-repo }}" linux
+
+    # Build dir lives outside the source tree so the source cache above doesn't
+    # absorb build artifacts; restore-keys reuses a previous dir for incremental
+    # rebuilds.
+    - name: Cache build dir
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.build-dir }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: ${{ inputs.restore-key }}
+
+    # A restored build dir from a different source checkout can reference paths
+    # the fresh clone lacks; drop it so the build is clean.
+    - name: Drop stale build dir if source was re-cloned
+      if: steps.linux-src-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: rm -rf "${{ inputs.build-dir }}"
+
+    # Layout mirrors agnocast_kmod/ so the tests' "../agnocast.h" includes
+    # resolve; .github/kunit/Kbuild is dropped in as the in-tree Makefile.
+    - name: Stage Agnocast sources into the kernel tree
+      shell: bash
+      run: |
+        set -euo pipefail
+        dst=linux/drivers/agnocast
+        rm -rf "${dst}"
+        mkdir -p "${dst}/agnocast_kunit"
+        cp agnocast_kmod/*.c agnocast_kmod/*.h "${dst}/"
+        cp agnocast_kmod/agnocast_kunit/*.c \
+           agnocast_kmod/agnocast_kunit/*.h \
+           agnocast_kmod/agnocast_kunit/Makefile.inc \
+           "${dst}/agnocast_kunit/"
+        cp .github/kunit/Kbuild "${dst}/Makefile"
+        if [ "${{ inputs.gcov }}" = "true" ]; then
+          echo 'GCOV_PROFILE := y' >> "${dst}/Makefile"
+        fi
+        if ! grep -q 'drivers/agnocast' linux/drivers/Makefile; then
+          echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
+        fi

--- a/.github/kunit/Kbuild
+++ b/.github/kunit/Kbuild
@@ -1,16 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #
-# In-tree kbuild file used ONLY by the UML/QEMU CI in
-# .github/workflows/kunit.yaml. The workflow copies the Agnocast kernel
-# sources into the kernel tree and drops this file in as their Makefile so
-# that the KUnit suite is linked into the test kernel (built-in, not a
-# loadable module — hosted CI runners cannot insmod unsigned modules).
+# In-tree kbuild file used only by the CI in .github/workflows/kunit.yaml, which
+# copies the Agnocast sources into the kernel tree and drops this in as their
+# Makefile so the KUnit suite is built into the kernel (built-in, not a module).
 #
-# Gated on CONFIG_KUNIT so it only compiles when the kunitconfig enables
-# KUnit. The object list mirrors the `KUNIT_BUILD=y` branch of
-# agnocast_kmod/Makefile; the 26 test objects are shared verbatim via
-# agnocast_kunit/Makefile.inc, so only this short core list must be kept in
-# sync if a new top-level source file is added.
+# The core object list mirrors the KUNIT_BUILD=y branch of agnocast_kmod/Makefile;
+# the test objects are shared via agnocast_kunit/Makefile.inc, so only this list
+# needs syncing when a new top-level source file is added.
 obj-$(CONFIG_KUNIT) += agnocast_kunit.o
 
 agnocast_kunit-objs := \

--- a/.github/kunit/Kbuild
+++ b/.github/kunit/Kbuild
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#
+# In-tree kbuild file used ONLY by the UML/QEMU CI in
+# .github/workflows/kunit.yaml. The workflow copies the Agnocast kernel
+# sources into the kernel tree and drops this file in as their Makefile so
+# that the KUnit suite is linked into the test kernel (built-in, not a
+# loadable module — hosted CI runners cannot insmod unsigned modules).
+#
+# Gated on CONFIG_KUNIT so it only compiles when the kunitconfig enables
+# KUnit. The object list mirrors the `KUNIT_BUILD=y` branch of
+# agnocast_kmod/Makefile; the 26 test objects are shared verbatim via
+# agnocast_kunit/Makefile.inc, so only this short core list must be kept in
+# sync if a new top-level source file is added.
+obj-$(CONFIG_KUNIT) += agnocast_kunit.o
+
+agnocast_kunit-objs := \
+  agnocast_kunit_main.o \
+  agnocast_main.o \
+  agnocast_memory_allocator.o \
+  agnocast_init.o \
+  agnocast_exit.o \
+  agnocast_ioctl.o \
+  agnocast_internal.o
+
+include $(src)/agnocast_kunit/Makefile.inc
+
+ccflags-y += -DKUNIT_BUILD -DVERSION='"ci-kunit"'

--- a/.github/kunit/coverage.config
+++ b/.github/kunit/coverage.config
@@ -1,0 +1,17 @@
+# Extra kconfig for the coverage job (.github/workflows/kunit-coverage.yaml),
+# merged on top of kunitconfig. Adds gcov plus the virtio-9p / serial /
+# initramfs support the coverage initramfs needs to boot and copy data out.
+CONFIG_GCOV_KERNEL=y
+CONFIG_DEBUG_FS=y
+CONFIG_BLK_DEV_INITRD=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_PCI=y
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_NET=y
+CONFIG_NET_9P=y
+CONFIG_NET_9P_VIRTIO=y
+CONFIG_9P_FS=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y

--- a/.github/kunit/kunitconfig
+++ b/.github/kunit/kunitconfig
@@ -1,12 +1,6 @@
-# Kernel config fragment consumed by .github/workflows/kunit.yaml.
-# kunit.py merges this into a defconfig before building the test kernel.
-#
-# Every option here MUST survive `make olddefconfig` (kunit.py treats a
-# dropped option as a hard error). That is why the dependency-providing
-# symbols are listed explicitly alongside the ones Agnocast actually needs:
-#   * CONFIG_SYSVIPC      -> required to enable CONFIG_IPC_NS
-#   * CONFIG_FTRACE       -> exposes the "Tracers" menu that hosts
-#                            CONFIG_ENABLE_DEFAULT_TRACERS
+# Kernel config fragment for kunit.py (see .github/workflows/kunit.yaml).
+# Each option must survive `make olddefconfig`, so the dependency-providing
+# symbols (SYSVIPC, FTRACE) are listed alongside the ones the suite needs.
 CONFIG_KUNIT=y
 CONFIG_KUNIT_DEBUGFS=y
 
@@ -15,8 +9,7 @@ CONFIG_SYSVIPC=y
 CONFIG_NAMESPACES=y
 CONFIG_IPC_NS=y
 
-# agnocast_init_exit_hook() looks up the `sched_process_exit` tracepoint via
-# for_each_kernel_tracepoint(); without tracepoints the suite init returns
-# -ENOENT and the whole suite fails to start.
+# The exit hook looks up the sched_process_exit tracepoint; without tracepoints
+# the suite fails to start (-ENOENT). FTRACE gates ENABLE_DEFAULT_TRACERS.
 CONFIG_FTRACE=y
 CONFIG_ENABLE_DEFAULT_TRACERS=y

--- a/.github/kunit/kunitconfig
+++ b/.github/kunit/kunitconfig
@@ -1,0 +1,22 @@
+# Kernel config fragment consumed by .github/workflows/kunit.yaml.
+# kunit.py merges this into a defconfig before building the test kernel.
+#
+# Every option here MUST survive `make olddefconfig` (kunit.py treats a
+# dropped option as a hard error). That is why the dependency-providing
+# symbols are listed explicitly alongside the ones Agnocast actually needs:
+#   * CONFIG_SYSVIPC      -> required to enable CONFIG_IPC_NS
+#   * CONFIG_FTRACE       -> exposes the "Tracers" menu that hosts
+#                            CONFIG_ENABLE_DEFAULT_TRACERS
+CONFIG_KUNIT=y
+CONFIG_KUNIT_DEBUGFS=y
+
+# Agnocast resolves topics per IPC namespace (current->nsproxy->ipc_ns).
+CONFIG_SYSVIPC=y
+CONFIG_NAMESPACES=y
+CONFIG_IPC_NS=y
+
+# agnocast_init_exit_hook() looks up the `sched_process_exit` tracepoint via
+# for_each_kernel_tracepoint(); without tracepoints the suite init returns
+# -ENOENT and the whole suite fails to start.
+CONFIG_FTRACE=y
+CONFIG_ENABLE_DEFAULT_TRACERS=y

--- a/.github/workflows/kunit-coverage.yaml
+++ b/.github/workflows/kunit-coverage.yaml
@@ -135,14 +135,16 @@ jobs:
           # Keep only Agnocast production .c (drop the KUnit test code).
           lcov --quiet --extract coverage.info '*/drivers/agnocast/*.c' -o coverage.info
           lcov --quiet --remove coverage.info '*/agnocast_kunit/*' '*/agnocast_kunit_main.c' -o coverage.info
-          genhtml --quiet coverage.info --output-directory coverage-html
-          # Emit the same table to the log (debuggable) and the job summary.
-          lcov --list coverage.info | tee coverage-list.txt
+          # Use genhtml's own summary for the report: it matches the uploaded
+          # HTML, whereas `lcov --list` mis-renders the rates under lcov 2.x
+          # (shows ~0% functions). The per-file breakdown is in the artifact.
+          genhtml coverage.info --output-directory coverage-html | tee genhtml.log
           {
-            echo '## Agnocast kmod KUnit coverage'
+            echo '## Agnocast kmod KUnit coverage (production .c only)'
             echo '```'
-            cat coverage-list.txt
+            grep -A2 'Overall coverage rate' genhtml.log
             echo '```'
+            echo '_Per-file breakdown: download the `agnocast-kunit-coverage` HTML artifact._'
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload HTML coverage report

--- a/.github/workflows/kunit-coverage.yaml
+++ b/.github/workflows/kunit-coverage.yaml
@@ -1,0 +1,149 @@
+name: kunit-coverage
+
+# Measures gcov line/function coverage for the Agnocast KUnit suite.
+#
+# The plain `kunit` workflow runs the suite for pass/fail; it can't report
+# coverage because that flow boots a kernel with no userspace and halts, so the
+# gcov data in /sys/kernel/debug/gcov is never exported. This job builds a
+# GCOV-instrumented kernel, boots it under QEMU with a tiny BusyBox initramfs
+# that copies /sys/kernel/debug/gcov out over a virtio-9p share, then runs lcov
+# on the host. Results go to the job summary and an HTML artifact.
+#
+# Shared setup (deps, kernel cache/clone, gcov-instrumented staging) lives in
+# the .github/actions/prepare-agnocast-kunit composite action.
+
+on:
+  pull_request:
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
+      - '.github/workflows/kunit-coverage.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
+      - '.github/workflows/kunit-coverage.yaml'
+
+concurrency:
+  group: kunit-coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  LINUX_REF: v6.12
+  LINUX_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+
+jobs:
+  agnocast-kunit-coverage:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare kernel and stage Agnocast sources (gcov-instrumented)
+        uses: ./.github/actions/prepare-agnocast-kunit
+        with:
+          linux-ref: ${{ env.LINUX_REF }}
+          linux-repo: ${{ env.LINUX_REPO }}
+          build-dir: kunit-build-cov
+          cache-key: kunit-cov-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/actions/prepare-agnocast-kunit/**', '.github/workflows/kunit-coverage.yaml') }}
+          restore-key: kunit-cov-${{ runner.os }}-${{ env.LINUX_REF }}-
+          gcov: 'true'
+          extra-packages: busybox-static cpio lcov
+
+      # Build the GCOV kernel. We boot it ourselves (below) rather than via
+      # `kunit.py run`, so we can attach an initramfs that exports the gcov data.
+      - name: Build GCOV-instrumented kernel
+        working-directory: linux
+        run: |
+          set -euo pipefail
+          ./tools/testing/kunit/kunit.py build \
+            --kunitconfig="${GITHUB_WORKSPACE}/.github/kunit/kunitconfig" \
+            --kunitconfig="${GITHUB_WORKSPACE}/.github/kunit/coverage.config" \
+            --arch=x86_64 \
+            --build_dir="${GITHUB_WORKSPACE}/kunit-build-cov" \
+            --jobs="$(nproc)"
+
+      # Minimal BusyBox initramfs whose /init mounts debugfs + a 9p share, copies
+      # the gcov tree out, and powers off. KUnit runs at boot (kunit.enable=1),
+      # before /init, so the gcov data is already populated. Build /init via echo
+      # (not a heredoc) so YAML indentation can't leak in and break the shebang.
+      - name: Build initramfs
+        run: |
+          set -euo pipefail
+          ir="${GITHUB_WORKSPACE}/initramfs"
+          rm -rf "${ir}"; mkdir -p "${ir}"/{bin,proc,sys,mnt,dev}
+          cp /bin/busybox "${ir}/bin/"
+          for a in sh mount cp dmesg poweroff sync; do ln -sf busybox "${ir}/bin/${a}"; done
+          {
+            echo '#!/bin/sh'
+            echo 'mount -t proc none /proc'
+            echo 'mount -t sysfs none /sys'
+            echo 'mount -t debugfs none /sys/kernel/debug'
+            echo 'mount -t 9p -o trans=virtio,version=9p2000.L hostshare /mnt'
+            echo 'cp -r /sys/kernel/debug/gcov /mnt/gcov'
+            echo 'dmesg > /mnt/dmesg.txt'
+            echo 'sync'
+            echo 'poweroff -f'
+          } > "${ir}/init"
+          chmod +x "${ir}/init"
+          ( cd "${ir}" && find . | cpio -o -H newc 2>/dev/null | gzip > "${GITHUB_WORKSPACE}/initramfs.cpio.gz" )
+
+      - name: Run suite under QEMU and collect gcov
+        run: |
+          set -euo pipefail
+          share="${GITHUB_WORKSPACE}/cov-share"
+          rm -rf "${share}"; mkdir -p "${share}"
+          timeout 300 qemu-system-x86_64 \
+            -kernel kunit-build-cov/arch/x86/boot/bzImage \
+            -initrd initramfs.cpio.gz \
+            -append "console=ttyS0 kunit.enable=1 rdinit=/init" \
+            -fsdev local,id=fs0,path="${share}",security_model=none \
+            -device virtio-9p-pci,fsdev=fs0,mount_tag=hostshare \
+            -no-reboot -nographic -m 2G | tee qemu-console.log
+          if grep -q '^not ok' qemu-console.log; then
+            echo "::error::A KUnit test failed; see the console log."
+            exit 1
+          fi
+          n=$(find "${share}/gcov" -name '*.gcda' -path '*drivers/agnocast*' 2>/dev/null | wc -l)
+          echo "agnocast .gcda files captured: ${n}"
+          if [ "${n}" -lt 1 ]; then
+            echo "::error::No agnocast gcov data captured."
+            exit 1
+          fi
+
+      - name: Build coverage report
+        run: |
+          set -euo pipefail
+          build="${GITHUB_WORKSPACE}/kunit-build-cov"
+          share="${GITHUB_WORKSPACE}/cov-share"
+          # The debugfs tree mirrors the absolute build path. Copy only the .gcda
+          # files next to their .gcno in the build dir (the tree's .gcno are
+          # symlinks back into the build dir, so copying them would self-collide).
+          while IFS= read -r f; do
+            cp "${f}" "${f#${share}/gcov}"
+          done < <(find "${share}/gcov${build}" -name '*.gcda')
+          lcov --capture --quiet --directory "${build}/drivers/agnocast" -o coverage.info
+          # Keep only Agnocast production .c (drop the KUnit test code).
+          lcov --quiet --extract coverage.info '*/drivers/agnocast/*.c' -o coverage.info
+          lcov --quiet --remove coverage.info '*/agnocast_kunit/*' '*/agnocast_kunit_main.c' -o coverage.info
+          genhtml --quiet coverage.info --output-directory coverage-html
+          {
+            echo '## Agnocast kmod KUnit coverage'
+            echo '```'
+            lcov --list coverage.info
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload HTML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agnocast-kunit-coverage-${{ github.run_id }}
+          path: coverage-html
+          if-no-files-found: ignore

--- a/.github/workflows/kunit-coverage.yaml
+++ b/.github/workflows/kunit-coverage.yaml
@@ -128,15 +128,20 @@ jobs:
           while IFS= read -r f; do
             cp "${f}" "${f#${share}/gcov}"
           done < <(find "${share}/gcov${build}" -name '*.gcda')
-          lcov --capture --quiet --directory "${build}/drivers/agnocast" -o coverage.info
+          # geninfo_unexecuted_blocks=1 keeps gcov/gcc version skew from
+          # mis-counting (the "unexecuted block ... non-zero hit count" warning).
+          lcov --capture --quiet --rc geninfo_unexecuted_blocks=1 \
+            --directory "${build}/drivers/agnocast" -o coverage.info
           # Keep only Agnocast production .c (drop the KUnit test code).
           lcov --quiet --extract coverage.info '*/drivers/agnocast/*.c' -o coverage.info
           lcov --quiet --remove coverage.info '*/agnocast_kunit/*' '*/agnocast_kunit_main.c' -o coverage.info
           genhtml --quiet coverage.info --output-directory coverage-html
+          # Emit the same table to the log (debuggable) and the job summary.
+          lcov --list coverage.info | tee coverage-list.txt
           {
             echo '## Agnocast kmod KUnit coverage'
             echo '```'
-            lcov --list coverage.info
+            cat coverage-list.txt
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/kunit-coverage.yaml
+++ b/.github/workflows/kunit-coverage.yaml
@@ -135,16 +135,33 @@ jobs:
           # Keep only Agnocast production .c (drop the KUnit test code).
           lcov --quiet --extract coverage.info '*/drivers/agnocast/*.c' -o coverage.info
           lcov --quiet --remove coverage.info '*/agnocast_kunit/*' '*/agnocast_kunit_main.c' -o coverage.info
-          # Use genhtml's own summary for the report: it matches the uploaded
-          # HTML, whereas `lcov --list` mis-renders the rates under lcov 2.x
-          # (shows ~0% functions). The per-file breakdown is in the artifact.
-          genhtml coverage.info --output-directory coverage-html | tee genhtml.log
+          genhtml --quiet coverage.info --output-directory coverage-html
+          # Build the per-file table straight from the lcov tracefile
+          # (LH/LF lines, FNH/FNF functions) rather than `lcov --list`, which
+          # mis-renders the rates under lcov 2.x (shows ~0% functions). These
+          # numbers are the same ones genhtml puts in the uploaded HTML report.
+          table=$(awk '
+            /^SF:/  { sf = $0; sub(/.*\//, "", sf) }
+            /^LF:/  { lf = substr($0, 4) }
+            /^LH:/  { lh = substr($0, 4) }
+            /^FNF:/ { ff = substr($0, 5) }
+            /^FNH:/ { fh = substr($0, 5) }
+            /^end_of_record/ {
+              printf "| %s | %.1f%% (%d/%d) | %.1f%% (%d/%d) |\n", \
+                sf, (lf ? 100*lh/lf : 0), lh, lf, (ff ? 100*fh/ff : 0), fh, ff
+              TLF += lf; TLH += lh; TFF += ff; TFH += fh
+            }
+            END {
+              printf "| **Total** | **%.1f%% (%d/%d)** | **%.1f%% (%d/%d)** |\n", \
+                (TLF ? 100*TLH/TLF : 0), TLH, TLF, (TFF ? 100*TFH/TFF : 0), TFH, TFF
+            }' coverage.info)
+          echo "${table}"
           {
             echo '## Agnocast kmod KUnit coverage (production .c only)'
-            echo '```'
-            grep -A2 'Overall coverage rate' genhtml.log
-            echo '```'
-            echo '_Per-file breakdown: download the `agnocast-kunit-coverage` HTML artifact._'
+            echo ''
+            echo '| File | Lines | Functions |'
+            echo '|---|---|---|'
+            echo "${table}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload HTML coverage report

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -8,9 +8,10 @@ name: kunit
 # insmods it, which CI runners block via kernel lockdown
 # (actions/runner-images#8623). kunit.py links the suite in instead.
 #
-# Why --arch=x86_64 and not kunit.py's default UML: the suite needs
-# CONFIG_IPC_NS and kernel tracepoints (the sched_process_exit hook), which a
-# UML build can't provide. The tests run in QEMU. See .github/kunit/kunitconfig.
+# Why --arch=x86_64 and not kunit.py's default UML: several tests call
+# copy_to_user, which UML can't service from the no-userspace KUnit context
+# (it panics with "Segfault with no mm"). x86_64 under QEMU runs the whole
+# suite. (IPC_NS and tracepoints, the suite's other needs, do work under UML.)
 #
 # Future: an --arch=arm64 matrix axis (qemu-system-aarch64) could be added to
 # catch arch-specific regressions.

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -1,0 +1,163 @@
+name: kunit
+
+# Runs the Agnocast kernel-module KUnit suite (agnocast_kmod/agnocast_kunit/).
+# kunit.py builds the suite into a throwaway kernel, boots it under QEMU, and
+# reports KTAP results -- no insmod, no root, no real hardware.
+#
+# Why kunit.py (not insmod): scripts/test/run_kunit.bash builds a .ko and
+# insmods it, which CI runners block via kernel lockdown
+# (actions/runner-images#8623). kunit.py links the suite in instead.
+#
+# Why --arch=x86_64 (not the default UML): Agnocast needs CONFIG_IPC_NS and
+# kernel tracepoints (the sched_process_exit hook), which a UML defconfig
+# cannot provide. See .github/kunit/kunitconfig.
+#
+# Future: --arch=arm64 (cross-compiled, qemu-system-aarch64) could be added as
+# a matrix axis if we ever need to catch arch-specific regressions.
+
+on:
+  pull_request:
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/workflows/kunit.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'agnocast_kmod/**'
+      - '.github/kunit/**'
+      - '.github/workflows/kunit.yaml'
+
+# Cancel superseded runs on the same ref so concurrent pushes don't fight over
+# the same cache entries.
+concurrency:
+  group: kunit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pinned LTS kernel for reproducible builds. Bump deliberately; the API guards
+  # in agnocast_kmod/Makefile already cover newer kernels.
+  LINUX_REF: v6.12
+  LINUX_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+  # Suite-name glob passed to kunit.py. Trailing '*' is resilient to a suite
+  # rename; the "no tests ran" guard below catches a zero-match (kunit.py itself
+  # exits 0 when the filter matches nothing).
+  KUNIT_FILTER: 'agnocast*'
+
+jobs:
+  agnocast-kunit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kunit.py prerequisites
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential flex bison libelf-dev libssl-dev bc python3 \
+            qemu-system-x86
+
+      # Cache the Linux source tree. Keyed on LINUX_REF only — safe for an
+      # immutable tag. If LINUX_REF is ever pointed at a moving branch, add a
+      # commit SHA or date to the key.
+      - name: Cache Linux source tree
+        id: linux-src-cache
+        uses: actions/cache@v4
+        with:
+          path: linux
+          key: linux-src-${{ env.LINUX_REF }}
+
+      - name: Shallow clone Linux ${{ env.LINUX_REF }}
+        if: steps.linux-src-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch "${LINUX_REF}" "${LINUX_REPO}" linux
+
+      # Cache kunit.py's build dir. It lives OUTSIDE the kernel source tree
+      # (kunit-build/, not linux/.kunit) so that the source-tree cache above
+      # does not absorb build artifacts. The exact key pins the build to the
+      # inputs that affect what gets compiled; restore-keys lets a previous
+      # build dir be reused so kbuild only recompiles the changed Agnocast
+      # objects instead of the whole kernel.
+      - name: Cache KUnit build dir
+        id: kunit-build-cache
+        uses: actions/cache@v4
+        with:
+          path: kunit-build
+          key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/workflows/kunit.yaml') }}
+          restore-keys: |
+            kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-
+
+      # If the source tree was just re-cloned but restore-keys brought back a
+      # build dir from a previous run, that dir may reference object paths the
+      # fresh tree lacks. Drop it so kunit.py does a clean build.
+      - name: Drop stale build dir if source was re-cloned
+        if: steps.linux-src-cache.outputs.cache-hit != 'true'
+        run: rm -rf kunit-build
+
+      # Stage the Agnocast sources into the kernel tree and hand kbuild our
+      # in-tree Makefile (.github/kunit/Kbuild). The layout mirrors agnocast_kmod/
+      # so the tests' "../agnocast.h" includes resolve.
+      - name: Stage Agnocast sources into Linux tree
+        run: |
+          set -euo pipefail
+          dst=linux/drivers/agnocast
+          rm -rf "${dst}"
+          mkdir -p "${dst}/agnocast_kunit"
+          cp agnocast_kmod/*.c agnocast_kmod/*.h "${dst}/"
+          cp agnocast_kmod/agnocast_kunit/*.c \
+             agnocast_kmod/agnocast_kunit/*.h \
+             agnocast_kmod/agnocast_kunit/Makefile.inc \
+             "${dst}/agnocast_kunit/"
+          cp .github/kunit/Kbuild "${dst}/Makefile"
+          if ! grep -q 'drivers/agnocast' linux/drivers/Makefile; then
+            echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
+          fi
+
+      # Build the suite into a kernel, boot it under QEMU, run the tests. The
+      # build dir is kept outside the source tree so the source cache above does
+      # not absorb build artifacts.
+      - name: Run Agnocast KUnit suite under QEMU
+        working-directory: linux
+        run: |
+          set -euo pipefail
+          ./tools/testing/kunit/kunit.py run \
+            --kunitconfig="${GITHUB_WORKSPACE}/.github/kunit/kunitconfig" \
+            --arch=x86_64 \
+            --build_dir="${GITHUB_WORKSPACE}/kunit-build" \
+            --jobs="$(nproc)" \
+            "${KUNIT_FILTER}" 2>&1 | tee "${GITHUB_WORKSPACE}/kunit-run.log"
+          # kunit.py exits 0 even when the filter matches zero suites; guard
+          # against a silent false-green after a suite rename.
+          ran=$(grep -oE 'Ran [0-9]+ tests' "${GITHUB_WORKSPACE}/kunit-run.log" | grep -oE '[0-9]+' | tail -1 || echo 0)
+          echo "KUnit tests ran: ${ran:-0}"
+          if [ "${ran:-0}" -lt 1 ]; then
+            echo "::error::No KUnit tests ran — check KUNIT_FILTER vs the suite name."
+            exit 1
+          fi
+
+      - name: Show KTAP results
+        if: always()
+        run: |
+          if [ -f kunit-build/test.log ]; then
+            echo "--- KTAP log ---"
+            cat kunit-build/test.log
+          fi
+
+      # On failure, upload the test log and resolved .config so the failure is
+      # debuggable without re-running the job.
+      - name: Upload KUnit artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kunit-debug-${{ github.run_id }}
+          path: |
+            kunit-run.log
+            kunit-build/test.log
+            kunit-build/.config
+          if-no-files-found: ignore

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -15,22 +15,25 @@ name: kunit
 #
 # Future: an --arch=arm64 matrix axis (qemu-system-aarch64) could be added to
 # catch arch-specific regressions.
+#
+# Shared setup (deps, kernel cache/clone, staging) lives in the
+# .github/actions/prepare-agnocast-kunit composite action.
 
 on:
   pull_request:
     paths:
       - 'agnocast_kmod/**'
       - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
       - '.github/workflows/kunit.yaml'
   push:
     branches: [main]
     paths:
       - 'agnocast_kmod/**'
       - '.github/kunit/**'
+      - '.github/actions/prepare-agnocast-kunit/**'
       - '.github/workflows/kunit.yaml'
 
-# Cancel superseded runs on the same ref so concurrent pushes don't fight over
-# the same cache entries.
 concurrency:
   group: kunit-${{ github.ref }}
   cancel-in-progress: true
@@ -55,69 +58,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install kunit.py prerequisites
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential flex bison libelf-dev libssl-dev bc python3 \
-            qemu-system-x86
-
-      # Cache the Linux source tree. Keyed on LINUX_REF only — safe for an
-      # immutable tag. If LINUX_REF is ever pointed at a moving branch, add a
-      # commit SHA or date to the key.
-      - name: Cache Linux source tree
-        id: linux-src-cache
-        uses: actions/cache@v4
+      - name: Prepare kernel and stage Agnocast sources
+        uses: ./.github/actions/prepare-agnocast-kunit
         with:
-          path: linux
-          key: linux-src-${{ env.LINUX_REF }}
+          linux-ref: ${{ env.LINUX_REF }}
+          linux-repo: ${{ env.LINUX_REPO }}
+          build-dir: kunit-build
+          cache-key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/actions/prepare-agnocast-kunit/**', '.github/workflows/kunit.yaml') }}
+          restore-key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-
 
-      - name: Shallow clone Linux ${{ env.LINUX_REF }}
-        if: steps.linux-src-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          git clone --depth 1 --branch "${LINUX_REF}" "${LINUX_REPO}" linux
-
-      # Cache kunit.py's build dir, kept outside the source tree so the cache
-      # above doesn't absorb build artifacts. restore-keys reuses a previous
-      # build dir, so only the changed Agnocast objects recompile.
-      - name: Cache KUnit build dir
-        id: kunit-build-cache
-        uses: actions/cache@v4
-        with:
-          path: kunit-build
-          key: kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-${{ hashFiles('agnocast_kmod/**', '.github/kunit/**', '.github/workflows/kunit.yaml') }}
-          restore-keys: |
-            kunit-build-${{ runner.os }}-${{ env.LINUX_REF }}-
-
-      # If the source tree was just re-cloned but restore-keys brought back a
-      # build dir from a previous run, that dir may reference object paths the
-      # fresh tree lacks. Drop it so kunit.py does a clean build.
-      - name: Drop stale build dir if source was re-cloned
-        if: steps.linux-src-cache.outputs.cache-hit != 'true'
-        run: rm -rf kunit-build
-
-      # Stage the Agnocast sources into the kernel tree and hand kbuild our
-      # in-tree Makefile (.github/kunit/Kbuild). The layout mirrors agnocast_kmod/
-      # so the tests' "../agnocast.h" includes resolve.
-      - name: Stage Agnocast sources into Linux tree
-        run: |
-          set -euo pipefail
-          dst=linux/drivers/agnocast
-          rm -rf "${dst}"
-          mkdir -p "${dst}/agnocast_kunit"
-          cp agnocast_kmod/*.c agnocast_kmod/*.h "${dst}/"
-          cp agnocast_kmod/agnocast_kunit/*.c \
-             agnocast_kmod/agnocast_kunit/*.h \
-             agnocast_kmod/agnocast_kunit/Makefile.inc \
-             "${dst}/agnocast_kunit/"
-          cp .github/kunit/Kbuild "${dst}/Makefile"
-          if ! grep -q 'drivers/agnocast' linux/drivers/Makefile; then
-            echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
-          fi
-
-      # Build the suite into a kernel, boot it under QEMU, run the tests.
       - name: Run Agnocast KUnit suite under QEMU
         working-directory: linux
         run: |
@@ -145,8 +94,6 @@ jobs:
             cat kunit-build/test.log
           fi
 
-      # On failure, upload the test log and resolved .config so the failure is
-      # debuggable without re-running the job.
       - name: Upload KUnit artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/kunit.yaml
+++ b/.github/workflows/kunit.yaml
@@ -8,12 +8,12 @@ name: kunit
 # insmods it, which CI runners block via kernel lockdown
 # (actions/runner-images#8623). kunit.py links the suite in instead.
 #
-# Why --arch=x86_64 (not the default UML): Agnocast needs CONFIG_IPC_NS and
-# kernel tracepoints (the sched_process_exit hook), which a UML defconfig
-# cannot provide. See .github/kunit/kunitconfig.
+# Why --arch=x86_64 and not kunit.py's default UML: the suite needs
+# CONFIG_IPC_NS and kernel tracepoints (the sched_process_exit hook), which a
+# UML build can't provide. The tests run in QEMU. See .github/kunit/kunitconfig.
 #
-# Future: --arch=arm64 (cross-compiled, qemu-system-aarch64) could be added as
-# a matrix axis if we ever need to catch arch-specific regressions.
+# Future: an --arch=arm64 matrix axis (qemu-system-aarch64) could be added to
+# catch arch-specific regressions.
 
 on:
   pull_request:
@@ -78,12 +78,9 @@ jobs:
           set -euo pipefail
           git clone --depth 1 --branch "${LINUX_REF}" "${LINUX_REPO}" linux
 
-      # Cache kunit.py's build dir. It lives OUTSIDE the kernel source tree
-      # (kunit-build/, not linux/.kunit) so that the source-tree cache above
-      # does not absorb build artifacts. The exact key pins the build to the
-      # inputs that affect what gets compiled; restore-keys lets a previous
-      # build dir be reused so kbuild only recompiles the changed Agnocast
-      # objects instead of the whole kernel.
+      # Cache kunit.py's build dir, kept outside the source tree so the cache
+      # above doesn't absorb build artifacts. restore-keys reuses a previous
+      # build dir, so only the changed Agnocast objects recompile.
       - name: Cache KUnit build dir
         id: kunit-build-cache
         uses: actions/cache@v4
@@ -119,9 +116,7 @@ jobs:
             echo 'obj-$(CONFIG_KUNIT) += agnocast/' >> linux/drivers/Makefile
           fi
 
-      # Build the suite into a kernel, boot it under QEMU, run the tests. The
-      # build dir is kept outside the source tree so the source cache above does
-      # not absorb build artifacts.
+      # Build the suite into a kernel, boot it under QEMU, run the tests.
       - name: Run Agnocast KUnit suite under QEMU
         working-directory: linux
         run: |

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -39,6 +39,7 @@ union ioctl_add_process_args {
   struct
   {
     bool is_performance_bridge_manager;
+    uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct
   {
@@ -400,7 +401,7 @@ int agnocast_ioctl_take_msg(
 
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_performance_bridge_manager,
-  union ioctl_add_process_args * ioctl_ret);
+  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret);
 
 int agnocast_ioctl_get_subscriber_num(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const pid_t pid,

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -66,6 +66,9 @@ struct process_info
   pid_t local_pid;
   struct mempool_entry * mempool_entry;
   const struct ipc_namespace * ipc_ns;
+  // The process's ROS_DOMAIN_ID (0 if unset), fixed for the process's lifetime.
+  // Used as the domain component of the topic key for this process's operations.
+  uint32_t domain_id;
   struct list_head exit_subscription_list;
   uint32_t exit_subscription_count;
   struct hlist_node node;
@@ -127,6 +130,9 @@ struct topic_wrapper
 {
   const struct ipc_namespace *
     ipc_ns;  // For use in separating topic namespaces when using containers.
+  // Part of the topic identity: topics with the same name/ipc_ns but different
+  // ROS_DOMAIN_ID are distinct wrappers and do not match (ROS 2 domain isolation).
+  uint32_t domain_id;
   char * key;
   struct rw_semaphore
     topic_rwsem;  // Per-topic rwsem: read for read-only ops, write for publish/receive/modify

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -36,23 +36,49 @@ static unsigned long get_topic_hash(const char * str)
 }
 
 static struct topic_wrapper * find_topic(
-  const char * topic_name, const struct ipc_namespace * ipc_ns)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
   struct topic_wrapper * entry;
   unsigned long hash_val = get_topic_hash(topic_name);
 
   hash_for_each_possible(topic_hashtable, entry, node, hash_val)
   {
-    if (ipc_eq(entry->ipc_ns, ipc_ns) && strcmp(entry->key, topic_name) == 0) return entry;
+    if (
+      ipc_eq(entry->ipc_ns, ipc_ns) && entry->domain_id == domain_id &&
+      strcmp(entry->key, topic_name) == 0)
+      return entry;
   }
 
   return NULL;
 }
 
-static int add_topic(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, struct topic_wrapper ** wrapper)
+// A process operates in exactly one ROS_DOMAIN_ID, recorded in its process_info.
+// Returns the default domain 0 if the process is not registered.
+// Caller must hold global_htables_rwsem (same as agnocast_find_process_info).
+static uint32_t get_process_domain_id(pid_t pid)
 {
-  *wrapper = find_topic(topic_name, ipc_ns);
+  struct process_info * proc_info = agnocast_find_process_info(pid);
+  return proc_info ? proc_info->domain_id : 0;
+}
+
+static uint32_t get_current_domain_id(void)
+{
+  return get_process_domain_id(current->tgid);
+}
+
+// find_topic variant for operations on behalf of the calling process: matches in
+// the caller's own domain. Caller holds global_htables_rwsem.
+static struct topic_wrapper * find_topic_for_current(
+  const char * topic_name, const struct ipc_namespace * ipc_ns)
+{
+  return find_topic(topic_name, ipc_ns, get_current_domain_id());
+}
+
+static int add_topic(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id,
+  struct topic_wrapper ** wrapper)
+{
+  *wrapper = find_topic(topic_name, ipc_ns, domain_id);
   if (*wrapper) {
     return 0;
   }
@@ -66,6 +92,7 @@ static int add_topic(
   }
 
   (*wrapper)->ipc_ns = ipc_ns;
+  (*wrapper)->domain_id = domain_id;
   (*wrapper)->key = kstrdup(topic_name, GFP_KERNEL);
   if (!(*wrapper)->key) {
     dev_warn(
@@ -352,7 +379,7 @@ int agnocast_ioctl_release_message_entry_reference(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -543,7 +570,7 @@ static bool has_alive_performance_bridge_manager(const struct ipc_namespace * ip
 
 int agnocast_ioctl_add_process(
   const pid_t pid, const struct ipc_namespace * ipc_ns, const bool is_performance_bridge_manager,
-  union ioctl_add_process_args * ioctl_ret)
+  const uint32_t domain_id, union ioctl_add_process_args * ioctl_ret)
 {
   int ret = 0;
 
@@ -586,6 +613,7 @@ int agnocast_ioctl_add_process(
   }
 
   new_proc_info->ipc_ns = ipc_ns;
+  new_proc_info->domain_id = domain_id;
 
   INIT_HLIST_NODE(&new_proc_info->node);
   uint32_t hash_val = hash_min(new_proc_info->global_pid, PROC_INFO_HASH_BITS);
@@ -610,7 +638,7 @@ int agnocast_ioctl_add_subscriber(
   down_write(&global_htables_rwsem);
 
   struct topic_wrapper * wrapper;
-  ret = add_topic(topic_name, ipc_ns, &wrapper);
+  ret = add_topic(topic_name, ipc_ns, get_process_domain_id(subscriber_pid), &wrapper);
   if (ret < 0) {
     goto unlock;
   }
@@ -640,7 +668,7 @@ int agnocast_ioctl_add_publisher(
   down_write(&global_htables_rwsem);
 
   struct topic_wrapper * wrapper;
-  ret = add_topic(topic_name, ipc_ns, &wrapper);
+  ret = add_topic(topic_name, ipc_ns, get_process_domain_id(publisher_pid), &wrapper);
   if (ret < 0) {
     goto unlock;
   }
@@ -768,7 +796,7 @@ int agnocast_ioctl_publish_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -927,7 +955,7 @@ int agnocast_ioctl_receive_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -984,7 +1012,7 @@ int agnocast_ioctl_take_msg(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1104,7 +1132,7 @@ int agnocast_ioctl_get_subscriber_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
 
   if (!wrapper) {
     up_read(&global_htables_rwsem);
@@ -1157,7 +1185,7 @@ int agnocast_ioctl_set_ros2_subscriber_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (wrapper) {
     down_write(&wrapper->topic_rwsem);
     wrapper->topic.ros2_subscriber_num = count;
@@ -1177,7 +1205,7 @@ int agnocast_ioctl_set_ros2_publisher_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (wrapper) {
     down_write(&wrapper->topic_rwsem);
     wrapper->topic.ros2_publisher_num = count;
@@ -1201,7 +1229,7 @@ int agnocast_ioctl_get_publisher_num(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
 
   if (!wrapper) {
     up_read(&global_htables_rwsem);
@@ -1532,7 +1560,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1618,7 +1646,7 @@ int agnocast_ioctl_get_topic_publisher_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1703,7 +1731,7 @@ int agnocast_ioctl_get_subscriber_qos(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_dbg(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1742,7 +1770,7 @@ int agnocast_ioctl_get_publisher_qos(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_dbg(agnocast_device, "Topic (topic_name=%s) not found. (%s)\n", topic_name, __func__);
     ret = -EINVAL;
@@ -1779,7 +1807,7 @@ int agnocast_ioctl_remove_subscriber(
 
   down_write(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     ret = -EINVAL;
     goto unlock;
@@ -1874,7 +1902,7 @@ int agnocast_ioctl_remove_publisher(
 
   down_write(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     ret = -EINVAL;
     goto unlock;
@@ -2155,7 +2183,9 @@ static long add_process_cmd(union ioctl_add_process_args __user * arg)
   union ioctl_add_process_args add_process_args;
   if (copy_from_user(&add_process_args, arg, sizeof(add_process_args))) return -EFAULT;
   bool is_performance_bridge_manager = add_process_args.is_performance_bridge_manager;
-  ret = agnocast_ioctl_add_process(pid, ipc_ns, is_performance_bridge_manager, &add_process_args);
+  uint32_t domain_id = add_process_args.domain_id;
+  ret = agnocast_ioctl_add_process(
+    pid, ipc_ns, is_performance_bridge_manager, domain_id, &add_process_args);
   if (ret == 0) {
     if (copy_to_user(arg, &add_process_args, sizeof(add_process_args))) return -EFAULT;
   }
@@ -2809,7 +2839,7 @@ int agnocast_increment_message_entry_rc(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     dev_warn(
       agnocast_device, "Topic (topic_name=%s) not found. (increment_message_entry_rc)\n",
@@ -2888,7 +2918,7 @@ bool agnocast_is_proc_exited(const pid_t pid)
 
 int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return 0;
   }
@@ -2905,7 +2935,7 @@ int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_nam
 bool agnocast_is_in_topic_entries(
   const char * topic_name, const struct ipc_namespace * ipc_ns, int64_t entry_id)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -2923,7 +2953,7 @@ int agnocast_get_entry_rc(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const int64_t entry_id,
   const topic_local_id_t pubsub_id)
 {
-  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return -1;
   }
@@ -2944,7 +2974,7 @@ int64_t agnocast_get_latest_received_entry_id(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t subscriber_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return -1;
   }
@@ -2960,7 +2990,7 @@ bool agnocast_is_in_subscriber_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t subscriber_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -2974,7 +3004,7 @@ bool agnocast_is_in_subscriber_htable(
 bool agnocast_is_in_publisher_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id)
 {
-  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns);
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
   if (!wrapper) {
     return false;
   }
@@ -3001,7 +3031,7 @@ int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns)
 
 bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns)
 {
-  return find_topic(topic_name, ipc_ns) != NULL;
+  return find_topic_for_current(topic_name, ipc_ns) != NULL;
 }
 
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -13,7 +13,7 @@ void test_case_add_process_normal(struct kunit * test)
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
@@ -31,12 +31,12 @@ void test_case_add_process_many(struct kunit * test)
   for (int i = 0; i < mempool_num - 1; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
   }
 
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   // ================================================
   // Assert
@@ -54,8 +54,8 @@ void test_case_add_process_twice(struct kunit * test)
 
   pid_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret1 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
-  int ret2 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret1 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
+  int ret2 = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
   KUNIT_EXPECT_EQ(test, ret2, -EINVAL);
@@ -73,11 +73,11 @@ void test_case_add_process_too_many(struct kunit * test)
   for (int i = 0; i < mempool_num; i++) {
     uint64_t local_pid = pid++;
     union ioctl_add_process_args args;
-    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+    agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
   }
   uint64_t local_pid = pid++;
   union ioctl_add_process_args args;
-  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, &args);
+  int ret = agnocast_ioctl_add_process(local_pid, current->nsproxy->ipc_ns, false, 0, &args);
 
   // ================================================
   // Assert

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -17,8 +17,60 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static int add_pubsub_pair(
+  struct kunit * test, const pid_t pub_pid, const pid_t sub_pid, const uint32_t qos_depth)
+{
+  union ioctl_add_publisher_args add_publisher_args;
+  int ret = agnocast_ioctl_add_publisher(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
+    IS_BRIDGE, &add_publisher_args);
+  if (ret < 0) return ret;
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  return agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, sub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
+    QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+}
+
+// A publisher and subscriber with the same topic name but different ROS_DOMAIN_ID
+// must produce two distinct topic wrappers (ROS 2 domain isolation).
+void test_case_add_subscriber_domain_isolation(struct kunit * test)
+{
+  const pid_t pub_pid = 2000;
+  const pid_t sub_pid = 2001;
+  setup_process_domain(test, pub_pid, 0);
+  setup_process_domain(test, sub_pid, 1);
+
+  KUNIT_ASSERT_EQ(test, add_pubsub_pair(test, pub_pid, sub_pid, 1), 0);
+
+  // Two wrappers: (TOPIC_NAME, ipc_ns, domain=0) and (TOPIC_NAME, ipc_ns, domain=1).
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 2);
+}
+
+// A publisher and subscriber in the same domain on the same topic share one
+// wrapper (unchanged behavior).
+void test_case_add_subscriber_same_domain_shared(struct kunit * test)
+{
+  const pid_t pub_pid = 2002;
+  const pid_t sub_pid = 2003;
+  setup_process_domain(test, pub_pid, 0);
+  setup_process_domain(test, sub_pid, 0);
+
+  KUNIT_ASSERT_EQ(test, add_pubsub_pair(test, pub_pid, sub_pid, 1), 0);
+
+  KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 1);
 }
 
 void test_case_add_subscriber_normal(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.h
@@ -2,9 +2,13 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_ADD_SUBSCRIBER              \
-  KUNIT_CASE(test_case_add_subscriber_normal), \
-    KUNIT_CASE(test_case_add_subscriber_too_many_subscribers)
+#define TEST_CASES_ADD_SUBSCRIBER                              \
+  KUNIT_CASE(test_case_add_subscriber_normal),                 \
+    KUNIT_CASE(test_case_add_subscriber_too_many_subscribers), \
+    KUNIT_CASE(test_case_add_subscriber_domain_isolation),     \
+    KUNIT_CASE(test_case_add_subscriber_same_domain_shared)
 
 void test_case_add_subscriber_normal(struct kunit * test);
 void test_case_add_subscriber_too_many_subscribers(struct kunit * test);
+void test_case_add_subscriber_domain_isolation(struct kunit * test);
+void test_case_add_subscriber_same_domain_shared(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_bridge_shutdown.c
@@ -14,13 +14,13 @@ void test_case_bridge_manager_flag_set_on_registration(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Verify the flag was set by checking a new process sees it
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -32,13 +32,13 @@ void test_case_bridge_manager_detected_by_new_process(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register normal process - should see bridge manager exists
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -50,7 +50,7 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   // Register bridge manager
   pid_t bridge_pid = pid_bs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Notify shutdown
@@ -59,7 +59,7 @@ void test_case_notify_bridge_shutdown_clears_flag(struct kunit * test)
   // Register normal process - should see no bridge manager
   pid_t normal_pid = pid_bs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_performance_bridge_daemon_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -14,7 +14,7 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   // Register bridge manager only
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - only bridge manager exists (process_num == 1)
@@ -27,7 +27,7 @@ void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test)
   // Verify is_performance_bridge_manager was cleared - new process should not see bridge manager
   pid_t normal_pid = pid_carbs++;
   union ioctl_add_process_args normal_args = {};
-  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, &normal_args);
+  ret = agnocast_ioctl_add_process(normal_pid, current->nsproxy->ipc_ns, false, 0, &normal_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_FALSE(test, normal_args.ret_performance_bridge_daemon_exist);
 }
@@ -39,13 +39,13 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   // Register bridge manager
   pid_t bridge_pid = pid_carbs++;
   union ioctl_add_process_args bridge_args = {};
-  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, &bridge_args);
+  int ret = agnocast_ioctl_add_process(bridge_pid, current->nsproxy->ipc_ns, true, 0, &bridge_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Register another process
   pid_t other_pid = pid_carbs++;
   union ioctl_add_process_args other_args = {};
-  ret = agnocast_ioctl_add_process(other_pid, current->nsproxy->ipc_ns, false, &other_args);
+  ret = agnocast_ioctl_add_process(other_pid, current->nsproxy->ipc_ns, false, 0, &other_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
 
   // Check shutdown - other process exists (process_num > 1)
@@ -58,7 +58,7 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   // Verify is_performance_bridge_manager is still set - new process should see bridge manager
   pid_t new_pid = pid_carbs++;
   union ioctl_add_process_args new_args = {};
-  ret = agnocast_ioctl_add_process(new_pid, current->nsproxy->ipc_ns, false, &new_args);
+  ret = agnocast_ioctl_add_process(new_pid, current->nsproxy->ipc_ns, false, 0, &new_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, new_args.ret_performance_bridge_daemon_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -27,7 +27,7 @@ static void setup_processes(struct kunit * test, const int process_num)
   union ioctl_add_process_args ioctl_ret;
   for (int i = 0; i < process_num; i++) {
     const pid_t pid = PID_BASE + i;
-    int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+    int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
     KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));
   }
@@ -37,7 +37,7 @@ static void setup_processes(struct kunit * test, const int process_num)
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   KUNIT_ASSERT_FALSE(test, agnocast_is_proc_exited(pid));

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -15,7 +15,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -15,7 +15,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -18,8 +18,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -36,8 +36,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -53,8 +53,8 @@ static void setup_one_publisher_with_bridge(struct kunit * test, char * topic_na
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -183,8 +183,8 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -18,8 +18,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -36,8 +36,8 @@ static void setup_one_subscriber_with_bridge(struct kunit * test, char * topic_n
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -54,8 +54,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -72,7 +72,7 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_process_args add_process_args;
   int ret1 =
-    agnocast_ioctl_add_process(intra_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+    agnocast_ioctl_add_process(intra_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -14,7 +14,7 @@ static const bool IS_BRIDGE = false;
 static void setup_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args add_process_args;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -44,8 +44,8 @@ static void setup_one_publisher(
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -66,7 +66,7 @@ static void setup_pub_sub_same_process(
 
   union ioctl_add_process_args add_process_args;
   int ret_proc =
-    agnocast_ioctl_add_process(common_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+    agnocast_ioctl_add_process(common_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   if (ret_addr) {
     *ret_addr = add_process_args.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   topic_local_id_t * subscriber_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -42,8 +42,8 @@ static void setup_one_publisher(
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -676,7 +676,7 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -718,8 +718,8 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_publisher(
@@ -756,8 +756,8 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -984,7 +984,7 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1027,7 +1027,7 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const pid_t pid = 1000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -24,8 +24,8 @@ static void setup_one_publisher(
   const pid_t PUBLISHER_PID = 2000;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(PUBLISHER_PID, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    PUBLISHER_PID, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
     TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH,
@@ -106,8 +106,8 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
 
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
-  int ret2 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret2 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -156,7 +156,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid1 = 1000;
   union ioctl_add_process_args add_process_args1;
   int ret2 = agnocast_ioctl_add_process(
-    subscriber_pid1, current->nsproxy->ipc_ns, false, &add_process_args1);
+    subscriber_pid1, current->nsproxy->ipc_ns, false, 0, &add_process_args1);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -175,7 +175,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
   const pid_t subscriber_pid2 = 1001;
   union ioctl_add_process_args add_process_args2;
   int ret5 = agnocast_ioctl_add_process(
-    subscriber_pid2, current->nsproxy->ipc_ns, false, &add_process_args2);
+    subscriber_pid2, current->nsproxy->ipc_ns, false, 0, &add_process_args2);
   KUNIT_ASSERT_EQ(test, ret5, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
@@ -232,8 +232,8 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
 
   const pid_t subscriber_pid = 1000;
   union ioctl_add_process_args add_process_args;
-  int ret2 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret2 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   union ioctl_add_subscriber_args add_subscriber_args;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -22,7 +22,7 @@ static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -22,7 +22,7 @@ static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 static uint64_t setup_one_process(struct kunit * test, const pid_t pid)
 {
   union ioctl_add_process_args ioctl_ret;
-  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &ioctl_ret);
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
   return ioctl_ret.ret_addr;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -14,8 +14,8 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
   publisher_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -17,8 +17,8 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -24,8 +24,8 @@ static void setup_one_subscriber(
   topic_local_id_t * subscriber_id)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
@@ -42,8 +42,8 @@ static void setup_one_publisher(
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
   union ioctl_add_process_args add_process_args;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   *ret_addr = add_process_args.ret_addr;
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -772,7 +772,7 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   // Arrange
   union ioctl_add_process_args add_process_args;
   const pid_t pid = 1000;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -817,8 +817,8 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
 
   union ioctl_add_process_args add_process_args;
   const pid_t publisher_pid = 1000;
-  int ret1 =
-    agnocast_ioctl_add_process(publisher_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
 
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth1 = 10;
@@ -859,8 +859,8 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   // Arrange
   union ioctl_add_process_args add_process_args;
   const pid_t subscriber_pid = 2000;
-  int ret1 =
-    agnocast_ioctl_add_process(subscriber_pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   const bool is_transient_local = false;
 
   union ioctl_add_subscriber_args add_subscriber_args1;
@@ -1021,7 +1021,7 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;
@@ -1066,7 +1066,7 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
   const bool allow_same_message = true;
 
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, &add_process_args);
+  int ret1 = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
 
   union ioctl_add_publisher_args add_publisher_args;

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -55,6 +55,7 @@ union ioctl_add_process_args {
   struct
   {
     bool is_performance_bridge_manager;
+    uint32_t domain_id;  // The process's ROS_DOMAIN_ID (0 if unset).
   };
   struct
   {

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -77,6 +77,10 @@ inline void validate_subscription_qos(const rclcpp::QoS & qos)
 }
 
 void validate_ld_preload();
+// Return the calling process's ROS_DOMAIN_ID parsed from the env var (0 if unset
+// or unparsable), matching ROS 2's default. Registered with the kmod so topics
+// in different domains are isolated.
+uint32_t get_ros_domain_id();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -158,6 +158,7 @@ initialize_agnocast_result acquire_agnocast_resources_for_bridge(BridgeMode brid
 {
   union ioctl_add_process_args add_process_args = {};
   add_process_args.is_performance_bridge_manager = (bridge_mode == BridgeMode::Performance);
+  add_process_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     throw std::runtime_error(std::string("AGNOCAST_ADD_PROCESS_CMD failed: ") + strerror(errno));
   }
@@ -474,6 +475,7 @@ struct initialize_agnocast_result initialize_agnocast(
   }
 
   union ioctl_add_process_args add_process_args = {};
+  add_process_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_ADD_PROCESS_CMD, &add_process_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_PROCESS_CMD failed: %s", strerror(errno));
     close(agnocast_fd);

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -91,6 +91,20 @@ static std::string performance_domain_suffix()
   return "_d" + std::string(domain_id);
 }
 
+uint32_t get_ros_domain_id()
+{
+  const char * domain_id_env = getenv("ROS_DOMAIN_ID");
+  if (domain_id_env == nullptr || domain_id_env[0] == '\0') {
+    return 0;
+  }
+  char * end = nullptr;
+  const unsigned long value = std::strtoul(domain_id_env, &end, 10);
+  if (*end != '\0') {
+    return 0;  // Unparsable: fall back to the default domain.
+  }
+  return static_cast<uint32_t>(value);
+}
+
 std::string create_mq_name_for_bridge(const pid_t pid)
 {
   std::string name = "/agnocast_bridge_manager@" + std::to_string(pid);


### PR DESCRIPTION
Experiment: #1398 (domain isolation) with the KUnit CI chain (#1368 and its base) cherry-picked on top, so the KUnit job runs the new `test_case_add_subscriber_domain_isolation` / `_same_domain_shared` cases. Not for merge — verifying the added KUnit tests pass in CI.