### PR TITLE
fix(agnocast_kmod): gate the performance bridge manager per (ipc_ns, domain)

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -553,15 +553,19 @@ int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret)
   return 0;
 }
 
-static bool has_alive_performance_bridge_manager(const struct ipc_namespace * ipc_ns)
+// A performance bridge manager is per-(ipc_ns, domain): its MQ name carries the
+// domain suffix, so each domain needs its own manager. Gate on the domain too,
+// otherwise a manager in one domain would suppress spawning in another.
+static bool has_alive_performance_bridge_manager(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
 {
   struct process_info * proc_info;
   int bkt;
   hash_for_each(proc_info_htable, bkt, proc_info, node)
   {
     if (
-      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->is_performance_bridge_manager &&
-      !proc_info->exited) {
+      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
+      proc_info->is_performance_bridge_manager && !proc_info->exited) {
       return true;
     }
   }
@@ -582,7 +586,8 @@ int agnocast_ioctl_add_process(
     goto unlock;
   }
   ioctl_ret->ret_unlink_daemon_exist = (get_process_num(ipc_ns) > 0);
-  ioctl_ret->ret_performance_bridge_daemon_exist = has_alive_performance_bridge_manager(ipc_ns);
+  ioctl_ret->ret_performance_bridge_daemon_exist =
+    has_alive_performance_bridge_manager(ipc_ns, domain_id);
 
   if (is_performance_bridge_manager && ioctl_ret->ret_performance_bridge_daemon_exist) {
     goto unlock;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -63,6 +63,35 @@ void test_case_add_process_twice(struct kunit * test)
   KUNIT_EXPECT_FALSE(test, agnocast_is_proc_exited(local_pid));
 }
 
+// A performance bridge manager is gated per-(ipc_ns, domain): a manager in one
+// domain must not suppress spawning a manager in another domain, while a second
+// manager in the same domain is suppressed.
+void test_case_add_process_perf_manager_per_domain(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  union ioctl_add_process_args args_d0;
+  int ret_d0 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0);
+  KUNIT_EXPECT_EQ(test, ret_d0, 0);
+  KUNIT_EXPECT_FALSE(test, args_d0.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+
+  // Different domain: not suppressed, so it is added and sees no existing manager.
+  union ioctl_add_process_args args_d1;
+  int ret_d1 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 1, &args_d1);
+  KUNIT_EXPECT_EQ(test, ret_d1, 0);
+  KUNIT_EXPECT_FALSE(test, args_d1.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+
+  // Same domain as the first: a manager already exists, so it is suppressed.
+  union ioctl_add_process_args args_d0_again;
+  int ret_d0_again =
+    agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0_again);
+  KUNIT_EXPECT_EQ(test, ret_d0_again, 0);
+  KUNIT_EXPECT_TRUE(test, args_d0_again.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+}
+
 void test_case_add_process_too_many(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -4,9 +4,12 @@
 
 #define TEST_CASES_ADD_PROCESS                                                      \
   KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
-    KUNIT_CASE(test_case_add_process_twice), KUNIT_CASE(test_case_add_process_too_many)
+    KUNIT_CASE(test_case_add_process_twice),                                        \
+    KUNIT_CASE(test_case_add_process_perf_manager_per_domain),                      \
+    KUNIT_CASE(test_case_add_process_too_many)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
 void test_case_add_process_twice(struct kunit * test);
+void test_case_add_process_perf_manager_per_domain(struct kunit * test);
 void test_case_add_process_too_many(struct kunit * test);


### PR DESCRIPTION
## Description

A performance bridge manager's MQ name carries the `ROS_DOMAIN_ID` suffix (`_d<domain>`), so each domain needs its own manager. The spawn gate `has_alive_performance_bridge_manager` matched only the IPC namespace, so a manager already running in one domain suppressed spawning a manager in another domain of the same namespace — the same-namespace / different-domain case (Case 2) never got its second manager.

Match the domain too: a process registering as a performance bridge manager is suppressed only when an alive manager already exists in the same `(ipc_ns, domain)`.

No ABI change — `add_process` already carries `domain_id` (#1398); this only refines the gate logic.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51895
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1403

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **kunit (added)**: `test_case_add_process_perf_manager_per_domain` — a manager in domain 0 does not suppress a manager in domain 1 (both registered), while a second manager in domain 0 is suppressed.
- Built `agnocast_kmod`.

## Version Update Label (Required)

- `need-patch-update` (no ABI change; backward-compatible spawn-gate fix)
