### PR TITLE
test(agnocast_e2e_test): add Case 2 cross-domain zero-copy e2e

### DIFF
--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Case 2 (same IPC namespace, cross-domain) zero-copy delivery e2e.
+#
+# Registers a domain bridge rule with the kmod, then runs an Agnocast publisher
+# in FROM_DOMAIN and subscriber in TO_DOMAIN (same IPC namespace) and asserts the
+# subscriber receives every message — proving kmod cross-domain matching without
+# any DDS/bridge node. Run after building + sourcing the workspace and loading
+# the kmod. Pure Case 2 uses no bridge, so AGNOCAST_BRIDGE_MODE=off is fine.
+
+set -eo pipefail
+
+if ! grep -q "^agnocast " /proc/modules; then
+    echo "ERROR: agnocast kernel module is not loaded." >&2
+    echo "Load it first: sudo insmod agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+TOPIC_NAME="${E2E_TOPIC_NAME:-/test_domain_bridge_topic}"
+FROM_DOMAIN="${E2E_FROM_DOMAIN:-1}"
+TO_DOMAIN="${E2E_TO_DOMAIN:-2}"
+
+# Register the rule before any endpoint joins. The rule is per-IPC-namespace, so
+# registering it from this shell (same namespace as the launch_test) suffices;
+# no daemon is needed for pure Case 2.
+echo "Registering domain bridge rule: ${TOPIC_NAME} ${FROM_DOMAIN}->${TO_DOMAIN}"
+python3 - "$TOPIC_NAME" "$FROM_DOMAIN" "$TO_DOMAIN" <<'PY'
+import ctypes
+import sys
+
+topic, from_domain, to_domain = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+lib.add_agnocast_domain_bridge_rule.argtypes = [ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
+rc = lib.add_agnocast_domain_bridge_rule(topic.encode('utf-8'), from_domain, to_domain)
+if rc != 0:
+    sys.stderr.write(f'add_agnocast_domain_bridge_rule failed (rc={rc})\n')
+sys.exit(0 if rc == 0 else 1)
+PY
+
+echo "Running Case 2 cross-domain delivery test..."
+E2E_TOPIC_NAME="$TOPIC_NAME" E2E_FROM_DOMAIN="$FROM_DOMAIN" E2E_TO_DOMAIN="$TO_DOMAIN" \
+    launch_test src/agnocast_e2e_test/test/test_domain_bridge.py

--- a/src/agnocast_e2e_test/test/test_domain_bridge.py
+++ b/src/agnocast_e2e_test/test/test_domain_bridge.py
@@ -1,0 +1,112 @@
+"""Case 2 (same IPC namespace, cross-domain) zero-copy delivery e2e.
+
+A domain bridge rule (FROM_DOMAIN -> TO_DOMAIN) must already be registered with
+the kmod (scripts/test/e2e_test_domain_bridge.bash does this before launching).
+An Agnocast publisher runs in FROM_DOMAIN and an Agnocast subscriber in
+TO_DOMAIN within the same IPC namespace; with the rule in place the subscriber
+receives the publisher's messages straight from shared memory (no DDS / bridge
+node), i.e. zero-copy across domains.
+
+The subscriber starts first so volatile messages are not missed.
+"""
+import os
+import unittest
+
+import launch_testing
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable, TimerAction
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+TOPIC_NAME = os.environ.get('E2E_TOPIC_NAME', '/test_domain_bridge_topic')
+FROM_DOMAIN = os.environ.get('E2E_FROM_DOMAIN', '1')
+TO_DOMAIN = os.environ.get('E2E_TO_DOMAIN', '2')
+QOS_DEPTH = 10
+PUB_NUM = 10
+
+
+def _agnocast_env(domain_id):
+    return {
+        'ROS_DOMAIN_ID': str(domain_id),
+        'LD_PRELOAD': f"libagnocast_heaphook.so:{os.getenv('LD_PRELOAD', '')}",
+    }
+
+
+def generate_test_description():
+    sub_container = ComposableNodeContainer(
+        name='db_listener_container',
+        namespace='',
+        package='agnocast_components',
+        executable='agnocast_component_container',
+        parameters=[{'get_next_timeout_ms': 1}],
+        composable_node_descriptions=[
+            ComposableNode(
+                package='agnocast_e2e_test',
+                plugin='TestSubscriber',
+                name='db_listener_node',
+                parameters=[{
+                    'topic_name': TOPIC_NAME,
+                    'qos_depth': QOS_DEPTH,
+                    'transient_local': False,
+                    'forever': False,
+                    'target_end_id': PUB_NUM - 1,
+                }],
+            )
+        ],
+        output='screen',
+        additional_env=_agnocast_env(TO_DOMAIN),
+    )
+
+    pub_container = ComposableNodeContainer(
+        name='db_talker_container',
+        namespace='',
+        package='agnocast_components',
+        executable='agnocast_component_container',
+        parameters=[{'get_next_timeout_ms': 1}],
+        composable_node_descriptions=[
+            ComposableNode(
+                package='agnocast_e2e_test',
+                plugin='TestPublisher',
+                name='db_talker_node',
+                parameters=[{
+                    'topic_name': TOPIC_NAME,
+                    'qos_depth': QOS_DEPTH,
+                    'transient_local': False,
+                    'init_pub_num': 0,
+                    'pub_num': PUB_NUM,
+                    'planned_pub_count': 0,  # Case 2 is pure Agnocast; no DDS sub to wait for.
+                    'forever': False,
+                }],
+            )
+        ],
+        output='screen',
+        additional_env=_agnocast_env(FROM_DOMAIN),
+    )
+
+    # Subscriber first (t=0) so it is connected before the publisher's volatile
+    # messages; publisher after a delay; ReadyToTest once both have run.
+    return (
+        LaunchDescription([
+            SetEnvironmentVariable('RCUTILS_LOGGING_BUFFERED_STREAM', '0'),
+            sub_container,
+            TimerAction(period=1.0, actions=[pub_container]),
+            TimerAction(period=10.0, actions=[launch_testing.actions.ReadyToTest()]),
+        ]),
+        {'test_pub': pub_container, 'test_sub': sub_container},
+    )
+
+
+class TestDomainBridgeCase2(unittest.TestCase):
+
+    def test_pub(self, proc_output, test_pub):
+        output = ''.join(o.text.decode('utf-8') for o in proc_output[test_pub])
+        for i in range(PUB_NUM):
+            self.assertEqual(output.count(f'Publishing {i}.'), 1)
+        self.assertEqual(output.count('All messages published. Shutting down.'), 1)
+
+    def test_sub_receives_across_domains(self, proc_output, test_sub):
+        output = ''.join(o.text.decode('utf-8') for o in proc_output[test_sub])
+        # Every published message reaches the other domain's subscriber.
+        for i in range(PUB_NUM):
+            self.assertEqual(output.count(f'Receiving {i}.'), 1)
+        self.assertEqual(output.count('All messages received. Shutting down.'), 1)


### PR DESCRIPTION
> **Stacked on #1418.** Domain-bridge (51895) stack: #1416 → #1417 → #1418 → **#1419 (this)**.

## Description

End-to-end test for Case 2 cross-domain zero-copy: registers a domain bridge rule, runs an Agnocast publisher in one domain and a subscriber in another within the same IPC namespace, and asserts the subscriber receives every message — exercising the kmod cross-domain matching end to end with no DDS / bridge node. Run via `scripts/test/e2e_test_domain_bridge.bash`. **Test-only.**

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application — manual Case 2 (talker domain 1 / listener domain 2, same IPC NS) passes; the new `e2e_test_domain_bridge.bash` automates it

## Version Update Label

- `need-patch-update` (tests only)
