### PR TITLE
feat(agnocast_kmod, agnocast_ioctl_wrapper)[needs minor version update]: make the kmod domain-aware (topic ioctls + bridge-manager spawn)

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -311,6 +311,10 @@ union ioctl_topic_list_args {
   struct
   {
     uint64_t topic_name_buffer_addr;
+    // Parallel array of uint32 domain_ids, one per returned topic name. The same
+    // topic name can appear in multiple domains, so the caller pairs name[i] with
+    // domain_id[i] to disambiguate. Pass 0 to skip domain output.
+    uint64_t domain_id_buffer_addr;
     uint32_t topic_name_buffer_size;
   };
   uint32_t ret_topic_num;
@@ -341,6 +345,9 @@ union ioctl_topic_info_args {
     struct name_info topic_name;
     uint64_t topic_info_ret_buffer_addr;
     uint32_t topic_info_ret_buffer_size;
+    // Which domain's endpoints to return. A topic name can exist in multiple
+    // domains; the caller selects one (paired with get_topic_list output).
+    uint32_t domain_id;
   };
   uint32_t ret_topic_info_ret_num;
 };

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1424,9 +1424,9 @@ int agnocast_ioctl_get_topic_list(
 
     if (topic_list_args->domain_id_buffer_addr) {
       uint32_t domain_id = wrapper->domain_id;
-      if (copy_to_user(
-            (uint32_t __user *)topic_list_args->domain_id_buffer_addr + topic_num, &domain_id,
-            sizeof(domain_id))) {
+      uint32_t __user * domain_id_buffer =
+        (uint32_t __user *)u64_to_user_ptr(topic_list_args->domain_id_buffer_addr);
+      if (copy_to_user(domain_id_buffer + topic_num, &domain_id, sizeof(domain_id))) {
         ret = -EFAULT;
         goto unlock;
       }
@@ -2147,6 +2147,20 @@ static int get_process_num(const struct ipc_namespace * ipc_ns)
   return count;
 }
 
+static int get_process_num_in_domain(const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
+{
+  int count = 0;
+  struct process_info * proc_info;
+  int bkt_proc_info;
+  hash_for_each(proc_info_htable, bkt_proc_info, proc_info, node)
+  {
+    if (ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id) {
+      count++;
+    }
+  }
+  return count;
+}
+
 int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
 {
   down_write(&global_htables_rwsem);
@@ -2163,8 +2177,11 @@ int agnocast_ioctl_check_and_request_bridge_shutdown(
   struct ioctl_check_and_request_bridge_shutdown_args * ioctl_ret)
 {
   down_write(&global_htables_rwsem);
-  // Request shutdown if there is no other process excluding poll_for_unlink.
-  if (get_process_num(ipc_ns) <= 1) {
+  // A performance bridge manager is per (ipc_ns, domain), so it must shut down once its
+  // own domain is empty -- counting the whole namespace would keep it alive while an
+  // unrelated domain is busy. The manager itself is the remaining process (count == 1),
+  // and poll_for_unlink is not registered here, so it is excluded.
+  if (get_process_num_in_domain(ipc_ns, get_process_domain_id(pid)) <= 1) {
     struct process_info * proc_info = agnocast_find_process_info(pid);
     if (proc_info) {
       proc_info->is_performance_bridge_manager = false;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1417,6 +1417,16 @@ int agnocast_ioctl_get_topic_list(
       goto unlock;
     }
 
+    if (topic_list_args->domain_id_buffer_addr) {
+      uint32_t domain_id = wrapper->domain_id;
+      if (copy_to_user(
+            (uint32_t __user *)topic_list_args->domain_id_buffer_addr + topic_num, &domain_id,
+            sizeof(domain_id))) {
+        ret = -EFAULT;
+        goto unlock;
+      }
+    }
+
     topic_num++;
   }
 
@@ -1560,7 +1570,7 @@ int agnocast_ioctl_get_topic_subscriber_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, topic_info_args->domain_id);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;
@@ -1646,7 +1656,7 @@ int agnocast_ioctl_get_topic_publisher_info(
 
   down_read(&global_htables_rwsem);
 
-  struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, topic_info_args->domain_id);
   if (!wrapper) {
     up_read(&global_htables_rwsem);
     return 0;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -553,15 +553,19 @@ int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret)
   return 0;
 }
 
-static bool has_alive_performance_bridge_manager(const struct ipc_namespace * ipc_ns)
+// A performance bridge manager is per-(ipc_ns, domain): its MQ name carries the
+// domain suffix, so each domain needs its own manager. Gate on the domain too,
+// otherwise a manager in one domain would suppress spawning in another.
+static bool has_alive_performance_bridge_manager(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
 {
   struct process_info * proc_info;
   int bkt;
   hash_for_each(proc_info_htable, bkt, proc_info, node)
   {
     if (
-      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->is_performance_bridge_manager &&
-      !proc_info->exited) {
+      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
+      proc_info->is_performance_bridge_manager && !proc_info->exited) {
       return true;
     }
   }
@@ -582,7 +586,8 @@ int agnocast_ioctl_add_process(
     goto unlock;
   }
   ioctl_ret->ret_unlink_daemon_exist = (get_process_num(ipc_ns) > 0);
-  ioctl_ret->ret_performance_bridge_daemon_exist = has_alive_performance_bridge_manager(ipc_ns);
+  ioctl_ret->ret_performance_bridge_daemon_exist =
+    has_alive_performance_bridge_manager(ipc_ns, domain_id);
 
   if (is_performance_bridge_manager && ioctl_ret->ret_performance_bridge_daemon_exist) {
     goto unlock;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -63,6 +63,35 @@ void test_case_add_process_twice(struct kunit * test)
   KUNIT_EXPECT_FALSE(test, agnocast_is_proc_exited(local_pid));
 }
 
+// A performance bridge manager is gated per-(ipc_ns, domain): a manager in one
+// domain must not suppress spawning a manager in another domain, while a second
+// manager in the same domain is suppressed.
+void test_case_add_process_perf_manager_per_domain(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  union ioctl_add_process_args args_d0;
+  int ret_d0 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0);
+  KUNIT_EXPECT_EQ(test, ret_d0, 0);
+  KUNIT_EXPECT_FALSE(test, args_d0.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+
+  // Different domain: not suppressed, so it is added and sees no existing manager.
+  union ioctl_add_process_args args_d1;
+  int ret_d1 = agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 1, &args_d1);
+  KUNIT_EXPECT_EQ(test, ret_d1, 0);
+  KUNIT_EXPECT_FALSE(test, args_d1.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+
+  // Same domain as the first: a manager already exists, so it is suppressed.
+  union ioctl_add_process_args args_d0_again;
+  int ret_d0_again =
+    agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, true, 0, &args_d0_again);
+  KUNIT_EXPECT_EQ(test, ret_d0_again, 0);
+  KUNIT_EXPECT_TRUE(test, args_d0_again.ret_performance_bridge_daemon_exist);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+}
+
 void test_case_add_process_too_many(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -4,9 +4,12 @@
 
 #define TEST_CASES_ADD_PROCESS                                                      \
   KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
-    KUNIT_CASE(test_case_add_process_twice), KUNIT_CASE(test_case_add_process_too_many)
+    KUNIT_CASE(test_case_add_process_twice),                                        \
+    KUNIT_CASE(test_case_add_process_perf_manager_per_domain),                      \
+    KUNIT_CASE(test_case_add_process_too_many)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
 void test_case_add_process_twice(struct kunit * test);
+void test_case_add_process_perf_manager_per_domain(struct kunit * test);
 void test_case_add_process_too_many(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.c
@@ -62,3 +62,27 @@ void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit 
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_TRUE(test, new_args.ret_performance_bridge_daemon_exist);
 }
+
+// A per-(ipc_ns, domain) manager shuts down once its own domain is empty, even if
+// another domain in the same namespace still has processes.
+void test_case_check_and_request_bridge_shutdown_per_domain(struct kunit * test)
+{
+  // Manager is the only process in domain 1.
+  pid_t mgr_d1 = pid_carbs++;
+  union ioctl_add_process_args mgr_args = {};
+  int ret = agnocast_ioctl_add_process(mgr_d1, current->nsproxy->ipc_ns, true, 1, &mgr_args);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+
+  // A normal process keeps domain 2 busy.
+  pid_t other_d2 = pid_carbs++;
+  union ioctl_add_process_args other_args = {};
+  ret = agnocast_ioctl_add_process(other_d2, current->nsproxy->ipc_ns, false, 2, &other_args);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+
+  // Domain 1 holds only the manager, so it should shut down despite domain 2 being busy.
+  struct ioctl_check_and_request_bridge_shutdown_args shutdown_args = {};
+  ret = agnocast_ioctl_check_and_request_bridge_shutdown(
+    mgr_d1, current->nsproxy->ipc_ns, &shutdown_args);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_TRUE(test, shutdown_args.ret_should_shutdown);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h
@@ -2,9 +2,11 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_CHECK_AND_REQUEST_BRIDGE_SHUTDOWN                  \
-  KUNIT_CASE(test_case_check_and_request_bridge_shutdown_when_alone), \
-    KUNIT_CASE(test_case_check_and_request_bridge_shutdown_when_others_exist)
+#define TEST_CASES_CHECK_AND_REQUEST_BRIDGE_SHUTDOWN                           \
+  KUNIT_CASE(test_case_check_and_request_bridge_shutdown_when_alone),          \
+    KUNIT_CASE(test_case_check_and_request_bridge_shutdown_when_others_exist), \
+    KUNIT_CASE(test_case_check_and_request_bridge_shutdown_per_domain)
 
 void test_case_check_and_request_bridge_shutdown_when_alone(struct kunit * test);
 void test_case_check_and_request_bridge_shutdown_when_others_exist(struct kunit * test);
+void test_case_check_and_request_bridge_shutdown_per_domain(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -18,6 +18,14 @@ static void setup_process(struct kunit * test, const pid_t pid)
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
+static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
 // Normal case: one publisher exists, should return count == 1
 void test_case_get_topic_pub_info_one_publisher(struct kunit * test)
 {
@@ -72,4 +80,35 @@ void test_case_get_topic_pub_info_topic_not_found(struct kunit * test)
     "/nonexistent_topic", current->nsproxy->ipc_ns, &topic_info_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, topic_info_args.ret_topic_info_ret_num, (uint32_t)0);
+}
+
+// The query selects the wrapper by domain: a publisher registered in domain 1 is
+// visible only when domain_id == 1, regardless of the caller's own domain.
+void test_case_get_topic_pub_info_selects_by_domain(struct kunit * test)
+{
+  const pid_t pid_d1 = 1001;
+  union ioctl_add_publisher_args add_pub_args;
+  int ret;
+
+  setup_process_domain(test, pid_d1, 1);
+  ret = agnocast_ioctl_add_publisher(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid_d1, QOS_DEPTH, false, IS_BRIDGE,
+    &add_pub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // domain 1: the topic exists -> the publisher is counted (copy_to_user
+  // fails with -EFAULT in KUnit context, but reaching it confirms the count).
+  union ioctl_topic_info_args args_d1 = {0};
+  args_d1.domain_id = 1;
+  args_d1.topic_info_ret_buffer_size = MAX_PUBLISHER_NUM;
+  ret = agnocast_ioctl_get_topic_publisher_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d1);
+  KUNIT_EXPECT_TRUE(test, ret == -EFAULT || (ret == 0 && args_d1.ret_topic_info_ret_num == 1));
+
+  // domain 0: no wrapper for this name -> nothing found.
+  union ioctl_topic_info_args args_d0 = {0};
+  args_d0.domain_id = 0;
+  args_d0.topic_info_ret_buffer_size = MAX_PUBLISHER_NUM;
+  ret = agnocast_ioctl_get_topic_publisher_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d0);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, args_d0.ret_topic_info_ret_num, (uint32_t)0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.h
@@ -2,11 +2,13 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_GET_TOPIC_PUBLISHER_INFO                 \
-  KUNIT_CASE(test_case_get_topic_pub_info_one_publisher),   \
-    KUNIT_CASE(test_case_get_topic_pub_info_no_publishers), \
-    KUNIT_CASE(test_case_get_topic_pub_info_topic_not_found)
+#define TEST_CASES_GET_TOPIC_PUBLISHER_INFO                   \
+  KUNIT_CASE(test_case_get_topic_pub_info_one_publisher),     \
+    KUNIT_CASE(test_case_get_topic_pub_info_no_publishers),   \
+    KUNIT_CASE(test_case_get_topic_pub_info_topic_not_found), \
+    KUNIT_CASE(test_case_get_topic_pub_info_selects_by_domain)
 
 void test_case_get_topic_pub_info_one_publisher(struct kunit * test);
 void test_case_get_topic_pub_info_no_publishers(struct kunit * test);
 void test_case_get_topic_pub_info_topic_not_found(struct kunit * test);
+void test_case_get_topic_pub_info_selects_by_domain(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -18,6 +18,14 @@ static void setup_process(struct kunit * test, const pid_t pid)
   KUNIT_ASSERT_EQ(test, ret, 0);
 }
 
+static void setup_process_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
 // Normal case: one subscriber exists, should return count == 1
 void test_case_get_topic_sub_info_one_subscriber(struct kunit * test)
 {
@@ -72,4 +80,35 @@ void test_case_get_topic_sub_info_topic_not_found(struct kunit * test)
     "/nonexistent_topic", current->nsproxy->ipc_ns, &topic_info_args);
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, topic_info_args.ret_topic_info_ret_num, (uint32_t)0);
+}
+
+// The query selects the wrapper by domain: a subscriber registered in domain 1 is
+// visible only when domain_id == 1, regardless of the caller's own domain.
+void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test)
+{
+  const pid_t pid_d1 = 1001;
+  union ioctl_add_subscriber_args add_sub_args;
+  int ret;
+
+  setup_process_domain(test, pid_d1, 1);
+  ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid_d1, QOS_DEPTH, false, false, false, false,
+    IS_BRIDGE, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // domain 1: the topic exists -> the subscriber is counted (copy_to_user
+  // fails with -EFAULT in KUnit context, but reaching it confirms the count).
+  union ioctl_topic_info_args args_d1 = {0};
+  args_d1.domain_id = 1;
+  args_d1.topic_info_ret_buffer_size = MAX_SUBSCRIBER_NUM;
+  ret = agnocast_ioctl_get_topic_subscriber_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d1);
+  KUNIT_EXPECT_TRUE(test, ret == -EFAULT || (ret == 0 && args_d1.ret_topic_info_ret_num == 1));
+
+  // domain 0: no wrapper for this name -> nothing found.
+  union ioctl_topic_info_args args_d0 = {0};
+  args_d0.domain_id = 0;
+  args_d0.topic_info_ret_buffer_size = MAX_SUBSCRIBER_NUM;
+  ret = agnocast_ioctl_get_topic_subscriber_info(TOPIC_NAME, current->nsproxy->ipc_ns, &args_d0);
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, args_d0.ret_topic_info_ret_num, (uint32_t)0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
@@ -2,11 +2,13 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                 \
-  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),   \
-    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers), \
-    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found)
+#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                  \
+  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),    \
+    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers),  \
+    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found), \
+    KUNIT_CASE(test_case_get_topic_sub_info_selects_by_domain)
 
 void test_case_get_topic_sub_info_one_subscriber(struct kunit * test);
 void test_case_get_topic_sub_info_no_subscribers(struct kunit * test);
 void test_case_get_topic_sub_info_topic_not_found(struct kunit * test);
+void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test);

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -31,6 +31,9 @@ union ioctl_topic_list_args {
   struct
   {
     uint64_t topic_name_buffer_addr;
+    // Parallel array of uint32 domain_ids (one per topic name). Pass 0 to skip.
+    // Must mirror agnocast_kmod/agnocast.h so _IOWR encodes the same size.
+    uint64_t domain_id_buffer_addr;
     uint32_t topic_name_buffer_size;
   };
   uint32_t ret_topic_num;
@@ -61,6 +64,9 @@ union ioctl_topic_info_args {
     struct name_info topic_name;
     uint64_t topic_info_ret_buffer_addr;
     uint32_t topic_info_ret_buffer_size;
+    // Which domain's endpoints to return (0 = default domain). Must mirror
+    // agnocast_kmod/agnocast.h so _IOWR encodes the same size.
+    uint32_t domain_id;
   };
   uint32_t ret_topic_info_ret_num;
 };

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -250,6 +250,9 @@ union ioctl_topic_info_args {
     struct name_info topic_name;
     uint64_t topic_info_ret_buffer_addr;
     uint32_t topic_info_ret_buffer_size;
+    // Which domain's endpoints to return (0 = default domain). Must mirror
+    // agnocast_kmod/agnocast.h so _IOWR encodes the same size.
+    uint32_t domain_id;
   };
   uint32_t ret_topic_info_ret_num;
 };


### PR DESCRIPTION
## Description

Two kmod changes that make the domain (`ROS_DOMAIN_ID`, isolated per topic in #1398) observable and actionable by the discovery / bridge layer.

Changes:

- **Topic list / info ioctls are domain-aware** (ABI): `get_topic_list` optionally fills a parallel `domain_id` array (one per topic name), and `get_topic_subscriber_info` / `get_topic_publisher_info` take an explicit `domain_id` input that selects the wrapper via `find_topic(name, ipc_ns, domain_id)`. The userspace ioctl wrapper mirrors the two arg structs so `_IOWR` encodes the matching size (it passes 0, so behavior is unchanged here). This lets a per-namespace consumer (the discovery agent) enumerate every domain.
- **Bridge manager spawn gate is per-(ipc_ns, domain)**: a performance bridge manager's MQ name carries the domain suffix, so each domain needs its own manager. `has_alive_performance_bridge_manager` now matches the domain too, so a manager already running in one domain no longer suppresses spawning a manager in another domain of the same namespace.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Stacked on #1398

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **kunit (added)**: `get_topic_subscriber_info` selects the wrapper by `domain_id` (a domain-1 subscriber is visible only for `domain_id == 1`); the bridge-manager spawn gate admits one manager per `(ipc_ns, domain)` and suppresses a second in the same domain.
- Built `agnocast_kmod` and `agnocast_ioctl_wrapper`.

## Version Update Label (Required)

- `need-minor-update` (topic list / info ioctl ABI: `ioctl_topic_list_args` / `ioctl_topic_info_args` layout change)
