### PR TITLE
fix(ci): apt update before rosdep install

### DIFF
--- a/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
+++ b/.github/workflows/build-and-test-agnocastlib-components-heaphook.yaml
@@ -95,6 +95,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends python3-rosdep
         sudo rosdep init
         rosdep update
+        sudo apt-get update
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO --skip-keys glog
 
     - name: Cache ccache


### PR DESCRIPTION
## Description
The `rosdep install` step was failing with a 404 when fetching `ros-jazzy-diagnostic-updater`, because ROS packages are rebuilt daily and the apt index from the earlier `apt-get update` had gone stale,pointing at a superseded .deb.
This adds a `sudo apt-get update` right before `rosdep install` to refresh the index and resolve the latest available versions.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
