### PR TITLE
feat(agnocast_kmod)[needs minor version update]: domain bridge for same-IPC-namespace cross-domain zero-copy

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -45,6 +45,9 @@ jobs:
           # COMPLEX_MACRO: the KUnit suite's TEST_CASES_* macros are comma-separated
           # KUNIT_CASE(...) lists that cannot be parenthesized; this is a false positive.
           IGNORE="$IGNORE,COMPLEX_MACRO"
+          # FILE_PATH_CHANGES: agnocast is an out-of-tree module with no entry in the
+          # kernel MAINTAINERS file, so adding or moving kmod files never needs one.
+          IGNORE="$IGNORE,FILE_PATH_CHANGES"
 
           git diff origin/${{ github.base_ref }}...HEAD -- agnocast_kmod/ \
             | ./checkpatch.pl --no-tree --show-types --ignore="$IGNORE" -

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -278,6 +278,13 @@ struct ioctl_set_ros2_publisher_num_args
   uint32_t ros2_publisher_num;
 };
 
+struct ioctl_add_domain_bridge_args
+{
+  struct name_info topic_name;
+  uint32_t from_domain;
+  uint32_t to_domain;
+};
+
 #define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
 #define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
 #define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
@@ -301,6 +308,7 @@ struct ioctl_set_ros2_publisher_num_args
   _IOW(0xA6, 25, struct ioctl_set_ros2_subscriber_num_args)
 #define AGNOCAST_SET_ROS2_PUBLISHER_NUM_CMD _IOW(0xA6, 26, struct ioctl_set_ros2_publisher_num_args)
 #define AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD _IO(0xA6, 27)
+#define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)
 
 // ================================================
 // ros2cli ioctls
@@ -442,6 +450,10 @@ int agnocast_ioctl_add_bridge(
 int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, bool is_r2a, const struct ipc_namespace * ipc_ns);
 
+int agnocast_ioctl_add_domain_bridge(
+  const char * topic_name, uint32_t from_domain, uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns);
+
 int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret);
 
 int agnocast_ioctl_get_topic_subscriber_info(
@@ -514,4 +526,7 @@ int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns);
 bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_namespace * ipc_ns);
+bool agnocast_get_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
+  uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
 #endif

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -529,4 +529,8 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
 bool agnocast_get_domain_rule(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
   uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
+// Returns the shared topic_struct's wrapper refcount for the wrapper in domain_id,
+// or 0 if no such wrapper exists. Used to observe domain-bridge grouping.
+int agnocast_topic_wrapper_refcnt(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id);
 #endif

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -37,10 +37,7 @@ static void remove_all_topics(void)
       kfree(sub_info);
     }
 
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+    agnocast_release_topic_wrapper(wrapper);
   }
 }
 

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -71,6 +71,19 @@ static void remove_all_bridge_info(void)
   }
 }
 
+static void remove_all_domain_rules(void)
+{
+  struct domain_bridge_rule * rule;
+  int bkt;
+  struct hlist_node * tmp;
+  hash_for_each_safe(domain_rule_htable, bkt, tmp, rule, node)
+  {
+    hash_del(&rule->node);
+    kfree(rule->topic_name);
+    kfree(rule);
+  }
+}
+
 // Called during module unload. Not an ioctl function, so we manage locks here directly.
 void agnocast_exit_free_data(void)
 {
@@ -78,6 +91,7 @@ void agnocast_exit_free_data(void)
   remove_all_topics();
   remove_all_process_info();
   remove_all_bridge_info();
+  remove_all_domain_rules();
   up_write(&global_htables_rwsem);
 }
 

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -7,36 +7,10 @@ static void remove_all_topics(void)
   struct hlist_node * tmp;
   int bkt;
 
+  // release frees the shared topic_struct (rbtree + pub/sub tables) once its
+  // last wrapper goes; for a grouped pair that is the second wrapper.
   hash_for_each_safe(topic_hashtable, bkt, tmp, wrapper, node)
   {
-    struct rb_root * root = &wrapper->topic->entries;
-    struct rb_node * node = rb_first(root);
-    while (node) {
-      struct entry_node * en = rb_entry(node, struct entry_node, node);
-      node = rb_next(node);
-      agnocast_remove_entry_node(wrapper, en);
-    }
-
-    struct publisher_info * pub_info;
-    int bkt_pub_info;
-    struct hlist_node * tmp_pub_info;
-    hash_for_each_safe(wrapper->topic->pub_info_htable, bkt_pub_info, tmp_pub_info, pub_info, node)
-    {
-      hash_del(&pub_info->node);
-      kfree(pub_info->node_name);
-      kfree(pub_info);
-    }
-
-    struct subscriber_info * sub_info;
-    int bkt_sub_info;
-    struct hlist_node * tmp_sub_info;
-    hash_for_each_safe(wrapper->topic->sub_info_htable, bkt_sub_info, tmp_sub_info, sub_info, node)
-    {
-      hash_del(&sub_info->node);
-      kfree(sub_info->node_name);
-      kfree(sub_info);
-    }
-
     agnocast_release_topic_wrapper(wrapper);
   }
 }

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -10,6 +10,7 @@ DECLARE_RWSEM(global_htables_rwsem);
 DEFINE_HASHTABLE(proc_info_htable, PROC_INFO_HASH_BITS);
 DEFINE_HASHTABLE(topic_hashtable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
+DEFINE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
 
 DEFINE_SPINLOCK(pid_queue_lock);
 pid_t exit_pid_queue[EXIT_QUEUE_SIZE];

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -187,6 +187,10 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
 {
   hash_del(&wrapper->node);
   kfree(wrapper->key);
+
+  // Grouped domains share one topic_struct, so it (and everything it owns) is
+  // torn down only when the last referencing wrapper is released. This is the
+  // single place that frees the shared rbtree and pub/sub tables.
   if (--wrapper->topic->wrapper_refcnt == 0) {
     struct rb_node * node = rb_first(&wrapper->topic->entries);
     while (node) {
@@ -195,6 +199,27 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
       rb_erase(&en->node, &wrapper->topic->entries);
       kfree(en);
     }
+
+    struct publisher_info * pub_info;
+    int bkt_pub;
+    struct hlist_node * tmp_pub;
+    hash_for_each_safe(wrapper->topic->pub_info_htable, bkt_pub, tmp_pub, pub_info, node)
+    {
+      hash_del(&pub_info->node);
+      kfree(pub_info->node_name);
+      kfree(pub_info);
+    }
+
+    struct subscriber_info * sub_info;
+    int bkt_sub;
+    struct hlist_node * tmp_sub;
+    hash_for_each_safe(wrapper->topic->sub_info_htable, bkt_sub, tmp_sub, sub_info, node)
+    {
+      hash_del(&sub_info->node);
+      kfree(sub_info->node_name);
+      kfree(sub_info);
+    }
+
     kfree(wrapper->topic);
   }
   kfree(wrapper);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -167,6 +167,39 @@ int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper)
   return count;
 }
 
+bool agnocast_wrapper_has_domain_endpoints(const struct topic_wrapper * wrapper)
+{
+  struct publisher_info * pub_info;
+  struct subscriber_info * sub_info;
+  int bkt;
+  hash_for_each(wrapper->topic->pub_info_htable, bkt, pub_info, node)
+  {
+    if (pub_info->domain_id == wrapper->domain_id) return true;
+  }
+  hash_for_each(wrapper->topic->sub_info_htable, bkt, sub_info, node)
+  {
+    if (sub_info->domain_id == wrapper->domain_id) return true;
+  }
+  return false;
+}
+
+void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
+{
+  hash_del(&wrapper->node);
+  kfree(wrapper->key);
+  if (--wrapper->topic->wrapper_refcnt == 0) {
+    struct rb_node * node = rb_first(&wrapper->topic->entries);
+    while (node) {
+      struct entry_node * en = rb_entry(node, struct entry_node, node);
+      node = rb_next(node);
+      rb_erase(&en->node, &wrapper->topic->entries);
+      kfree(en);
+    }
+    kfree(wrapper->topic);
+  }
+  kfree(wrapper);
+}
+
 bool agnocast_is_referenced(struct entry_node * en)
 {
   return !bitmap_empty(en->referencing_subscribers, MAX_TOPIC_LOCAL_ID);
@@ -301,14 +334,9 @@ void agnocast_process_exit_cleanup(const pid_t pid)
 
     pre_handler_subscriber_exit(wrapper, pid, proc_info);
 
-    // Check if we can release the topic_wrapper
-    if (
-      agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-      agnocast_get_size_sub_info_htable(wrapper) == 0) {
-      hash_del(&wrapper->node);
-      kfree(wrapper->key);
-      kfree(wrapper->topic);
-      kfree(wrapper);
+    // Release this wrapper once its own domain has no endpoints left.
+    if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+      agnocast_release_topic_wrapper(wrapper);
     }
   }
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -80,6 +80,9 @@ extern DECLARE_HASHTABLE(proc_info_htable, PROC_INFO_HASH_BITS);
 struct publisher_info
 {
   topic_local_id_t id;
+  // The endpoint's ROS domain. Equals the owning wrapper's domain; carried per
+  // endpoint because grouped wrappers share one htable holding both domains.
+  uint32_t domain_id;
   pid_t pid;
   char * node_name;
   uint32_t qos_depth;
@@ -92,6 +95,8 @@ struct publisher_info
 struct subscriber_info
 {
   topic_local_id_t id;
+  // The endpoint's ROS domain (see publisher_info::domain_id).
+  uint32_t domain_id;
   pid_t pid;
   uint32_t qos_depth;
   bool qos_is_transient_local;
@@ -126,6 +131,10 @@ struct topic_struct
   uint32_t ros2_publisher_num;   // Updated by Bridge Manager
   // Per-topic rwsem: read for read-only ops, write for publish/receive/modify.
   struct rw_semaphore rwsem;
+  // Number of topic_wrappers sharing this struct. 1 normally; 2 when a domain
+  // bridge rule groups two domains' wrappers onto one entry/id space. The struct
+  // is freed only when the last referencing wrapper is dropped.
+  uint32_t wrapper_refcnt;
 };
 
 struct topic_wrapper
@@ -185,6 +194,10 @@ int agnocast_get_size_sub_info_htable(struct topic_wrapper * wrapper);
 
 int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper);
 
+// True if the (possibly shared) topic_struct holds any endpoint in this wrapper's
+// own domain. Used to decide when to drop a single wrapper of a grouped pair.
+bool agnocast_wrapper_has_domain_endpoints(const struct topic_wrapper * wrapper);
+
 bool agnocast_is_referenced(struct entry_node * en);
 
 struct process_info * agnocast_find_process_info(const pid_t pid);
@@ -192,6 +205,11 @@ struct process_info * agnocast_find_process_info(const pid_t pid);
 void agnocast_free_exit_subscription_list(struct process_info * proc_info);
 
 void agnocast_remove_entry_node(struct topic_wrapper * wrapper, struct entry_node * en);
+
+// Unlink a wrapper and free it. The shared topic_struct (its rbtree and the
+// struct itself) is freed only when the last referencing wrapper is dropped, so
+// a grouped partner keeps working until it too is released.
+void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper);
 
 long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -165,6 +165,22 @@ struct bridge_info
 
 extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 
+// A domain bridge rule relays one topic between two ROS domains within one IPC
+// namespace (from_domain -> to_domain). v1 supports a single domain pair per
+// (topic, ipc_ns); see agnocast_ioctl_add_domain_bridge.
+struct domain_bridge_rule
+{
+  char * topic_name;
+  const struct ipc_namespace * ipc_ns;
+  uint32_t domain_a;  // canonical ordering: domain_a < domain_b
+  uint32_t domain_b;
+  bool a_to_b;  // deliver domain_a's publications to domain_b's subscribers
+  bool b_to_a;
+  struct hlist_node node;
+};
+
+extern DECLARE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
+
 int agnocast_get_size_sub_info_htable(struct topic_wrapper * wrapper);
 
 int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper);

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -120,6 +120,8 @@ static inline long copy_name_from_user(char * dst, size_t dst_size, const struct
   return 0;
 }
 
+struct domain_bridge_rule;
+
 struct topic_struct
 {
   struct rb_root entries;
@@ -135,6 +137,9 @@ struct topic_struct
   // bridge rule groups two domains' wrappers onto one entry/id space. The struct
   // is freed only when the last referencing wrapper is dropped.
   uint32_t wrapper_refcnt;
+  // The domain bridge rule covering this topic, or NULL if none. Cached here so
+  // the publish/receive hot path can check delivery direction without a lookup.
+  const struct domain_bridge_rule * rule;
 };
 
 struct topic_wrapper

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -180,8 +180,9 @@ struct bridge_info
 extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 
 // A domain bridge rule relays one topic between two ROS domains within one IPC
-// namespace (from_domain -> to_domain). v1 supports a single domain pair per
-// (topic, ipc_ns); see agnocast_ioctl_add_domain_bridge.
+// namespace. The pair is stored canonically (domain_a < domain_b) with the enabled
+// direction(s) in a_to_b / b_to_a. See agnocast_ioctl_add_domain_bridge for the rules
+// on adding one.
 struct domain_bridge_rule
 {
   char * topic_name;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1224,14 +1224,15 @@ int agnocast_ioctl_get_subscriber_num(
   uint32_t inter_count = 0;
   uint32_t intra_count = 0;
 
-  // The caller is a publisher in wrapper->domain_id; count only the subscribers
-  // it actually delivers to. For a one-way bridge rule this excludes the
-  // opposite-domain subscribers; for ungrouped topics every subscriber qualifies.
+  // Match ROS 2's get_subscription_count: report only same-domain subscribers.
+  // A bridge rule still delivers cross-domain (see the publish/receive paths),
+  // but a publisher does not count subscribers in another domain. Ungrouped
+  // topics hold only one domain, so this is a no-op for them.
   struct subscriber_info * sub_info;
   int bkt_sub;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
-    if (!domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+    if (sub_info->domain_id != wrapper->domain_id) {
       continue;
     }
     if (sub_info->is_bridge) {
@@ -1326,15 +1327,16 @@ int agnocast_ioctl_get_publisher_num(
 
   ioctl_ret->ret_ros2_publisher_num = wrapper->topic->ros2_publisher_num;
 
-  // The caller is a subscriber in wrapper->domain_id; count only the publishers
-  // that actually deliver to it. For a one-way bridge rule this excludes the
-  // opposite-domain publishers; for ungrouped topics every publisher qualifies.
+  // Match ROS 2's get_publisher_count: report only same-domain publishers.
+  // A bridge rule still delivers cross-domain (see the publish/receive paths),
+  // but a subscriber does not count publishers in another domain. Ungrouped
+  // topics hold only one domain, so this is a no-op for them.
   uint32_t publisher_num = 0;
   struct publisher_info * pub_info;
   int bkt_pub;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub, pub_info, node)
   {
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+    if (pub_info->domain_id != wrapper->domain_id) {
       continue;
     }
     publisher_num++;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -99,11 +99,18 @@ static struct topic_struct * find_grouped_topic_struct(
 }
 
 // Whether a publication in pub_domain may be delivered to a subscriber in
-// sub_domain within a (possibly grouped) topic_struct. Same domain is always
-// allowed; cross-domain delivery is opened per rule direction in a later change.
-static bool domain_delivery_allowed(uint32_t pub_domain, uint32_t sub_domain)
+// sub_domain within this topic_struct. Same domain is always allowed; crossing
+// domains requires a rule permitting that direction (from_domain -> to_domain).
+static bool domain_delivery_allowed(
+  const struct topic_struct * topic, uint32_t pub_domain, uint32_t sub_domain)
 {
-  return pub_domain == sub_domain;
+  if (pub_domain == sub_domain) return true;
+
+  const struct domain_bridge_rule * rule = topic->rule;
+  if (!rule) return false;
+  if (pub_domain == rule->domain_a && sub_domain == rule->domain_b) return rule->a_to_b;
+  if (pub_domain == rule->domain_b && sub_domain == rule->domain_a) return rule->b_to_a;
+  return false;
 }
 
 static int add_topic(
@@ -158,6 +165,7 @@ static int add_topic(
     (*wrapper)->topic->ros2_subscriber_num = 0;
     (*wrapper)->topic->ros2_publisher_num = 0;
     (*wrapper)->topic->wrapper_refcnt = 1;
+    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns);
   }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
@@ -901,7 +909,8 @@ int agnocast_ioctl_publish_msg(
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
     if (sub_info->is_take_sub) continue;
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) continue;
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id))
+      continue;
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
       continue;
     }
@@ -986,7 +995,7 @@ static int receive_msg_core(
       continue;
     }
 
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1131,7 +1140,7 @@ int agnocast_ioctl_take_msg(
       continue;
     }
 
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1656,10 +1665,12 @@ int agnocast_ioctl_get_topic_subscriber_info(
   struct topic_info_ret __user * user_buffer =
     (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
-  // Count actual subscribers first
+  // Count actual subscribers first. The htable may be shared with a bridged
+  // domain, so only count endpoints in the requested domain.
   uint32_t subscriber_num = 0;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
+    if (sub_info->domain_id != wrapper->domain_id) continue;
     subscriber_num++;
   }
 
@@ -1685,6 +1696,8 @@ int agnocast_ioctl_get_topic_subscriber_info(
   uint32_t idx = 0;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
+    if (sub_info->domain_id != wrapper->domain_id) continue;
+
     if (!sub_info->node_name) {
       kvfree(topic_info_mem);
       ret = -EFAULT;
@@ -1742,10 +1755,12 @@ int agnocast_ioctl_get_topic_publisher_info(
   struct topic_info_ret __user * user_buffer =
     (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
-  // Count actual publishers first
+  // Count actual publishers first. The htable may be shared with a bridged
+  // domain, so only count endpoints in the requested domain.
   uint32_t publisher_num = 0;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
   {
+    if (pub_info->domain_id != wrapper->domain_id) continue;
     publisher_num++;
   }
 
@@ -1771,6 +1786,8 @@ int agnocast_ioctl_get_topic_publisher_info(
   uint32_t idx = 0;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
   {
+    if (pub_info->domain_id != wrapper->domain_id) continue;
+
     if (!pub_info->node_name) {
       kvfree(topic_info_mem);
       ret = -EFAULT;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2164,6 +2164,9 @@ int agnocast_ioctl_add_domain_bridge(
 
   if (from_domain == to_domain) return -EINVAL;
 
+  // Store the pair canonically (domain_a < domain_b), keeping direction only as the
+  // a_to_b / b_to_a flags: grouping (find_grouped_topic_struct) cares only about the pair,
+  // while direction is enforced at delivery (domain_delivery_allowed).
   const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
   const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
   const bool lo_to_hi = (from_domain == lo);
@@ -2174,6 +2177,8 @@ int agnocast_ioctl_add_domain_bridge(
   if (existing) {
     // Re-declaring the same pair just adds the reverse direction; a third domain
     // on the same topic is rejected (v1 supports a single pair per topic).
+    // TODO: support >2 domains per topic (fan-out, e.g. 1->2 and 1->3) by storing a
+    // domain group instead of a fixed pair and grouping N wrappers onto one topic_struct.
     if (existing->domain_a != lo || existing->domain_b != hi) {
       ret = -EBUSY;
       goto unlock;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2101,6 +2101,82 @@ unlock:
   return ret;
 }
 
+static struct domain_bridge_rule * find_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns)
+{
+  struct domain_bridge_rule * rule;
+  uint32_t hash_val = full_name_hash(NULL, topic_name, strlen(topic_name));
+  hash_for_each_possible(domain_rule_htable, rule, node, hash_val)
+  {
+    if (ipc_ns == rule->ipc_ns && strcmp(rule->topic_name, topic_name) == 0) {
+      return rule;
+    }
+  }
+  return NULL;
+}
+
+int agnocast_ioctl_add_domain_bridge(
+  const char * topic_name, const uint32_t from_domain, const uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns)
+{
+  int ret = 0;
+
+  if (from_domain == to_domain) return -EINVAL;
+
+  const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
+  const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
+  const bool lo_to_hi = (from_domain == lo);
+
+  down_write(&global_htables_rwsem);
+
+  struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
+  if (existing) {
+    // Re-declaring the same pair just adds the reverse direction; a third domain
+    // on the same topic is rejected (v1 supports a single pair per topic).
+    if (existing->domain_a != lo || existing->domain_b != hi) {
+      ret = -EBUSY;
+      goto unlock;
+    }
+    existing->a_to_b |= lo_to_hi;
+    existing->b_to_a |= !lo_to_hi;
+    goto unlock;
+  }
+
+  // Grouping merges the two domains' id and entry_id spaces, which is only safe
+  // before either side has allocated any; reject if an endpoint already joined.
+  if (find_topic(topic_name, ipc_ns, from_domain) || find_topic(topic_name, ipc_ns, to_domain)) {
+    ret = -EBUSY;
+    goto unlock;
+  }
+
+  struct domain_bridge_rule * rule = kmalloc(sizeof(*rule), GFP_KERNEL);
+  if (!rule) {
+    ret = -ENOMEM;
+    goto unlock;
+  }
+  rule->topic_name = kstrdup(topic_name, GFP_KERNEL);
+  if (!rule->topic_name) {
+    kfree(rule);
+    ret = -ENOMEM;
+    goto unlock;
+  }
+  rule->ipc_ns = ipc_ns;
+  rule->domain_a = lo;
+  rule->domain_b = hi;
+  rule->a_to_b = lo_to_hi;
+  rule->b_to_a = !lo_to_hi;
+  INIT_HLIST_NODE(&rule->node);
+  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, topic_name, strlen(topic_name)));
+
+  dev_info(
+    agnocast_device, "Domain bridge rule added (topic=%s, %u->%u).\n", topic_name, from_domain,
+    to_domain);
+
+unlock:
+  up_write(&global_htables_rwsem);
+  return ret;
+}
+
 int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, const bool is_r2a, const struct ipc_namespace * ipc_ns)
 {
@@ -2737,6 +2813,22 @@ static long add_bridge_cmd(struct ioctl_add_bridge_args __user * arg)
   return ret;
 }
 
+static long add_domain_bridge_cmd(struct ioctl_add_domain_bridge_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_add_domain_bridge_args domain_bridge_args;
+  if (copy_from_user(&domain_bridge_args, arg, sizeof(domain_bridge_args))) return -EFAULT;
+
+  char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  int ret =
+    copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &domain_bridge_args.topic_name);
+  if (ret) return ret;
+
+  return agnocast_ioctl_add_domain_bridge(
+    topic_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain, ipc_ns);
+}
+
 static long remove_bridge_cmd(struct ioctl_remove_bridge_args __user * arg)
 {
   int ret = 0;
@@ -2861,6 +2953,8 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
       return add_bridge_cmd((struct ioctl_add_bridge_args __user *)arg);
     case AGNOCAST_REMOVE_BRIDGE_CMD:
       return remove_bridge_cmd((struct ioctl_remove_bridge_args __user *)arg);
+    case AGNOCAST_ADD_DOMAIN_BRIDGE_CMD:
+      return add_domain_bridge_cmd((struct ioctl_add_domain_bridge_args __user *)arg);
     case AGNOCAST_CHECK_AND_REQUEST_BRIDGE_SHUTDOWN_CMD:
       return check_and_request_bridge_shutdown_cmd(
         (struct ioctl_check_and_request_bridge_shutdown_args __user *)arg);
@@ -3098,6 +3192,19 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
     return br_info->pid;
   }
   return -1;
+}
+
+bool agnocast_get_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
+  uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
+{
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  if (!rule) return false;
+  *domain_a = rule->domain_a;
+  *domain_b = rule->domain_b;
+  *a_to_b = rule->a_to_b;
+  *b_to_a = rule->b_to_a;
+  return true;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2175,10 +2175,12 @@ int agnocast_ioctl_add_domain_bridge(
 
   struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
   if (existing) {
-    // Re-declaring the same pair just adds the reverse direction; a third domain
-    // on the same topic is rejected (v1 supports a single pair per topic).
-    // TODO: support >2 domains per topic (fan-out, e.g. 1->2 and 1->3) by storing a
-    // domain group instead of a fixed pair and grouping N wrappers onto one topic_struct.
+    // Re-declaring the same pair just adds the reverse direction. A third domain on a
+    // topic is rejected: the current implementation supports exactly one domain pair per
+    // topic (no fan-out such as 1->2 and 1->3 on the same topic). This is the one place
+    // that enforces it.
+    // TODO: support >2 domains per topic by storing a domain group instead of a fixed
+    // pair and grouping N wrappers onto one topic_struct.
     if (existing->domain_a != lo || existing->domain_b != hi) {
       ret = -EBUSY;
       goto unlock;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -74,6 +74,38 @@ static struct topic_wrapper * find_topic_for_current(
   return find_topic(topic_name, ipc_ns, get_current_domain_id());
 }
 
+static struct domain_bridge_rule * find_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns);
+
+// If a domain bridge rule pairs this domain with another whose wrapper already
+// exists, return that partner's topic_struct so the new wrapper can share it.
+static struct topic_struct * find_grouped_topic_struct(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
+{
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  if (!rule) return NULL;
+
+  uint32_t partner_domain;
+  if (domain_id == rule->domain_a) {
+    partner_domain = rule->domain_b;
+  } else if (domain_id == rule->domain_b) {
+    partner_domain = rule->domain_a;
+  } else {
+    return NULL;
+  }
+
+  struct topic_wrapper * partner = find_topic(topic_name, ipc_ns, partner_domain);
+  return partner ? partner->topic : NULL;
+}
+
+// Whether a publication in pub_domain may be delivered to a subscriber in
+// sub_domain within a (possibly grouped) topic_struct. Same domain is always
+// allowed; cross-domain delivery is opened per rule direction in a later change.
+static bool domain_delivery_allowed(uint32_t pub_domain, uint32_t sub_domain)
+{
+  return pub_domain == sub_domain;
+}
+
 static int add_topic(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id,
   struct topic_wrapper ** wrapper)
@@ -91,36 +123,42 @@ static int add_topic(
     return -ENOMEM;
   }
 
-  (*wrapper)->topic = kmalloc(sizeof(struct topic_struct), GFP_KERNEL);
-  if (!(*wrapper)->topic) {
-    dev_warn(
-      agnocast_device,
-      "Failed to allocate topic_struct for a new topic (topic_name=%s) by kmalloc. (%s)\n",
-      topic_name, __func__);
-    kfree(*wrapper);
-    return -ENOMEM;
-  }
-
-  (*wrapper)->ipc_ns = ipc_ns;
-  (*wrapper)->domain_id = domain_id;
   (*wrapper)->key = kstrdup(topic_name, GFP_KERNEL);
   if (!(*wrapper)->key) {
     dev_warn(
       agnocast_device, "Failed to add a new topic (topic_name=%s) by kstrdup. (%s)\n", topic_name,
       __func__);
-    kfree((*wrapper)->topic);
     kfree(*wrapper);
     return -ENOMEM;
   }
+  (*wrapper)->ipc_ns = ipc_ns;
+  (*wrapper)->domain_id = domain_id;
 
-  init_rwsem(&(*wrapper)->topic->rwsem);
-  (*wrapper)->topic->entries = RB_ROOT;
-  hash_init((*wrapper)->topic->pub_info_htable);
-  hash_init((*wrapper)->topic->sub_info_htable);
-  (*wrapper)->topic->current_pubsub_id = 0;
-  (*wrapper)->topic->current_entry_id = 0;
-  (*wrapper)->topic->ros2_subscriber_num = 0;
-  (*wrapper)->topic->ros2_publisher_num = 0;
+  struct topic_struct * grouped = find_grouped_topic_struct(topic_name, ipc_ns, domain_id);
+  if (grouped) {
+    (*wrapper)->topic = grouped;
+    grouped->wrapper_refcnt++;
+  } else {
+    (*wrapper)->topic = kmalloc(sizeof(struct topic_struct), GFP_KERNEL);
+    if (!(*wrapper)->topic) {
+      dev_warn(
+        agnocast_device,
+        "Failed to allocate topic_struct for a new topic (topic_name=%s) by kmalloc. (%s)\n",
+        topic_name, __func__);
+      kfree((*wrapper)->key);
+      kfree(*wrapper);
+      return -ENOMEM;
+    }
+    init_rwsem(&(*wrapper)->topic->rwsem);
+    (*wrapper)->topic->entries = RB_ROOT;
+    hash_init((*wrapper)->topic->pub_info_htable);
+    hash_init((*wrapper)->topic->sub_info_htable);
+    (*wrapper)->topic->current_pubsub_id = 0;
+    (*wrapper)->topic->current_entry_id = 0;
+    (*wrapper)->topic->ros2_subscriber_num = 0;
+    (*wrapper)->topic->ros2_publisher_num = 0;
+    (*wrapper)->topic->wrapper_refcnt = 1;
+  }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
   dev_dbg(agnocast_device, "Topic (topic_name=%s) added. (%s)\n", topic_name, __func__);
@@ -195,6 +233,7 @@ static int insert_subscriber_info(
   wrapper->topic->current_pubsub_id++;
 
   (*new_info)->id = new_id;
+  (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = subscriber_pid;
   (*new_info)->qos_depth = qos_depth;
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
@@ -297,6 +336,7 @@ static int insert_publisher_info(
   wrapper->topic->current_pubsub_id++;
 
   (*new_info)->id = new_id;
+  (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = publisher_pid;
   (*new_info)->node_name = node_name_copy;
   (*new_info)->qos_depth = qos_depth;
@@ -861,6 +901,7 @@ int agnocast_ioctl_publish_msg(
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
     if (sub_info->is_take_sub) continue;
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) continue;
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
       continue;
     }
@@ -942,6 +983,10 @@ static int receive_msg_core(
     }
 
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+      continue;
+    }
+
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1083,6 +1128,10 @@ int agnocast_ioctl_take_msg(
     }
 
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+      continue;
+    }
+
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1906,21 +1955,8 @@ int agnocast_ioctl_remove_subscriber(
     }
   }
 
-  if (
-    agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-    agnocast_get_size_sub_info_htable(wrapper) == 0) {
-    struct rb_node * n = rb_first(&wrapper->topic->entries);
-    while (n) {
-      struct entry_node * en = rb_entry(n, struct entry_node, node);
-      n = rb_next(n);
-      rb_erase(&en->node, &wrapper->topic->entries);
-      kfree(en);
-    }
-
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+  if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+    agnocast_release_topic_wrapper(wrapper);
     dev_dbg(agnocast_device, "Topic %s removed (empty).\n", topic_name);
   }
 
@@ -3205,6 +3241,13 @@ bool agnocast_get_domain_rule(
   *a_to_b = rule->a_to_b;
   *b_to_a = rule->b_to_a;
   return true;
+}
+
+int agnocast_topic_wrapper_refcnt(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
+{
+  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, domain_id);
+  return wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2031,20 +2031,8 @@ int agnocast_ioctl_remove_publisher(
     }
   }
 
-  if (
-    agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-    agnocast_get_size_sub_info_htable(wrapper) == 0) {
-    struct rb_node * n = rb_first(&wrapper->topic->entries);
-    while (n) {
-      struct entry_node * en = rb_entry(n, struct entry_node, node);
-      n = rb_next(n);
-      agnocast_remove_entry_node(wrapper, en);
-    }
-
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+  if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+    agnocast_release_topic_wrapper(wrapper);
     dev_dbg(agnocast_device, "Topic %s removed (empty).\n", topic_name);
   }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -550,6 +550,12 @@ static int set_publisher_shm_info(
       continue;
     }
 
+    // A subscriber only reads from publishers that deliver to it; a one-way
+    // bridge rule can exclude opposite-domain publishers, so skip mapping them.
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+      continue;
+    }
+
     const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
     if (!proc_info || proc_info->exited) {
       continue;
@@ -1218,10 +1224,16 @@ int agnocast_ioctl_get_subscriber_num(
   uint32_t inter_count = 0;
   uint32_t intra_count = 0;
 
+  // The caller is a publisher in wrapper->domain_id; count only the subscribers
+  // it actually delivers to. For a one-way bridge rule this excludes the
+  // opposite-domain subscribers; for ungrouped topics every subscriber qualifies.
   struct subscriber_info * sub_info;
   int bkt_sub;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
+    if (!domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+      continue;
+    }
     if (sub_info->is_bridge) {
       ioctl_ret->ret_a2r_bridge_exist = true;
     }
@@ -1312,18 +1324,25 @@ int agnocast_ioctl_get_publisher_num(
 
   down_read(&wrapper->topic->rwsem);
 
-  ioctl_ret->ret_publisher_num = agnocast_get_size_pub_info_htable(wrapper);
   ioctl_ret->ret_ros2_publisher_num = wrapper->topic->ros2_publisher_num;
 
+  // The caller is a subscriber in wrapper->domain_id; count only the publishers
+  // that actually deliver to it. For a one-way bridge rule this excludes the
+  // opposite-domain publishers; for ungrouped topics every publisher qualifies.
+  uint32_t publisher_num = 0;
   struct publisher_info * pub_info;
   int bkt_pub;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub, pub_info, node)
   {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+      continue;
+    }
+    publisher_num++;
     if (pub_info->is_bridge) {
       ioctl_ret->ret_r2a_bridge_exist = true;
-      break;
     }
   }
+  ioctl_ret->ret_publisher_num = publisher_num;
 
   struct subscriber_info * sub_info;
   int bkt_sub;
@@ -3246,20 +3265,27 @@ bool agnocast_get_domain_rule(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
   uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
 {
+  down_read(&global_htables_rwsem);
   const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
-  if (!rule) return false;
-  *domain_a = rule->domain_a;
-  *domain_b = rule->domain_b;
-  *a_to_b = rule->a_to_b;
-  *b_to_a = rule->b_to_a;
-  return true;
+  bool found = rule != NULL;
+  if (found) {
+    *domain_a = rule->domain_a;
+    *domain_b = rule->domain_b;
+    *a_to_b = rule->a_to_b;
+    *b_to_a = rule->b_to_a;
+  }
+  up_read(&global_htables_rwsem);
+  return found;
 }
 
 int agnocast_topic_wrapper_refcnt(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
+  down_read(&global_htables_rwsem);
   const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, domain_id);
-  return wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
+  int refcnt = wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
+  up_read(&global_htables_rwsem);
+  return refcnt;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -14,6 +14,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_get_subscriber_qos.o \
   agnocast_kunit_add_bridge.o \
   agnocast_kunit_remove_bridge.o \
+  agnocast_kunit_domain_bridge.o \
   agnocast_kunit_set_ros2_subscriber_num.o \
   agnocast_kunit_set_ros2_publisher_num.o \
   agnocast_kunit_do_exit.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -227,49 +227,50 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
 }
 
-// A publisher's subscriber count must include only the subscribers it delivers to:
-// same-domain ones always, opposite-domain ones only in the rule's direction. With
-// a 1 -> 2 rule, a domain-2 publisher reaches the domain-2 subscriber but not the
-// domain-1 one.
+// A publisher reports only same-domain subscribers, matching ROS 2's
+// get_subscription_count. With a 1 -> 2 rule a domain-1 publisher still delivers
+// to the domain-2 subscriber, but must not count it.
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
 
-  setup_process_in_domain(test, current->tgid, 2);
+  setup_process_in_domain(test, current->tgid, 1);
   add_publisher_for(test, current->tgid);
-  setup_process_in_domain(test, 1002, 2);
-  add_subscriber_for(test, 1002);
   setup_process_in_domain(test, 1001, 1);
   add_subscriber_for(test, 1001);
+  setup_process_in_domain(test, 1002, 2);
+  add_subscriber_for(test, 1002);
 
   union ioctl_get_subscriber_num_args args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, current->tgid, &args),
     0);
+  // Only the domain-1 subscriber is counted; the cross-domain (domain-2) one is not.
   KUNIT_EXPECT_EQ(test, args.ret_other_process_subscriber_num, (uint32_t)1);
   KUNIT_EXPECT_EQ(test, args.ret_same_process_subscriber_num, (uint32_t)0);
 }
 
-// A subscriber's publisher count must include only the publishers that deliver to
-// it. With a 1 -> 2 rule, a domain-1 subscriber sees the domain-1 publisher but not
-// the domain-2 one (2 -> 1 is not allowed).
+// A subscriber reports only same-domain publishers, matching ROS 2's
+// get_publisher_count. With a 1 -> 2 rule a domain-2 subscriber still receives
+// from the domain-1 publisher, but must not count it.
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
 
-  setup_process_in_domain(test, current->tgid, 1);
+  setup_process_in_domain(test, current->tgid, 2);
   add_subscriber_for(test, current->tgid);
-  setup_process_in_domain(test, 1000, 1);
+  setup_process_in_domain(test, 1000, 2);
   add_publisher_for(test, 1000);
-  setup_process_in_domain(test, 1001, 2);
+  setup_process_in_domain(test, 1001, 1);
   add_publisher_for(test, 1001);
 
   union ioctl_get_publisher_num_args args;
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns, &args), 0);
+  // Only the domain-2 publisher is counted; the cross-domain (domain-1) one is not.
   KUNIT_EXPECT_EQ(test, args.ret_publisher_num, (uint32_t)1);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_domain_bridge.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
+
+void test_case_add_domain_bridge_normal(struct kunit * test)
+{
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_EQ(test, domain_a, 1);
+  KUNIT_EXPECT_EQ(test, domain_b, 2);
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_FALSE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test)
+{
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
+{
+  // Re-declaring the same pair in reverse records the reverse direction on the
+  // existing rule rather than creating a second one.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns), 0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_TRUE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+  // A different domain pair on the same topic is rejected (v1 is pair-only).
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -8,6 +8,8 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+#define KUNIT_PUB_SHM_BUF_SIZE 4
+
 static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 
 // Returns the process's mempool base address, used as a valid publish address.
@@ -223,4 +225,78 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
+}
+
+// A publisher's subscriber count must include only the subscribers it delivers to:
+// same-domain ones always, opposite-domain ones only in the rule's direction. With
+// a 1 -> 2 rule, a domain-2 publisher reaches the domain-2 subscriber but not the
+// domain-1 one.
+void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 2);
+  add_publisher_for(test, current->tgid);
+  setup_process_in_domain(test, 1002, 2);
+  add_subscriber_for(test, 1002);
+  setup_process_in_domain(test, 1001, 1);
+  add_subscriber_for(test, 1001);
+
+  union ioctl_get_subscriber_num_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, current->tgid, &args),
+    0);
+  KUNIT_EXPECT_EQ(test, args.ret_other_process_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, args.ret_same_process_subscriber_num, (uint32_t)0);
+}
+
+// A subscriber's publisher count must include only the publishers that deliver to
+// it. With a 1 -> 2 rule, a domain-1 subscriber sees the domain-1 publisher but not
+// the domain-2 one (2 -> 1 is not allowed).
+void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+
+  union ioctl_get_publisher_num_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns, &args), 0);
+  KUNIT_EXPECT_EQ(test, args.ret_publisher_num, (uint32_t)1);
+}
+
+// A subscriber maps only the mempools of publishers that deliver to it. With a
+// 1 -> 2 rule, the domain-1 subscriber maps the domain-1 publisher but skips the
+// domain-2 one, so the opposite-domain mempool is never referenced.
+void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+
+  union ioctl_receive_msg_args receive_args;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_receive_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, sub_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+      &receive_args),
+    0);
+
+  KUNIT_EXPECT_EQ(test, receive_args.ret_pub_shm_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, (pid_t)1000);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -7,11 +7,16 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
-static void setup_process_in_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
+
+// Returns the process's mempool base address, used as a valid publish address.
+static uint64_t setup_process_in_domain(
+  struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args args;
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+  return args.ret_addr;
 }
 
 static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
@@ -110,4 +115,50 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test)
   // Both domains' wrappers point at one shared topic_struct (refcnt 2).
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 2);
+}
+
+void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // publish resolves the wrapper by the caller's domain, so the caller and the
+  // publisher are both in domain 1.
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_for(test, 1001);
+
+  union ioctl_publish_msg_args publish_args;
+  int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+    ARRAY_SIZE(subscriber_ids_buf), &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // The domain-2 subscriber receives the domain-1 publication (rule 1 -> 2).
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
+}
+
+void test_case_domain_bridge_direction_respected(struct kunit * test)
+{
+  // Only 1 -> 2 is declared; the reverse direction must not deliver.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 1);
+  add_subscriber_for(test, 1001);
+
+  union ioctl_publish_msg_args publish_args;
+  int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+    ARRAY_SIZE(subscriber_ids_buf), &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // The domain-1 subscriber must not receive a domain-2 publication (no 2 -> 1).
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -185,6 +185,25 @@ void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
 }
 
+// Same as above, but the dropped endpoint is a subscriber: remove_subscriber must
+// release only its own domain's wrapper and keep the shared struct for domain 2.
+void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_subscriber(TOPIC_NAME, current->nsproxy->ipc_ns, sub_id), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
+}
+
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -4,6 +4,7 @@
 #include "../agnocast.h"
 
 #include <kunit/test.h>
+#include <linux/delay.h>
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
@@ -161,4 +162,46 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 
   // The domain-1 subscriber must not receive a domain-2 publication (no 2 -> 1).
   KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)0);
+}
+
+void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // remove_publisher resolves the wrapper by the caller's domain, so the caller
+  // is in domain 1 alongside the publisher being removed.
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  // Dropping domain 1's last endpoint drops its wrapper, but the shared struct
+  // must survive for domain 2 (refcnt 2 -> 1); freeing it here would be a UAF.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_publisher(TOPIC_NAME, current->nsproxy->ipc_ns, pub_id), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
+}
+
+void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  // Both domains' processes exit: each wrapper is dropped as its domain empties,
+  // and the shared struct is freed only with the last one (KASAN checks the free).
+  agnocast_enqueue_exit_pid(1000);
+  agnocast_enqueue_exit_pid(1001);
+  msleep(20);  // let exit_worker_thread drain both pids
+
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -88,7 +88,7 @@ void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
-  // A different domain pair on the same topic is rejected (v1 is pair-only).
+  // A different domain pair on the same topic is rejected (one pair per topic).
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -7,6 +7,36 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+static void setup_process_in_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+}
+
+static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_publisher_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+    0);
+  return args.ret_id;
+}
+
+static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_subscriber_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
+      &args),
+    0);
+  return args.ret_id;
+}
+
 void test_case_add_domain_bridge_normal(struct kunit * test)
 {
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
@@ -55,4 +85,29 @@ void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
   // A different domain pair on the same topic is rejected (v1 is pair-only).
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test)
+{
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+
+  // The topic's domain-1 id space is already allocated, so grouping is unsafe.
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_domain_bridge_groups_wrappers(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+
+  // Both domains' wrappers point at one shared topic_struct (refcnt 2).
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 2);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -2,13 +2,17 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_DOMAIN_BRIDGE                                  \
-  KUNIT_CASE(test_case_add_domain_bridge_normal),                 \
-    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected), \
-    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),    \
-    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected)
+#define TEST_CASES_DOMAIN_BRIDGE                                           \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                          \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),          \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),             \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),         \
+    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
 void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);
+void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test);
+void test_case_domain_bridge_groups_wrappers(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -13,7 +13,10 @@
     KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),   \
-    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),          \
+    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),       \
+    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),        \
+    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -26,3 +29,6 @@ void test_case_domain_bridge_direction_respected(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);
+void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test);
+void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test);
+void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -8,7 +8,9 @@
     KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),             \
     KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),         \
     KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
-    KUNIT_CASE(test_case_domain_bridge_groups_wrappers)
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                   \
+    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
+    KUNIT_CASE(test_case_domain_bridge_direction_respected)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -16,3 +18,5 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);
 void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test);
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
+void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
+void test_case_domain_bridge_direction_respected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -12,6 +12,7 @@
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
     KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),   \
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
@@ -23,4 +24,5 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
+void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_DOMAIN_BRIDGE                                  \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                 \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected), \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),    \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected)
+
+void test_case_add_domain_bridge_normal(struct kunit * test);
+void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
+void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
+void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -10,7 +10,9 @@
     KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
     KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                   \
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
-    KUNIT_CASE(test_case_domain_bridge_direction_respected)
+    KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -20,3 +22,5 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
+void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
+void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -7,6 +7,7 @@
 #include "agnocast_kunit/agnocast_kunit_bridge_shutdown.h"
 #include "agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h"
 #include "agnocast_kunit/agnocast_kunit_do_exit.h"
+#include "agnocast_kunit/agnocast_kunit_domain_bridge.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_publisher_num.h"
@@ -50,6 +51,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_GET_PUBLISHER_QOS,
   TEST_CASES_ADD_BRIDGE,
   TEST_CASES_REMOVE_BRIDGE,
+  TEST_CASES_DOMAIN_BRIDGE,
   TEST_CASES_SET_ROS2_SUBSCRIBER_NUM,
   TEST_CASES_SET_ROS2_PUBLISHER_NUM,
   TEST_CASES_DO_EXIT,


### PR DESCRIPTION
> **Stacked on #1416.** Domain-bridge (51895) stack: #1416 → **#1417 (this)** → #1418.

## Description

Implement same-IPC-namespace cross-domain zero-copy matching in the kmod (two ROS domains in one namespace share a mempool, so a publisher in one reaches a subscriber in the other with no copy):

- New `domain_bridge_rule` table + `ADD_DOMAIN_BRIDGE` ioctl (cmd 28): the per-IPC daemon registers a `(topic, from_domain, to_domain)` rule.
- **Grouping (merged `topic_struct`)**: the two ruled wrappers share one `topic_struct` (rbtree / id+entry_id counters / reference bitmap / lock). Each endpoint carries its own `domain_id`; `publish`/`receive`/`take` filter delivery via `domain_delivery_allowed(pub_domain, sub_domain)` (same domain always allowed; cross-domain per rule direction).
- **Lifetime**: the shared `topic_struct` is reference-counted (`wrapper_refcnt`) — a wrapper is dropped when its own domain has no endpoints; the struct is freed only with the last wrapper, so a grouped partner keeps working.
- Rule injection is rejected (`-EBUSY`) if a ruled domain already has endpoints, or if a third domain is added to a topic — the current implementation supports exactly one domain pair per topic (no fan-out like `1->2` plus `1->3` on the same topic; there's a TODO to lift this).

When no rule exists, behavior is byte-for-byte identical to today (the filter is trivially true; `wrapper_refcnt`=1). Chosen over the "directional domain group" alternative because it keeps the entry-lifetime and locking invariants unchanged (design doc §3.4/§5).

Adds 11 KUnit cases (rule validation, grouping/refcnt, cross-domain delivery + direction, lifetime under remove/exit).

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51895
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) — pass (no regression)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) — pass
- [ ] kunit tests (required when modifying the kernel module) — 11 new cases; run in CI (this kernel lacks `CONFIG_KUNIT`)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) — pass
- [ ] sample application

kmod builds `-Werror`; clang-format clean.

No separate manual test — the cross-domain behavior is fully automated:

- **kmod logic** — the 11 KUnit cases: rule validation (`same_domain_rejected`, `third_domain_rejected`, `rejected_when_endpoint_exists`, `reverse_direction`), `groups_wrappers` + `wrapper_refcnt`, `cross_domain_enumeration`, `direction_respected`, `partial_remove_keeps_struct`, `partial_remove_sub_keeps_struct`, `exit_frees_shared_struct`.
- **End-to-end** (real processes, cross-domain delivery) — `scripts/test/e2e_test_domain_bridge.bash`, added in #1418.

## Version Update Label

- `need-minor-update` (new `ADD_DOMAIN_BRIDGE` ioctl — kmod ABI addition)

