### PR TITLE
refactor(agnocastlib): extract common code in subscription to SubscriptionBase

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -108,6 +108,11 @@ protected:
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     SubscriptionRole role, const std::string & node_name, const std::string & type_name);
 
+  template <typename NodeT>
+  rclcpp::QoS init_base(
+    NodeT * node, const rclcpp::QoS & qos, const std::string & type_name, bool is_take_sub,
+    const SubscriptionOptions & options, SubscriptionRole role);
+
 public:
   SubscriptionBase(rclcpp::Node * node, const std::string & topic_name);
   SubscriptionBase(agnocast::Node * node, const std::string & topic_name);
@@ -155,18 +160,6 @@ class Subscription : public SubscriptionBase
     rclcpp::CallbackGroup::SharedPtr callback_group, agnocast::SubscriptionOptions options,
     SubscriptionRole role)
   {
-    const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
-      override_qos ? node->get_node_parameters_interface() : nullptr;
-    const rclcpp::QoS actual_qos =
-      override_qos ? rclcpp::detail::declare_qos_parameters(
-                       options.qos_overriding_options, node_parameters, topic_name_, qos,
-                       rclcpp::detail::SubscriptionQosParametersTraits{})
-                   : qos;
-
-    validate_subscription_qos(actual_qos);
-
-    const std::string node_name = node->get_fully_qualified_name();
     // Gated to message types — service types pulled in by
     // BasicService<ServiceT> have no rosidl message name. The empty string
     // signals "skip registry" to initialize().
@@ -174,7 +167,8 @@ class Subscription : public SubscriptionBase
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    initialize(actual_qos, false, options.ignore_local_publications, role, node_name, type_name);
+
+    const rclcpp::QoS actual_qos = init_base(node, qos, type_name, false, options, role);
 
     mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 
@@ -278,18 +272,6 @@ private:
     NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options,
     SubscriptionRole role)
   {
-    const bool override_qos = options.qos_overriding_options.get_policy_kinds().size() > 0;
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
-      override_qos ? node->get_node_parameters_interface() : nullptr;
-    const rclcpp::QoS actual_qos =
-      override_qos ? rclcpp::detail::declare_qos_parameters(
-                       options.qos_overriding_options, node_parameters, topic_name_, qos,
-                       rclcpp::detail::SubscriptionQosParametersTraits{})
-                   : qos;
-
-    validate_subscription_qos(actual_qos);
-
-    const std::string node_name = node->get_fully_qualified_name();
     // Gated to message types — service types pulled in by
     // BasicService<ServiceT> have no rosidl message name. The empty string
     // signals "skip registry" to initialize().
@@ -297,9 +279,7 @@ private:
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    initialize(actual_qos, true, options.ignore_local_publications, role, node_name, type_name);
-
-    return actual_qos;
+    return init_base(node, qos, type_name, true, options, role);
   }
 
 public:

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -66,6 +66,37 @@ void SubscriptionBase::initialize(
   }
 }
 
+template <typename NodeT>
+rclcpp::QoS SubscriptionBase::init_base(
+  NodeT * node, const rclcpp::QoS & qos, const std::string & type_name, bool is_take_sub,
+  const SubscriptionOptions & options, SubscriptionRole role)
+{
+  const bool override_qos = !options.qos_overriding_options.get_policy_kinds().empty();
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
+    override_qos ? node->get_node_parameters_interface() : nullptr;
+  const rclcpp::QoS actual_qos = override_qos
+                                   ? rclcpp::detail::declare_qos_parameters(
+                                       options.qos_overriding_options, node_parameters, topic_name_,
+                                       qos, rclcpp::detail::SubscriptionQosParametersTraits{})
+                                   : qos;
+
+  validate_subscription_qos(actual_qos);
+
+  const std::string node_name = node->get_fully_qualified_name();
+  initialize(
+    actual_qos, is_take_sub, options.ignore_local_publications, role, node_name, type_name);
+
+  return actual_qos;
+}
+
+template rclcpp::QoS SubscriptionBase::init_base<rclcpp::Node>(
+  rclcpp::Node *, const rclcpp::QoS &, const std::string &, bool, const SubscriptionOptions &,
+  SubscriptionRole);
+
+template rclcpp::QoS SubscriptionBase::init_base<agnocast::Node>(
+  agnocast::Node *, const rclcpp::QoS &, const std::string &, bool, const SubscriptionOptions &,
+  SubscriptionRole);
+
 uint32_t get_publisher_count_core(const std::string & topic_name)
 {
   union ioctl_get_publisher_num_args args = {};
@@ -159,20 +190,7 @@ rclcpp::QoS GenericSubscription::constructor_impl(
   TypeErasedCallback callback, rclcpp::CallbackGroup::SharedPtr callback_group,
   const agnocast::SubscriptionOptions & options, SubscriptionRole role)
 {
-  const bool override_qos = !options.qos_overriding_options.get_policy_kinds().empty();
-  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
-    override_qos ? node->get_node_parameters_interface() : nullptr;
-  const rclcpp::QoS actual_qos = override_qos
-                                   ? rclcpp::detail::declare_qos_parameters(
-                                       options.qos_overriding_options, node_parameters, topic_name_,
-                                       qos, rclcpp::detail::SubscriptionQosParametersTraits{})
-                                   : qos;
-
-  validate_subscription_qos(actual_qos);
-
-  const std::string node_name = node->get_fully_qualified_name();
-
-  initialize(actual_qos, false, options.ignore_local_publications, role, node_name, topic_type);
+  const rclcpp::QoS actual_qos = init_base(node, qos, topic_type, false, options, role);
 
   mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
 


### PR DESCRIPTION
## Description

Extract the duplicated sequence below into `SubscriptionBase::init_base<NodeT>`, eliminating repetition across three `constructor_impl` methods (`Subscription`, `TakeSubscription`, `GenericSubscription`):

1. QoS override calculation (`declare_qos_parameters`)
2. `validate_subscription_qos`
3. `initialize` call

Also unifies the `!options.qos_overriding_options.get_policy_kinds().empty()` check style (`.size() > 0` → `.empty()`), which was already used in `GenericSubscription`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`