### PR TITLE
feat(agnocast_ioctl_wrapper, ros2agnocast_discovery_agent): stamp the real domain_id on discovered topics

### DIFF
--- a/src/agnocast_ioctl_wrapper/src/topic_info.cpp
+++ b/src/agnocast_ioctl_wrapper/src/topic_info.cpp
@@ -11,7 +11,8 @@
 
 extern "C" {
 
-struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * topic_info_ret_count)
+struct topic_info_ret * get_agnocast_sub_nodes(
+  const char * topic_name, int * topic_info_ret_count, uint32_t domain_id)
 {
   *topic_info_ret_count = 0;
 
@@ -39,6 +40,7 @@ struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * to
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(agnocast_topic_info_ret_buffer);
   topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
+  topic_info_args.domain_id = domain_id;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD failed");
     free(agnocast_topic_info_ret_buffer);
@@ -57,7 +59,8 @@ struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * to
   return agnocast_topic_info_ret_buffer;
 }
 
-struct topic_info_ret * get_agnocast_pub_nodes(const char * topic_name, int * topic_info_ret_count)
+struct topic_info_ret * get_agnocast_pub_nodes(
+  const char * topic_name, int * topic_info_ret_count, uint32_t domain_id)
 {
   *topic_info_ret_count = 0;
 
@@ -85,6 +88,7 @@ struct topic_info_ret * get_agnocast_pub_nodes(const char * topic_name, int * to
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(agnocast_topic_info_ret_buffer);
   topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
+  topic_info_args.domain_id = domain_id;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD, &topic_info_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD failed");
     free(agnocast_topic_info_ret_buffer);

--- a/src/agnocast_ioctl_wrapper/src/topic_list.cpp
+++ b/src/agnocast_ioctl_wrapper/src/topic_list.cpp
@@ -11,7 +11,9 @@
 
 extern "C" {
 
-char ** get_agnocast_topics(int * topic_count)
+// domain_buffer (optional, may be nullptr) is a caller-allocated array of
+// MAX_TOPIC_NUM uint32; on return domain_buffer[i] is the domain of topic[i].
+char ** get_agnocast_topics(int * topic_count, uint32_t * domain_buffer)
 {
   *topic_count = 0;
 
@@ -35,6 +37,7 @@ char ** get_agnocast_topics(int * topic_count)
 
   ioctl_topic_list_args topic_list_args = {};
   topic_list_args.topic_name_buffer_addr = reinterpret_cast<uint64_t>(agnocast_topic_buffer);
+  topic_list_args.domain_id_buffer_addr = reinterpret_cast<uint64_t>(domain_buffer);
   topic_list_args.topic_name_buffer_size = MAX_TOPIC_NUM;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_LIST_CMD, &topic_list_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_LIST_CMD failed");

--- a/src/ros2agnocast/ros2agnocast/_ioctl.py
+++ b/src/ros2agnocast/ros2agnocast/_ioctl.py
@@ -33,14 +33,17 @@ def _load_lib() -> Optional[ctypes.CDLL]:
         lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
     except OSError:
         return None
-    lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_topics.argtypes = [
+        ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_uint32)]
     lib.get_agnocast_topics.restype = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))
     lib.free_agnocast_topics.argtypes = [
         ctypes.POINTER(ctypes.POINTER(ctypes.c_char)), ctypes.c_int]
     lib.free_agnocast_topics.restype = None
-    lib.get_agnocast_sub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_sub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_sub_nodes.restype = ctypes.POINTER(_TopicInfoRet)
-    lib.get_agnocast_pub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_pub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(_TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(_TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
@@ -59,10 +62,10 @@ def _endpoint_from_topic_info_ret(tir: _TopicInfoRet) -> AgnocastEndpoint:
 
 
 @contextmanager
-def _endpoints(lib, fn, topic_name: str):
+def _endpoints(lib, fn, topic_name: str, domain_id: int = 0):
     """Yield a list[AgnocastEndpoint] for one topic; free the ctypes buffer on exit."""
     count = ctypes.c_int()
-    arr = fn(topic_name.encode('utf-8'), ctypes.byref(count))
+    arr = fn(topic_name.encode('utf-8'), ctypes.byref(count), domain_id)
     try:
         if not arr:
             yield []
@@ -100,7 +103,9 @@ def self_ns_snapshot() -> Optional[AgnocastDaemonState]:
     state.topics = []
 
     topic_count = ctypes.c_int()
-    topic_array = lib.get_agnocast_topics(ctypes.byref(topic_count))
+    # The CLI is not domain-aware yet: it queries the default domain (0). Full
+    # per-domain CLI output is a follow-up; here we only keep the ABI in sync.
+    topic_array = lib.get_agnocast_topics(ctypes.byref(topic_count), None)
     try:
         for i in range(topic_count.value):
             tname = ctypes.cast(topic_array[i], ctypes.c_char_p).value.decode('utf-8')
@@ -108,9 +113,9 @@ def self_ns_snapshot() -> Optional[AgnocastDaemonState]:
             t.topic_name = tname
             t.type_name = ''
             t.domain_id = 0
-            with _endpoints(lib, lib.get_agnocast_pub_nodes, tname) as pubs:
+            with _endpoints(lib, lib.get_agnocast_pub_nodes, tname, 0) as pubs:
                 t.publishers = pubs
-            with _endpoints(lib, lib.get_agnocast_sub_nodes, tname) as subs:
+            with _endpoints(lib, lib.get_agnocast_sub_nodes, tname, 0) as subs:
                 t.subscribers = subs
             state.topics.append(t)
     finally:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -59,6 +59,9 @@ SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
 # constants — they happen to share the value 256 today.
 NODE_NAME_BUFFER_SIZE = 256
 TOPIC_NAME_BUFFER_SIZE = 256
+# Mirror of MAX_TOPIC_NUM in agnocast_kmod/agnocast.h; sizes the parallel
+# domain_id buffer handed to get_agnocast_topics.
+MAX_TOPIC_NUM = 1024
 # How long a remote daemon's last snapshot may sit in _remote_states without
 # being refreshed before we drop it. Matches the gossip Liveliness lease so
 # DDS-side liveliness loss and local prune happen on the same timescale.
@@ -81,7 +84,10 @@ def _load_ioctl_wrapper():
     """Load libagnocast_ioctl_wrapper.so and set argtypes for the symbols we use."""
     lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
 
-    lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_topics.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
     lib.get_agnocast_topics.restype = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))
     lib.free_agnocast_topics.argtypes = [
         ctypes.POINTER(ctypes.POINTER(ctypes.c_char)),
@@ -89,9 +95,11 @@ def _load_ioctl_wrapper():
     ]
     lib.free_agnocast_topics.restype = None
 
-    lib.get_agnocast_sub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_sub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_sub_nodes.restype = ctypes.POINTER(TopicInfoRet)
-    lib.get_agnocast_pub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_pub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
@@ -133,7 +141,8 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
     supplies the type names and pids that the ioctl does not expose.
     """
     topic_count = ctypes.c_int()
-    topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count))
+    domain_buffer = (ctypes.c_uint32 * MAX_TOPIC_NUM)()
+    topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count), domain_buffer)
     topics = []
     if not topic_names_ptr:
         return topics
@@ -142,15 +151,20 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
         for i in range(topic_count.value):
             topic_name_b = ctypes.cast(topic_names_ptr[i], ctypes.c_char_p).value
             topic_name = topic_name_b.decode('utf-8', errors='replace')
+            # The same topic name can occur once per domain; each row is a
+            # distinct (name, domain) pair that becomes its own AgnocastTopic.
+            domain_id = domain_buffer[i]
 
             agnocast_topic = AgnocastTopic()
             agnocast_topic.topic_name = topic_name
             agnocast_topic.type_name = ''
-            agnocast_topic.domain_id = 0
+            agnocast_topic.domain_id = domain_id
             agnocast_topic.publishers = _collect_endpoints(
-                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, 'pub', registry)
+                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, domain_id, 'pub',
+                registry)
             agnocast_topic.subscribers = _collect_endpoints(
-                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, 'sub', registry)
+                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, domain_id, 'sub',
+                registry)
             # Type name comes from the tmpfs registry; any registered
             # endpoint on this topic carries the same type (ROS 2
             # invariant), so the first non-empty one wins.
@@ -179,10 +193,10 @@ def _resolve_topic_type(
 
 
 def _collect_endpoints(
-        getter, lib, topic_name_b: bytes, topic_name: str, role: str,
+        getter, lib, topic_name_b: bytes, topic_name: str, domain_id: int, role: str,
         registry: TypeRegistryReader | None = None) -> list:
     count = ctypes.c_int()
-    array = getter(topic_name_b, ctypes.byref(count))
+    array = getter(topic_name_b, ctypes.byref(count), domain_id)
     endpoints = []
     if not array:
         return endpoints

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -72,9 +72,14 @@ def test_ioctl_to_endpoint_fills_pid_from_registry():
     assert ep.pid == 4242
 
 
-def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
-    """Build a ctypes-flavoured mock that returns the given topic data."""
+def _make_mock_lib(topic_to_endpoints: dict, topic_domains: dict | None = None) -> MagicMock:
+    """Build a ctypes-flavoured mock that returns the given topic data.
+
+    ``topic_domains`` optionally maps a topic name to its domain_id (default 0);
+    the mock writes it into the parallel domain buffer the agent passes.
+    """
     lib = MagicMock()
+    topic_domains = topic_domains or {}
 
     topic_names = list(topic_to_endpoints.keys())
 
@@ -86,15 +91,17 @@ def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
     char_pp = (ctypes.POINTER(ctypes.c_char) * len(name_storage))(
         *(ctypes.cast(b, ctypes.POINTER(ctypes.c_char)) for b in name_storage))
 
-    def get_topics(count_ptr):
+    def get_topics(count_ptr, domain_buf):
         count_ptr._obj.value = len(topic_names)
+        for i, name in enumerate(topic_names):
+            domain_buf[i] = topic_domains.get(name, 0)
         return char_pp
 
     lib.get_agnocast_topics = MagicMock(side_effect=get_topics)
     lib.free_agnocast_topics = MagicMock()
 
     def make_endpoints_getter(direction):
-        def getter(topic_name_b, count_ptr):
+        def getter(topic_name_b, count_ptr, domain_id):
             name = topic_name_b.decode('utf-8')
             infos = topic_to_endpoints.get(name, {}).get(direction, [])
             count_ptr._obj.value = len(infos)
@@ -134,6 +141,21 @@ def test_read_local_topics_combines_pub_and_sub():
     assert topic.publishers[0].qos_depth == 3
     assert len(topic.subscribers) == 1
     assert topic.subscribers[0].node_name == '/listener_node'
+
+
+def test_read_local_topics_stamps_domain_id():
+    """The real domain_id from the ioctl is stamped onto the gossip topic."""
+    pub_info = _make_info('/talker_node')
+    lib = _make_mock_lib(
+        {'/chatter': {'pub': [pub_info], 'sub': []}},
+        topic_domains={'/chatter': 7})
+
+    topics = read_local_topics(lib)
+    assert len(topics) == 1
+    assert topics[0].domain_id == 7
+    # The per-topic domain is forwarded to the endpoint queries.
+    _name, _count, domain_arg = lib.get_agnocast_pub_nodes.call_args.args
+    assert domain_arg == 7
 
 
 def test_read_local_topics_resolves_type_from_registry():


### PR DESCRIPTION
## Description

The discovery agent hardcoded `domain_id = 0` on every gossiped topic, so cross-namespace bridge decisions could not respect `ROS_DOMAIN_ID`. This threads the real domain through the ioctl wrapper so the per-namespace agent reports each topic's true domain.

Changes:

- **agnocast_ioctl_wrapper**: `get_agnocast_topics` fills a parallel `domain_id` array (one per topic name); `get_agnocast_sub_nodes` / `get_agnocast_pub_nodes` take a `domain_id` input that selects the wrapper.
- **ros2agnocast_discovery_agent**: pairs `name[i]` with `domain[i]`, builds one `AgnocastTopic` per `(name, domain)`, stamps the real `domain_id`, and forwards it to the endpoint queries.
- **ros2agnocast** (CLI): binding updated to the new wrapper signatures; it stays on the default domain (0). Full per-domain CLI output is a follow-up.

No kmod ABI change — this builds on the domain-aware ioctls from #1403.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1404

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **pytest**: `ros2agnocast_discovery_agent` (44 passed, incl. new `test_read_local_topics_stamps_domain_id` asserting the real domain is stamped and forwarded) and `ros2agnocast` CLI (83 passed) with the updated bindings.
- Built `agnocast_ioctl_wrapper`.

## Version Update Label (Required)

- `need-patch-update` (userspace wrapper / agent only; no kmod ABI change)
