### PR TITLE
chore(docs, ros2agnocast, agnocast_kmod): reflect standard bridge removal

### DIFF
--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -57,10 +57,10 @@ struct exit_subscription_entry
 struct process_info
 {
   bool exited;
-  // Used to track whether this process is an alive Performance Bridge Manager.
-  // Standard Bridge Manager also updates this flag for consistency, but the flag
-  // is not used for Standard Bridge spawn decisions (Standard bridges are spawned
-  // per-process, not per-IPC-namespace).
+  // Tracks whether this process is the alive Bridge Manager for the IPC namespace.
+  // The name is kept as "is_performance_bridge_manager" for ABI compatibility with existing
+  // kmod interfaces, even though the Standard Bridge has been removed and this now refers
+  // to the single unified Bridge Manager.
   bool is_performance_bridge_manager;
   pid_t global_pid;
   pid_t local_pid;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2109,7 +2109,6 @@ int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
   down_write(&global_htables_rwsem);
   struct process_info * proc_info = agnocast_find_process_info(pid);
   if (proc_info) {
-    // Unconditionally clear the flag; standard bridge managers also call this for consistency.
     proc_info->is_performance_bridge_manager = false;
   }
   up_write(&global_htables_rwsem);

--- a/docs/agnocast_ros2_bridge.md
+++ b/docs/agnocast_ros2_bridge.md
@@ -33,71 +33,41 @@ flowchart LR
 
 ## Bridge Modes
 
-Agnocast supports three bridge modes controlled by the `AGNOCAST_BRIDGE_MODE` environment variable:
+Agnocast supports the following bridge modes controlled by the `AGNOCAST_BRIDGE_MODE` environment variable:
 
 | Mode | Value | Description |
 |------|-------|-------------|
 | Off | `0` or `off` | Bridge disabled; no ROS 2 interoperability |
-| Standard | `1` or `standard` | One bridge manager per Agnocast process (default) |
-| Performance | `2` or `performance` | Single global bridge manager for all processes |
+| On | `3` or `on` | Bridge enabled (default). One bridge manager per IPC namespace |
 
 **Note:**
 
-- Values are case-insensitive (e.g., `Standard`, `OFF`, `Performance` are valid).
-- If an unknown value is provided, it falls back to Standard mode with a warning.
+- Values are case-insensitive (e.g., `On`, `OFF`, are valid).
+- If an unknown value is provided, it falls back to On mode with a warning.
+- `1` / `standard` and `2` / `performance` are accepted for backward compatibility but are deprecated aliases for On mode.
 
-### Standard Mode vs Performance Mode
+## Bridge Architecture
 
-Standard Mode and Performance Mode have distinct trade-offs regarding resource usage, isolation, and setup complexity.
-
-| Feature | [Standard Mode](#standard-mode-default) | [Performance Mode](#performance-mode) |
-| :--- | :--- | :--- |
-| Architecture | Distributed: 1 Bridge Manager per Agnocast process. | Centralized: 1 Global Bridge Manager for all processes. |
-| Resource Usage | High: Increases linearly with the number of processes. | Low: Minimal overhead. Efficient for systems with many nodes. |
-| Activation Strategy | Eager: Starts immediately regardless of ROS 2 status. | Lazy: Starts only when a counterpart exists ([See Conditions](#bridge-activation-conditions)). |
-| Isolation & Safety | High: Bridges are isolated. If one bridge crashes, others are unaffected. | Low: Shared process. A crash in the manager affects all bridged topics. |
-| Setup | Easy: No preparation needed. Works dynamically. | Complex: Requires pre-compiled plugins ([See Setup](#performance-mode-setup)). |
-
-### Standard Mode (Default)
-
-Each Agnocast process spawns its own bridge manager as a forked child process. This provides process isolation and is suitable for most use cases.
-
-```mermaid
-flowchart TB    
-    subgraph ParentB ["Parent Process B"]
-        ProcB[Agnocast Process B]
-    end
-
-    subgraph ParentA ["Parent Process A"]
-        ProcA[Agnocast Process A]
-    end
-    
-    subgraph ChildB ["Child Process B"]
-        BMB[Bridge Manager B]
-    end
-
-    subgraph ChildA ["Child Process A"]
-        BMA[Bridge Manager A]
-    end
-    
-    ProcA --> BMA
-    ProcB --> BMB
-```
-
-### Performance Mode
-
-A single bridge manager handles all bridge requests across the system. This reduces resource usage when running many Agnocast processes but requires pre-compiled bridge plugins for each message type.
+A global bridge manager handles all bridge requests for all Agnocast processes within an IPC namespace. All topics within the same namespace share this manager.
 
 ```mermaid
 flowchart TD
     ProcessA[Agnocast Process A]
     ProcessB[Agnocast Process B]
 
-    GlobalBM[Performance Bridge Manager]
+    GlobalBM[Bridge Manager]
 
     ProcessA --> GlobalBM
     ProcessB --> GlobalBM
 ```
+
+### Activation Strategy
+
+Bridges are activated **lazily**: a bridge is created only when both an Agnocast endpoint and an external ROS 2 endpoint exist for the same topic. It is destroyed when either endpoint is removed. This avoids unnecessary overhead when there is no ROS 2 counterpart.
+
+### Isolation & Safety
+
+Because a single bridge manager process is shared across all Agnocast processes in the IPC namespace, a crash in the bridge manager will affect all bridged topics.
 
 ## Configuration
 
@@ -106,15 +76,10 @@ flowchart TD
 Set `AGNOCAST_BRIDGE_MODE` before launching your application:
 
 ```bash
-# Standard mode (Default)
-export AGNOCAST_BRIDGE_MODE=standard
+# Bridge enabled (default)
+export AGNOCAST_BRIDGE_MODE=on
 # OR
-export AGNOCAST_BRIDGE_MODE=1
-
-# Performance mode
-export AGNOCAST_BRIDGE_MODE=performance
-# OR
-export AGNOCAST_BRIDGE_MODE=2
+export AGNOCAST_BRIDGE_MODE=3
 
 # Disable bridge
 export AGNOCAST_BRIDGE_MODE=off
@@ -132,14 +97,16 @@ def generate_launch_description():
             package='your_package',
             executable='your_node',
             name='your_node',
-            env={'AGNOCAST_BRIDGE_MODE': 'standard'}
+            env={'AGNOCAST_BRIDGE_MODE': 'on'}
         ),
     ])
 ```
 
-### Performance Mode Setup
+### Bridge Plugins (Performance Optimization)
 
-Performance mode requires pre-compiled bridge plugins for each message type used. Generate and build them using the following steps:
+The bridge works out of the box without any additional setup. Internally, it dynamically resolves topic message types at runtime.
+
+For higher throughput, you can optionally provide pre-compiled type-specific bridge plugins via the `agnocast_bridge_plugins` package. When a plugin is available for a given message type, the bridge uses it; otherwise, it falls back to the generic bridge automatically.
 
 **1. Generate the plugin package:**
 
@@ -160,16 +127,14 @@ ros2 agnocast generate-bridge-plugins --all --output-dir ~/my_ws/src/agnocast_br
 colcon build --packages-select agnocast_bridge_plugins
 ```
 
-**3. Source and run:**
+**3. Source:**
 
 ```bash
 source install/setup.bash
-export AGNOCAST_BRIDGE_MODE=performance
-# Run your application
 ```
 
 > [!NOTE]
-> If you add new custom message types later, regenerate and rebuild the plugins to support them in Performance Mode.
+> If you add new custom message types later, regenerate and rebuild the plugins.
 
 #### Advanced: Custom Plugin Path
 
@@ -178,15 +143,6 @@ You can specify custom plugin search paths using the `AGNOCAST_BRIDGE_PLUGINS_PA
 ```bash
 export AGNOCAST_BRIDGE_PLUGINS_PATH=/path/to/plugins:/another/path
 ```
-
-## Bridge Activation Conditions
-
-Bridges are not always active. The activation conditions differ between Standard mode and Performance mode.
-
-| Mode | Bridge Creation (Start) | Bridge Destruction (Stop) | Behavior Summary |
-| :--- | :--- | :--- | :--- |
-| Standard |Agnocast endpoint exists. | Agnocast endpoint removed. | Eager: Bridges are created immediately when an Agnocast node starts, regardless of whether a ROS 2 counterpart exists. |
-| Performance | Agnocast endpoint and External ROS 2 endpoint exist. | Agnocast endpoint removed or External ROS 2 endpoint removed. | Lazy: Bridges are only created when there is an active pair of sender/receiver across the domains, reducing unnecessary overhead. |
 
 ## QoS Behavior
 

--- a/docs/agnocast_ros2_bridge.md
+++ b/docs/agnocast_ros2_bridge.md
@@ -38,7 +38,7 @@ Agnocast supports the following bridge modes controlled by the `AGNOCAST_BRIDGE_
 | Mode | Value | Description |
 |------|-------|-------------|
 | Off | `0` or `off` | Bridge disabled; no ROS 2 interoperability |
-| On | `3` or `on` | Bridge enabled (default). One bridge manager per IPC namespace |
+| On | `on` | Bridge enabled (default). One bridge manager per IPC namespace |
 
 **Note:**
 
@@ -78,8 +78,6 @@ Set `AGNOCAST_BRIDGE_MODE` before launching your application:
 ```bash
 # Bridge enabled (default)
 export AGNOCAST_BRIDGE_MODE=on
-# OR
-export AGNOCAST_BRIDGE_MODE=3
 
 # Disable bridge
 export AGNOCAST_BRIDGE_MODE=off

--- a/docs/message_queue.md
+++ b/docs/message_queue.md
@@ -39,7 +39,7 @@ The message queue is also used for communication between Agnocast processes and 
 
 The message queue is used as follows:
 
-- The first Agnocast process spawns a global Bridge Manager that opens `/agnocast_bridge_manager@-1` as a receiver.
+- The first Agnocast process spawns a global Bridge Manager that opens `/agnocast_bridge_manager@-1` (optionally with a `_d<ROS_DOMAIN_ID>` suffix when `ROS_DOMAIN_ID` is set) as a receiver.
 - All Agnocast processes send bridge requests to this shared message queue.
 - Upon receiving the request, the Bridge Manager creates the appropriate bridge if conditions are met.
 

--- a/docs/message_queue.md
+++ b/docs/message_queue.md
@@ -37,34 +37,13 @@ To satisfy the second rule, all the occurrence of `/` in topic names are replace
 
 The message queue is also used for communication between Agnocast processes and Bridge Manager processes. When an Agnocast publisher or subscriber is created, it sends a bridge request to the Bridge Manager via message queue.
 
-### Standard Mode
+The message queue is used as follows:
 
-In Standard mode, each Agnocast process forks its own Bridge Manager. The message queue is used as follows:
-
-- When an Agnocast process starts, it forks a Bridge Manager child process. The Bridge Manager opens a message queue as a receiver.
-- When an Agnocast publisher calls `create_publisher`, it sends a bridge request (A2R direction) to the Bridge Manager's message queue.
-- When an Agnocast subscriber calls `create_subscription`, it sends a bridge request (R2A direction) to the Bridge Manager's message queue.
+- The first Agnocast process spawns a global Bridge Manager that opens `/agnocast_bridge_manager@-1` as a receiver.
+- All Agnocast processes send bridge requests to this shared message queue.
 - Upon receiving the request, the Bridge Manager creates the appropriate bridge if conditions are met.
 
-The message definition for Standard mode contains factory function information:
-
-```cpp
-struct MqMsgBridge {
-  BridgeFactoryInfo factory;  // shared library path, symbol name, function offsets
-  BridgeTargetInfo target;    // topic name, target ID
-  BridgeDirection direction;  // ROS2_TO_AGNOCAST or AGNOCAST_TO_ROS2
-};
-```
-
-### Performance Mode
-
-In Performance mode, a single global Bridge Manager handles all bridge requests. The message queue is used as follows:
-
-- The first Agnocast process spawns a global Performance Bridge Manager that opens a message queue as a receiver.
-- All Agnocast processes send bridge requests to this shared message queue.
-- The Performance Bridge Manager loads pre-compiled plugins based on the message type.
-
-The message definition for Performance mode is simpler:
+The message definition is:
 
 ```cpp
 struct MqMsgPerformanceBridge {
@@ -74,11 +53,5 @@ struct MqMsgPerformanceBridge {
 };
 ```
 
-### Naming rules
-
-The Bridge Manager message queue is named using the process ID:
-
-| Mode | Message Queue Name | Description |
-|------|-------------------|-------------|
-| Standard | `/agnocast_bridge_manager@{pid}` | `{pid}` is the PID of the bridge manager's parent process |
-| Performance | `/agnocast_bridge_manager@-1` | Uses virtual PID `-1` for the global manager |
+> [!NOTE]
+> The struct is named `MqMsgPerformanceBridge` for historical reasons. Before the bridge implementation was unified, this message format was specific to the "Performance Bridge" as opposed to the "Standard Bridge". The Standard Bridge has since been removed, but the struct name has been kept as-is to minimize churn.

--- a/docs/ros2_command_extension.md
+++ b/docs/ros2_command_extension.md
@@ -42,14 +42,14 @@ This does not necessarily mean that a bridge process is currently running. If th
 
 | pub | sub | bridge | display |
 | :--- | :--- | :--- | :--- |
-| rclcpp::publisher | rclcpp::subscription | off / standard / performance | /my_topic |
+| rclcpp::publisher | rclcpp::subscription | off / on | /my_topic |
 | agnocast::publisher | rclcpp::subscription | off | /my_topic (WARN: Agnocast and ROS 2 endpoints exist but bridge is not active) |
-| agnocast::publisher | rclcpp::subscription | standard / performance | /my_topic (Agnocast enabled, bridged) |
+| agnocast::publisher | rclcpp::subscription | on | /my_topic (Agnocast enabled, bridged) |
 | rclcpp::publisher | agnocast::subscription | off | /my_topic (WARN: Agnocast and ROS 2 endpoints exist but bridge is not active) |
-| rclcpp::publisher | agnocast::subscription | standard / performance | /my_topic (Agnocast enabled, bridged) |
-| agnocast::publisher | agnocast::subscription | off / standard / performance | /my_topic (Agnocast enabled) |
-| agnocast::publisher | non | off / standard / performance | /my_topic (Agnocast enabled) |
-| non | agnocast::subscription | off / standard / performance | /my_topic (Agnocast enabled) |
+| rclcpp::publisher | agnocast::subscription | on | /my_topic (Agnocast enabled, bridged) |
+| agnocast::publisher | agnocast::subscription | off / on | /my_topic (Agnocast enabled) |
+| agnocast::publisher | non | off / on | /my_topic (Agnocast enabled) |
+| non | agnocast::subscription | off / on | /my_topic (Agnocast enabled) |
 
 #### Notes
 

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -30,7 +30,7 @@ BridgeMode get_bridge_mode()
   if (val == "0" || val == "off") {
     return BridgeMode::Off;
   }
-  if (val == "3" || val == "on") {
+  if (val == "on") {
     return BridgeMode::On;
   }
   if (val == "1" || val == "standard") {

--- a/src/ros2agnocast/ros2agnocast/verb/agnocast_bridge_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/agnocast_bridge_daemon_status.py
@@ -132,18 +132,24 @@ class _BridgeResult:
 
 def _build_summary(results: list[_BridgeResult]) -> tuple[str, bool]:
     if not results:
-        return 'NG. There is no bridge daemon process.', True
+        return 'NG. The bridge daemon is not running.', True
 
-    if len(results) >= 2:
-        pids = ', '.join(str(r.pid) for r in results)
-        return f'NG. There are multiple performance bridge processes. (PIDs: {pids})', True
+    ok_results = [r for r in results if r.is_ok]
+    ng_results = [r for r in results if not r.is_ok]
 
-    first_ng_result = next((r for r in results if not r.is_ok), None)
-    if first_ng_result is not None:
-        pid = first_ng_result.pid
-        return f'NG. The performance bridge process is not working. (PID: {pid})', True
+    if ng_results:
+        first_ng = ng_results[0]
+        return (
+            f'NG. A bridge daemon is not working.'
+            f' (PID: {first_ng.pid}): {first_ng.ng_message}',
+            True,
+        )
 
-    return f'OK. A performance bridge is running. (PID: {results[0].pid})', False
+    if len(ok_results) >= 2:
+        pids = ', '.join(str(r.pid) for r in ok_results)
+        return f'NG. Multiple bridge daemons are running. (PIDs: {pids})', True
+
+    return f'OK. The bridge daemon is running. (PID: {ok_results[0].pid})', False
 
 
 class BridgeDaemonStatusVerb(VerbExtension):
@@ -255,14 +261,7 @@ class BridgeDaemonStatusVerb(VerbExtension):
             print(f'IPC namespace inode: {ipc_inode}')
             print()
 
-        if verbose:
-            print('Summary:')
-            print(f'  {summary}')
-        else:
-            print(summary)
-
         if verbose and results:
-            print()
             print('Bridge Status:')
             type_width = max(len(f'({r.bridge_type.capitalize()})') for r in results)
             pid_width = max(len(str(r.pid)) for r in results)
@@ -273,5 +272,8 @@ class BridgeDaemonStatusVerb(VerbExtension):
                     print(f'  PID {pid_str} {type_label} OK')
                 else:
                     print(f'  PID {pid_str} {type_label} NG: {r.ng_message}')
+            print()
+
+        print(summary)
 
         return 1 if is_ng else 0

--- a/src/ros2agnocast/ros2agnocast/verb/agnocast_bridge_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/agnocast_bridge_daemon_status.py
@@ -75,7 +75,7 @@ class BridgeControlSocket:
         """Connect to the socket, receive the JSON payload, and return a typed result.
 
         The daemon sends a JSON payload immediately on connection:
-        ``{"type":"standard"|"performance","ipc_ns":<int>,"pid":<int>}``
+        ``{"type":"performance","ipc_ns":<int>,"pid":<int>}``
         """
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         chunks: list[bytes] = []
@@ -116,44 +116,34 @@ _NG_MSG_UNKNOWN_TYPE = (
     'Response contains an unknown bridge type. '
     'Please ensure the CLI and agnocastlib versions are compatible.'
 )
+_NG_MSG_STANDARD_TYPE = (
+    'Response contains a standard bridge type, which is no longer supported. '
+    'Please ensure the CLI and agnocastlib versions are compatible.'
+)
 
 @dataclass
 class _BridgeResult:
     pid: int
     ipc_ns: int
-    bridge_type: str  # 'performance', 'standard', or 'unknown'
+    bridge_type: str  # 'performance' or 'unknown'
     is_ok: bool
     ng_message: str = field(default='')
 
 
 def _build_summary(results: list[_BridgeResult]) -> tuple[str, bool]:
-    perf_results = [r for r in results if r.bridge_type == 'performance']
-    std_results = [r for r in results if r.bridge_type == 'standard']
-
     if not results:
         return 'NG. There is no bridge daemon process.', True
-    if len(perf_results) >= 2:
-        pids = ', '.join(str(r.pid) for r in perf_results)
-        return f'NG. There are multiple performance bridge processes. (PIDs: {pids})', True
-    if perf_results and std_results:
+
+    if len(results) >= 2:
         pids = ', '.join(str(r.pid) for r in results)
-        return f'NG. Both performance and standard bridge processes exist. (PIDs: {pids})', True
+        return f'NG. There are multiple performance bridge processes. (PIDs: {pids})', True
 
     first_ng_result = next((r for r in results if not r.is_ok), None)
     if first_ng_result is not None:
         pid = first_ng_result.pid
-        if first_ng_result.bridge_type == 'performance':
-            return f'NG. The performance bridge process is not working. (PID: {pid})', True
-        if first_ng_result.bridge_type == 'standard':
-            return f'NG. A standard bridge process is not working. (PID: {pid})', True
-        return f'NG. A bridge process is not working. (PID: {pid})', True
+        return f'NG. The performance bridge process is not working. (PID: {pid})', True
 
-    if perf_results:
-        return f'OK. A performance bridge is running. (PID: {perf_results[0].pid})', False
-    if len(std_results) == 1:
-        return f'OK. A standard bridge is running. (PID: {std_results[0].pid})', False
-    pids = ', '.join(str(r.pid) for r in std_results)
-    return f'OK. Standard bridges are running. (PIDs: {pids})', False
+    return f'OK. A performance bridge is running. (PID: {results[0].pid})', False
 
 
 class BridgeDaemonStatusVerb(VerbExtension):
@@ -208,7 +198,17 @@ class BridgeDaemonStatusVerb(VerbExtension):
                 continue
 
             bridge_type = recv_result.type
-            if bridge_type not in ('performance', 'standard'):
+            if bridge_type == 'standard':
+                results.append(_BridgeResult(
+                    pid=pid,
+                    ipc_ns=ipc_inode,
+                    bridge_type='unknown',
+                    is_ok=False,
+                    ng_message=_NG_MSG_STANDARD_TYPE,
+                ))
+                continue
+
+            if bridge_type != 'performance':
                 results.append(_BridgeResult(
                     pid=pid,
                     ipc_ns=ipc_inode,

--- a/src/ros2agnocast/ros2agnocast/verb/agnocast_generate_bridge_plugins.py
+++ b/src/ros2agnocast/ros2agnocast/verb/agnocast_generate_bridge_plugins.py
@@ -90,7 +90,6 @@ class GenerateBridgePluginsVerb(VerbExtension):
         print('\nNext steps:')
         print(f'  1. colcon build --packages-select agnocast_bridge_plugins')
         print(f'  2. source install/setup.bash')
-        print(f'  3. export AGNOCAST_BRIDGE_MODE=performance')
         return 0
 
     def _get_all_types(self, interface_type):

--- a/src/ros2agnocast/test/test_bridge_daemon_status.py
+++ b/src/ros2agnocast/test/test_bridge_daemon_status.py
@@ -101,21 +101,7 @@ def test_build_summary_single_performance_ok():
     assert '100' in summary
 
 
-def test_build_summary_single_standard_ok():
-    summary, is_ng = _build_summary([_ok(200, 'standard')])
-    assert is_ng is False
-    assert 'standard' in summary.lower()
-    assert '200' in summary
-
-
-def test_build_summary_multiple_standard_ok():
-    summary, is_ng = _build_summary([_ok(200, 'standard'), _ok(201, 'standard')])
-    assert is_ng is False
-    assert '200' in summary
-    assert '201' in summary
-
-
-def test_build_summary_multiple_performance_is_ng():
+def test_build_summary_multiple_bridges_is_ng():
     summary, is_ng = _build_summary([_ok(100, 'performance'), _ok(101, 'performance')])
     assert is_ng is True
     assert 'multiple' in summary.lower()
@@ -123,24 +109,11 @@ def test_build_summary_multiple_performance_is_ng():
     assert '101' in summary
 
 
-def test_build_summary_mixed_performance_and_standard_is_ng():
-    summary, is_ng = _build_summary([_ok(100, 'performance'), _ok(200, 'standard')])
-    assert is_ng is True
-    assert 'both' in summary.lower()
-
-
 def test_build_summary_performance_ng():
     summary, is_ng = _build_summary([_ng(100, 'performance')])
     assert is_ng is True
     assert 'performance' in summary.lower()
     assert '100' in summary
-
-
-def test_build_summary_standard_ng():
-    summary, is_ng = _build_summary([_ng(200, 'standard')])
-    assert is_ng is True
-    assert 'standard' in summary.lower()
-    assert '200' in summary
 
 
 def test_build_summary_unknown_type_ng():
@@ -179,18 +152,6 @@ def _unique_abstract_addr(suffix: str = '') -> str:
     return f'\x00agnocast_bridge_test_{os.getpid()}_{threading.get_ident()}{suffix}'
 
 
-def test_recv_msg_returns_ok_for_valid_standard_json():
-    addr = _unique_abstract_addr('_std')
-    payload = b'{"type":"standard","ipc_ns":42,"pid":123}'
-    t = _start_server(addr, payload)
-    result = BridgeControlSocket(addr).recv_msg(timeout_sec=2.0)
-    t.join(timeout=2.0)
-    assert isinstance(result, RecvMsgOk)
-    assert result.type == 'standard'
-    assert result.ipc_ns == 42
-    assert result.pid == 123
-
-
 def test_recv_msg_returns_ok_for_valid_performance_json():
     addr = _unique_abstract_addr('_perf')
     payload = b'{"type":"performance","ipc_ns":99,"pid":456}'
@@ -227,7 +188,7 @@ def test_recv_msg_returns_parse_error_for_invalid_json():
 
 def test_recv_msg_returns_parse_error_for_missing_fields():
     addr = _unique_abstract_addr('_missingfields')
-    t = _start_server(addr, payload=b'{"type":"standard"}')
+    t = _start_server(addr, payload=b'{"type":"performance"}')
     result = BridgeControlSocket(addr).recv_msg(timeout_sec=2.0)
     t.join(timeout=2.0)
     assert isinstance(result, RecvMsgParseError)
@@ -251,16 +212,6 @@ def _make_verb(result_map: dict) -> BridgeDaemonStatusVerb:
     return verb
 
 
-def test_collect_bridge_results_ok_standard():
-    ipc_inode, pid = 100, 200
-    sock_addr = br._abstract_socket_addr_for_pid(ipc_inode, pid)
-    verb = _make_verb({sock_addr: RecvMsgOk(type='standard', ipc_ns=ipc_inode, pid=pid)})
-    results = verb._collect_bridge_results([pid], ipc_inode, timeout_sec=1.0)
-    assert len(results) == 1
-    assert results[0].is_ok is True
-    assert results[0].bridge_type == 'standard'
-
-
 def test_collect_bridge_results_ok_performance():
     ipc_inode, pid = 100, 200
     sock_addr = br._abstract_socket_addr_for_pid(ipc_inode, pid)
@@ -269,6 +220,16 @@ def test_collect_bridge_results_ok_performance():
     assert len(results) == 1
     assert results[0].is_ok is True
     assert results[0].bridge_type == 'performance'
+
+
+def test_collect_bridge_results_standard_type_gives_unknown_ng():
+    ipc_inode, pid = 100, 200
+    sock_addr = br._abstract_socket_addr_for_pid(ipc_inode, pid)
+    verb = _make_verb({sock_addr: RecvMsgOk(type='standard', ipc_ns=ipc_inode, pid=pid)})
+    results = verb._collect_bridge_results([pid], ipc_inode, timeout_sec=1.0)
+    assert results[0].is_ok is False
+    assert results[0].bridge_type == 'unknown'
+    assert results[0].ng_message == br._NG_MSG_STANDARD_TYPE
 
 
 def test_collect_bridge_results_recv_failed_gives_unknown_ng():
@@ -304,7 +265,7 @@ def test_collect_bridge_results_unknown_bridge_type_gives_ng():
 def test_collect_bridge_results_mismatched_pid_gives_ng():
     ipc_inode, pid = 100, 200
     sock_addr = br._abstract_socket_addr_for_pid(ipc_inode, pid)
-    verb = _make_verb({sock_addr: RecvMsgOk(type='standard', ipc_ns=ipc_inode, pid=999)})
+    verb = _make_verb({sock_addr: RecvMsgOk(type='performance', ipc_ns=ipc_inode, pid=999)})
     results = verb._collect_bridge_results([pid], ipc_inode, timeout_sec=1.0)
     assert results[0].is_ok is False
     assert 'pid=999' in results[0].ng_message
@@ -313,7 +274,7 @@ def test_collect_bridge_results_mismatched_pid_gives_ng():
 def test_collect_bridge_results_mismatched_ipc_ns_gives_ng():
     ipc_inode, pid = 100, 200
     sock_addr = br._abstract_socket_addr_for_pid(ipc_inode, pid)
-    verb = _make_verb({sock_addr: RecvMsgOk(type='standard', ipc_ns=999, pid=pid)})
+    verb = _make_verb({sock_addr: RecvMsgOk(type='performance', ipc_ns=999, pid=pid)})
     results = verb._collect_bridge_results([pid], ipc_inode, timeout_sec=1.0)
     assert results[0].is_ok is False
     assert 'ipc_ns=999' in results[0].ng_message

--- a/src/ros2agnocast/test/test_bridge_daemon_status.py
+++ b/src/ros2agnocast/test/test_bridge_daemon_status.py
@@ -91,13 +91,13 @@ def _ng(pid: int, bridge_type: str, msg: str = 'error') -> _BridgeResult:
 def test_build_summary_no_results_is_ng():
     summary, is_ng = _build_summary([])
     assert is_ng is True
-    assert 'no bridge' in summary.lower()
+    assert 'not running' in summary.lower()
 
 
 def test_build_summary_single_performance_ok():
     summary, is_ng = _build_summary([_ok(100, 'performance')])
     assert is_ng is False
-    assert 'performance' in summary.lower()
+    assert 'running' in summary.lower()
     assert '100' in summary
 
 
@@ -112,7 +112,7 @@ def test_build_summary_multiple_bridges_is_ng():
 def test_build_summary_performance_ng():
     summary, is_ng = _build_summary([_ng(100, 'performance')])
     assert is_ng is True
-    assert 'performance' in summary.lower()
+    assert 'not working' in summary.lower()
     assert '100' in summary
 
 


### PR DESCRIPTION
## Description

This PR reflects the removal of the Standard bridge across documentation, ros2agnocast, and kmod comments.

With the exception noted below, **this PR completes the Standard bridge removal across the entire repository**.

- The name "Performance bridge" is intentionally kept as-is in the agnocastlib and kmod implementation to minimize merge conflicts with other in-flight changes.

### Changes

#### Documentation

- `docs/agnocast_ros2_bridge.md`
- `docs/message_queue.md`
- `docs/ros2_command_extension.md`

#### ros2agnocast

- `agnocast_bridge_daemon_status`: Since Standard bridges no longer exist, we expect the `type` field of the JSON message from bridge daemons to always be `"performance"`. If a JSON message with `"standard"` is received, it will now output a version incompatibility warning. The actual message content output by this command remains unchanged.

- `agnocast_generate_bridge_plugins`: Removed `export AGNOCAST_BRIDGE_MODE=performance` from the "Next steps" output printed at the end of the command. While this output is part of the user-facing API, no applications are expected to depend on it programmatically. Therefore, this change is considered acceptable as a `need-patch-update`.

#### kmod

- Updated comments that referred to Standard bridges.

## Related links

https://github.com/autowarefoundation/agnocast/pull/1402

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

- The `kmod` changes are comment-only; there are no behavioral changes.
- The internal identifier `is_performance_bridge_manager` is intentionally left unchanged to minimize conflicts with other in-flight development.

## Version Update Label (Required)

`need-patch-update`