### PR TITLE
feat(agnocast_ioctl_wrapper, ros2agnocast_discovery_agent): make cross-NS discovery and bridge decisions domain-aware

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1390,6 +1390,13 @@ void agnocast_commit_exit_process(
   up_write(&global_htables_rwsem);
 }
 
+// Intentionally namespace-scoped, not caller-domain-scoped: this returns every
+// domain's topics, each stamped with its domain_id, rather than filtering to the
+// caller's ROS_DOMAIN_ID. get_topic_*_info takes a domain input and filters here;
+// the list stays broad so one call serves both a per-(NS, domain) consumer (which
+// filters client-side -- cheap) and a cross-domain view (e.g. a future domain-aware
+// `ros2 topic list_agnocast`). Revisit by adding a domain input if a strictly
+// per-domain enumeration is ever needed.
 int agnocast_ioctl_get_topic_list(
   const struct ipc_namespace * ipc_ns, union ioctl_topic_list_args * topic_list_args)
 {

--- a/src/agnocast_ioctl_wrapper/src/topic_info.cpp
+++ b/src/agnocast_ioctl_wrapper/src/topic_info.cpp
@@ -11,7 +11,8 @@
 
 extern "C" {
 
-struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * topic_info_ret_count)
+struct topic_info_ret * get_agnocast_sub_nodes(
+  const char * topic_name, int * topic_info_ret_count, uint32_t domain_id)
 {
   *topic_info_ret_count = 0;
 
@@ -39,6 +40,7 @@ struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * to
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(agnocast_topic_info_ret_buffer);
   topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
+  topic_info_args.domain_id = domain_id;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD failed");
     free(agnocast_topic_info_ret_buffer);
@@ -57,7 +59,8 @@ struct topic_info_ret * get_agnocast_sub_nodes(const char * topic_name, int * to
   return agnocast_topic_info_ret_buffer;
 }
 
-struct topic_info_ret * get_agnocast_pub_nodes(const char * topic_name, int * topic_info_ret_count)
+struct topic_info_ret * get_agnocast_pub_nodes(
+  const char * topic_name, int * topic_info_ret_count, uint32_t domain_id)
 {
   *topic_info_ret_count = 0;
 
@@ -85,6 +88,7 @@ struct topic_info_ret * get_agnocast_pub_nodes(const char * topic_name, int * to
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(agnocast_topic_info_ret_buffer);
   topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
+  topic_info_args.domain_id = domain_id;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD, &topic_info_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD failed");
     free(agnocast_topic_info_ret_buffer);

--- a/src/agnocast_ioctl_wrapper/src/topic_list.cpp
+++ b/src/agnocast_ioctl_wrapper/src/topic_list.cpp
@@ -11,9 +11,17 @@
 
 extern "C" {
 
-char ** get_agnocast_topics(int * topic_count)
+// When domain_ids_out is non-null, on success *domain_ids_out receives a malloc'd
+// array of *topic_count domain_ids parallel to the returned topic names; the caller
+// frees it with free_agnocast_topic_domains. The domain buffer is allocated here so
+// it always matches the name buffer's capacity — the caller never sizes it. Pass
+// nullptr to skip domain output.
+char ** get_agnocast_topics(int * topic_count, uint32_t ** domain_ids_out)
 {
   *topic_count = 0;
+  if (domain_ids_out != nullptr) {
+    *domain_ids_out = nullptr;
+  }
 
   int fd = open("/dev/agnocast", O_RDONLY);
   if (fd < 0) {
@@ -33,17 +41,30 @@ char ** get_agnocast_topics(int * topic_count)
     return nullptr;
   }
 
+  uint32_t * domain_buffer = nullptr;
+  if (domain_ids_out != nullptr) {
+    domain_buffer = static_cast<uint32_t *>(malloc(MAX_TOPIC_NUM * sizeof(uint32_t)));
+    if (domain_buffer == nullptr) {
+      free(agnocast_topic_buffer);
+      close(fd);
+      return nullptr;
+    }
+  }
+
   ioctl_topic_list_args topic_list_args = {};
   topic_list_args.topic_name_buffer_addr = reinterpret_cast<uint64_t>(agnocast_topic_buffer);
+  topic_list_args.domain_id_buffer_addr = reinterpret_cast<uint64_t>(domain_buffer);
   topic_list_args.topic_name_buffer_size = MAX_TOPIC_NUM;
   if (ioctl(fd, AGNOCAST_GET_TOPIC_LIST_CMD, &topic_list_args) < 0) {
     perror("AGNOCAST_GET_TOPIC_LIST_CMD failed");
+    free(domain_buffer);
     free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
   }
 
   if (topic_list_args.ret_topic_num == 0) {
+    free(domain_buffer);
     free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
@@ -54,6 +75,7 @@ char ** get_agnocast_topics(int * topic_count)
   char ** topic_array = static_cast<char **>(malloc(*topic_count * sizeof(char *)));
   if (topic_array == nullptr) {
     *topic_count = 0;
+    free(domain_buffer);
     free(agnocast_topic_buffer);
     close(fd);
     return nullptr;
@@ -69,9 +91,15 @@ char ** get_agnocast_topics(int * topic_count)
       free(topic_array);
       topic_array = nullptr;
       *topic_count = 0;
+      free(domain_buffer);
+      domain_buffer = nullptr;
       break;
     }
     std::strcpy(topic_array[i], agnocast_topic_buffer + i * TOPIC_NAME_BUFFER_SIZE);
+  }
+
+  if (domain_ids_out != nullptr) {
+    *domain_ids_out = domain_buffer;
   }
 
   free(agnocast_topic_buffer);
@@ -79,4 +107,8 @@ char ** get_agnocast_topics(int * topic_count)
   return topic_array;
 }
 
+void free_agnocast_topic_domains(uint32_t * domain_ids)
+{
+  free(domain_ids);
+}
 }  // extern "C"

--- a/src/agnocast_ioctl_wrapper/src/topic_list.cpp
+++ b/src/agnocast_ioctl_wrapper/src/topic_list.cpp
@@ -11,11 +11,14 @@
 
 extern "C" {
 
-// When domain_ids_out is non-null, on success *domain_ids_out receives a malloc'd
-// array of *topic_count domain_ids parallel to the returned topic names; the caller
-// frees it with free_agnocast_topic_domains. The domain buffer is allocated here so
-// it always matches the name buffer's capacity — the caller never sizes it. Pass
-// nullptr to skip domain output.
+// When domain_ids_out is non-null, the function allocates a buffer into *domain_ids_out and
+// passes its address to the GET_TOPIC_LIST ioctl, which fills it with the topics' domain ids.
+// It is the same size as the topic buffer and maps one-to-one to it (the id at index i is
+// topic i's domain).
+// Allocation and freeing of the returned buffers are unified in this layer (the ioctl
+// wrapper) for simplicity, so the caller never sizes them and frees the domain buffer with
+// free_agnocast_topic_domains.
+// Pass nullptr as domain_ids_out when you don't need the buffer to be allocated.
 char ** get_agnocast_topics(int * topic_count, uint32_t ** domain_ids_out)
 {
   *topic_count = 0;

--- a/src/ros2agnocast/ros2agnocast/_ioctl.py
+++ b/src/ros2agnocast/ros2agnocast/_ioctl.py
@@ -33,14 +33,17 @@ def _load_lib() -> Optional[ctypes.CDLL]:
         lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
     except OSError:
         return None
-    lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_topics.argtypes = [
+        ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32))]
     lib.get_agnocast_topics.restype = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))
     lib.free_agnocast_topics.argtypes = [
         ctypes.POINTER(ctypes.POINTER(ctypes.c_char)), ctypes.c_int]
     lib.free_agnocast_topics.restype = None
-    lib.get_agnocast_sub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_sub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_sub_nodes.restype = ctypes.POINTER(_TopicInfoRet)
-    lib.get_agnocast_pub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_pub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(_TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(_TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
@@ -59,10 +62,10 @@ def _endpoint_from_topic_info_ret(tir: _TopicInfoRet) -> AgnocastEndpoint:
 
 
 @contextmanager
-def _endpoints(lib, fn, topic_name: str):
+def _endpoints(lib, fn, topic_name: str, domain_id: int = 0):
     """Yield a list[AgnocastEndpoint] for one topic; free the ctypes buffer on exit."""
     count = ctypes.c_int()
-    arr = fn(topic_name.encode('utf-8'), ctypes.byref(count))
+    arr = fn(topic_name.encode('utf-8'), ctypes.byref(count), domain_id)
     try:
         if not arr:
             yield []
@@ -100,7 +103,9 @@ def self_ns_snapshot() -> Optional[AgnocastDaemonState]:
     state.topics = []
 
     topic_count = ctypes.c_int()
-    topic_array = lib.get_agnocast_topics(ctypes.byref(topic_count))
+    # The CLI is not domain-aware yet: it queries the default domain (0). Full
+    # per-domain CLI output is a follow-up; here we only keep the ABI in sync.
+    topic_array = lib.get_agnocast_topics(ctypes.byref(topic_count), None)
     try:
         for i in range(topic_count.value):
             tname = ctypes.cast(topic_array[i], ctypes.c_char_p).value.decode('utf-8')
@@ -108,9 +113,9 @@ def self_ns_snapshot() -> Optional[AgnocastDaemonState]:
             t.topic_name = tname
             t.type_name = ''
             t.domain_id = 0
-            with _endpoints(lib, lib.get_agnocast_pub_nodes, tname) as pubs:
+            with _endpoints(lib, lib.get_agnocast_pub_nodes, tname, 0) as pubs:
                 t.publishers = pubs
-            with _endpoints(lib, lib.get_agnocast_sub_nodes, tname) as subs:
+            with _endpoints(lib, lib.get_agnocast_sub_nodes, tname, 0) as subs:
                 t.subscribers = subs
             state.topics.append(t)
     finally:

--- a/src/ros2agnocast/ros2agnocast/_ioctl.py
+++ b/src/ros2agnocast/ros2agnocast/_ioctl.py
@@ -103,8 +103,10 @@ def self_ns_snapshot() -> Optional[AgnocastDaemonState]:
     state.topics = []
 
     topic_count = ctypes.c_int()
-    # The CLI is not domain-aware yet: it queries the default domain (0). Full
-    # per-domain CLI output is a follow-up; here we only keep the ABI in sync.
+    # TODO: make the CLI domain-aware. It currently queries only the default
+    # domain (0) -- pass a real domain_ids array here and use each topic's
+    # stamped domain for get_agnocast_{pub,sub}_nodes below, instead of
+    # hardcoding 0. For now we only keep the ABI in sync.
     topic_array = lib.get_agnocast_topics(ctypes.byref(topic_count), None)
     try:
         for i in range(topic_count.value):

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -83,17 +83,24 @@ def _load_ioctl_wrapper():
     """Load libagnocast_ioctl_wrapper.so and set argtypes for the symbols we use."""
     lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
 
-    lib.get_agnocast_topics.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_topics.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_uint32)),
+    ]
     lib.get_agnocast_topics.restype = ctypes.POINTER(ctypes.POINTER(ctypes.c_char))
     lib.free_agnocast_topics.argtypes = [
         ctypes.POINTER(ctypes.POINTER(ctypes.c_char)),
         ctypes.c_int,
     ]
     lib.free_agnocast_topics.restype = None
+    lib.free_agnocast_topic_domains.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+    lib.free_agnocast_topic_domains.restype = None
 
-    lib.get_agnocast_sub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_sub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_sub_nodes.restype = ctypes.POINTER(TopicInfoRet)
-    lib.get_agnocast_pub_nodes.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+    lib.get_agnocast_pub_nodes.argtypes = [
+        ctypes.c_char_p, ctypes.POINTER(ctypes.c_int), ctypes.c_uint32]
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
@@ -135,7 +142,11 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
     supplies the type names and pids that the ioctl does not expose.
     """
     topic_count = ctypes.c_int()
-    topic_names_ptr = lib.get_agnocast_topics(ctypes.byref(topic_count))
+    # The wrapper allocates the domain array (sized to match the name buffer) and
+    # returns it here; we own it and free it below.
+    domain_ids_ptr = ctypes.POINTER(ctypes.c_uint32)()
+    topic_names_ptr = lib.get_agnocast_topics(
+        ctypes.byref(topic_count), ctypes.pointer(domain_ids_ptr))
     topics = []
     if not topic_names_ptr:
         return topics
@@ -144,15 +155,20 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
         for i in range(topic_count.value):
             topic_name_b = ctypes.cast(topic_names_ptr[i], ctypes.c_char_p).value
             topic_name = topic_name_b.decode('utf-8', errors='replace')
+            # The same topic name can occur once per domain; each row is a
+            # distinct (name, domain) pair that becomes its own AgnocastTopic.
+            domain_id = domain_ids_ptr[i]
 
             agnocast_topic = AgnocastTopic()
             agnocast_topic.topic_name = topic_name
             agnocast_topic.type_name = ''
-            agnocast_topic.domain_id = 0
+            agnocast_topic.domain_id = domain_id
             agnocast_topic.publishers = _collect_endpoints(
-                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, 'pub', registry)
+                lib.get_agnocast_pub_nodes, lib, topic_name_b, topic_name, domain_id, 'pub',
+                registry)
             agnocast_topic.subscribers = _collect_endpoints(
-                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, 'sub', registry)
+                lib.get_agnocast_sub_nodes, lib, topic_name_b, topic_name, domain_id, 'sub',
+                registry)
             # Type name comes from the tmpfs registry; any registered
             # endpoint on this topic carries the same type (ROS 2
             # invariant), so the first non-empty one wins.
@@ -163,6 +179,7 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
             topics.append(agnocast_topic)
     finally:
         lib.free_agnocast_topics(topic_names_ptr, topic_count.value)
+        lib.free_agnocast_topic_domains(domain_ids_ptr)
 
     return topics
 
@@ -181,10 +198,10 @@ def _resolve_topic_type(
 
 
 def _collect_endpoints(
-        getter, lib, topic_name_b: bytes, topic_name: str, role: str,
+        getter, lib, topic_name_b: bytes, topic_name: str, domain_id: int, role: str,
         registry: TypeRegistryReader | None = None) -> list:
     count = ctypes.c_int()
-    array = getter(topic_name_b, ctypes.byref(count))
+    array = getter(topic_name_b, ctypes.byref(count), domain_id)
     endpoints = []
     if not array:
         return endpoints

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -62,6 +62,9 @@ class BridgeRequest:
     qos_depth: int
     qos_is_transient_local: bool
     qos_is_reliable: bool
+    # Selects the target bridge_manager's MQ (one manager per domain); not part
+    # of the wire payload, since that manager already runs in this domain.
+    domain_id: int = 0
 
 
 def serialize_request(req: BridgeRequest) -> bytes:
@@ -79,17 +82,18 @@ def serialize_request(req: BridgeRequest) -> bytes:
 
 
 def _resolve_types(local_state, remote_states) -> dict:
-    """Resolve each topic's message type, preferring local then any remote.
+    """Resolve each ``(topic, domain)``'s message type, preferring local then any remote.
 
-    A bridge is deduped per ``(topic, direction)``, so its type must be resolved
-    per-topic across local + *all* remotes: the remote that supplies the
-    opposite-role endpoint may lack the type while another snapshot has it.
+    The type must be resolved across local + *all* remotes: the remote that
+    supplies the opposite-role endpoint may lack the type while another snapshot
+    has it.
     """
-    types = {t.topic_name: t.type_name for t in local_state.topics if t.type_name}
+    types = {
+        (t.topic_name, t.domain_id): t.type_name for t in local_state.topics if t.type_name}
     for remote in remote_states.values():
         for t in remote.topics:
             if t.type_name:
-                types.setdefault(t.topic_name, t.type_name)
+                types.setdefault((t.topic_name, t.domain_id), t.type_name)
     return types
 
 
@@ -97,18 +101,20 @@ def decide_bridges(local_state, remote_states) -> list:
     """Return the bridge requests this namespace should issue this tick.
 
     ``remote_states`` maps ``(host_uuid, ipc_ns_inode)`` to AgnocastDaemonState.
-    Requests are collapsed to one per ``(topic, direction)``.
+    Topics match only within the same domain (a bridge never crosses domains;
+    cross-domain relaying is the external domain_bridge's job), and requests are
+    collapsed to one per ``(topic, domain, direction)``.
     """
     requests = {}
 
-    local_by_topic = {t.topic_name: t for t in local_state.topics}
+    local_by_topic = {(t.topic_name, t.domain_id): t for t in local_state.topics}
     types = _resolve_types(local_state, remote_states)
 
     for (host_uuid, ipc_ns_inode), remote in remote_states.items():
         if host_uuid == local_state.host_uuid and ipc_ns_inode == local_state.ipc_ns_inode:
             continue
         for remote_topic in remote.topics:
-            local_topic = local_by_topic.get(remote_topic.topic_name)
+            local_topic = local_by_topic.get((remote_topic.topic_name, remote_topic.domain_id))
             if local_topic is None:
                 continue
 
@@ -117,13 +123,14 @@ def decide_bridges(local_state, remote_states) -> list:
             remote_pubs = [p for p in remote_topic.publishers if not p.is_bridge]
             remote_subs = [s for s in remote_topic.subscribers if not s.is_bridge]
 
-            type_name = types.get(local_topic.topic_name)
+            domain_id = local_topic.domain_id
+            type_name = types.get((local_topic.topic_name, domain_id))
             if not type_name:
                 continue
 
             if local_pubs and remote_subs:
                 pub = local_pubs[0]
-                key = (local_topic.topic_name, DIRECTION_AGNOCAST_TO_ROS2)
+                key = (local_topic.topic_name, domain_id, DIRECTION_AGNOCAST_TO_ROS2)
                 requests.setdefault(key, BridgeRequest(
                     topic_name=local_topic.topic_name,
                     type_name=type_name,
@@ -131,11 +138,12 @@ def decide_bridges(local_state, remote_states) -> list:
                     qos_depth=pub.qos_depth,
                     qos_is_transient_local=pub.qos_is_transient_local,
                     qos_is_reliable=pub.qos_is_reliable,
+                    domain_id=domain_id,
                 ))
 
             if local_subs and remote_pubs:
                 sub = local_subs[0]
-                key = (local_topic.topic_name, DIRECTION_ROS2_TO_AGNOCAST)
+                key = (local_topic.topic_name, domain_id, DIRECTION_ROS2_TO_AGNOCAST)
                 requests.setdefault(key, BridgeRequest(
                     topic_name=local_topic.topic_name,
                     type_name=type_name,
@@ -143,16 +151,16 @@ def decide_bridges(local_state, remote_states) -> list:
                     qos_depth=sub.qos_depth,
                     qos_is_transient_local=sub.qos_is_transient_local,
                     qos_is_reliable=sub.qos_is_reliable,
+                    domain_id=domain_id,
                 ))
 
     return list(requests.values())
 
 
-def _performance_mq_name() -> str:
+def _performance_mq_name(domain_id: int) -> str:
     name = _PERFORMANCE_MQ_NAME
-    domain_id = os.environ.get('ROS_DOMAIN_ID')
     if domain_id:
-        name += '_d' + domain_id
+        name += '_d' + str(domain_id)
     return name
 
 
@@ -183,12 +191,12 @@ def send_request(mq_name: str, payload: bytes) -> Optional[str]:
 def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
     """Deliver each request to the per-namespace bridge_manager MQ.
 
-    The MQ is absent until a bridge_manager is up; ``send_request`` skips
+    Each request goes to the manager that owns its domain (one per domain). The
+    MQ is absent until that bridge_manager is up; ``send_request`` skips
     ENOENT/EAGAIN so a missing or full queue never stalls the daemon, and the
     request is re-issued idempotently next tick.
     """
-    perf_mq = _performance_mq_name()
     for req in requests:
-        err = send_request(perf_mq, serialize_request(req))
+        err = send_request(_performance_mq_name(req.domain_id), serialize_request(req))
         if err is not None and logger is not None:
             logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -72,9 +72,14 @@ def test_ioctl_to_endpoint_fills_pid_from_registry():
     assert ep.pid == 4242
 
 
-def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
-    """Build a ctypes-flavoured mock that returns the given topic data."""
+def _make_mock_lib(topic_to_endpoints: dict, topic_domains: dict | None = None) -> MagicMock:
+    """Build a ctypes-flavoured mock that returns the given topic data.
+
+    ``topic_domains`` optionally maps a topic name to its domain_id (default 0);
+    the mock fills the wrapper-owned domain array returned via the out-pointer.
+    """
     lib = MagicMock()
+    topic_domains = topic_domains or {}
 
     topic_names = list(topic_to_endpoints.keys())
 
@@ -86,15 +91,24 @@ def _make_mock_lib(topic_to_endpoints: dict) -> MagicMock:
     char_pp = (ctypes.POINTER(ctypes.c_char) * len(name_storage))(
         *(ctypes.cast(b, ctypes.POINTER(ctypes.c_char)) for b in name_storage))
 
-    def get_topics(count_ptr):
+    # Keep the domain arrays alive for the duration of the call (the wrapper would
+    # own this memory; here the mock does).
+    domain_storage = []
+
+    def get_topics(count_ptr, domain_ids_out):
         count_ptr._obj.value = len(topic_names)
+        arr = (ctypes.c_uint32 * len(topic_names))(
+            *(topic_domains.get(name, 0) for name in topic_names))
+        domain_storage.append(arr)
+        domain_ids_out[0] = ctypes.cast(arr, ctypes.POINTER(ctypes.c_uint32))
         return char_pp
 
     lib.get_agnocast_topics = MagicMock(side_effect=get_topics)
     lib.free_agnocast_topics = MagicMock()
+    lib.free_agnocast_topic_domains = MagicMock()
 
     def make_endpoints_getter(direction):
-        def getter(topic_name_b, count_ptr):
+        def getter(topic_name_b, count_ptr, domain_id):
             name = topic_name_b.decode('utf-8')
             infos = topic_to_endpoints.get(name, {}).get(direction, [])
             count_ptr._obj.value = len(infos)
@@ -134,6 +148,21 @@ def test_read_local_topics_combines_pub_and_sub():
     assert topic.publishers[0].qos_depth == 3
     assert len(topic.subscribers) == 1
     assert topic.subscribers[0].node_name == '/listener_node'
+
+
+def test_read_local_topics_stamps_domain_id():
+    """The real domain_id from the ioctl is stamped onto the gossip topic."""
+    pub_info = _make_info('/talker_node')
+    lib = _make_mock_lib(
+        {'/chatter': {'pub': [pub_info], 'sub': []}},
+        topic_domains={'/chatter': 7})
+
+    topics = read_local_topics(lib)
+    assert len(topics) == 1
+    assert topics[0].domain_id == 7
+    # The per-topic domain is forwarded to the endpoint queries.
+    _name, _count, domain_arg = lib.get_agnocast_pub_nodes.call_args.args
+    assert domain_arg == 7
 
 
 def test_read_local_topics_resolves_type_from_registry():

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -32,11 +32,11 @@ def _endpoint(node, depth=10, transient=False, reliable=True, is_bridge=False):
     return ep
 
 
-def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None):
+def _topic(name, type_name='std_msgs/msg/Int32', pubs=None, subs=None, domain=0):
     t = AgnocastTopic()
     t.topic_name = name
     t.type_name = type_name
-    t.domain_id = 0
+    t.domain_id = domain
     t.publishers = pubs or []
     t.subscribers = subs or []
     return t
@@ -143,6 +143,25 @@ def test_decide_skips_when_only_same_role_present():
     assert decide_bridges(local, {('OTHER', 222): remote}) == []
 
 
+def test_decide_skips_cross_domain_match():
+    # Same topic name but different domains must not be bridged: isolation holds
+    # and cross-domain relaying is the external domain_bridge's job.
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=0)])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/rs')], domain=1)])
+    assert decide_bridges(local, {('OTHER', 222): remote}) == []
+
+
+def test_decide_matches_within_same_nonzero_domain():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=5)])
+    remote = _state(host_uuid='OTHER', ipc_ns=222,
+                    topics=[_topic('/x', subs=[_endpoint('/rs')], domain=5)])
+    reqs = decide_bridges(local, {('OTHER', 222): remote})
+    assert len(reqs) == 1
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].domain_id == 5
+
+
 def test_decide_collapses_duplicates_across_remotes():
     local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')])])
     remote_a = _state(host_uuid='A', ipc_ns=1, topics=[_topic('/x', subs=[_endpoint('/sa')])])
@@ -182,3 +201,16 @@ def test_dispatch_targets_per_namespace_mq(monkeypatch):
 
     assert all(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
     assert len(sent) == 1
+
+
+def test_dispatch_routes_to_per_domain_mq(monkeypatch):
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+
+    dispatch_requests([
+        BridgeRequest('/a', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=0),
+        BridgeRequest('/b', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=5),
+    ])
+
+    assert sent == ['/agnocast_daemon_bridge_perf', '/agnocast_daemon_bridge_perf_d5']


### PR DESCRIPTION
## Description

Thread the real domain through the discovery pipeline so cross-NS bridge decisions respect `ROS_DOMAIN_ID`, building on the domain-aware kmod ioctls in the base PR (#1409).

Changes:

- **Discovery agent stamps the real `domain_id`** (it was hardcoded to 0): `get_agnocast_topics` returns a parallel domain array and `get_agnocast_sub_nodes` / `get_agnocast_pub_nodes` take a `domain_id` input (ioctl wrapper); the per-NS agent pairs `name[i]` with `domain[i]` and builds one `AgnocastTopic` per `(name, domain)`. The `ros2agnocast` CLI binding is updated to the new signatures but stays on the default domain (0) — full per-domain CLI output is a follow-up.
- **Bridge decider is domain-aware**: matches local and remote topics by `(topic, domain)` so a bridge is created only within the same domain (cross-domain relaying is the external `domain_bridge`'s job, and bridging across domains would break isolation), dedups per `(topic, domain, direction)`, and dispatches each request to the bridge_manager that owns its domain (`_d<domain>` MQ).

No kmod ABI / wire-format change — the per-domain manager already runs in the target domain, so `domain_id` only routes the request and is not serialized.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE
- Builds on #1409 (merged)

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

In addition:

- **pytest**: `ros2agnocast_discovery_agent` 47 passed (incl. domain stamping + forwarding, cross-domain match skipped, same-domain bridged, per-domain `_d<domain>` MQ routing) and `ros2agnocast` CLI 83 passed with the updated bindings.
- Built `agnocast_ioctl_wrapper`.

## Version Update Label (Required)

- `need-patch-update` (userspace wrapper / agent / CLI only; no kmod ABI or wire-format change)
