### PR TITLE
fix(ros2agnocast_discovery_agent): dedup the discovery agent per (IPC namespace, ROS_DOMAIN_ID)

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -5,15 +5,17 @@ Reads the local Agnocast state via the existing NS-scoped ioctl wrapper
 ``/_agnocast_discovery`` so other namespaces and ECUs running ros2agnocast
 tooling can observe and make bridge generation decisions.
 
-One daemon process is intended to run per IPC namespace. To make duplicate
+One daemon process is intended to run per (IPC namespace, ROS_DOMAIN_ID):
+gossip is published on the agent's DDS domain, so a namespace shared by
+launches in different domains needs one agent per domain. To make duplicate
 launches (e.g. one node spawning the agent and another ``ros2 launch``
 session also trying to spawn one) safe, the agent acquires an
-``flock(2)``-based singleton lock on a per-IPC-namespace file before
-starting; subsequent instances detect the held lock and exit cleanly
-(code 0), leaving exactly one live agent per namespace. Emitting a single
-agent per launch tree is the launch side's responsibility; this lock is
-the cross-invocation safety net for when separate launches target the
-same namespace.
+``flock(2)``-based singleton lock on a per-(namespace, domain) file before
+starting; subsequent instances in the same (namespace, domain) detect the
+held lock and exit cleanly (code 0), leaving exactly one live agent per
+(namespace, domain). Emitting a single agent per launch tree is the launch
+side's responsibility; this lock is the cross-invocation safety net for when
+separate launches target the same (namespace, domain).
 """
 
 import ctypes
@@ -213,14 +215,31 @@ def _read_ipc_ns_inode() -> int:
     return os.stat(SELF_IPC_NS_PATH).st_ino
 
 
-def _singleton_lock_path(ipc_ns_inode: int) -> str:
-    """Return the singleton lock-file path for this IPC namespace.
+def _read_ros_domain_id() -> int:
+    """Return ROS_DOMAIN_ID from the environment (0 if unset, empty, or
+    unparsable), matching ROS 2's default and the kmod's get_ros_domain_id."""
+    raw = os.environ.get('ROS_DOMAIN_ID')
+    if not raw:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
 
-    Co-located with the rest of Agnocast tmpfs state so a container
-    overriding ``AGNOCAST_TMPFS_DIR`` keeps the lock under the same root.
+
+def _singleton_lock_path(ipc_ns_inode: int, domain_id: int) -> str:
+    """Return the singleton lock-file path for this (IPC namespace, domain).
+
+    Keyed by both the IPC namespace and ROS_DOMAIN_ID: gossip is published on
+    the agent's DDS domain, so launches sharing a namespace but using different
+    domains each need their own agent and must not deduplicate against each
+    other.
+
+    Co-located with the rest of Agnocast tmpfs state so a container overriding
+    ``AGNOCAST_TMPFS_DIR`` keeps the lock under the same root.
     """
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
-    return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}.lock')
+    return os.path.join(root, f'agnocast_discovery_agent_{ipc_ns_inode}_d{domain_id}.lock')
 
 
 class LockStatus(Enum):
@@ -240,9 +259,9 @@ class SingletonLockAttempt:
     file: IO | None = None
 
 
-def _try_acquire_singleton_lock(ipc_ns_inode: int) -> SingletonLockAttempt:
-    """Try to take an exclusive ``flock(2)`` on the per-IPC-namespace lock file."""
-    lock_path = _singleton_lock_path(ipc_ns_inode)
+def _try_acquire_singleton_lock(ipc_ns_inode: int, domain_id: int) -> SingletonLockAttempt:
+    """Try to take an exclusive ``flock(2)`` on the per-(IPC namespace, domain) lock file."""
+    lock_path = _singleton_lock_path(ipc_ns_inode, domain_id)
     try:
         fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644)
     except OSError as e:
@@ -300,13 +319,14 @@ class DiscoveryAgent(Node):
         self._host_uuid = _read_host_uuid()
         self._host_hostname = socket.gethostname()
         self._ipc_ns_inode = _read_ipc_ns_inode()
-        # Multiple agents may run on one ECU (one per IPC NS); disambiguate.
+        self._domain_id = _read_ros_domain_id()
+        # Multiple agents may run on one ECU (one per (IPC NS, domain)); disambiguate.
         host_short = self._host_uuid.replace('-', '')[:8]
         # Force use_sim_time=False so the 1 Hz timer + clock reads are
         # wall-clock regardless of /clock; sim-time playback would otherwise
         # stretch the publish cadence past the liveliness lease window.
         super().__init__(
-            f'agnocast_discovery_agent_{host_short}_{self._ipc_ns_inode}',
+            f'agnocast_discovery_agent_{host_short}_{self._ipc_ns_inode}_d{self._domain_id}',
             parameter_overrides=[Parameter('use_sim_time', value=False)],
         )
         self._lib = _load_ioctl_wrapper()
@@ -400,11 +420,12 @@ def main(argv=None) -> int:
     # launch emits one agent per tree, so a held lock always means a separate
     # launch/run — never a same-tree sibling — which exiting can't affect.
     ipc_ns_inode = _read_ipc_ns_inode()
-    lock_attempt = _try_acquire_singleton_lock(ipc_ns_inode)
+    domain_id = _read_ros_domain_id()
+    lock_attempt = _try_acquire_singleton_lock(ipc_ns_inode, domain_id)
     if lock_attempt.status == LockStatus.HELD:
         sys.stderr.write(
             'agnocast_discovery_agent: another instance is already running in this '
-            f'IPC namespace (inode={ipc_ns_inode}); exiting.\n')
+            f'IPC namespace (inode={ipc_ns_inode}, domain={domain_id}); exiting.\n')
         return 0
     if lock_attempt.status == LockStatus.ERROR:
         # Don't masquerade as "already running" — propagate failure so

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -215,33 +215,45 @@ def test_read_host_uuid_returns_uuid_string():
 def test_singleton_lock_path_honors_tmpfs_dir(monkeypatch, tmp_path):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import _singleton_lock_path
-    assert _singleton_lock_path(42) == str(tmp_path / 'agnocast_discovery_agent_42.lock')
+    assert _singleton_lock_path(42, 3) == str(tmp_path / 'agnocast_discovery_agent_42_d3.lock')
 
 
 def test_singleton_lock_path_defaults_to_dev_shm(monkeypatch):
     monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
     from ros2agnocast_discovery_agent.agent import _singleton_lock_path
-    assert _singleton_lock_path(42) == '/dev/shm/agnocast_discovery_agent_42.lock'
+    assert _singleton_lock_path(42, 0) == '/dev/shm/agnocast_discovery_agent_42_d0.lock'
+
+
+def test_read_ros_domain_id_parses_env(monkeypatch):
+    from ros2agnocast_discovery_agent.agent import _read_ros_domain_id
+    monkeypatch.delenv('ROS_DOMAIN_ID', raising=False)
+    assert _read_ros_domain_id() == 0
+    monkeypatch.setenv('ROS_DOMAIN_ID', '7')
+    assert _read_ros_domain_id() == 7
+    monkeypatch.setenv('ROS_DOMAIN_ID', '')   # unset-equivalent -> default 0
+    assert _read_ros_domain_id() == 0
+    monkeypatch.setenv('ROS_DOMAIN_ID', 'abc')  # unparsable -> default 0
+    assert _read_ros_domain_id() == 0
 
 
 def test_acquire_singleton_lock_succeeds_when_free(monkeypatch, tmp_path):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
-    attempt = _try_acquire_singleton_lock(123)
+    attempt = _try_acquire_singleton_lock(123, 0)
     assert attempt.status == LockStatus.ACQUIRED
     attempt.file.close()
 
 
 def test_acquire_singleton_lock_blocks_second_attempt(monkeypatch, tmp_path):
-    """A second acquire in the same process reports HELD while the first is alive."""
+    """A second acquire in the same (NS, domain) reports HELD while the first is alive."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
-    first = _try_acquire_singleton_lock(456)
+    first = _try_acquire_singleton_lock(456, 0)
     assert first.status == LockStatus.ACQUIRED
-    assert _try_acquire_singleton_lock(456).status == LockStatus.HELD
+    assert _try_acquire_singleton_lock(456, 0).status == LockStatus.HELD
     first.file.close()
     # After releasing, a new acquire succeeds.
-    third = _try_acquire_singleton_lock(456)
+    third = _try_acquire_singleton_lock(456, 0)
     assert third.status == LockStatus.ACQUIRED
     third.file.close()
 
@@ -250,12 +262,25 @@ def test_acquire_singleton_lock_independent_per_ipc_ns(monkeypatch, tmp_path):
     """Different IPC NS inodes get independent locks."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
-    lock_a = _try_acquire_singleton_lock(111)
-    lock_b = _try_acquire_singleton_lock(222)
+    lock_a = _try_acquire_singleton_lock(111, 0)
+    lock_b = _try_acquire_singleton_lock(222, 0)
     assert lock_a.status == LockStatus.ACQUIRED
     assert lock_b.status == LockStatus.ACQUIRED
     lock_a.file.close()
     lock_b.file.close()
+
+
+def test_acquire_singleton_lock_independent_per_domain(monkeypatch, tmp_path):
+    """Same IPC NS but different ROS_DOMAIN_ID get independent locks, so two
+    launches sharing a namespace in different domains each run their own agent."""
+    monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
+    from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
+    lock_d1 = _try_acquire_singleton_lock(111, 1)
+    lock_d3 = _try_acquire_singleton_lock(111, 3)
+    assert lock_d1.status == LockStatus.ACQUIRED
+    assert lock_d3.status == LockStatus.ACQUIRED
+    lock_d1.file.close()
+    lock_d3.file.close()
 
 
 def test_acquire_singleton_lock_reports_error_on_unwritable_dir(monkeypatch):
@@ -263,7 +288,7 @@ def test_acquire_singleton_lock_reports_error_on_unwritable_dir(monkeypatch):
     from HELD) so the caller can surface a non-zero exit code."""
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/nonexistent_path_for_agnocast_test')
     from ros2agnocast_discovery_agent.agent import LockStatus, _try_acquire_singleton_lock
-    assert _try_acquire_singleton_lock(789).status == LockStatus.ERROR
+    assert _try_acquire_singleton_lock(789, 0).status == LockStatus.ERROR
 
 
 def test_main_exits_promptly_when_another_agent_holds_the_lock(monkeypatch, tmp_path):
@@ -276,9 +301,10 @@ def test_main_exits_promptly_when_another_agent_holds_the_lock(monkeypatch, tmp_
     """
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', str(tmp_path))
     from ros2agnocast_discovery_agent.agent import (
-        LockStatus, _read_ipc_ns_inode, _try_acquire_singleton_lock, main)
+        LockStatus, _read_ipc_ns_inode, _read_ros_domain_id,
+        _try_acquire_singleton_lock, main)
 
-    holder = _try_acquire_singleton_lock(_read_ipc_ns_inode())
+    holder = _try_acquire_singleton_lock(_read_ipc_ns_inode(), _read_ros_domain_id())
     assert holder.status == LockStatus.ACQUIRED
     try:
         result = {}


### PR DESCRIPTION
## Description

The discovery agent's singleton `flock(2)` (and node name) keyed only on the IPC namespace, so two launches sharing a namespace but using different `ROS_DOMAIN_ID`s deduplicated against each other.

Fix: key the lock path and node name on `(ipc_ns_inode, domain_id)` so each domain runs its own agent. The launch-tree guard (one spawn per `ros2 launch`) is unchanged. No kmod / ABI change.

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894

## How was this PR tested?
- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- **pytest** (`ros2agnocast_discovery_agent`, 45 passed): per-domain lock independence, `_read_ros_domain_id` parsing, `_d<domain>` lock path.
- **Manual** — same IPC namespace, two domains (kmod not required):
  ```bash
  source install/setup.bash
  # shell A / shell B:
  ROS_DOMAIN_ID=1 ros2 launch ros2agnocast_discovery_agent discovery_agent.launch.xml
  ROS_DOMAIN_ID=3 ros2 launch ros2agnocast_discovery_agent discovery_agent.launch.xml

  # verify both agents run:
  ls /dev/shm/agnocast_discovery_agent_*_d*.lock     # -> ..._<ns>_d1.lock AND ..._<ns>_d3.lock
  ROS_DOMAIN_ID=1 ros2 node list | grep discovery    # -> ..._d1
  ROS_DOMAIN_ID=3 ros2 node list | grep discovery    # -> ..._d3
  ```
  Before this fix: a single `..._<ns>.lock`, the second agent logs `another instance is already running ... exiting`, and only one domain shows the node.

## Version Update Label (Required)

- `need-patch-update`
