### PR TITLE
feat(agnocast_ioctl_wrapper, ros2agnocast_discovery_agent): register domain bridge rules from YAML

### DIFF
--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Case 2 (same IPC namespace, cross-domain) zero-copy e2e.
+#
+# Registers a domain bridge rule for the sample topic, then runs the sample
+# talker in FROM_DOMAIN and the sample listener in TO_DOMAIN as SEPARATE launches
+# and asserts the listener received the talker's messages — cross-domain delivery
+# through the kmod with no DDS / bridge node.
+#
+# Two separate launches (not one launch file) are required: each `ros2 launch`
+# runs entirely under one ROS_DOMAIN_ID, including the composable-node loader. A
+# single launch can't load nodes into containers on two different domains.
+#
+# Each launch is run under `timeout` so it self-terminates (SIGINT, then SIGKILL
+# after a grace period) — Agnocast container shutdown can stall on SIGINT, so we
+# never block on a graceful exit.
+#
+# Run on a freshly loaded kmod — the rule must be registered before any endpoint
+# for the topic joins. Pure Case 2 uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
+
+set -uo pipefail
+
+if ! grep -q "^agnocast " /proc/modules; then
+    echo "ERROR: agnocast kernel module is not loaded." >&2
+    echo "Load it first: sudo insmod agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+TOPIC="${E2E_TOPIC_NAME:-/my_topic}"   # the sample app's topic
+FROM_DOMAIN="${E2E_FROM_DOMAIN:-1}"
+TO_DOMAIN="${E2E_TO_DOMAIN:-2}"
+RUN_SECONDS="${E2E_RUN_SECONDS:-10}"
+
+echo "Registering domain bridge rule: ${TOPIC} ${FROM_DOMAIN}->${TO_DOMAIN}"
+if ! python3 - "$TOPIC" "$FROM_DOMAIN" "$TO_DOMAIN" <<'PY'
+import ctypes, sys
+lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+lib.add_agnocast_domain_bridge_rule.argtypes = [ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
+rc = lib.add_agnocast_domain_bridge_rule(sys.argv[1].encode(), int(sys.argv[2]), int(sys.argv[3]))
+if rc != 0:
+    sys.stderr.write(f"add_agnocast_domain_bridge_rule failed (rc={rc})\n")
+sys.exit(0 if rc == 0 else 1)
+PY
+then
+    echo "Rule registration failed (was the kmod freshly loaded?)." >&2
+    exit 1
+fi
+
+SUBLOG="$(mktemp)"; PUBLOG="$(mktemp)"
+LISTEN_SECS=$((5 + RUN_SECONDS + 3))   # listener: startup + run + drain
+TALK_SECS=$((RUN_SECONDS + 3))         # talker: starts 5 s later
+
+echo "Starting listener in domain ${TO_DOMAIN} (subscriber first), ~${LISTEN_SECS}s ..."
+timeout -s INT -k 5 "$LISTEN_SECS" \
+    env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$TO_DOMAIN" \
+    ros2 launch agnocast_sample_application listener.launch.xml > "$SUBLOG" 2>&1 &
+SUB_PID=$!
+sleep 5
+
+echo "Starting talker in domain ${FROM_DOMAIN}, ~${TALK_SECS}s ..."
+timeout -s INT -k 5 "$TALK_SECS" \
+    env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$FROM_DOMAIN" \
+    ros2 launch agnocast_sample_application talker.launch.xml > "$PUBLOG" 2>&1 &
+PUB_PID=$!
+
+echo "Running (auto-stop via timeout) ..."
+wait "$SUB_PID" "$PUB_PID" 2>/dev/null || true
+sleep 1
+
+echo "--- talker log (tail) ---";   tail -n 3 "$PUBLOG"
+echo "--- listener log (tail) ---"; tail -n 3 "$SUBLOG"
+
+pub_count=$(grep -c "publish message: id=" "$PUBLOG" || true)
+sub_count=$(grep -c "subscribe message: id=" "$SUBLOG" || true)
+echo "published=${pub_count}  received(cross-domain)=${sub_count}"
+
+if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then
+    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (Case 2 zero-copy)."
+    exit 0
+fi
+echo "FAIL: cross-domain delivery not observed (published=${pub_count}, received=${sub_count})." >&2
+exit 1

--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -31,20 +31,20 @@ TO_DOMAIN="${E2E_TO_DOMAIN:-2}"
 RUN_SECONDS="${E2E_RUN_SECONDS:-10}"
 
 echo "Registering domain bridge rule: ${TOPIC} ${FROM_DOMAIN}->${TO_DOMAIN}"
-if ! python3 - "$TOPIC" "$FROM_DOMAIN" "$TO_DOMAIN" <<'PY'
-import ctypes, sys
-lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
-lib.add_agnocast_domain_bridge_rule.argtypes = [ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
-rc = lib.add_agnocast_domain_bridge_rule(sys.argv[1].encode(), int(sys.argv[2]), int(sys.argv[3]))
-if rc != 0:
-    sys.stderr.write(f"add_agnocast_domain_bridge_rule failed (rc={rc})\n")
-sys.exit(0 if rc == 0 else 1)
-PY
-then
+# Register through the same tool production uses, not an inline ioctl call.
+BRIDGE_CONFIG="$(mktemp --suffix=.yaml)"
+cat > "$BRIDGE_CONFIG" <<YAML
+from_domain: ${FROM_DOMAIN}
+to_domain: ${TO_DOMAIN}
+topics:
+  "${TOPIC}":
+YAML
+if ! ros2 run ros2agnocast_discovery_agent register_domain_bridge --config "$BRIDGE_CONFIG"; then
     echo "Rule registration failed (was the kmod freshly loaded?)." >&2
+    rm -f "$BRIDGE_CONFIG"
     exit 1
 fi
+rm -f "$BRIDGE_CONFIG"
 
 SUBLOG="$(mktemp)"; PUBLOG="$(mktemp)"
 LISTEN_SECS=$((5 + RUN_SECONDS + 3))   # listener: startup + run + drain

--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Case 2 (same IPC namespace, cross-domain) zero-copy e2e.
+# Same-IPC-namespace cross-domain zero-copy e2e (two ROS domains, one mempool).
 #
 # Registers a domain bridge rule for the sample topic, then runs the sample
 # talker in FROM_DOMAIN and the sample listener in TO_DOMAIN as SEPARATE launches
@@ -15,7 +15,7 @@
 # never block on a graceful exit.
 #
 # Run on a freshly loaded kmod — the rule must be registered before any endpoint
-# for the topic joins. Pure Case 2 uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
+# for the topic joins. This path uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
 
 set -uo pipefail
 
@@ -75,7 +75,7 @@ sub_count=$(grep -c "subscribe message: id=" "$SUBLOG" || true)
 echo "published=${pub_count}  received(cross-domain)=${sub_count}"
 
 if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then
-    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (Case 2 zero-copy)."
+    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (cross-domain zero-copy)."
     exit 0
 fi
 echo "FAIL: cross-domain delivery not observed (published=${pub_count}, received=${sub_count})." >&2

--- a/src/agnocast_ioctl_wrapper/CMakeLists.txt
+++ b/src/agnocast_ioctl_wrapper/CMakeLists.txt
@@ -4,7 +4,7 @@ project(agnocast_ioctl_wrapper)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
-add_library(agnocast_ioctl_wrapper SHARED src/topic_list.cpp src/node_info.cpp src/topic_info.cpp src/version.cpp)
+add_library(agnocast_ioctl_wrapper SHARED src/topic_list.cpp src/node_info.cpp src/topic_info.cpp src/version.cpp src/domain_bridge.cpp)
 
 ament_target_dependencies(agnocast_ioctl_wrapper rclcpp)
 

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -79,9 +79,18 @@ struct ioctl_get_version_args
   char ret_version[VERSION_BUFFER_LEN];
 };
 
+// Mirrors agnocast_kmod/agnocast.h so _IOW encodes the same size.
+struct ioctl_add_domain_bridge_args
+{
+  struct name_info topic_name;
+  uint32_t from_domain;
+  uint32_t to_domain;
+};
+
 #define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
 #define AGNOCAST_GET_TOPIC_LIST_CMD _IOWR(0xA6, 20, union ioctl_topic_list_args)
 #define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOWR(0xA6, 21, union ioctl_topic_info_args)
 #define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOWR(0xA6, 22, union ioctl_topic_info_args)
 #define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOWR(0xA6, 23, union ioctl_node_info_args)
 #define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOWR(0xA6, 24, union ioctl_node_info_args)
+#define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -16,6 +16,13 @@ extern "C" {
 int add_agnocast_domain_bridge_rule(
   const char * topic_name, uint32_t from_domain, uint32_t to_domain)
 {
+  // Exported C symbol: guard the pointer so a null from a caller returns an
+  // error instead of segfaulting in strlen() below.
+  if (topic_name == nullptr) {
+    errno = EINVAL;
+    return -1;
+  }
+
   int fd = open("/dev/agnocast", O_RDONLY);
   if (fd < 0) {
     if (errno == ENOENT) {

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -1,0 +1,43 @@
+#include "agnocast_ioctl.hpp"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+
+// Register a domain bridge rule with the kmod so it relays the topic between
+// from_domain and to_domain within this process's IPC namespace. Returns 0 on
+// success, -1 on failure.
+int add_agnocast_domain_bridge_rule(
+  const char * topic_name, uint32_t from_domain, uint32_t to_domain)
+{
+  int fd = open("/dev/agnocast", O_RDONLY);
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      fprintf(stderr, "%s", AGNOCAST_DEVICE_NOT_FOUND_MSG);
+    } else {
+      perror("Failed to open /dev/agnocast");
+    }
+    return -1;
+  }
+
+  ioctl_add_domain_bridge_args args = {};
+  args.topic_name = {topic_name, strlen(topic_name)};
+  args.from_domain = from_domain;
+  args.to_domain = to_domain;
+
+  if (ioctl(fd, AGNOCAST_ADD_DOMAIN_BRIDGE_CMD, &args) < 0) {
+    perror("AGNOCAST_ADD_DOMAIN_BRIDGE_CMD failed");
+    close(fd);
+    return -1;
+  }
+
+  close(fd);
+  return 0;
+}
+}

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2agnocast_discovery_msgs</exec_depend>
   <exec_depend>agnocast_ioctl_wrapper</exec_depend>
+  <!-- Parsing the domain_bridge YAML; rosdep/bloom installs ignore setup.py's
+       install_requires, so the runtime dep must be declared here too. -->
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -43,8 +43,10 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastEndpoint,
     AgnocastTopic,
 )
+import yaml
 
 from . import bridge_decider
+from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
 
 
@@ -104,6 +106,10 @@ def _load_ioctl_wrapper():
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
+
+    lib.add_agnocast_domain_bridge_rule.argtypes = [
+        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
 
     return lib
 
@@ -372,10 +378,33 @@ class DiscoveryAgent(Node):
 
         self._timer = self.create_timer(PUBLISH_INTERVAL_SEC, self._on_tick)
 
+        # Inject domain bridge rules at startup, before application endpoints can
+        # join (the kmod rejects a rule once a domain has allocated ids).
+        self._register_domain_bridge_rules()
+
         self.get_logger().info(
             f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode} '
             f'version={self._agnocast_version}')
+
+    def _register_domain_bridge_rules(self) -> None:
+        path = os.environ.get(domain_bridge_config.CONFIG_ENV)
+        if not path:
+            return
+        try:
+            rules = domain_bridge_config.load_domain_bridge_rules(path)
+        except (OSError, yaml.YAMLError) as e:
+            self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
+            return
+        for topic, from_domain, to_domain in rules:
+            # Idempotent in the kmod, so every per-domain agent in this namespace
+            # may register the same rule without conflict.
+            ret = self._lib.add_agnocast_domain_bridge_rule(
+                topic.encode('utf-8'), from_domain, to_domain)
+            if ret != 0:
+                self.get_logger().warning(
+                    f'failed to register domain bridge rule '
+                    f'{topic} {from_domain}->{to_domain} (ret={ret})')
 
     def _on_tick(self) -> None:
         self._registry.rebuild()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -43,10 +43,8 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastEndpoint,
     AgnocastTopic,
 )
-import yaml
 
 from . import bridge_decider
-from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
 
 
@@ -106,10 +104,6 @@ def _load_ioctl_wrapper():
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
-
-    lib.add_agnocast_domain_bridge_rule.argtypes = [
-        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
 
     return lib
 
@@ -378,34 +372,10 @@ class DiscoveryAgent(Node):
 
         self._timer = self.create_timer(PUBLISH_INTERVAL_SEC, self._on_tick)
 
-        # Inject domain bridge rules at startup, before application endpoints can
-        # join (the kmod rejects a rule once a domain has allocated ids).
-        self._register_domain_bridge_rules()
-
         self.get_logger().info(
             f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode} '
             f'version={self._agnocast_version}')
-
-    def _register_domain_bridge_rules(self) -> None:
-        path = os.environ.get(domain_bridge_config.CONFIG_ENV)
-        if not path:
-            return
-        try:
-            rules = domain_bridge_config.load_domain_bridge_rules(path)
-        except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
-            # A bad config must not take the daemon down: warn and run without rules.
-            self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
-            return
-        for topic, from_domain, to_domain in rules:
-            # Idempotent in the kmod, so every per-domain agent in this namespace
-            # may register the same rule without conflict.
-            ret = self._lib.add_agnocast_domain_bridge_rule(
-                topic.encode('utf-8'), from_domain, to_domain)
-            if ret != 0:
-                self.get_logger().warning(
-                    f'failed to register domain bridge rule '
-                    f'{topic} {from_domain}->{to_domain} (ret={ret})')
 
     def _on_tick(self) -> None:
         self._registry.rebuild()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -393,7 +393,8 @@ class DiscoveryAgent(Node):
             return
         try:
             rules = domain_bridge_config.load_domain_bridge_rules(path)
-        except (OSError, yaml.YAMLError) as e:
+        except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+            # A bad config must not take the daemon down: warn and run without rules.
             self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
             return
         for topic, from_domain, to_domain in rules:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,9 +1,9 @@
 """Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
 rules the Agnocast daemon registers with the kmod.
 
-The same YAML drives both the external ``domain_bridge`` node (cross-ECU, Case 8)
-and the daemon's kmod rule injection that opens same-namespace zero-copy
-cross-domain delivery (Case 2). Only the topic name and domain pair matter here;
+The same YAML drives both the external ``domain_bridge`` node (cross-ECU, via DDS)
+and the daemon's kmod rule injection that opens same-IPC-namespace zero-copy
+cross-domain delivery. Only the topic name and domain pair matter here;
 ``type`` and other fields are ignored.
 """
 import yaml

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,0 +1,39 @@
+"""Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
+rules the Agnocast daemon registers with the kmod.
+
+The same YAML drives both the external ``domain_bridge`` node (cross-ECU, Case 8)
+and the daemon's kmod rule injection that opens same-namespace zero-copy
+cross-domain delivery (Case 2). Only the topic name and domain pair matter here;
+``type`` and other fields are ignored.
+"""
+import yaml
+
+# Operators point the daemon at the config by setting this to the YAML path.
+CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
+
+
+def parse_domain_bridge_config(text):
+    """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
+
+    ``from_domain`` / ``to_domain`` are taken from the top level and may be
+    overridden per topic. Entries without a resolvable domain pair are skipped.
+    """
+    doc = yaml.safe_load(text) or {}
+    default_from = doc.get('from_domain')
+    default_to = doc.get('to_domain')
+
+    rules = []
+    for topic_name, spec in (doc.get('topics') or {}).items():
+        spec = spec or {}
+        from_domain = spec.get('from_domain', default_from)
+        to_domain = spec.get('to_domain', default_to)
+        if from_domain is None or to_domain is None:
+            continue
+        rules.append((str(topic_name), int(from_domain), int(to_domain)))
+    return rules
+
+
+def load_domain_bridge_rules(path):
+    """Read and parse the ``domain_bridge`` YAML at ``path``."""
+    with open(path, encoding='utf-8') as f:
+        return parse_domain_bridge_config(f.read())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -11,25 +11,53 @@ import yaml
 # Operators point the daemon at the config by setting this to the YAML path.
 CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
 
+# Domain ids cross the ioctl boundary as ctypes.c_uint32, so an out-of-range
+# value would wrap silently; reject it here instead.
+_UINT32_MAX = 0xFFFFFFFF
+
+
+def _as_domain_id(value):
+    """Coerce a YAML domain value to a uint32, raising ``ValueError`` if invalid."""
+    domain = int(value)  # ValueError on non-numeric, TypeError on a list/dict
+    if not 0 <= domain <= _UINT32_MAX:
+        raise ValueError(f'domain id {domain} out of range [0, {_UINT32_MAX}]')
+    return domain
+
 
 def parse_domain_bridge_config(text):
     """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
 
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
-    overridden per topic. Entries without a resolvable domain pair are skipped.
+    overridden per topic. Topics without a resolvable domain pair are skipped.
+
+    Raises ``ValueError`` / ``TypeError`` on a structurally malformed document
+    (non-mapping root, ``topics``, or topic spec) or an out-of-range domain id.
+    The daemon catches both and runs without rules rather than crashing.
     """
     doc = yaml.safe_load(text) or {}
+    if not isinstance(doc, dict):
+        raise ValueError('domain bridge config root must be a mapping')
+
+    topics = doc.get('topics')
+    if topics is None:
+        topics = {}
+    if not isinstance(topics, dict):
+        raise ValueError("'topics' must be a mapping")
+
     default_from = doc.get('from_domain')
     default_to = doc.get('to_domain')
 
     rules = []
-    for topic_name, spec in (doc.get('topics') or {}).items():
-        spec = spec or {}
+    for topic_name, spec in topics.items():
+        if spec is None:
+            spec = {}
+        elif not isinstance(spec, dict):
+            raise ValueError(f'spec for topic {topic_name!r} must be a mapping')
         from_domain = spec.get('from_domain', default_from)
         to_domain = spec.get('to_domain', default_to)
         if from_domain is None or to_domain is None:
             continue
-        rules.append((str(topic_name), int(from_domain), int(to_domain)))
+        rules.append((str(topic_name), _as_domain_id(from_domain), _as_domain_id(to_domain)))
     return rules
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,5 +1,4 @@
-"""Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
-rules the Agnocast daemon registers with the kmod.
+"""Parse a ROS 2 ``domain_bridge`` YAML into kmod rule tuples.
 
 The same YAML drives both the external ``domain_bridge`` node (cross-ECU, via DDS)
 and the daemon's kmod rule injection that opens same-IPC-namespace zero-copy
@@ -25,10 +24,13 @@ def _as_domain_id(value):
 
 
 def parse_domain_bridge_config(text):
-    """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
+    """Return ``(rules, skipped)``.
 
+    ``rules`` is a list of ``(topic_name, from_domain, to_domain)`` tuples.
+    ``skipped`` lists the topic names dropped for lack of a resolvable domain
+    pair, so the caller can surface them instead of dropping them silently.
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
-    overridden per topic. Topics without a resolvable domain pair are skipped.
+    overridden per topic.
 
     Raises ``ValueError`` / ``TypeError`` on a structurally malformed document
     (non-mapping root, ``topics``, or topic spec) or an out-of-range domain id.
@@ -48,6 +50,7 @@ def parse_domain_bridge_config(text):
     default_to = doc.get('to_domain')
 
     rules = []
+    skipped = []
     for topic_name, spec in topics.items():
         if spec is None:
             spec = {}
@@ -56,12 +59,13 @@ def parse_domain_bridge_config(text):
         from_domain = spec.get('from_domain', default_from)
         to_domain = spec.get('to_domain', default_to)
         if from_domain is None or to_domain is None:
+            skipped.append(str(topic_name))
             continue
         rules.append((str(topic_name), _as_domain_id(from_domain), _as_domain_id(to_domain)))
-    return rules
+    return rules, skipped
 
 
 def load_domain_bridge_rules(path):
-    """Read and parse the ``domain_bridge`` YAML at ``path``."""
+    """Read and parse the ``domain_bridge`` YAML at ``path``; return ``(rules, skipped)``."""
     with open(path, encoding='utf-8') as f:
         return parse_domain_bridge_config(f.read())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -1,0 +1,72 @@
+"""Register Agnocast domain bridge rules with the kernel module.
+
+Reads a ROS 2 ``domain_bridge`` YAML and registers each
+``(topic, from_domain, to_domain)`` rule through the ioctl wrapper.
+
+Run this once, before any application node for the bridged topics starts: the
+kmod rejects a rule once an endpoint exists in either domain. The tool is
+standalone and idempotent (the kmod folds duplicate rules), so it can run from
+a boot-time one-shot, a launch file, or by hand. It is independent of the
+discovery agent, which is observability-only and never registers rules.
+"""
+import argparse
+import ctypes
+import os
+import sys
+
+import yaml
+
+from . import domain_bridge_config
+
+
+def _load_add_rule_symbol():
+    """Load the ioctl wrapper and return the bound add_agnocast_domain_bridge_rule."""
+    lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+    lib.add_agnocast_domain_bridge_rule.argtypes = [
+        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
+    return lib.add_agnocast_domain_bridge_rule
+
+
+def main(argv=None) -> int:
+    """Register every rule in the config; return non-zero if any is rejected."""
+    parser = argparse.ArgumentParser(
+        description='Register Agnocast domain bridge rules with the kernel module.')
+    parser.add_argument(
+        '--config',
+        default=os.environ.get(domain_bridge_config.CONFIG_ENV),
+        help='path to the domain_bridge YAML '
+             f'(default: ${domain_bridge_config.CONFIG_ENV})')
+    args = parser.parse_args(argv)
+
+    if not args.config:
+        parser.error(
+            f'no config given; pass --config or set {domain_bridge_config.CONFIG_ENV}')
+
+    try:
+        rules = domain_bridge_config.load_domain_bridge_rules(args.config)
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+        print(f'error: cannot load {args.config}: {e}', file=sys.stderr)
+        return 1
+
+    add_rule = _load_add_rule_symbol()
+    failures = 0
+    for topic, from_domain, to_domain in rules:
+        if add_rule(topic.encode('utf-8'), from_domain, to_domain) == 0:
+            print(f'registered: {topic} {from_domain}->{to_domain}')
+            continue
+        # A non-zero return most likely means an endpoint for the topic already
+        # exists in one of the domains; the rule must precede every node.
+        failures += 1
+        print(
+            f'error: failed to register {topic} {from_domain}->{to_domain}; '
+            'was a publisher/subscriber already started?', file=sys.stderr)
+
+    if failures:
+        print(f'error: {failures} of {len(rules)} rule(s) rejected', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -44,10 +44,14 @@ def main(argv=None) -> int:
             f'no config given; pass --config or set {domain_bridge_config.CONFIG_ENV}')
 
     try:
-        rules = domain_bridge_config.load_domain_bridge_rules(args.config)
+        rules, skipped = domain_bridge_config.load_domain_bridge_rules(args.config)
     except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
         print(f'error: cannot load {args.config}: {e}', file=sys.stderr)
         return 1
+
+    for topic in skipped:
+        print(f'warning: skipping {topic}: no from_domain/to_domain resolved '
+              '(set them at the top level or on the topic)', file=sys.stderr)
 
     add_rule = _load_add_rule_symbol()
     failures = 0
@@ -55,12 +59,12 @@ def main(argv=None) -> int:
         if add_rule(topic.encode('utf-8'), from_domain, to_domain) == 0:
             print(f'registered: {topic} {from_domain}->{to_domain}')
             continue
-        # A non-zero return most likely means an endpoint for the topic already
-        # exists in one of the domains; the rule must precede every node.
+        # The wrapper prints the specific errno to stderr just above; the usual
+        # cause is that an endpoint already exists, since a rule must precede
+        # every node in either domain.
         failures += 1
-        print(
-            f'error: failed to register {topic} {from_domain}->{to_domain}; '
-            'was a publisher/subscriber already started?', file=sys.stderr)
+        print(f'error: failed to register {topic} {from_domain}->{to_domain}',
+              file=sys.stderr)
 
     if failures:
         print(f'error: {failures} of {len(rules)} rule(s) rejected', file=sys.stderr)

--- a/src/ros2agnocast_discovery_agent/scripts/register_domain_bridge
+++ b/src/ros2agnocast_discovery_agent/scripts/register_domain_bridge
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Wrapper so `ros2 run ros2agnocast_discovery_agent register_domain_bridge` works.
+
+ament_python's `entry_points` would normally produce a binary in `bin/`, but
+`ros2 run` looks in `lib/<pkg>/`. The setup.py installs this file to
+`lib/<pkg>/register_domain_bridge` so the standard ros2 run discovery rule finds it.
+"""
+import sys
+
+from ros2agnocast_discovery_agent.register_domain_bridge import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -13,7 +13,7 @@ setup(
         ('share/' + package_name + '/launch', ['launch/discovery_agent.launch.xml']),
         ('lib/' + package_name, ['scripts/discovery_agent']),
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
     extras_require={'test': ['pytest']},
     maintainer='Keita Morisaki, Takahiro Ishikawa-Aso, Koichi Imai, Takumi Jin',

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -11,7 +11,10 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/launch', ['launch/discovery_agent.launch.xml']),
-        ('lib/' + package_name, ['scripts/discovery_agent']),
+        ('share/' + package_name + '/systemd',
+            ['systemd/agnocast-domain-bridge.service.example', 'systemd/README.md']),
+        ('lib/' + package_name,
+            ['scripts/discovery_agent', 'scripts/register_domain_bridge']),
     ],
     install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
@@ -27,6 +30,8 @@ setup(
     entry_points={
         'console_scripts': [
             'discovery_agent = ros2agnocast_discovery_agent.agent:main',
+            'register_domain_bridge = '
+            'ros2agnocast_discovery_agent.register_domain_bridge:main',
         ],
     },
 )

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -1,0 +1,31 @@
+# Registering domain bridge rules at boot
+
+Agnocast domain bridge rules must be registered **before any publisher or
+subscriber for the bridged topics exists** — the kernel module rejects a rule
+once a domain has allocated endpoint ids. Registration is therefore a one-time
+boot step, independent of the discovery agent (which is observability-only and
+never registers rules).
+
+`register_domain_bridge` (a console script in this package) reads a ROS 2
+`domain_bridge` YAML and registers each rule:
+
+```bash
+ros2 run ros2agnocast_discovery_agent register_domain_bridge --config /etc/agnocast/domain_bridge.yaml
+# or set AGNOCAST_DOMAIN_BRIDGE_CONFIG and run it with no arguments
+```
+
+Run it once, ordered so that it:
+
+1. runs **after** the Agnocast kernel module is loaded (so `/dev/agnocast` exists),
+2. runs **after** the filesystem holding the config is mounted, and
+3. completes **before** any application node for the bridged topics starts.
+
+`agnocast-domain-bridge.service.example` is a reference systemd one-shot that
+expresses exactly this ordering (`After=` the kmod, `RequiresMountsFor=` the
+config, `Before=` your application target). Agnocast does not ship an installed
+unit or assume systemd — an init script or a container entrypoint that
+satisfies the same ordering works just as well.
+
+The tool is idempotent (the kmod folds duplicate rules) and exits non-zero if
+any rule is rejected, so a misordering — a node started first — fails loudly
+instead of silently leaving topics unbridged.

--- a/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
+++ b/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
@@ -1,0 +1,29 @@
+# Example systemd unit: register Agnocast domain bridge rules before applications.
+#
+# This is a REFERENCE, not an installed unit. Agnocast does not assume systemd
+# (see README.md). Copy it to /etc/systemd/system/, adjust the unit names,
+# paths, and target for your deployment, then `systemctl enable` it.
+#
+# What matters is the ordering (see README.md): register AFTER the kmod is
+# loaded and the config filesystem is mounted, and BEFORE any node that uses
+# the bridged topics starts. The dependencies below express exactly that.
+
+[Unit]
+Description=Register Agnocast domain bridge rules
+# /dev/agnocast must exist first. Point this at whatever loads the kmod.
+After=agnocast-kmod.service
+Requires=agnocast-kmod.service
+# The partition holding the config must be mounted before we read it.
+RequiresMountsFor=/etc/agnocast
+# Rules must be in place before any application node comes up.
+Before=my-robot-apps.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=AGNOCAST_DOMAIN_BRIDGE_CONFIG=/etc/agnocast/domain_bridge.yaml
+# Source ROS 2 and the workspace so `ros2 run` resolves, then register.
+ExecStart=/bin/bash -lc 'source /opt/ros/$ROS_DISTRO/setup.bash && ros2 run ros2agnocast_discovery_agent register_domain_bridge'
+
+[Install]
+WantedBy=multi-user.target

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -61,3 +61,58 @@ topics:
 """
     with pytest.raises(ValueError):
         parse_domain_bridge_config(text)
+
+
+def test_out_of_range_domain_raises():
+    # uint32 overflow would wrap silently at the ioctl boundary, so reject it.
+    text = """
+from_domain: 1
+to_domain: 4294967296
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)
+
+
+def test_negative_domain_raises():
+    text = """
+from_domain: -1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)
+
+
+# Malformed structure must raise a caught exception (ValueError/TypeError), not
+# AttributeError, so the daemon runs without rules instead of crashing.
+
+def test_non_mapping_root_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('- a\n- b\n')
+
+
+def test_non_mapping_topics_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('topics:\n  - chatter\n  - special\n')
+
+
+def test_non_mapping_topic_spec_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('from_domain: 1\nto_domain: 2\ntopics:\n  chatter: oops\n')
+
+
+def test_null_topic_spec_with_top_level_domains_is_used():
+    # `chatter:` with no body is a None spec; it should fall back to the
+    # top-level domains, not crash.
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+"""
+    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -1,0 +1,47 @@
+"""Unit tests for parsing the domain_bridge YAML into kmod rule tuples.
+
+These exercise the pure parser only; no kmod, DDS, or file I/O is involved.
+"""
+
+from ros2agnocast_discovery_agent.domain_bridge_config import parse_domain_bridge_config
+
+
+def test_top_level_domains_apply_to_each_topic():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+
+
+def test_per_topic_domains_override_top_level():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+  special:
+    from_domain: 3
+    to_domain: 4
+"""
+    rules = parse_domain_bridge_config(text)
+    assert ('chatter', 1, 2) in rules
+    assert ('special', 3, 4) in rules
+
+
+def test_topic_without_resolvable_domain_pair_is_skipped():
+    text = """
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    assert parse_domain_bridge_config(text) == []
+
+
+def test_empty_or_topicless_config_yields_no_rules():
+    assert parse_domain_bridge_config('') == []
+    assert parse_domain_bridge_config('topics:') == []

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -3,6 +3,8 @@
 These exercise the pure parser only; no kmod, DDS, or file I/O is involved.
 """
 
+import pytest
+
 from ros2agnocast_discovery_agent.domain_bridge_config import parse_domain_bridge_config
 
 
@@ -45,3 +47,17 @@ topics:
 def test_empty_or_topicless_config_yields_no_rules():
     assert parse_domain_bridge_config('') == []
     assert parse_domain_bridge_config('topics:') == []
+
+
+def test_non_integer_domain_raises():
+    # A non-integer domain raises; the agent catches this and runs without rules
+    # rather than crashing at startup.
+    text = """
+from_domain: not_a_number
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -16,7 +16,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+    assert parse_domain_bridge_config(text) == ([('chatter', 1, 2)], [])
 
 
 def test_per_topic_domains_override_top_level():
@@ -30,23 +30,26 @@ topics:
     from_domain: 3
     to_domain: 4
 """
-    rules = parse_domain_bridge_config(text)
+    rules, skipped = parse_domain_bridge_config(text)
     assert ('chatter', 1, 2) in rules
     assert ('special', 3, 4) in rules
+    assert skipped == []
 
 
-def test_topic_without_resolvable_domain_pair_is_skipped():
+def test_topic_without_resolvable_domain_pair_is_reported_as_skipped():
     text = """
 topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == []
+    rules, skipped = parse_domain_bridge_config(text)
+    assert rules == []
+    assert skipped == ['chatter']
 
 
 def test_empty_or_topicless_config_yields_no_rules():
-    assert parse_domain_bridge_config('') == []
-    assert parse_domain_bridge_config('topics:') == []
+    assert parse_domain_bridge_config('') == ([], [])
+    assert parse_domain_bridge_config('topics:') == ([], [])
 
 
 def test_non_integer_domain_raises():
@@ -115,4 +118,4 @@ to_domain: 2
 topics:
   chatter:
 """
-    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+    assert parse_domain_bridge_config(text) == ([('chatter', 1, 2)], [])

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -45,6 +45,16 @@ def test_returns_nonzero_when_a_rule_is_rejected(tmp_path, monkeypatch):
     assert register_domain_bridge.main(['--config', cfg]) == 1
 
 
+def test_skipped_topic_is_reported(tmp_path, monkeypatch, capsys):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    # No domains resolve for 'chatter', so it is skipped rather than registered.
+    cfg = _write_config(tmp_path, 'topics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    assert fake.calls == []
+    assert 'skipping chatter' in capsys.readouterr().err
+
+
 def test_returns_nonzero_on_unreadable_config(tmp_path, monkeypatch):
     monkeypatch.setattr(
         register_domain_bridge, '_load_add_rule_symbol',

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -1,0 +1,62 @@
+"""Tests for the standalone domain bridge rule injector."""
+import pytest
+
+from ros2agnocast_discovery_agent import register_domain_bridge
+from ros2agnocast_discovery_agent.domain_bridge_config import CONFIG_ENV
+
+
+class FakeAddRule:
+    """Stand-in for the ioctl wrapper symbol: records calls, returns a code per topic."""
+
+    def __init__(self, codes=None):
+        self.calls = []
+        self._codes = codes or {}
+
+    def __call__(self, topic, from_domain, to_domain):
+        name = topic.decode('utf-8')
+        self.calls.append((name, from_domain, to_domain))
+        return self._codes.get(name, 0)
+
+
+def _write_config(tmp_path, text):
+    path = tmp_path / 'bridge.yaml'
+    path.write_text(text)
+    return str(path)
+
+
+def test_no_config_is_usage_error(monkeypatch):
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    with pytest.raises(SystemExit):
+        register_domain_bridge.main([])
+
+
+def test_registers_every_rule(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    assert fake.calls == [('chatter', 1, 2)]
+
+
+def test_returns_nonzero_when_a_rule_is_rejected(tmp_path, monkeypatch):
+    fake = FakeAddRule(codes={'chatter': -16})  # -EBUSY: an endpoint already exists
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 1
+
+
+def test_returns_nonzero_on_unreadable_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_rule_symbol',
+        lambda: pytest.fail('the wrapper must not load when the config is unreadable'))
+    missing = str(tmp_path / 'does_not_exist.yaml')
+    assert register_domain_bridge.main(['--config', missing]) == 1
+
+
+def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n')
+    monkeypatch.setenv(CONFIG_ENV, cfg)
+    assert register_domain_bridge.main([]) == 0
+    assert fake.calls == [('image', 3, 4)]


### PR DESCRIPTION
> **Stacked on #1417.** Domain-bridge (51895) stack: #1416 → #1417 → **#1418 (this)**.

## Description

Userspace path to register the kmod domain-bridge rules from #1417, plus the cross-domain e2e test.

- `agnocast_ioctl_wrapper`: exports `add_agnocast_domain_bridge_rule(topic, from_domain, to_domain)` + the matching ioctl arg struct / cmd.
- `ros2agnocast_discovery_agent`: a standalone `register_domain_bridge` console script reads a ROS 2 `domain_bridge` YAML and registers each `(topic, from, to)` rule. It is idempotent and exits non-zero if a rule is rejected. The discovery agent does **not** register rules.
- A reference `systemd` one-shot + README (`systemd/agnocast-domain-bridge.service.example`) document the required ordering.
- e2e `scripts/test/e2e_test_domain_bridge.bash`: registers a rule, runs the sample talker/listener in two domains in one IPC namespace, and checks the message crosses domains with no DDS / bridge node (zero-copy).

## Related links

- Jira (TIER IV internal link): https://tier4.atlassian.net/browse/T4DEV-51895
- Design doc (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A (kmod untouched)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`colcon test` (`ros2agnocast_discovery_agent`) passes — `domain_bridge` YAML parsing (`parse_domain_bridge_config`, incl. malformed / out-of-range) and the `register_domain_bridge` tool (register / fail-loud / env fallback). Cross-domain e2e (`scripts/test/e2e_test_domain_bridge.bash`) on a freshly loaded kmod: talker (d1) reaches listener (d2), no DDS / bridge node.

## Notes for reviewers

A rule must be registered **before any publisher/subscriber for that topic exists in either domain** — otherwise the kmod returns `-EBUSY` (grouping merges the two domains' id spaces, safe only before anything is created; see #1417). The discovery agent comes up alongside the first node, so it cannot reliably precede those endpoints; that is why registration is a separate, one-time step run before applications — e.g. a boot step ordered after the kmod load and before the app launches (the shipped `.service.example`).

## Post-merge checklist

- [ ] Reflect in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) — domain-bridge guide (autowarefoundation/agnocast_doc#41).

## Version Update Label

- `need-patch-update` (userspace + test only; no kmod / ABI change)
