### PR TITLE
fix(ros2agnocast_discovery_agent): scope each agent's discovery to its own domain

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -133,13 +133,21 @@ def _ioctl_to_endpoint(
     return ep
 
 
-def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
+def read_local_topics(
+        lib, registry: TypeRegistryReader | None = None,
+        own_domain_id: int | None = None) -> list:
     """Snapshot the current namespace's Agnocast topics via the ioctl wrapper.
 
     Returns a list of AgnocastTopic msgs. The ioctl returns only the caller's
     IPC namespace, so the daemon process just being inside that namespace is
     sufficient to scope the result. The optional ``registry`` argument
     supplies the type names and pids that the ioctl does not expose.
+
+    When ``own_domain_id`` is given, only topics in that domain are returned.
+    Each agent is per-(IPC namespace, domain) and gossips on its own DDS domain,
+    so it must report only its own domain's topics; otherwise it would leak
+    other domains' endpoints onto its channel and let its bridge decider issue
+    requests for domains it does not own.
     """
     topic_count = ctypes.c_int()
     # The wrapper allocates the domain array (sized to match the name buffer) and
@@ -158,6 +166,8 @@ def read_local_topics(lib, registry: TypeRegistryReader | None = None) -> list:
             # The same topic name can occur once per domain; each row is a
             # distinct (name, domain) pair that becomes its own AgnocastTopic.
             domain_id = domain_ids_ptr[i]
+            if own_domain_id is not None and domain_id != own_domain_id:
+                continue
 
             agnocast_topic = AgnocastTopic()
             agnocast_topic.topic_name = topic_name
@@ -413,7 +423,7 @@ class DiscoveryAgent(Node):
         msg.host_uuid = self._host_uuid
         msg.host_hostname = self._host_hostname
         msg.ipc_ns_inode = self._ipc_ns_inode
-        msg.topics = read_local_topics(self._lib, self._registry)
+        msg.topics = read_local_topics(self._lib, self._registry, self._domain_id)
         return msg
 
     def _on_remote_state(self, msg: AgnocastDaemonState) -> None:

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -165,6 +165,20 @@ def test_read_local_topics_stamps_domain_id():
     assert domain_arg == 7
 
 
+def test_read_local_topics_filters_by_own_domain():
+    """A per-(NS, domain) agent reports only its own domain's topics."""
+    lib = _make_mock_lib(
+        {
+            '/chatter': {'pub': [_make_info('/talker_d1')], 'sub': []},
+            '/mrm': {'pub': [_make_info('/talker_d3')], 'sub': []},
+        },
+        topic_domains={'/chatter': 1, '/mrm': 3})
+
+    topics = read_local_topics(lib, own_domain_id=1)
+    assert [t.topic_name for t in topics] == ['/chatter']
+    assert topics[0].domain_id == 1
+
+
 def test_read_local_topics_resolves_type_from_registry():
     """A registry entry for any endpoint on the topic populates `type_name`."""
     from ros2agnocast_discovery_agent.type_registry import RegistryEntry


### PR DESCRIPTION
> **Stacked on #1410.** 51894 follow-up (sibling to the domain-bridge stack #1416–#1418).

## Description

Each discovery agent is per-(IPC namespace, `ROS_DOMAIN_ID`), but `read_local_topics` enumerated and gossiped **every** domain's topics. That leaked other domains' endpoints onto the agent's own DDS channel and let its bridge decider issue requests for domains it does not own (duplicating what another domain's agent already makes).

This PR filters `read_local_topics` to the agent's own `ROS_DOMAIN_ID`, so each agent reports and bridges only its own domain — consistent with the per-(NS, domain) model. The decider needs no change: with the local snapshot scoped, cross-domain remote topics no longer match. The signature stays backward-compatible (`own_domain_id=None` ⇒ no filter), so existing tests are unaffected.

Follow-up to #1410 (which made the bridge *decisions* domain-aware; this makes the *enumeration / gossip* domain-aware).

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51894
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Discovery-agent (Python) change only — no kmod / agnocastlib / ABI change — so the kernel-module and e2e items above are N/A. Verified with:

- `pytest` (`ros2agnocast_discovery_agent`, 50 passed), including a new case asserting an agent reports only its own domain's topics (`test_read_local_topics_filters_by_own_domain`).

## Version Update Label

- `need-patch-update` (discovery agent only; no kmod / ABI change)
