### PR TITLE
fix(agnocastlib): add default template params to wait_for_service

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -193,9 +193,9 @@ public:
    *  @param timeout Maximum duration to wait (-1 = wait forever).
    *  @return True if service became available, false on timeout. */
   AGNOCAST_PUBLIC
-  template <typename RepT, typename RatioT>
+  template <typename RepT = int64_t, typename RatioT = std::milli>
   bool wait_for_service(
-    std::chrono::duration<RepT, RatioT> timeout = std::chrono::nanoseconds(-1)) const
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1)) const
   {
     return wait_for_service_nanoseconds(
       node_base_->get_context(), service_name_,


### PR DESCRIPTION
## Description

This PR adds default template parameters to `wait_for_service()` in `Client`. Previously, compilation would fail if it was called without any argument (i.e., using the default argument).

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] Exercised in an integration test (#1424).

## Notes for reviewers
