### PR TITLE
refactor(agnocastlib): remove the BridgeRegistrationPolicy template parameter from pub/sub classes

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -80,8 +80,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRegistrationPolicy>>(
-    node, topic_name, qos, options);
+  return std::make_shared<Publisher<MessageT>>(node, topic_name, qos, options);
 }
 
 /// @brief Create an Agnocast publisher (Stage 1 free function, history-depth overload).
@@ -101,7 +100,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPublisher<MessageT, AgnocastToRosPubsubRegistrationPolicy>>(
+  return std::make_shared<Publisher<MessageT>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), options);
 }
 

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -164,7 +164,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
+  return std::make_shared<Subscription<MessageT>>(
     node, topic_name, qos, std::forward<Func>(callback), options);
 }
 
@@ -187,7 +187,7 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicSubscription<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
+  return std::make_shared<Subscription<MessageT>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
     std::forward<Func>(callback), options);
 }
@@ -207,7 +207,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
+  return std::make_shared<PollingSubscriber<MessageT>>(
     node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
 }
 
@@ -226,8 +226,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_subscription(
   static_assert(
     std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
     "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
-  return std::make_shared<BasicPollingSubscriber<MessageT, RosToAgnocastPubsubRegistrationPolicy>>(
-    node, topic_name, qos);
+  return std::make_shared<PollingSubscriber<MessageT>>(node, topic_name, qos);
 }
 
 /// @brief Create an Agnocast generic subscription (Stage 1 free function, QoS overload).

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -24,8 +24,6 @@
 namespace agnocast
 {
 
-struct NoBridgeRegistrationPolicy;
-
 bool service_is_ready_core(const std::string & service_name);
 bool wait_for_service_nanoseconds(
   const rclcpp::Context::SharedPtr & context, const std::string & service_name,
@@ -99,7 +97,7 @@ private:
   };
 
   using ServiceRequestPublisher = Publisher<RequestT>;
-  using ServiceResponseSubscriber = BasicSubscription<ResponseT, NoBridgeRegistrationPolicy>;
+  using ServiceResponseSubscriber = Subscription<ResponseT>;
 
   std::atomic<int64_t> next_sequence_number_;
   std::mutex seqno2_response_call_info_mtx_;
@@ -151,7 +149,8 @@ private:
     SubscriptionOptions options{group};
     std::string topic_name = create_service_response_topic_name(service_name_, node_name_);
     subscriber_ = std::make_shared<ServiceResponseSubscriber>(
-      node, topic_name, qos, std::move(subscriber_callback), options);
+      node, topic_name, qos, std::move(subscriber_callback), options,
+      SubscriptionRole::AgnocastOnly);
   }
 
 public:

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -98,7 +98,7 @@ private:
     }
   };
 
-  using ServiceRequestPublisher = BasicPublisher<RequestT, NoBridgeRegistrationPolicy>;
+  using ServiceRequestPublisher = Publisher<RequestT>;
   using ServiceResponseSubscriber = BasicSubscription<ResponseT, NoBridgeRegistrationPolicy>;
 
   std::atomic<int64_t> next_sequence_number_;
@@ -124,7 +124,8 @@ private:
 
     agnocast::PublisherOptions pub_options;
     publisher_ = std::make_shared<ServiceRequestPublisher>(
-      node, create_service_request_topic_name(service_name_), qos, pub_options);
+      node, create_service_request_topic_name(service_name_), qos, pub_options,
+      PublisherRole::AgnocastOnly);
 
     auto subscriber_callback = [this, node](ipc_shared_ptr<ResponseT> && response) {
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -6,26 +6,16 @@
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_tracepoint_wrapper.h"
 #include "agnocast/agnocast_utils.hpp"
-#include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialized_message.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
 
-#include <fcntl.h>
 #include <mqueue.h>
-#include <string.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <cstdint>
-#include <cstring>
-#include <functional>
 #include <mutex>
-#include <queue>
-#include <thread>
 
 namespace agnocast
 {
@@ -102,33 +92,7 @@ protected:
   template <typename NodeT>
   rclcpp::QoS init_base(
     NodeT * node, const std::string & topic_name, const std::string & type_name,
-    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge)
-  {
-    if (options.do_always_ros2_publish) {
-      RCLCPP_ERROR(
-        logger,
-        "The 'do_always_ros2_publish' option is deprecated. "
-        "Use the AGNOCAST_BRIDGE_MODE environment variable instead.");
-    }
-
-    topic_name_ = node->get_node_topics_interface()->resolve_topic_name(topic_name);
-
-    auto node_parameters = node->get_node_parameters_interface();
-    const rclcpp::QoS actual_qos =
-      options.qos_overriding_options.get_policy_kinds().size()
-        ? rclcpp::detail::declare_qos_parameters(
-            options.qos_overriding_options, node_parameters, topic_name_, qos,
-            rclcpp::detail::PublisherQosParametersTraits{})
-        : qos;
-
-    validate_publisher_qos(actual_qos);
-
-    const std::string node_name = node->get_fully_qualified_name();
-    id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
-    generate_gid();
-
-    return actual_qos;
-  }
+    const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
 
 public:
   PublisherBase() = default;
@@ -166,14 +130,21 @@ public:
   }
 };
 
-// Internal implementation — users should use agnocast::Publisher<MessageT> instead.
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicPublisher : public PublisherBase
+/**
+ * @brief Mirrors `rclcpp::Publisher` semantics: the topic type is supplied as a template
+ * type argument `MessageT`. It allocates a memory region for a message using
+ * borrow_loaned_message() and publishes it via zero-copy IPC using publish().
+ *
+ * @tparam MessageT ROS message type.
+ */
+AGNOCAST_PUBLIC
+template <typename MessageT>
+class Publisher : public PublisherBase
 {
   template <typename NodeT>
   rclcpp::QoS constructor_impl(
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    const PublisherOptions & options, const bool is_bridge)
+    const PublisherOptions & options, const PublisherRole role)
   {
     // Gated to message types only — service types pulled in by
     // BasicService<ServiceT> have no rosidl message name. The empty string
@@ -183,22 +154,17 @@ class BasicPublisher : public PublisherBase
       type_name = rosidl_generator_traits::name<MessageT>();
     }
 
-    const rclcpp::QoS actual_qos =
-      this->init_base(node, topic_name, type_name, qos, options, is_bridge);
-
-    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
-
-    return actual_qos;
+    return this->init_base(node, topic_name, type_name, qos, options, role);
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicPublisher<MessageT, BridgeRegistrationPolicy>>;
+  using SharedPtr = std::shared_ptr<Publisher<MessageT>>;
 
-  BasicPublisher(
+  Publisher(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    const PublisherOptions & options, const bool is_bridge = false)
+    const PublisherOptions & options, const PublisherRole role = PublisherRole::Default)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, is_bridge);
+    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, role);
 
     TRACEPOINT(
       agnocast_publisher_init, static_cast<const void *>(this),
@@ -207,11 +173,12 @@ public:
       topic_name_.c_str(), actual_qos.depth());
   }
 
-  BasicPublisher(
+  Publisher(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    const PublisherOptions & options = PublisherOptions{})
+    const PublisherOptions & options = PublisherOptions{},
+    const PublisherRole role = PublisherRole::Default)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, false);
+    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, role);
 
     TRACEPOINT(
       agnocast_publisher_init, static_cast<const void *>(this),
@@ -321,18 +288,5 @@ public:
   AGNOCAST_PUBLIC
   void publish(const rclcpp::SerializedMessage & serialized_msg);
 };
-
-struct AgnocastToRosPubsubRegistrationPolicy;
-
-/**
- * @brief The user-facing Agnocast publisher type.
- * Alias for `BasicPublisher<MessageT>`. Use this type (not BasicPublisher directly) when declaring
- * publisher variables.
- * @tparam MessageT  ROS message type.
- */
-AGNOCAST_PUBLIC
-template <typename MessageT>
-using Publisher =
-  agnocast::BasicPublisher<MessageT, agnocast::AgnocastToRosPubsubRegistrationPolicy>;
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -50,7 +50,7 @@ private:
   };
 
   using ServiceResponsePublisher = Publisher<ResponseT>;
-  using ServiceRequestSubscriber = BasicSubscription<RequestT, NoBridgeRegistrationPolicy>;
+  using ServiceRequestSubscriber = Subscription<RequestT>;
 
   const std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string service_name_;
@@ -134,11 +134,13 @@ private:
     if constexpr (is_basic_cb<Func>::value) {
       subscriber_ = std::make_shared<ServiceRequestSubscriber>(
         node, topic_name, qos_,
-        wrap_basic_service_callback_for_subscriber(std::forward<Func>(callback)), options);
+        wrap_basic_service_callback_for_subscriber(std::forward<Func>(callback)), options,
+        SubscriptionRole::AgnocastOnly);
     } else if constexpr (is_deferred_cb<Func>::value) {
       subscriber_ = std::make_shared<ServiceRequestSubscriber>(
         node, topic_name, qos_,
-        wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), options);
+        wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), options,
+        SubscriptionRole::AgnocastOnly);
     }
 
     BridgeRegistrationPolicy::template register_bridge<NodeT, ServiceT>(node, service_name_);

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -49,7 +49,7 @@ private:
     int64_t _sequence_number;
   };
 
-  using ServiceResponsePublisher = BasicPublisher<ResponseT, NoBridgeRegistrationPolicy>;
+  using ServiceResponsePublisher = Publisher<ResponseT>;
   using ServiceRequestSubscriber = BasicSubscription<RequestT, NoBridgeRegistrationPolicy>;
 
   const std::variant<rclcpp::Node *, agnocast::Node *> node_;
@@ -71,7 +71,8 @@ private:
           [this, &pub, &node_name](auto * node) {
             std::string topic_name = create_service_response_topic_name(service_name_, node_name);
             agnocast::PublisherOptions pub_options;
-            pub = std::make_shared<ServiceResponsePublisher>(node, topic_name, qos_, pub_options);
+            pub = std::make_shared<ServiceResponsePublisher>(
+              node, topic_name, qos_, pub_options, PublisherRole::AgnocastOnly);
             publishers_[node_name] = pub;
           },
           node_);

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -41,8 +41,8 @@ extern int agnocast_fd;
 constexpr int64_t ENTRY_ID_NOT_ASSIGNED = -1;
 
 // Forward declaration for friend access
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicPublisher;
+template <typename MessageT>
+class Publisher;
 
 namespace detail
 {
@@ -101,9 +101,9 @@ AGNOCAST_PUBLIC
 template <typename T>
 class ipc_shared_ptr
 {
-  // Allow BasicPublisher to call invalidate_all_references()
-  template <typename MessageT, typename BridgeRegistrationPolicy>
-  friend class BasicPublisher;
+  // Allow Publisher to call invalidate_all_references()
+  template <typename MessageT>
+  friend class Publisher;
 
   // Allow converting constructors to access private members of ipc_shared_ptr<U>
   template <typename U>
@@ -125,7 +125,7 @@ class ipc_shared_ptr
   // Invalidates all references sharing this handle's control block (publisher-side only).
   // After this call, any dereference (operator->, operator*) on copies will std::terminate(),
   // and get()/operator bool() will return nullptr/false.
-  // Private: only BasicPublisher::publish() should call this.
+  // Private: only Publisher::publish() should call this.
   void invalidate_all_references() noexcept
   {
     if (control_) {
@@ -135,7 +135,7 @@ class ipc_shared_ptr
 
   // Publisher-side constructor (entry_id not yet assigned).
   // Creates control block for reference counting and one-shot invalidation.
-  // Private: users must call BasicPublisher::borrow_loaned_message() instead of constructing
+  // Private: users must call Publisher::borrow_loaned_message() instead of constructing
   // directly. This ensures proper memory allocation via the heaphook allocator.
   // Note: ptr must point to heap-allocated memory; destructor calls delete if not published.
   explicit ipc_shared_ptr(T * ptr, const std::string & topic_name, const topic_local_id_t pubsub_id)

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -10,21 +10,14 @@
 #include "rclcpp/detail/qos_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <fcntl.h>
 #include <mqueue.h>
-#include <string.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <atomic>
 #include <cstdint>
-#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace agnocast
@@ -111,9 +104,9 @@ class SubscriptionBase
 protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
-  union ioctl_add_subscriber_args initialize(
+  void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
-    const bool is_bridge, const std::string & node_name, const std::string & type_name);
+    SubscriptionRole role, const std::string & node_name, const std::string & type_name);
 
 public:
   SubscriptionBase(rclcpp::Node * node, const std::string & topic_name);
@@ -140,9 +133,18 @@ public:
   }
 };
 
-// Internal implementation — users should use agnocast::Subscription<MessageT> instead.
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicSubscription : public SubscriptionBase
+/**
+ * @brief Agnocast subscription for a compile-time known message type.
+ *
+ * Delivers messages via a callback that is invoked each time a publisher
+ * writes to the topic. Allocate instances with
+ * `agnocast::create_subscription<MessageT>()` or construct directly.
+ *
+ * @tparam MessageT  ROS message type.
+ */
+AGNOCAST_PUBLIC
+template <typename MessageT>
+class Subscription : public SubscriptionBase
 {
   std::pair<mqd_t, std::string> mq_subscription_;
   uint32_t callback_info_id_;
@@ -151,7 +153,7 @@ class BasicSubscription : public SubscriptionBase
   rclcpp::QoS constructor_impl(
     NodeT * node, const rclcpp::QoS & qos, Func && callback,
     rclcpp::CallbackGroup::SharedPtr callback_group, agnocast::SubscriptionOptions options,
-    const bool is_bridge)
+    SubscriptionRole role)
   {
     const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
@@ -172,11 +174,7 @@ class BasicSubscription : public SubscriptionBase
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    union ioctl_add_subscriber_args add_subscriber_args = initialize(
-      actual_qos, false, options.ignore_local_publications, is_bridge, node_name, type_name);
-
-    id_ = add_subscriber_args.ret_id;
-    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
+    initialize(actual_qos, false, options.ignore_local_publications, role, node_name, type_name);
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
@@ -189,12 +187,12 @@ class BasicSubscription : public SubscriptionBase
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicSubscription<MessageT, BridgeRegistrationPolicy>>;
+  using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
 
   template <typename Func>
-  BasicSubscription(
+  Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
-    agnocast::SubscriptionOptions options, const bool is_bridge = false)
+    agnocast::SubscriptionOptions options, SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
@@ -203,7 +201,7 @@ public:
     const char * callback_symbol = tracetools::get_symbol(callback);
 
     const rclcpp::QoS actual_qos =
-      constructor_impl(node, qos, std::forward<Func>(callback), callback_group, options, is_bridge);
+      constructor_impl(node, qos, std::forward<Func>(callback), callback_group, options, role);
 
     {
       uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id_;
@@ -217,9 +215,10 @@ public:
   }
 
   template <typename Func>
-  BasicSubscription(
+  Subscription(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    Func && callback, agnocast::SubscriptionOptions options)
+    Func && callback, agnocast::SubscriptionOptions options,
+    SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
@@ -228,7 +227,7 @@ public:
     const char * callback_symbol = tracetools::get_symbol(callback);
 
     const rclcpp::QoS actual_qos =
-      constructor_impl(node, qos, std::forward<Func>(callback), callback_group, options, false);
+      constructor_impl(node, qos, std::forward<Func>(callback), callback_group, options, role);
 
     {
       uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id_;
@@ -240,7 +239,7 @@ public:
     }
   }
 
-  ~BasicSubscription()
+  ~Subscription()
   {
     // Remove from callback info map to prevent stale references on re-subscription and to avoid
     // fd reuse conflicts. When mq_close() is called in remove_mq(), the OS may later reuse the
@@ -255,9 +254,17 @@ public:
   }
 };
 
-// Internal implementation — users should use agnocast::TakeSubscription<MessageT> instead.
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicTakeSubscription : public SubscriptionBase
+/**
+ * @brief Agnocast polling take-subscription for a compile-time known message type.
+ *
+ * Does not use a callback; the caller retrieves the latest message by calling
+ * take(). Use PollingSubscriber<MessageT> for a higher-level wrapper.
+ *
+ * @tparam MessageT  ROS message type.
+ */
+AGNOCAST_PUBLIC
+template <typename MessageT>
+class TakeSubscription : public SubscriptionBase
 {
 private:
   // Cached pointer from the most recent take(allow_same_message=true) call.
@@ -268,7 +275,8 @@ private:
 
   template <typename NodeT>
   rclcpp::QoS constructor_impl(
-    NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options)
+    NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options,
+    SubscriptionRole role)
   {
     const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
@@ -289,24 +297,21 @@ private:
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    union ioctl_add_subscriber_args add_subscriber_args =
-      initialize(actual_qos, true, options.ignore_local_publications, false, node_name, type_name);
-
-    id_ = add_subscriber_args.ret_id;
-    BridgeRegistrationPolicy::template register_bridge<MessageT>(topic_name_, id_);
+    initialize(actual_qos, true, options.ignore_local_publications, role, node_name, type_name);
 
     return actual_qos;
   }
 
 public:
-  using SharedPtr = std::shared_ptr<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>;
+  using SharedPtr = std::shared_ptr<TakeSubscription<MessageT>>;
 
-  BasicTakeSubscription(
+  TakeSubscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options);
+    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
 
     {
       auto default_cbg = node->get_node_base_interface()->get_default_callback_group();
@@ -321,12 +326,13 @@ public:
     }
   }
 
-  BasicTakeSubscription(
+  TakeSubscription(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options);
+    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
 
     {
       auto default_cbg = get_default_callback_group_for_tracepoint(node);
@@ -413,29 +419,40 @@ public:
   }
 };
 
-// Internal implementation — users should use agnocast::PollingSubscriber<MessageT> instead.
-template <typename MessageT, typename BridgeRegistrationPolicy>
-class BasicPollingSubscriber
+/**
+ * @brief Agnocast polling subscriber for a compile-time known message type.
+ *
+ * Wraps TakeSubscription<MessageT> and exposes a simple take_data() API
+ * that always returns the most recent message (or an empty pointer if nothing
+ * has been published yet).
+ *
+ * @tparam MessageT  ROS message type.
+ */
+AGNOCAST_PUBLIC
+template <typename MessageT>
+class PollingSubscriber
 {
-  typename BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>::SharedPtr subscriber_;
+  typename TakeSubscription<MessageT>::SharedPtr subscriber_;
 
 public:
-  using SharedPtr = std::shared_ptr<BasicPollingSubscriber<MessageT, BridgeRegistrationPolicy>>;
+  using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT>>;
 
-  explicit BasicPollingSubscriber(
+  explicit PollingSubscriber(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1},
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
   {
-    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>(
-      node, topic_name, qos, options);
+    subscriber_ =
+      std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options, role);
   };
 
-  explicit BasicPollingSubscriber(
+  explicit PollingSubscriber(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1},
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions())
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
   {
-    subscriber_ = std::make_shared<BasicTakeSubscription<MessageT, BridgeRegistrationPolicy>>(
-      node, topic_name, qos, options);
+    subscriber_ =
+      std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options, role);
   };
 
   /// @deprecated Use take_data() instead.
@@ -543,31 +560,5 @@ public:
   // (forward-declared in this header via agnocast_callback_info.hpp).
   ~GenericSubscription();
 };
-
-struct RosToAgnocastPubsubRegistrationPolicy;
-
-/// @brief The user-facing event-driven subscription type.
-/// Alias for `BasicSubscription<MessageT>`. Use this type (not BasicSubscription directly) when
-/// declaring subscription variables.
-AGNOCAST_PUBLIC
-template <typename MessageT>
-using Subscription =
-  agnocast::BasicSubscription<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
-
-/// @brief The user-facing polling take-subscription type.
-/// Alias for `BasicTakeSubscription<MessageT>`. Use this type (not BasicTakeSubscription directly)
-/// when declaring take-subscription variables.
-AGNOCAST_PUBLIC
-template <typename MessageT>
-using TakeSubscription =
-  agnocast::BasicTakeSubscription<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
-
-/// @brief The user-facing polling subscriber type.
-/// Alias for `BasicPollingSubscriber<MessageT>`. Use this type (not BasicPollingSubscriber
-/// directly) when declaring polling subscriber variables.
-AGNOCAST_PUBLIC
-template <typename MessageT>
-using PollingSubscriber =
-  agnocast::BasicPollingSubscriber<MessageT, agnocast::RosToAgnocastPubsubRegistrationPolicy>;
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -30,9 +30,6 @@ namespace agnocast
 
 static constexpr size_t DEFAULT_QOS_DEPTH = 10;
 
-template <typename MessageT>
-void send_performance_pubsub_bridge_registration(
-  const std::string & topic_name, topic_local_id_t id, BridgeDirection direction);
 inline void send_performance_pubsub_bridge_registration_by_type_name(
   const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
   BridgeDirection direction);
@@ -40,16 +37,6 @@ template <typename ServiceT>
 void send_performance_service_bridge_registration(
   const std::string & service_name, BridgeDirection direction,
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity);
-
-template <typename MessageT>
-void register_pubsub_bridge_core(
-  const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
-{
-  auto bridge_mode = get_bridge_mode();
-  if (bridge_mode == BridgeMode::On) {
-    send_performance_pubsub_bridge_registration<MessageT>(topic_name, id, direction);
-  }
-}
 
 inline void register_pubsub_bridge_by_type_name(
   const std::string & topic_name, topic_local_id_t id, const std::string & message_type,
@@ -74,17 +61,6 @@ void register_service_bridge_core(
   }
 }
 
-// Policy for agnocast::Subscription.
-// Registers a bridge that forwards messages from ROS 2 to Agnocast (R2A).
-struct RosToAgnocastPubsubRegistrationPolicy
-{
-  template <typename MessageT>
-  static void register_bridge(const std::string & topic_name, topic_local_id_t id)
-  {
-    register_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::ROS2_TO_AGNOCAST);
-  }
-};
-
 // Policy for agnocast::Service.
 // Registers a bridge that forwards requests from ROS 2 to Agnocast (R2A).
 struct RosToAgnocastServiceRegistrationPolicy
@@ -99,25 +75,6 @@ struct RosToAgnocastServiceRegistrationPolicy
     }
     register_service_bridge_core<ServiceT>(
       service_name, BridgeDirection::ROS2_TO_AGNOCAST, shadow_node_identity);
-  }
-};
-
-// Dummy policy to avoid circular header dependencies.
-// Used internally by BridgeNode, Service, and Client where bridge registrations
-// are not needed and would cause include cycles.
-struct NoBridgeRegistrationPolicy
-{
-  template <typename T, typename... Args>
-  static void register_bridge(Args &&... args)
-  {
-    register_bridge_impl(std::forward<Args>(args)...);
-  }
-
-private:
-  static void register_bridge_impl(const std::string &, topic_local_id_t) {}
-  template <typename NodeT>
-  static void register_bridge_impl(NodeT *, const std::string &)
-  {
   }
 };
 
@@ -161,15 +118,6 @@ void send_mq_message(
   }
 
   mq_close(mq);
-}
-
-template <typename MessageT>
-void send_performance_pubsub_bridge_registration(
-  const std::string & topic_name, topic_local_id_t id, BridgeDirection direction)
-{
-  const std::string message_type_name = rosidl_generator_traits::name<MessageT>();
-  send_performance_pubsub_bridge_registration_by_type_name(
-    topic_name, id, message_type_name, direction);
 }
 
 inline void send_performance_pubsub_bridge_registration_by_type_name(

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -85,17 +85,6 @@ struct RosToAgnocastPubsubRegistrationPolicy
   }
 };
 
-// Policy for agnocast::Publisher.
-// Registers a bridge that forwards messages from Agnocast to ROS 2 (A2R).
-struct AgnocastToRosPubsubRegistrationPolicy
-{
-  template <typename MessageT>
-  static void register_bridge(const std::string & topic_name, topic_local_id_t id)
-  {
-    register_pubsub_bridge_core<MessageT>(topic_name, id, BridgeDirection::AGNOCAST_TO_ROS2);
-  }
-};
-
 // Policy for agnocast::Service.
 // Registers a bridge that forwards requests from ROS 2 to Agnocast (R2A).
 struct RosToAgnocastServiceRegistrationPolicy

--- a/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
+++ b/src/agnocastlib/include/agnocast/message_filters/subscriber.hpp
@@ -276,7 +276,7 @@ public:
       topic_ = topic;
       qos_ = qos;
       options_ = options;
-      sub_ = std::make_shared<BasicSubscription<M, RosToAgnocastPubsubRegistrationPolicy>>(
+      sub_ = std::make_shared<Subscription<M>>(
         node, topic, detail::to_rclcpp_qos(qos),
         [this](ipc_shared_ptr<M> msg) { this->cb(std::move(msg)); }, options);
       node_raw_ = node;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -217,7 +217,7 @@ rclcpp::QoS PublisherBase::init_base(
   topic_name_ = node->get_node_topics_interface()->resolve_topic_name(topic_name);
 
   auto node_parameters = node->get_node_parameters_interface();
-  const rclcpp::QoS actual_qos = options.qos_overriding_options.get_policy_kinds().size()
+  const rclcpp::QoS actual_qos = !options.qos_overriding_options.get_policy_kinds().empty()
                                    ? rclcpp::detail::declare_qos_parameters(
                                        options.qos_overriding_options, node_parameters, topic_name_,
                                        qos, rclcpp::detail::PublisherQosParametersTraits{})

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -231,8 +231,16 @@ rclcpp::QoS PublisherBase::init_base(
   generate_gid();
 
   if (role == PublisherRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, type_name, BridgeDirection::AGNOCAST_TO_ROS2);
+    if (!type_name.empty()) {
+      register_pubsub_bridge_by_type_name(
+        topic_name_, id_, type_name, BridgeDirection::AGNOCAST_TO_ROS2);
+    } else {
+      RCLCPP_WARN(
+        logger,
+        "Bridge registration is skipped because the type_name is empty (topic: '%s'). "
+        "Please make sure to specify the valid message type in normal use case.",
+        topic_name_.c_str());
+    }
   }
 
   return actual_qos;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -235,9 +235,9 @@ rclcpp::QoS PublisherBase::init_base(
       register_pubsub_bridge_by_type_name(
         topic_name_, id_, type_name, BridgeDirection::AGNOCAST_TO_ROS2);
     } else {
-      RCLCPP_WARN(
+      RCLCPP_ERROR(
         logger,
-        "Bridge registration is skipped because the type_name is empty (topic: '%s'). "
+        "A2R bridge registration is skipped because the type_name is empty (topic: '%s'). "
         "Please make sure to specify the valid message type in normal use case.",
         topic_name_.c_str());
     }

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -3,6 +3,7 @@
 #include "agnocast/bridge/agnocast_bridge_node.hpp"
 #include "agnocast/internal/type_registry_writer.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "rclcpp/detail/qos_parameters.hpp"
 
 #include <rclcpp/typesupport_helpers.hpp>
 #include <rosidl_runtime_cpp/message_initialization.hpp>
@@ -201,6 +202,49 @@ uint32_t get_intra_subscription_count_core(const std::string & topic_name)
   return get_subscriber_count_args.ret_same_process_subscriber_num;
 }
 
+template <typename NodeT>
+rclcpp::QoS PublisherBase::init_base(
+  NodeT * node, const std::string & topic_name, const std::string & type_name,
+  const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role)
+{
+  if (options.do_always_ros2_publish) {
+    RCLCPP_ERROR(
+      logger,
+      "The 'do_always_ros2_publish' option is deprecated. "
+      "Use the AGNOCAST_BRIDGE_MODE environment variable instead.");
+  }
+
+  topic_name_ = node->get_node_topics_interface()->resolve_topic_name(topic_name);
+
+  auto node_parameters = node->get_node_parameters_interface();
+  const rclcpp::QoS actual_qos = options.qos_overriding_options.get_policy_kinds().size()
+                                   ? rclcpp::detail::declare_qos_parameters(
+                                       options.qos_overriding_options, node_parameters, topic_name_,
+                                       qos, rclcpp::detail::PublisherQosParametersTraits{})
+                                   : qos;
+
+  validate_publisher_qos(actual_qos);
+
+  const bool is_bridge = (role == PublisherRole::BridgeInternal);
+  const std::string node_name = node->get_fully_qualified_name();
+  id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
+  generate_gid();
+
+  if (role == PublisherRole::Default) {
+    register_pubsub_bridge_by_type_name(
+      topic_name_, id_, type_name, BridgeDirection::AGNOCAST_TO_ROS2);
+  }
+
+  return actual_qos;
+}
+
+template rclcpp::QoS PublisherBase::init_base<rclcpp::Node>(
+  rclcpp::Node *, const std::string &, const std::string &, const rclcpp::QoS &,
+  const PublisherOptions &, PublisherRole);
+template rclcpp::QoS PublisherBase::init_base<agnocast::Node>(
+  agnocast::Node *, const std::string &, const std::string &, const rclcpp::QoS &,
+  const PublisherOptions &, PublisherRole);
+
 void PublisherBase::generate_gid()
 {
   constexpr size_t kPidOffset = 2;
@@ -286,16 +330,7 @@ rclcpp::QoS GenericPublisher::constructor_impl(
   members_ = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
     introspection_handle->data);
 
-  const bool is_bridge = (role == PublisherRole::BridgeInternal);
-  const rclcpp::QoS actual_qos =
-    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
-
-  if (role == PublisherRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
-  }
-
-  return actual_qos;
+  return this->init_base(node, topic_name, topic_type, qos, options, role);
 }
 
 GenericPublisher::GenericPublisher(

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -53,8 +53,16 @@ void SubscriptionBase::initialize(
   id_ = add_subscriber_args.ret_id;
 
   if (role == SubscriptionRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, type_name, BridgeDirection::ROS2_TO_AGNOCAST);
+    if (!type_name.empty()) {
+      register_pubsub_bridge_by_type_name(
+        topic_name_, id_, type_name, BridgeDirection::ROS2_TO_AGNOCAST);
+    } else {
+      RCLCPP_WARN(
+        logger,
+        "Bridge registration is skipped because the type_name is empty (topic: '%s'). "
+        "Please make sure to specify the valid message type in normal use case.",
+        topic_name_.c_str());
+    }
   }
 }
 

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -1,4 +1,5 @@
 #include "agnocast/agnocast.hpp"
+#include "agnocast/bridge/agnocast_bridge_node.hpp"
 #include "agnocast/internal/type_registry_writer.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 #include "rclcpp/typesupport_helpers.hpp"
@@ -21,9 +22,9 @@ SubscriptionBase::SubscriptionBase(
   validate_ld_preload();
 }
 
-union ioctl_add_subscriber_args SubscriptionBase::initialize(
+void SubscriptionBase::initialize(
   const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
-  const bool is_bridge, const std::string & node_name, const std::string & type_name)
+  SubscriptionRole role, const std::string & node_name, const std::string & type_name)
 {
   // Announce to the per-IPC-namespace discovery agent before the kmod call so
   // the registry line is in place whenever a later snapshot sees the
@@ -42,14 +43,19 @@ union ioctl_add_subscriber_args SubscriptionBase::initialize(
   add_subscriber_args.qos_is_reliable = qos.reliability() == rclcpp::ReliabilityPolicy::Reliable;
   add_subscriber_args.is_take_sub = is_take_sub;
   add_subscriber_args.ignore_local_publications = ignore_local_publications;
-  add_subscriber_args.is_bridge = is_bridge;
+  add_subscriber_args.is_bridge = (role == SubscriptionRole::BridgeInternal);
   if (ioctl(agnocast_fd, AGNOCAST_ADD_SUBSCRIBER_CMD, &add_subscriber_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_ADD_SUBSCRIBER_CMD failed: %s", strerror(errno));
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
 
-  return add_subscriber_args;
+  id_ = add_subscriber_args.ret_id;
+
+  if (role == SubscriptionRole::Default) {
+    register_pubsub_bridge_by_type_name(
+      topic_name_, id_, type_name, BridgeDirection::ROS2_TO_AGNOCAST);
+  }
 }
 
 uint32_t get_publisher_count_core(const std::string & topic_name)
@@ -158,16 +164,7 @@ rclcpp::QoS GenericSubscription::constructor_impl(
 
   const std::string node_name = node->get_fully_qualified_name();
 
-  const bool is_bridge = (role == SubscriptionRole::BridgeInternal);
-  union ioctl_add_subscriber_args add_subscriber_args = initialize(
-    actual_qos, false, options.ignore_local_publications, is_bridge, node_name, topic_type);
-
-  id_ = add_subscriber_args.ret_id;
-
-  if (role == SubscriptionRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, topic_type, BridgeDirection::ROS2_TO_AGNOCAST);
-  }
+  initialize(actual_qos, false, options.ignore_local_publications, role, node_name, topic_type);
 
   mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -57,9 +57,9 @@ void SubscriptionBase::initialize(
       register_pubsub_bridge_by_type_name(
         topic_name_, id_, type_name, BridgeDirection::ROS2_TO_AGNOCAST);
     } else {
-      RCLCPP_WARN(
+      RCLCPP_ERROR(
         logger,
-        "Bridge registration is skipped because the type_name is empty (topic: '%s'). "
+        "R2A bridge registration is skipped because the type_name is empty (topic: '%s'). "
         "Please make sure to specify the valid message type in normal use case.",
         topic_name_.c_str());
     }

--- a/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_transform_listener.cpp
@@ -62,17 +62,14 @@ void remove_mq(const std::pair<mqd_t, std::string> &)
 {
 }
 
-union ioctl_add_subscriber_args SubscriptionBase::initialize(
-  const rclcpp::QoS & qos, const bool, const bool, const bool, const std::string &,
+void SubscriptionBase::initialize(
+  const rclcpp::QoS & qos, const bool, const bool, SubscriptionRole, const std::string &,
   const std::string &)
 {
   initialize_subscriber_call_count++;
   initialized_topic_names.push_back(topic_name_);
   initialized_qos_values.push_back(qos);
-  union ioctl_add_subscriber_args args {
-  };
-  args.ret_id = 0;
-  return args;
+  id_ = 0;
 }
 
 BridgeMode get_bridge_mode()

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -20,14 +20,14 @@ extern "C" PerformancePubsubBridgeResult create_r2a_pubsub_bridge_@(snake_type_n
   const rclcpp::QoS & sub_qos)
 {
   using MsgT = @(cpp_type);
-  using AgnoPub = agnocast::BasicPublisher<MsgT, agnocast::NoBridgeRegistrationPolicy>;
+  using AgnoPub = agnocast::Publisher<MsgT>;
 
   auto agno_pub = std::make_shared<AgnoPub>(
     node.get(),
     topic_name,
     rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).transient_local(),
     agnocast::PublisherOptions{},
-    true);
+    agnocast::PublisherRole::BridgeInternal);
 
   return create_r2a_generic_bridge(
     node, topic_name, sub_qos, "@(msg_type)",

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -79,14 +79,14 @@ extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge_@(snake_type_n
   sub_opts.ignore_local_publications = true;
   sub_opts.callback_group = cb_group;
 
-  using AgnoSub = agnocast::BasicSubscription<MsgT, agnocast::NoBridgeRegistrationPolicy>;
+  using AgnoSub = agnocast::Subscription<MsgT>;
   auto agno_sub = std::make_shared<AgnoSub>(
     node.get(),
     topic_name,
     sub_qos,
     agno_callback,
     sub_opts,
-    true);
+    agnocast::SubscriptionRole::BridgeInternal);
 
   return {agno_sub, cb_group};
 }


### PR DESCRIPTION
## Description

Removes the `BridgeRegistrationPolicy` template parameter from the pub/sub types (`Publisher`, `Subscription`, `TakeSubscription`, `PollingSubscriber`).

### Background

Previously, bridge registration behavior was controlled by a policy type as a second template argument (e.g., `BasicPublisher<MessageT, AgnocastToRosPubsubRegistrationPolicy>`). The user-facing types (like `Publisher<MessageT>`) were type aliases for these `Basic*` template classes. 

This design had the following drawbacks:

- **Code duplication**: The bridge registration call was duplicated in every `constructor_impl`. Each policy struct was just a basic wrapper doing the same thing.
- **Unnecessary template complexity**: The `BridgeRegistrationPolicy` parameter was originally added to fix a circular header dependency (#750). Since that issue is now resolved, we no longer need it. We can simply use an enum (`PublisherRole` / `SubscriptionRole`) as a constructor argument to control bridge requests.

> **Note:** Using a policy pattern does not significantly reduce runtime overhead here, because it is only called once during construction. Instead, removing it improves build times and reduces header dependencies.

### Changes

- **Replaced template classes with concrete classes**: `BasicPublisher<MessageT, Policy>`, `BasicSubscription<MessageT, Policy>`, etc., are now replaced by `Publisher<MessageT>`, `Subscription<MessageT>`, etc. These new classes take an enum (`PublisherRole` / `SubscriptionRole`) instead of a template policy.
- **Consolidated registration logic**: Bridge registration logic is merged into `PublisherBase::init_base` and `SubscriptionBase::initialize`. This removes duplicated calls from each class.
- **Moved implementation to `.cpp` file**: Moved `PublisherBase::init_base` from the header file to `agnocast_publisher.cpp` (with explicit instantiations for `rclcpp::Node` and `agnocast::Node`). This reduces header dependencies and speeds up incremental builds.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

This PR does not change `BasicService<ServiceT, BridgeRegistrationPolicy>`. Service-level bridge registration uses a different policy mechanism. We will update it in a future PR (follow-up).

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` because the public APIs marked as `AGNOCAST_PUBLIC` are not changed. 