### PR TITLE
feat(agnocast_kmod, agnocast_ioctl_wrapper)[needs minor version update]: make topic list / info ioctls domain-aware

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -311,6 +311,10 @@ union ioctl_topic_list_args {
   struct
   {
     uint64_t topic_name_buffer_addr;
+    // Parallel array of uint32 domain_ids, one per returned topic name. The same
+    // topic name can appear in multiple domains, so the caller pairs name[i] with
+    // domain_id[i] to disambiguate. Pass 0 to skip domain output.
+    uint64_t domain_id_buffer_addr;
     uint32_t topic_name_buffer_size;
   };
   uint32_t ret_topic_num;
@@ -341,6 +345,9 @@ union ioctl_topic_info_args {
     struct name_info topic_name;
     uint64_t topic_info_ret_buffer_addr;
     uint32_t topic_info_ret_buffer_size;
+    // Which domain's endpoints to return. A topic name can exist in multiple
+    // domains; the caller selects one (paired with get_topic_list output).
+    uint32_t domain_id;
   };
   uint32_t ret_topic_info_ret_num;
 };

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1417,6 +1417,16 @@ int agnocast_ioctl_get_topic_list(
       goto unlock;
     }
 
+    if (topic_list_args->domain_id_buffer_addr) {
+      uint32_t domain_id = wrapper->domain_id;
+      if (copy_to_user(
+            (uint32_t __user *)topic_list_args->domain_id_buffer_addr + topic_num, &domain_id,
+            sizeof(domain_id))) {
+        ret = -EFAULT;
+        goto unlock;
+      }
+    }
+
     topic_num++;
   }
 
@@ -1560,7 +1570,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, topic_info_args->domain_id);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1646,7 +1656,7 @@ int agnocast_ioctl_get_topic_publisher_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, topic_info_args->domain_id);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -18,6 +18,14 @@ static void setup_process(struct kunit * test, const pid_t pid)
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
+static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
 // Normal case: one subscriber exists, should return count == 1
 void test_case_get_topic_sub_info_one_subscriber(struct kunit * test)
 {
@@ -72,4 +80,35 @@ void test_case_get_topic_sub_info_topic_not_found(struct kunit * test)
     "/nonexistent_topic", current->nsproxy->ipc_ns, &topic_info_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, topic_info_args.ret_topic_info_ret_num, (uint32_t)0);
+}
+
+// The query selects the wrapper by domain: a subscriber registered in domain 1 is
+// visible only when domain_id == 1, regardless of the caller's own domain.
+void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test)
+{
+  const pid_t pid_d1 = 1001;
+  union ioctl_add_subscriber_args add_sub_args;
+  int ret;
+
+  setup_process_domain(test, pid_d1, 1);
+  ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid_d1, QOS_DEPTH, false, false, false, false,
+    IS_BRIDGE, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // domain 1: the topic exists -> the subscriber is counted (copy_to_user
+  // fails with -EFAULT in KUnit context, but reaching it confirms the count).
+  union ioctl_topic_info_args args_d1 = {0};
+  args_d1.domain_id = 1;
+  args_d1.topic_info_ret_buffer_size = MAX_SUBSCRIBER_NUM;
+  ret = agnocast_ioctl_get_topic_subscriber_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d1);
+  KUNIT_EXPECT_TRUE(test, ret == -EFAULT || (ret == 0 && args_d1.ret_topic_info_ret_num == 1));
+
+  // domain 0: no wrapper for this name -> nothing found.
+  union ioctl_topic_info_args args_d0 = {0};
+  args_d0.domain_id = 0;
+  args_d0.topic_info_ret_buffer_size = MAX_SUBSCRIBER_NUM;
+  ret = agnocast_ioctl_get_topic_subscriber_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d0);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, args_d0.ret_topic_info_ret_num, (uint32_t)0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
@@ -2,11 +2,13 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                 \
-  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),   \
-    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers), \
-    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found)
+#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                  \
+  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),    \
+    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers),  \
+    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found), \
+    KUNIT_CASE(test_case_get_topic_sub_info_selects_by_domain)
 
 void test_case_get_topic_sub_info_one_subscriber(struct kunit * test);
 void test_case_get_topic_sub_info_no_subscribers(struct kunit * test);
 void test_case_get_topic_sub_info_topic_not_found(struct kunit * test);
+void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test);

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -31,6 +31,9 @@ union ioctl_topic_list_args {
   struct
   {
     uint64_t topic_name_buffer_addr;
+    // Parallel array of uint32 domain_ids (one per topic name). Pass 0 to skip.
+    // Must mirror agnocast_kmod/agnocast.h so _IOWR encodes the same size.
+    uint64_t domain_id_buffer_addr;
     uint32_t topic_name_buffer_size;
   };
   uint32_t ret_topic_num;
@@ -61,6 +64,9 @@ union ioctl_topic_info_args {
     struct name_info topic_name;
     uint64_t topic_info_ret_buffer_addr;
     uint32_t topic_info_ret_buffer_size;
+    // Which domain's endpoints to return (0 = default domain). Must mirror
+    // agnocast_kmod/agnocast.h so _IOWR encodes the same size.
+    uint32_t domain_id;
   };
   uint32_t ret_topic_info_ret_num;
 };


### PR DESCRIPTION
## Description

After topic isolation by `ROS_DOMAIN_ID` (#1398), the same topic name can exist in multiple domains within one IPC namespace. The ros2cli-facing ioctls could not distinguish them: `get_topic_list` returned bare names, and `get_topic_subscriber_info` / `get_topic_publisher_info` resolved only the caller's domain. This makes those ioctls domain-aware so a per-namespace consumer (the discovery agent) can enumerate every domain.

Changes:

- **agnocast_kmod**: `get_topic_list` optionally fills a parallel `domain_id` array (one per topic name); `get_topic_subscriber_info` / `get_topic_publisher_info` take an explicit `domain_id` input and select the wrapper via `find_topic(name, ipc_ns, domain_id)`.
- **agnocast_ioctl_wrapper**: mirror the two arg structs so `_IOWR` encodes the same size. The wrapper passes `0` (no domain output / default domain), so userspace behavior is unchanged in this PR.

Scope: kmod / ioctl plumbing only. Consuming the domain (discovery agent stamps the real `domain_id`, decider keys bridge decisions on domain) lands in follow-up PRs.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1398

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **kunit (added)**: `get_topic_subscriber_info` selects the wrapper by `domain_id` — a subscriber registered in domain 1 is visible only for `domain_id == 1`, and domain 0 returns nothing.
- Built `agnocast_kmod` and `agnocast_ioctl_wrapper`; the wrapper ABI sync keeps the `ros2 agnocast` CLI working unchanged (e2e not run yet — draft).

## Version Update Label (Required)

- `need-minor-update` (kmod ioctl ABI: `ioctl_topic_list_args` / `ioctl_topic_info_args` layout change)
