### PR TITLE
fix(agnocastlib): handle Agnocast node in wait_for_service() context check

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -120,7 +121,7 @@ private:
     service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
 
     check_context_ok_ = [context = node->get_node_base_interface()->get_context()]() {
-      if constexpr (std::is_base_of_v<agnocast::Node, NodeT>) {
+      if constexpr (std::is_same_v<agnocast::Node, NodeT>) {
         return agnocast::ok();
       } else {
         return rclcpp::ok(context);

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -29,7 +29,7 @@ struct NoBridgeRegistrationPolicy;
 
 bool service_is_ready_core(const std::string & service_name);
 bool wait_for_service_nanoseconds(
-  const std::function<bool()> & check_context_valid, const std::string & service_name,
+  const std::function<bool()> & check_context_ok, const std::string & service_name,
   std::chrono::nanoseconds timeout);
 
 extern int agnocast_fd;
@@ -107,7 +107,7 @@ private:
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   std::string node_name_;
   std::string service_name_;
-  std::function<bool()> check_context_valid_;
+  std::function<bool()> check_context_ok_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
@@ -119,7 +119,7 @@ private:
     node_name_ = node->get_fully_qualified_name();
     service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
 
-    check_context_valid_ = [context = node->get_node_base_interface()->get_context()]() {
+    check_context_ok_ = [context = node->get_node_base_interface()->get_context()]() {
       if constexpr (std::is_base_of_v<agnocast::Node, NodeT>) {
         return agnocast::ok();
       } else {
@@ -206,7 +206,7 @@ public:
     std::chrono::duration<RepT, RatioT> timeout = std::chrono::nanoseconds(-1)) const
   {
     return wait_for_service_nanoseconds(
-      check_context_valid_, service_name_,
+      check_context_ok_, service_name_,
       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));
   }
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -6,6 +6,7 @@
 #include "agnocast/agnocast_smart_pointer.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/node/agnocast_context.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -28,7 +29,7 @@ struct NoBridgeRegistrationPolicy;
 
 bool service_is_ready_core(const std::string & service_name);
 bool wait_for_service_nanoseconds(
-  const rclcpp::Context::SharedPtr & context, const std::string & service_name,
+  const std::function<bool()> & check_context_valid, const std::string & service_name,
   std::chrono::nanoseconds timeout);
 
 extern int agnocast_fd;
@@ -105,8 +106,8 @@ private:
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   std::string node_name_;
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   std::string service_name_;
+  std::function<bool()> check_context_valid_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
@@ -116,8 +117,15 @@ private:
     rclcpp::CallbackGroup::SharedPtr group)
   {
     node_name_ = node->get_fully_qualified_name();
-    node_base_ = node->get_node_base_interface();
     service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
+
+    check_context_valid_ = [context = node->get_node_base_interface()->get_context()]() {
+      if constexpr (std::is_base_of_v<agnocast::Node, NodeT>) {
+        return agnocast::ok();
+      } else {
+        return rclcpp::ok(context);
+      }
+    };
 
     // TransientLocal durability is not allowed for services.
     const rclcpp::QoS qos = rclcpp::QoS(qos_arg).durability_volatile();
@@ -198,7 +206,7 @@ public:
     std::chrono::duration<RepT, RatioT> timeout = std::chrono::nanoseconds(-1)) const
   {
     return wait_for_service_nanoseconds(
-      node_base_->get_context(), service_name_,
+      check_context_valid_, service_name_,
       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));
   }
 

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -47,7 +47,7 @@ bool service_is_ready_core(const std::string & service_name)
 }
 
 bool wait_for_service_nanoseconds(
-  const std::function<bool()> & check_context_valid, const std::string & service_name,
+  const std::function<bool()> & check_context_ok, const std::string & service_name,
   nanoseconds timeout)
 {
   auto start = steady_clock::now();
@@ -62,7 +62,7 @@ bool wait_for_service_nanoseconds(
   nanoseconds time_to_wait =
     timeout > nanoseconds(0) ? timeout - (steady_clock::now() - start) : nanoseconds::max();
   do {
-    if (!check_context_valid()) {
+    if (!check_context_ok()) {
       return false;
     }
     nanoseconds interval = std::min(time_to_wait, duration_cast<nanoseconds>(100ms));

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -47,7 +47,8 @@ bool service_is_ready_core(const std::string & service_name)
 }
 
 bool wait_for_service_nanoseconds(
-  const rclcpp::Context::SharedPtr & context, const std::string & service_name, nanoseconds timeout)
+  const std::function<bool()> & check_context_valid, const std::string & service_name,
+  nanoseconds timeout)
 {
   auto start = steady_clock::now();
   if (service_is_ready_core(service_name)) {
@@ -61,10 +62,7 @@ bool wait_for_service_nanoseconds(
   nanoseconds time_to_wait =
     timeout > nanoseconds(0) ? timeout - (steady_clock::now() - start) : nanoseconds::max();
   do {
-    // TODO(Koichi98): agnocast::ok is planned to be implemented.
-    // For standalone agnocast nodes (without rclcpp::init()), context->is_valid() returns false,
-    // so we skip the rclcpp::ok() check in that case.
-    if ((context && context->is_valid()) ? !rclcpp::ok(context) : false) {
+    if (!check_context_valid()) {
       return false;
     }
     nanoseconds interval = std::min(time_to_wait, duration_cast<nanoseconds>(100ms));


### PR DESCRIPTION
## Description

This PR fixes the context check of `wait_for_service()` in `Client`. Specifically, it branches on the node type; `agnocast::ok()` is used for Agnocast nodes, while `rclcpp::ok(node_context)` is used for rclcpp nodes.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] Exercised in integration tests (#1424)

## Notes for reviewers

