### PR TITLE
docs: add post-merge agnocast_doc reflection checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,10 @@
 
 ## Notes for reviewers
 
+## Post-merge checklist
+
+- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
+
 ## Version Update Label (Required)
 
 Please add **exactly one** of the following labels to this PR:


### PR DESCRIPTION
## Description

Add a "Post-merge tasks" section to the PR template with a checklist item reminding contributors to reflect their changes in the [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) documentation repository after merging (when documentation needs updating).

This makes documentation updates an explicit, trackable step in the PR workflow so that doc changes are not forgotten after a code change is merged. The section is placed between "Notes for reviewers" and "Version Update Label", and follows the existing English-only convention of the template.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.