### PR TITLE
feat(ros2agnocast_discovery_agent): make cross-NS bridge decisions domain-aware

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -62,6 +62,9 @@ class BridgeRequest:
     qos_depth: int
     qos_is_transient_local: bool
     qos_is_reliable: bool
+    # Selects the target bridge_manager's MQ (one manager per domain); not part
+    # of the wire payload, since that manager already runs in this domain.
+    domain_id: int = 0
 
 
 def serialize_request(req: BridgeRequest) -> bytes:
@@ -79,17 +82,18 @@ def serialize_request(req: BridgeRequest) -> bytes:
 
 
 def _resolve_types(local_state, remote_states) -> dict:
-    """Resolve each topic's message type, preferring local then any remote.
+    """Resolve each ``(topic, domain)``'s message type, preferring local then any remote.
 
-    A bridge is deduped per ``(topic, direction)``, so its type must be resolved
-    per-topic across local + *all* remotes: the remote that supplies the
-    opposite-role endpoint may lack the type while another snapshot has it.
+    The type must be resolved across local + *all* remotes: the remote that
+    supplies the opposite-role endpoint may lack the type while another snapshot
+    has it.
     """
-    types = {t.topic_name: t.type_name for t in local_state.topics if t.type_name}
+    types = {
+        (t.topic_name, t.domain_id): t.type_name for t in local_state.topics if t.type_name}
     for remote in remote_states.values():
         for t in remote.topics:
             if t.type_name:
-                types.setdefault(t.topic_name, t.type_name)
+                types.setdefault((t.topic_name, t.domain_id), t.type_name)
     return types
 
 
@@ -97,18 +101,20 @@ def decide_bridges(local_state, remote_states) -> list:
     """Return the bridge requests this namespace should issue this tick.
 
     ``remote_states`` maps ``(host_uuid, ipc_ns_inode)`` to AgnocastDaemonState.
-    Requests are collapsed to one per ``(topic, direction)``.
+    Topics match only within the same domain (a bridge never crosses domains;
+    cross-domain relaying is the external domain_bridge's job), and requests are
+    collapsed to one per ``(topic, domain, direction)``.
     """
     requests = {}
 
-    local_by_topic = {t.topic_name: t for t in local_state.topics}
+    local_by_topic = {(t.topic_name, t.domain_id): t for t in local_state.topics}
     types = _resolve_types(local_state, remote_states)
 
     for (host_uuid, ipc_ns_inode), remote in remote_states.items():
         if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
             continue
         for remote_topic in remote.topics:
-            local_topic = local_by_topic.get(remote_topic.topic_name)
+            local_topic = local_by_topic.get((remote_topic.topic_name, remote_topic.domain_id))
             if local_topic is None:
                 continue
 
@@ -117,13 +123,14 @@ def decide_bridges(local_state, remote_states) -> list:
             remote_pubs = [p for p in remote_topic.publishers if not p.is_bridge]
             remote_subs = [s for s in remote_topic.subscribers if not s.is_bridge]
 
-            type_name = types.get(local_topic.topic_name)
+            domain_id = local_topic.domain_id
+            type_name = types.get((local_topic.topic_name, domain_id))
             if not type_name:
                 continue
 
             if local_pubs and remote_subs:
                 pub = local_pubs[0]
-                key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
+                key = (local_topic.topic_name, domain_id, DIRECTION_AGNOCAST_TO_ROS2)
                 requests.setdefault(key, BridgeRequest(
                     topic_name=local_topic.topic_name,
                     type_name=type_name,
@@ -131,11 +138,12 @@ def decide_bridges(local_state, remote_states) -> list:
                     qos_depth=pub.qos_depth,
                     qos_is_transient_local=pub.qos_is_transient_local,
                     qos_is_reliable=pub.qos_is_reliable,
+                    domain_id=domain_id,
                 ))
 
             if local_subs and remote_pubs:
                 sub = local_subs[0]
-                key = (local_topic.topic_name, DIRECTION_ROS2_TO_AGNOCAST)
+                key = (local_topic.topic_name, domain_id, DIRECTION_ROS2_TO_AGNOCAST)
                 requests.setdefault(key, BridgeRequest(
                     topic_name=local_topic.topic_name,
                     type_name=type_name,
@@ -143,16 +151,16 @@ def decide_bridges(local_state, remote_states) -> list:
                     qos_depth=sub.qos_depth,
                     qos_is_transient_local=sub.qos_is_transient_local,
                     qos_is_reliable=sub.qos_is_reliable,
+                    domain_id=domain_id,
                 ))
 
     return list(requests.values())
 
 
-def _performance_mq_name() -> str:
+def _performance_mq_name(domain_id: int) -> str:
     name = _PERFORMANCE_MQ_NAME
-    domain_id = os.environ.get('ROS_DOMAIN_ID')
     if domain_id:
-        name += '_d' + domain_id
+        name += '_d' + str(domain_id)
     return name
 
 
@@ -183,12 +191,12 @@ def send_request(mq_name: str, payload: bytes) -> Optional[str]:
 def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
     """Deliver each request to the per-namespace bridge_manager MQ.
 
-    The MQ is absent until a bridge_manager is up; ``send_request`` skips
+    Each request goes to the manager that owns its domain (one per domain). The
+    MQ is absent until that bridge_manager is up; ``send_request`` skips
     ENOENT/EAGAIN so a missing or full queue never stalls the daemon, and the
     request is re-issued idempotently next tick.
     """
-    perf_mq = _performance_mq_name()
     for req in requests:
-        err = send_request(perf_mq, serialize_request(req))
+        err = send_request(_performance_mq_name(req.domain_id), serialize_request(req))
         if err is not None and logger is not None:
             logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -32,11 +32,11 @@ def _endpoint(node, depth=10, transient=False, reliable=True, is_bridge=False):
     return ep
 
 
-def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None):
+def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None, domain=0):
     t = AgnocastTopic()
     t.topic_name = name
     t.type_name = type_name
-    t.domain_id = 0
+    t.domain_id = domain
     t.publishers = pubs or []
     t.subscribers = subs or []
     return t
@@ -143,6 +143,25 @@ def test_decide_skips_when_only_same_role_present():
     assert decide_bridges(local, {('OTHER', 222): remote}) == []
 
 
+def test_decide_skips_cross_domain_match():
+    # Same topic name but different domains must not be bridged: isolation holds
+    # and cross-domain relaying is the external domain_bridge's job.
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=0)])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/rs')], domain=1)])
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_matches_within_same_nonzero_domain():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=5)])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/rs')], domain=5)])
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].domain_id == 5
+
+
 def test_decide_collapses_duplicates_across_remotes():
     local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
     remote_a = _state(host_uuid='A', ipc_ns=1, topics=[_topic('/x', subs=[_endpoint('/sa')])])
@@ -182,3 +201,16 @@ def test_dispatch_targets_per_namespace_mq(monkeypatch):
 
     assert all(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
     assert len(sent) == 1
+
+
+def test_dispatch_routes_to_per_domain_mq(monkeypatch):
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+
+    dispatch_requests([
+        BridgeRequest('/a', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=0),
+        BridgeRequest('/b', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=5),
+    ])
+
+    assert sent == ['/agnocast_daemon_bridge_perf', '/agnocast_daemon_bridge_perf_d5']


### PR DESCRIPTION
## Description

With the discovery agent now reporting each topic's real domain (#1405), the bridge decider must respect it. Otherwise the same topic name in two domains would be matched and bridged, breaking `ROS_DOMAIN_ID` isolation.

Changes (`bridge_decider.py`):

- Match local and remote topics by `(topic, domain)` — a cross-NS bridge is created only **within the same domain**. Cross-domain relaying is the external `domain_bridge`'s job.
- Dedup requests per `(topic, domain, direction)`.
- Dispatch each request to the bridge_manager that owns its domain (one manager per domain, addressed by the `_d<domain>` MQ suffix) instead of the agent's own `ROS_DOMAIN_ID`.

The wire payload is unchanged: the per-domain manager already runs in the target domain, so `domain_id` only routes the request and is not serialized (`sizeof(MqMsgDaemonBridge)` stays 524).

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1405

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **pytest** (`ros2agnocast_discovery_agent`, 47 passed incl. flake8/pep257), with new cases: cross-domain match is skipped, same non-zero domain is bridged, and dispatch routes to the per-domain `_d<domain>` MQ.

## Version Update Label (Required)

- `need-patch-update` (discovery agent logic only; no ABI / wire-format change)
