### PR TITLE
fix(ros2agnocast): probe the per-(namespace, domain) discovery-agent lock

### DIFF
--- a/src/ros2agnocast/package.xml
+++ b/src/ros2agnocast/package.xml
@@ -29,6 +29,9 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <!-- discovery-daemon-status duplicates the agent's singleton-lock path; a test
+       cross-checks the two builders, so it needs the agent package importable. -->
+  <test_depend>ros2agnocast_discovery_agent</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/ros2agnocast/ros2agnocast/verb/agnocast_discovery_daemon_status.py
+++ b/src/ros2agnocast/ros2agnocast/verb/agnocast_discovery_daemon_status.py
@@ -1,12 +1,14 @@
-"""Check that the per-IPC-namespace Agnocast discovery agent is alive.
+"""Check that this (IPC namespace, ROS_DOMAIN_ID)'s Agnocast discovery agent is alive.
 
 The agent publishes the local Agnocast state on ``/_agnocast_discovery``
 for cross-namespace observability. If the agent is not running (or
 running in a different IPC namespace), that observability silently stops
 working — this verb gives the operator a single place to confirm liveness.
 
-This command only inspects the **current** IPC namespace (the one the
-command itself runs in); run it inside the namespace you want to check.
+The agent runs one instance per (IPC namespace, ROS_DOMAIN_ID), so this
+command only inspects the **current** namespace and domain (the ones the
+command itself runs in); run it inside the namespace and with the
+ROS_DOMAIN_ID you want to check.
 
 Default output is a single one-line verdict — nothing else:
 
@@ -18,18 +20,18 @@ Default output is a single one-line verdict — nothing else:
 
 The verdict is driven by two internal checks:
 
-  * **process** — the agent holds an exclusive ``flock(2)`` on its per-NS
-    singleton lock file for its whole lifetime, so we probe that lock. The
-    lock path encodes the IPC namespace, so this needs no executable-path
-    matching.
+  * **process** — the agent holds an exclusive ``flock(2)`` on its
+    per-(namespace, domain) singleton lock file for its whole lifetime, so we
+    probe that lock. The lock path encodes the IPC namespace and ROS_DOMAIN_ID,
+    so this needs no executable-path matching.
   * **gossip** — a snapshot from this IPC namespace is received on
     ``/_agnocast_discovery`` within the timeout. ``gossip`` OK implies
     ``process`` OK (an agent that publishes is alive), so it is the primary,
     end-to-end signal; ``process`` only distinguishes "not running" from
     "running but not publishing" when ``gossip`` is NG.
 
-``--verbose`` additionally prints the IPC namespace inode, each check's
-result, and a ``type_registry`` line (how many live Agnocast processes have
+``--verbose`` additionally prints the IPC namespace inode, the ROS_DOMAIN_ID,
+each check's result, and a ``type_registry`` line (how many live Agnocast processes have
 registered). None of those affect the exit code — they are context, not part
 of the verdict.
 
@@ -60,28 +62,44 @@ def _self_ipc_ns_inode():
     return os.stat('/proc/self/ns/ipc').st_ino
 
 
-def _singleton_lock_path(my_ns_inode) -> str:
-    """Path of the agent's per-IPC-namespace singleton lock.
+def _read_ros_domain_id() -> int:
+    """Return ROS_DOMAIN_ID from the environment (0 if unset, empty, or
+    unparsable), matching ``ros2agnocast_discovery_agent.agent._read_ros_domain_id``
+    so this verb resolves the same domain the agent locked under.
+    """
+    raw = os.environ.get('ROS_DOMAIN_ID')
+    if not raw:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def _singleton_lock_path(my_ns_inode, domain_id) -> str:
+    """Path of the agent's per-(IPC namespace, domain) singleton lock.
 
     Must match ``_singleton_lock_path`` in
     ``ros2agnocast_discovery_agent.agent``, including the ``AGNOCAST_TMPFS_DIR``
-    override, so this verb probes the same file the agent locks.
+    override and the ``_d<domain>`` suffix, so this verb probes the same file the
+    agent locks. The agent runs one instance per (namespace, domain), so the
+    domain is part of the path.
     """
     root = os.environ.get('AGNOCAST_TMPFS_DIR') or '/dev/shm'
-    return os.path.join(root, f'agnocast_discovery_agent_{my_ns_inode}.lock')
+    return os.path.join(root, f'agnocast_discovery_agent_{my_ns_inode}_d{domain_id}.lock')
 
 
-def _check_daemon_process(my_ns_inode):
+def _check_daemon_process(my_ns_inode, domain_id):
     """Return (ok, reason) for the daemon-liveness check.
 
-    The agent holds an exclusive ``flock(2)`` on its per-NS lock file for its
-    whole lifetime. We probe that lock with a non-blocking ``LOCK_EX``: if we
-    cannot take it, a live agent in this namespace is holding it. The kernel
-    releases the lock when the holder dies, so a lock we *can* take (or a
-    missing file) means no live agent. ``reason`` is a short phrase for the
-    verdict breakdown, not a full sentence.
+    The agent holds an exclusive ``flock(2)`` on its per-(namespace, domain) lock
+    file for its whole lifetime. We probe that lock with a non-blocking
+    ``LOCK_EX``: if we cannot take it, a live agent for this (namespace, domain)
+    is holding it. The kernel releases the lock when the holder dies, so a lock
+    we *can* take (or a missing file) means no live agent. ``reason`` is a short
+    phrase for the verdict breakdown, not a full sentence.
     """
-    lock_path = _singleton_lock_path(my_ns_inode)
+    lock_path = _singleton_lock_path(my_ns_inode, domain_id)
     if not os.path.exists(lock_path):
         return False, f'no singleton lock file ({lock_path})'
 
@@ -181,8 +199,9 @@ class DiscoveryDaemonStatusVerb(VerbExtension):
         warn_if_gossip_timeout_overridden(args)
 
         my_ns_inode = _self_ipc_ns_inode()
+        my_domain_id = _read_ros_domain_id()
 
-        proc_ok, proc_reason = _check_daemon_process(my_ns_inode)
+        proc_ok, proc_reason = _check_daemon_process(my_ns_inode, my_domain_id)
         # gossip is the end-to-end signal, but it only matters if a process is
         # up; skip its timeout wait when the agent clearly isn't running.
         if proc_ok:
@@ -191,7 +210,7 @@ class DiscoveryDaemonStatusVerb(VerbExtension):
             gossip_ok, gossip_reason = None, None
 
         if args.verbose:
-            print(f'IPC namespace inode: {my_ns_inode}')
+            print(f'IPC namespace inode: {my_ns_inode}, ROS_DOMAIN_ID: {my_domain_id}')
             print(f'  process:       {"OK" if proc_ok else "NG"} ({proc_reason})')
             if gossip_ok is None:
                 print('  gossip:        skipped (agent not running)')

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -10,6 +10,8 @@ import tempfile
 from argparse import Namespace
 from unittest.mock import patch
 
+import pytest
+
 from ros2agnocast.verb import agnocast_discovery_daemon_status as ds
 
 
@@ -64,7 +66,7 @@ def test_describe_type_registry_stale_pid_noted():
 def test_check_daemon_process_missing_lock_is_ng():
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-            ok, reason = ds._check_daemon_process(424242)
+            ok, reason = ds._check_daemon_process(424242, 0)
         assert ok is False
         assert 'no singleton lock file' in reason
 
@@ -73,23 +75,28 @@ def test_check_daemon_process_free_lock_is_ng():
     """Lock file exists but nobody holds it -> no live agent."""
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 424242
-        open(os.path.join(tmpdir, f'agnocast_discovery_agent_{ns_inode}.lock'), 'w').close()
+        domain_id = 0
+        open(os.path.join(
+            tmpdir, f'agnocast_discovery_agent_{ns_inode}_d{domain_id}.lock'), 'w').close()
         with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-            ok, reason = ds._check_daemon_process(ns_inode)
+            ok, reason = ds._check_daemon_process(ns_inode, domain_id)
         assert ok is False
         assert 'free' in reason
 
 
 def test_check_daemon_process_held_lock_is_ok():
-    """A held flock (as the real agent holds it) -> OK."""
+    """A held flock (as the real agent holds it) -> OK. A non-zero domain also
+    proves the domain is part of the probed path."""
     with tempfile.TemporaryDirectory() as tmpdir:
         ns_inode = 424242
-        lock_path = os.path.join(tmpdir, f'agnocast_discovery_agent_{ns_inode}.lock')
+        domain_id = 2
+        lock_path = os.path.join(
+            tmpdir, f'agnocast_discovery_agent_{ns_inode}_d{domain_id}.lock')
         holder = open(lock_path, 'w')
         try:
             fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             with patch.dict(os.environ, {'AGNOCAST_TMPFS_DIR': tmpdir}):
-                ok, reason = ds._check_daemon_process(ns_inode)
+                ok, reason = ds._check_daemon_process(ns_inode, domain_id)
             assert ok is True
             assert 'holds the singleton lock' in reason
         finally:
@@ -100,10 +107,21 @@ def test_check_daemon_process_held_lock_is_ok():
 
 def test_singleton_lock_path_honors_agnocast_tmpfs_dir(monkeypatch):
     monkeypatch.setenv('AGNOCAST_TMPFS_DIR', '/run/custom')
-    assert ds._singleton_lock_path(7) == '/run/custom/agnocast_discovery_agent_7.lock'
+    assert ds._singleton_lock_path(7, 2) == '/run/custom/agnocast_discovery_agent_7_d2.lock'
 
     monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
-    assert ds._singleton_lock_path(7) == '/dev/shm/agnocast_discovery_agent_7.lock'
+    assert ds._singleton_lock_path(7, 0) == '/dev/shm/agnocast_discovery_agent_7_d0.lock'
+
+
+def test_singleton_lock_path_matches_agent(monkeypatch):
+    """The verb must probe the exact file the agent locks. The path is duplicated
+    in two packages, so this cross-checks them to catch drift (e.g. the domain
+    suffix added by the per-(namespace, domain) agent change)."""
+    agent = pytest.importorskip('ros2agnocast_discovery_agent.agent')
+    monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
+    for ns_inode, domain_id in [(7, 0), (4026531839, 2), (12345, 7)]:
+        assert ds._singleton_lock_path(ns_inode, domain_id) == \
+            agent._singleton_lock_path(ns_inode, domain_id)
 
 
 def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):

--- a/src/ros2agnocast/test/test_discovery_daemon_status.py
+++ b/src/ros2agnocast/test/test_discovery_daemon_status.py
@@ -10,9 +10,8 @@ import tempfile
 from argparse import Namespace
 from unittest.mock import patch
 
-import pytest
-
 from ros2agnocast.verb import agnocast_discovery_daemon_status as ds
+from ros2agnocast_discovery_agent import agent as discovery_agent
 
 
 # --- type_registry: informational description (no OK/NG) --------------------
@@ -113,15 +112,25 @@ def test_singleton_lock_path_honors_agnocast_tmpfs_dir(monkeypatch):
     assert ds._singleton_lock_path(7, 0) == '/dev/shm/agnocast_discovery_agent_7_d0.lock'
 
 
+def test_read_ros_domain_id(monkeypatch):
+    monkeypatch.delenv('ROS_DOMAIN_ID', raising=False)
+    assert ds._read_ros_domain_id() == 0
+    monkeypatch.setenv('ROS_DOMAIN_ID', '')
+    assert ds._read_ros_domain_id() == 0
+    monkeypatch.setenv('ROS_DOMAIN_ID', '5')
+    assert ds._read_ros_domain_id() == 5
+    monkeypatch.setenv('ROS_DOMAIN_ID', 'notanint')
+    assert ds._read_ros_domain_id() == 0
+
+
 def test_singleton_lock_path_matches_agent(monkeypatch):
     """The verb must probe the exact file the agent locks. The path is duplicated
     in two packages, so this cross-checks them to catch drift (e.g. the domain
     suffix added by the per-(namespace, domain) agent change)."""
-    agent = pytest.importorskip('ros2agnocast_discovery_agent.agent')
     monkeypatch.delenv('AGNOCAST_TMPFS_DIR', raising=False)
     for ns_inode, domain_id in [(7, 0), (4026531839, 2), (12345, 7)]:
         assert ds._singleton_lock_path(ns_inode, domain_id) == \
-            agent._singleton_lock_path(ns_inode, domain_id)
+            discovery_agent._singleton_lock_path(ns_inode, domain_id)
 
 
 def test_type_registry_base_honors_agnocast_tmpfs_dir(monkeypatch):


### PR DESCRIPTION
## Description

#1415 made the discovery agent run one instance per `(IPC namespace, ROS_DOMAIN_ID)` and moved its singleton lock to `agnocast_discovery_agent_{inode}_d{domain}.lock`. This updates the `discovery-daemon-status` verb to probe that same per-domain path (deriving `ROS_DOMAIN_ID` the way the agent does), so the verb and the agent stay in sync.

## Related links

- #1415

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required) — N/A (CLI-only; no kmod/agnocastlib change)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required) — N/A
- [ ] kunit tests (required when modifying the kernel module) — N/A (kmod untouched)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) — N/A
- [ ] sample application

`pytest src/ros2agnocast/test/test_discovery_daemon_status.py` — 15 passed.

Manually: with `discovery_agent` running in `ROS_DOMAIN_ID=2`, `discovery-daemon-status` reports `OK` (`--verbose` shows it probing `…_d2.lock`); `ROS_DOMAIN_ID=3` (no agent) reports `NG`.

## Notes for reviewers

The lock-path format is duplicated in `ros2agnocast` (this verb) and `ros2agnocast_discovery_agent` (the agent); a new cross-package test asserts the two builders agree so they can't drift.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

- `need-patch-update`
