### PR TITLE
feat(agnocast_kmod)[needs minor version update]: manage the discovery agent in a kmod registry

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -47,6 +47,7 @@ union ioctl_add_process_args {
     uint64_t ret_shm_size;
     bool ret_unlink_daemon_exist;
     bool ret_performance_bridge_daemon_exist;
+    bool ret_discovery_agent_exist;
   };
 };
 
@@ -266,6 +267,12 @@ struct ioctl_check_and_request_bridge_shutdown_args
   bool ret_should_shutdown;
 };
 
+struct ioctl_discovery_agent_should_exit_args
+{
+  uint32_t domain_id;
+  bool ret_should_exit;
+};
+
 struct ioctl_set_ros2_subscriber_num_args
 {
   struct name_info topic_name;
@@ -309,6 +316,8 @@ struct ioctl_add_domain_bridge_args
 #define AGNOCAST_SET_ROS2_PUBLISHER_NUM_CMD _IOW(0xA6, 26, struct ioctl_set_ros2_publisher_num_args)
 #define AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD _IO(0xA6, 27)
 #define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)
+#define AGNOCAST_DISCOVERY_AGENT_SHOULD_EXIT_CMD \
+  _IOWR(0xA6, 29, struct ioctl_discovery_agent_should_exit_args)
 
 // ================================================
 // ros2cli ioctls
@@ -483,6 +492,9 @@ int agnocast_ioctl_set_ros2_publisher_num(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t count);
 
 int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid);
+
+int agnocast_ioctl_discovery_agent_should_exit(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_should_exit);
 
 int agnocast_ioctl_get_exit_process(
   const struct ipc_namespace * ipc_ns, struct ioctl_get_exit_process_args * ioctl_ret,

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -267,10 +267,33 @@ struct ioctl_check_and_request_bridge_shutdown_args
   bool ret_should_shutdown;
 };
 
+// The caller's IPC namespace and pid come from `current` in the kmod, so they are
+// not passed here; only the domain is (the kernel cannot infer a ROS_DOMAIN_ID).
 struct ioctl_discovery_agent_should_exit_args
 {
   uint32_t domain_id;
+  // false: read-only idle poll (userspace counts consecutive idle polls before exiting).
+  // true: atomic exit gate -- deregister iff the domain is truly empty, serialized against
+  // add_process so a process racing in vetoes the exit instead of being orphaned.
+  bool commit;
   bool ret_should_exit;
+};
+
+// The caller's IPC namespace and pid come from `current` in the kmod, so they are
+// not passed here; only the domain is (the kernel cannot infer a ROS_DOMAIN_ID).
+struct ioctl_add_discovery_agent_args
+{
+  uint32_t domain_id;
+  bool ret_already_exists;  // true: another agent already owns this (ns, domain); caller must exit
+};
+
+// The caller's IPC namespace and pid come from `current` in the kmod, so they are
+// not passed here; only the domain is (the kernel cannot infer a ROS_DOMAIN_ID).
+struct ioctl_discovery_agent_exists_args
+{
+  uint32_t domain_id;
+  bool
+    ret_exists;  // whether an agent is registered for this (ns, domain); read-only liveness query
 };
 
 struct ioctl_set_ros2_subscriber_num_args
@@ -318,6 +341,9 @@ struct ioctl_add_domain_bridge_args
 #define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)
 #define AGNOCAST_DISCOVERY_AGENT_SHOULD_EXIT_CMD \
   _IOWR(0xA6, 29, struct ioctl_discovery_agent_should_exit_args)
+#define AGNOCAST_ADD_DISCOVERY_AGENT_CMD _IOWR(0xA6, 30, struct ioctl_add_discovery_agent_args)
+#define AGNOCAST_DISCOVERY_AGENT_EXISTS_CMD \
+  _IOWR(0xA6, 31, struct ioctl_discovery_agent_exists_args)
 
 // ================================================
 // ros2cli ioctls
@@ -494,7 +520,15 @@ int agnocast_ioctl_set_ros2_publisher_num(
 int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid);
 
 int agnocast_ioctl_discovery_agent_should_exit(
-  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_should_exit);
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const uint32_t domain_id, const bool commit,
+  bool * ret_should_exit);
+
+int agnocast_ioctl_add_discovery_agent(
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const uint32_t domain_id,
+  struct ioctl_add_discovery_agent_args * ioctl_ret);
+
+int agnocast_ioctl_discovery_agent_exists(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_exists);
 
 int agnocast_ioctl_get_exit_process(
   const struct ipc_namespace * ipc_ns, struct ioctl_get_exit_process_args * ioctl_ret,
@@ -518,6 +552,7 @@ int agnocast_increment_message_entry_rc(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
   const int64_t entry_id);
 int agnocast_get_alive_proc_num(void);
+int agnocast_get_discovery_agent_num(void);
 bool agnocast_is_proc_exited(const pid_t pid);
 int agnocast_get_topic_entries_num(const char * topic_name, const struct ipc_namespace * ipc_ns);
 int64_t agnocast_get_latest_received_entry_id(

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -29,6 +29,18 @@ static void remove_all_process_info(void)
   // No explicit synchronize_rcu() needed: kfree_rcu() defers freeing until after the grace period.
 }
 
+static void remove_all_discovery_agents(void)
+{
+  struct discovery_agent_info * agent;
+  int bkt;
+  struct hlist_node * tmp;
+  hash_for_each_safe(discovery_agent_htable, bkt, tmp, agent, node)
+  {
+    hash_del_rcu(&agent->node);
+    kfree_rcu(agent, rcu_head);
+  }
+}
+
 static void remove_all_bridge_info(void)
 {
   struct bridge_info * br_info;
@@ -61,6 +73,7 @@ void agnocast_exit_free_data(void)
   down_write(&global_htables_rwsem);
   remove_all_topics();
   remove_all_process_info();
+  remove_all_discovery_agents();
   remove_all_bridge_info();
   remove_all_domain_rules();
   up_write(&global_htables_rwsem);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -8,6 +8,7 @@ struct device * agnocast_device;
 DECLARE_RWSEM(global_htables_rwsem);
 
 DEFINE_HASHTABLE(proc_info_htable, PROC_INFO_HASH_BITS);
+DEFINE_HASHTABLE(discovery_agent_htable, DISCOVERY_AGENT_HASH_BITS);
 DEFINE_HASHTABLE(topic_hashtable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
@@ -305,10 +306,27 @@ void agnocast_enqueue_exit_pid(const pid_t pid)
   }
 }
 
-// RCU-protected check: returns true if pid is registered in agnocast.
+// Caller holds global_htables_rwsem (write).
+void agnocast_remove_discovery_agent_by_pid(const pid_t pid)
+{
+  struct discovery_agent_info * agent;
+  struct hlist_node * tmp;
+  hash_for_each_possible_safe(
+    discovery_agent_htable, agent, tmp, node, hash_min(pid, DISCOVERY_AGENT_HASH_BITS))
+  {
+    if (agent->pid == pid) {
+      hash_del_rcu(&agent->node);
+      kfree_rcu(agent, rcu_head);
+      return;
+    }
+  }
+}
+
+// RCU-protected check: returns true if pid is a registered agnocast process or discovery agent.
 bool is_agnocast_pid(const pid_t pid)
 {
   struct process_info * proc_info;
+  struct discovery_agent_info * agent;
   bool found = false;
   rcu_read_lock();
   hash_for_each_possible_rcu(proc_info_htable, proc_info, node, hash_min(pid, PROC_INFO_HASH_BITS))
@@ -316,6 +334,16 @@ bool is_agnocast_pid(const pid_t pid)
     if (proc_info->global_pid == pid) {
       found = true;
       break;
+    }
+  }
+  if (!found) {
+    hash_for_each_possible_rcu(
+      discovery_agent_htable, agent, node, hash_min(pid, DISCOVERY_AGENT_HASH_BITS))
+    {
+      if (agent->pid == pid) {
+        found = true;
+        break;
+      }
     }
   }
   rcu_read_unlock();
@@ -327,6 +355,10 @@ bool is_agnocast_pid(const pid_t pid)
 void agnocast_process_exit_cleanup(const pid_t pid)
 {
   down_write(&global_htables_rwsem);
+
+  // The discovery agent is tracked outside proc_info and has no proc_info entry, so drain it
+  // here before the proc_info lookup (which would otherwise return early for the agent's pid).
+  agnocast_remove_discovery_agent_by_pid(pid);
 
   // The PID was already filtered by is_agnocast_pid() in the kprobe handler, but the state may
   // have changed between then and now (e.g., the process was already cleaned up by a prior call).

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -44,6 +44,8 @@ extern struct rw_semaphore global_htables_rwsem;
 #define PUB_INFO_HASH_BITS 3
 #define SUB_INFO_HASH_BITS 5
 #define PROC_INFO_HASH_BITS 10
+// At most one agent per (IPC namespace, domain), so the table is tiny.
+#define DISCOVERY_AGENT_HASH_BITS 4
 
 // Allocated in pre_handler_subscriber_exit(), freed in agnocast_commit_exit_process() after
 // the daemon successfully copies the data to user-space.
@@ -195,6 +197,27 @@ struct domain_bridge_rule
 };
 
 extern DECLARE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
+
+// The discovery agent's liveness, owned by the kmod so the fork gate and the
+// singleton claim share one source of truth (no userspace flock). Hashed by pid
+// (removal and is_agnocast_pid() are by pid); a (ns, domain) lookup scans. Unlike
+// process_info there is no `exited` flag: the entry is removed the moment the
+// agent exits, so "registered" always means "alive".
+struct discovery_agent_info
+{
+  pid_t pid;
+  const struct ipc_namespace * ipc_ns;
+  uint32_t domain_id;
+  struct hlist_node node;
+  struct rcu_head rcu_head;  // read from the atomic sched_process_exit path via is_agnocast_pid()
+};
+
+extern DECLARE_HASHTABLE(discovery_agent_htable, DISCOVERY_AGENT_HASH_BITS);
+
+// Both require global_htables_rwsem held (read for find, write for remove).
+struct discovery_agent_info * agnocast_find_discovery_agent(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
+void agnocast_remove_discovery_agent_by_pid(const pid_t pid);
 
 int agnocast_get_size_sub_info_htable(struct topic_wrapper * wrapper);
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -656,7 +656,7 @@ int agnocast_ioctl_add_process(
   ioctl_ret->ret_unlink_daemon_exist = (get_process_num(ipc_ns) > 0);
   ioctl_ret->ret_performance_bridge_daemon_exist =
     has_alive_performance_bridge_manager(ipc_ns, domain_id);
-  ioctl_ret->ret_discovery_agent_exist = (get_alive_process_num_in_domain(ipc_ns, domain_id) > 0);
+  ioctl_ret->ret_discovery_agent_exist = (agnocast_find_discovery_agent(ipc_ns, domain_id) != NULL);
 
   if (is_performance_bridge_manager && ioctl_ret->ret_performance_bridge_daemon_exist) {
     goto unlock;
@@ -2361,12 +2361,89 @@ int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
   return 0;
 }
 
-// The agent is not a registered Agnocast process, so it passes its own ROS_DOMAIN_ID.
+// Caller holds global_htables_rwsem (read). Scans because the table is keyed by pid.
+struct discovery_agent_info * agnocast_find_discovery_agent(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
+{
+  struct discovery_agent_info * agent;
+  int bkt;
+  hash_for_each(discovery_agent_htable, bkt, agent, node)
+  {
+    if (ipc_eq(agent->ipc_ns, ipc_ns) && agent->domain_id == domain_id) {
+      return agent;
+    }
+  }
+  return NULL;
+}
+
+// The agent is not a registered Agnocast process, so it passes its own pid + ROS_DOMAIN_ID.
+//
+// commit == false: read-only idle poll; userspace counts consecutive idle polls before exiting.
+// commit == true: the atomic exit gate. Deregister iff the domain is truly empty, under the same
+// write lock add_process takes -- so either a starting process is counted first and vetoes the
+// exit (ret_should_exit = false), or the agent deregisters first and that process then spawns a
+// replacement. Neither ordering leaves live processes without an agent.
 int agnocast_ioctl_discovery_agent_should_exit(
-  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_should_exit)
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const uint32_t domain_id, const bool commit,
+  bool * ret_should_exit)
+{
+  if (!commit) {
+    down_read(&global_htables_rwsem);
+    *ret_should_exit = (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0);
+    up_read(&global_htables_rwsem);
+    return 0;
+  }
+
+  down_write(&global_htables_rwsem);
+  if (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0) {
+    agnocast_remove_discovery_agent_by_pid(pid);
+    *ret_should_exit = true;
+  } else {
+    *ret_should_exit = false;
+  }
+  up_write(&global_htables_rwsem);
+  return 0;
+}
+
+// Atomic singleton claim; replaces the userspace flock. The first caller for a (ns, domain) wins
+// and is recorded; a later caller loses (ret_already_exists = true) and must exit.
+int agnocast_ioctl_add_discovery_agent(
+  const pid_t pid, const struct ipc_namespace * ipc_ns, const uint32_t domain_id,
+  struct ioctl_add_discovery_agent_args * ioctl_ret)
+{
+  int ret = 0;
+  // Deterministic default so the -ENOMEM path never returns a stale flag to userspace.
+  ioctl_ret->ret_already_exists = false;
+  down_write(&global_htables_rwsem);
+
+  if (agnocast_find_discovery_agent(ipc_ns, domain_id)) {
+    ioctl_ret->ret_already_exists = true;
+    goto unlock;
+  }
+
+  struct discovery_agent_info * agent = kmalloc(sizeof(struct discovery_agent_info), GFP_KERNEL);
+  if (!agent) {
+    ret = -ENOMEM;
+    goto unlock;
+  }
+  agent->pid = pid;
+  agent->ipc_ns = ipc_ns;
+  agent->domain_id = domain_id;
+  INIT_HLIST_NODE(&agent->node);
+  hash_add_rcu(discovery_agent_htable, &agent->node, hash_min(pid, DISCOVERY_AGENT_HASH_BITS));
+
+unlock:
+  up_write(&global_htables_rwsem);
+  return ret;
+}
+
+// Read-only liveness query for the CLI status verb. Now that the kmod owns agent liveness, this
+// is the authoritative "is the agent alive?" signal (replacing the userspace flock probe).
+int agnocast_ioctl_discovery_agent_exists(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_exists)
 {
   down_read(&global_htables_rwsem);
-  *ret_should_exit = (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0);
+  *ret_exists = (agnocast_find_discovery_agent(ipc_ns, domain_id) != NULL);
   up_read(&global_htables_rwsem);
   return 0;
 }
@@ -3012,13 +3089,39 @@ static long notify_bridge_shutdown_cmd(void)
 static long discovery_agent_should_exit_cmd(
   struct ioctl_discovery_agent_should_exit_args __user * arg)
 {
+  const pid_t pid = current->tgid;
   const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
 
   struct ioctl_discovery_agent_should_exit_args args;
   if (copy_from_user(&args, arg, sizeof(args))) return -EFAULT;
 
-  int ret =
-    agnocast_ioctl_discovery_agent_should_exit(ipc_ns, args.domain_id, &args.ret_should_exit);
+  int ret = agnocast_ioctl_discovery_agent_should_exit(
+    pid, ipc_ns, args.domain_id, args.commit, &args.ret_should_exit);
+  if (copy_to_user(arg, &args, sizeof(args))) return -EFAULT;
+  return ret;
+}
+
+static long add_discovery_agent_cmd(struct ioctl_add_discovery_agent_args __user * arg)
+{
+  const pid_t pid = current->tgid;
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_add_discovery_agent_args args;
+  if (copy_from_user(&args, arg, sizeof(args))) return -EFAULT;
+
+  int ret = agnocast_ioctl_add_discovery_agent(pid, ipc_ns, args.domain_id, &args);
+  if (copy_to_user(arg, &args, sizeof(args))) return -EFAULT;
+  return ret;
+}
+
+static long discovery_agent_exists_cmd(struct ioctl_discovery_agent_exists_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_discovery_agent_exists_args args;
+  if (copy_from_user(&args, arg, sizeof(args))) return -EFAULT;
+
+  int ret = agnocast_ioctl_discovery_agent_exists(ipc_ns, args.domain_id, &args.ret_exists);
   if (copy_to_user(arg, &args, sizeof(args))) return -EFAULT;
   return ret;
 }
@@ -3084,6 +3187,10 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
     case AGNOCAST_DISCOVERY_AGENT_SHOULD_EXIT_CMD:
       return discovery_agent_should_exit_cmd(
         (struct ioctl_discovery_agent_should_exit_args __user *)arg);
+    case AGNOCAST_ADD_DISCOVERY_AGENT_CMD:
+      return add_discovery_agent_cmd((struct ioctl_add_discovery_agent_args __user *)arg);
+    case AGNOCAST_DISCOVERY_AGENT_EXISTS_CMD:
+      return discovery_agent_exists_cmd((struct ioctl_discovery_agent_exists_args __user *)arg);
     default:
       return -EINVAL;
   }
@@ -3162,6 +3269,21 @@ int agnocast_get_alive_proc_num(void)
       count++;
     }
   }
+  return count;
+}
+
+int agnocast_get_discovery_agent_num(void)
+{
+  int count = 0;
+  struct discovery_agent_info * agent;
+  int bkt;
+  // Serialize against the exit path's hash_del_rcu()+kfree_rcu(), which runs under the write lock.
+  down_read(&global_htables_rwsem);
+  hash_for_each(discovery_agent_htable, bkt, agent, node)
+  {
+    count++;
+  }
+  up_read(&global_htables_rwsem);
   return count;
 }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -427,6 +427,9 @@ static struct entry_node * find_message_entry(
 
 // Forward declaration
 static int get_process_num(const struct ipc_namespace * ipc_ns);
+static int get_process_num_in_domain(const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
+static int get_alive_process_num_in_domain(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id);
 
 // Release subscriber reference from message entry (set boolean flag to false).
 // Called when subscriber's last ipc_shared_ptr reference is destroyed.
@@ -653,6 +656,7 @@ int agnocast_ioctl_add_process(
   ioctl_ret->ret_unlink_daemon_exist = (get_process_num(ipc_ns) > 0);
   ioctl_ret->ret_performance_bridge_daemon_exist =
     has_alive_performance_bridge_manager(ipc_ns, domain_id);
+  ioctl_ret->ret_discovery_agent_exist = (get_alive_process_num_in_domain(ipc_ns, domain_id) > 0);
 
   if (is_performance_bridge_manager && ioctl_ret->ret_performance_bridge_daemon_exist) {
     goto unlock;
@@ -2326,6 +2330,26 @@ static int get_process_num_in_domain(const struct ipc_namespace * ipc_ns, const 
   return count;
 }
 
+// Like get_process_num_in_domain() but excludes processes that have exited and are still
+// pending cleanup. The discovery agent tracks live endpoints, so an exited entry that lingers
+// until the unlink daemon drains it must not gate the agent's spawn or self-exit.
+static int get_alive_process_num_in_domain(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id)
+{
+  int count = 0;
+  struct process_info * proc_info;
+  int bkt_proc_info;
+  hash_for_each(proc_info_htable, bkt_proc_info, proc_info, node)
+  {
+    if (
+      ipc_eq(ipc_ns, proc_info->ipc_ns) && proc_info->domain_id == domain_id &&
+      !proc_info->exited) {
+      count++;
+    }
+  }
+  return count;
+}
+
 int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
 {
   down_write(&global_htables_rwsem);
@@ -2334,6 +2358,16 @@ int agnocast_ioctl_notify_bridge_shutdown(const pid_t pid)
     proc_info->is_performance_bridge_manager = false;
   }
   up_write(&global_htables_rwsem);
+  return 0;
+}
+
+// The agent is not a registered Agnocast process, so it passes its own ROS_DOMAIN_ID.
+int agnocast_ioctl_discovery_agent_should_exit(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, bool * ret_should_exit)
+{
+  down_read(&global_htables_rwsem);
+  *ret_should_exit = (get_alive_process_num_in_domain(ipc_ns, domain_id) == 0);
+  up_read(&global_htables_rwsem);
   return 0;
 }
 
@@ -2975,6 +3009,20 @@ static long notify_bridge_shutdown_cmd(void)
   return ret;
 }
 
+static long discovery_agent_should_exit_cmd(
+  struct ioctl_discovery_agent_should_exit_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_discovery_agent_should_exit_args args;
+  if (copy_from_user(&args, arg, sizeof(args))) return -EFAULT;
+
+  int ret =
+    agnocast_ioctl_discovery_agent_should_exit(ipc_ns, args.domain_id, &args.ret_should_exit);
+  if (copy_to_user(arg, &args, sizeof(args))) return -EFAULT;
+  return ret;
+}
+
 long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
 {
   switch (cmd) {
@@ -3033,6 +3081,9 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
       return set_ros2_publisher_num_cmd((struct ioctl_set_ros2_publisher_num_args __user *)arg);
     case AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD:
       return notify_bridge_shutdown_cmd();
+    case AGNOCAST_DISCOVERY_AGENT_SHOULD_EXIT_CMD:
+      return discovery_agent_should_exit_cmd(
+        (struct ioctl_discovery_agent_should_exit_args __user *)arg);
     default:
       return -EINVAL;
   }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -5,6 +5,7 @@
 #include "../agnocast_memory_allocator.h"
 
 #include <kunit/test.h>
+#include <linux/delay.h>
 
 static pid_t pid = 1000;
 void test_case_add_process_normal(struct kunit * test)
@@ -90,6 +91,80 @@ void test_case_add_process_perf_manager_per_domain(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret_d0_again, 0);
   KUNIT_EXPECT_TRUE(test, args_d0_again.ret_performance_bridge_daemon_exist);
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
+}
+
+// Spawn gate is per-(ipc_ns, domain): first process sees none, a later one sees
+// it, a first process in another domain sees none again.
+void test_case_add_process_discovery_agent_per_domain(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  union ioctl_add_process_args first_d0;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 0, &first_d0), 0);
+  KUNIT_EXPECT_FALSE(test, first_d0.ret_discovery_agent_exist);
+
+  union ioctl_add_process_args second_d0;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 0, &second_d0), 0);
+  KUNIT_EXPECT_TRUE(test, second_d0.ret_discovery_agent_exist);
+
+  union ioctl_add_process_args first_d1;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 1, &first_d1), 0);
+  KUNIT_EXPECT_FALSE(test, first_d1.ret_discovery_agent_exist);
+}
+
+// The agent self-exit query is true only when its (ipc_ns, domain) has no process.
+void test_case_discovery_agent_should_exit(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  bool should_exit = false;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 7, &should_exit), 0);
+  KUNIT_EXPECT_TRUE(test, should_exit);  // empty domain
+
+  union ioctl_add_process_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 7, &args), 0);
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 7, &should_exit), 0);
+  KUNIT_EXPECT_FALSE(test, should_exit);  // domain 7 now has a process
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 8, &should_exit), 0);
+  KUNIT_EXPECT_TRUE(test, should_exit);  // a different, empty domain
+}
+
+// A domain whose only process has exited but is not yet drained must be treated as empty:
+// the exited entry lingers in proc_info_htable until the unlink daemon reaps it, and it must
+// neither keep the discovery agent alive nor block a fresh agent from spawning.
+void test_case_discovery_agent_ignores_exited_process(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  const pid_t exited_pid = pid++;
+  union ioctl_add_process_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(exited_pid, current->nsproxy->ipc_ns, false, 9, &args), 0);
+  KUNIT_EXPECT_FALSE(test, args.ret_discovery_agent_exist);  // first live process in domain 9
+
+  agnocast_enqueue_exit_pid(exited_pid);
+  msleep(10);  // let exit_worker_thread mark the process exited
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(exited_pid));
+
+  bool should_exit = false;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 9, &should_exit), 0);
+  KUNIT_EXPECT_TRUE(test, should_exit);  // exited-but-not-drained must not keep the agent alive
+
+  union ioctl_add_process_args next_args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 9, &next_args), 0);
+  KUNIT_EXPECT_FALSE(
+    test, next_args.ret_discovery_agent_exist);  // exited predecessor is not counted
 }
 
 void test_case_add_process_too_many(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.c
@@ -93,78 +93,203 @@ void test_case_add_process_perf_manager_per_domain(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 2);
 }
 
-// Spawn gate is per-(ipc_ns, domain): first process sees none, a later one sees
-// it, a first process in another domain sees none again.
-void test_case_add_process_discovery_agent_per_domain(struct kunit * test)
+// The first agent to claim a (ns, domain) wins and is recorded.
+void test_case_discovery_agent_register_first_wins(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
 
-  union ioctl_add_process_args first_d0;
+  struct ioctl_add_discovery_agent_args reg;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 0, &first_d0), 0);
-  KUNIT_EXPECT_FALSE(test, first_d0.ret_discovery_agent_exist);
-
-  union ioctl_add_process_args second_d0;
-  KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 0, &second_d0), 0);
-  KUNIT_EXPECT_TRUE(test, second_d0.ret_discovery_agent_exist);
-
-  union ioctl_add_process_args first_d1;
-  KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 1, &first_d1), 0);
-  KUNIT_EXPECT_FALSE(test, first_d1.ret_discovery_agent_exist);
+    test, agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 10, &reg), 0);
+  KUNIT_EXPECT_FALSE(test, reg.ret_already_exists);
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 1);
 }
 
-// The agent self-exit query is true only when its (ipc_ns, domain) has no process.
-void test_case_discovery_agent_should_exit(struct kunit * test)
+// A second claim on the same (ns, domain) loses; the registry keeps exactly one agent.
+void test_case_discovery_agent_register_duplicate_loses(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  struct ioctl_add_discovery_agent_args first;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 11, &first), 0);
+  KUNIT_EXPECT_FALSE(test, first.ret_already_exists);
+
+  struct ioctl_add_discovery_agent_args second;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 11, &second), 0);
+  KUNIT_EXPECT_TRUE(test, second.ret_already_exists);
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 1);
+}
+
+// The fork gate reflects agent registration, not the process count: a live process alone does
+// not make the agent "exist"; registering one does.
+void test_case_discovery_agent_exist_reflects_registration(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  union ioctl_add_process_args before;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 12, &before), 0);
+  KUNIT_EXPECT_FALSE(test, before.ret_discovery_agent_exist);  // process alive, no agent yet
+
+  struct ioctl_add_discovery_agent_args reg;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 12, &reg), 0);
+
+  union ioctl_add_process_args after;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 12, &after), 0);
+  KUNIT_EXPECT_TRUE(test, after.ret_discovery_agent_exist);  // now an agent is registered
+}
+
+// commit on an empty domain deregisters the agent and tells it to exit.
+void test_case_discovery_agent_commit_exit_when_idle(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  const pid_t agent_pid = pid++;
+  struct ioctl_add_discovery_agent_args reg;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_pid, current->nsproxy->ipc_ns, 13, &reg), 0);
 
   bool should_exit = false;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 7, &should_exit), 0);
-  KUNIT_EXPECT_TRUE(test, should_exit);  // empty domain
-
-  union ioctl_add_process_args args;
-  KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 7, &args), 0);
-
-  KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 7, &should_exit), 0);
-  KUNIT_EXPECT_FALSE(test, should_exit);  // domain 7 now has a process
-
-  KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 8, &should_exit), 0);
-  KUNIT_EXPECT_TRUE(test, should_exit);  // a different, empty domain
+    test,
+    agnocast_ioctl_discovery_agent_should_exit(
+      agent_pid, current->nsproxy->ipc_ns, 13, true, &should_exit),
+    0);
+  KUNIT_EXPECT_TRUE(test, should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 0);  // deregistered
 }
 
-// A domain whose only process has exited but is not yet drained must be treated as empty:
-// the exited entry lingers in proc_info_htable until the unlink daemon reaps it, and it must
-// neither keep the discovery agent alive nor block a fresh agent from spawning.
-void test_case_discovery_agent_ignores_exited_process(struct kunit * test)
+// commit is vetoed while the domain still has a live process; the agent stays registered.
+void test_case_discovery_agent_commit_exit_vetoed_when_busy(struct kunit * test)
 {
-  KUNIT_ASSERT_EQ(test, agnocast_get_alive_proc_num(), 0);
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
 
-  const pid_t exited_pid = pid++;
-  union ioctl_add_process_args args;
+  const pid_t agent_pid = pid++;
+  struct ioctl_add_discovery_agent_args reg;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(exited_pid, current->nsproxy->ipc_ns, false, 9, &args), 0);
-  KUNIT_EXPECT_FALSE(test, args.ret_discovery_agent_exist);  // first live process in domain 9
+    test, agnocast_ioctl_add_discovery_agent(agent_pid, current->nsproxy->ipc_ns, 14, &reg), 0);
 
-  agnocast_enqueue_exit_pid(exited_pid);
-  msleep(10);  // let exit_worker_thread mark the process exited
-  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(exited_pid));
+  union ioctl_add_process_args proc;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 14, &proc), 0);
+
+  bool should_exit = true;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_discovery_agent_should_exit(
+      agent_pid, current->nsproxy->ipc_ns, 14, true, &should_exit),
+    0);
+  KUNIT_EXPECT_FALSE(test, should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 1);  // retained
+}
+
+// The agent has no proc_info, so its liveness must be wired into the exit pipeline: its pid is an
+// agnocast pid while registered, and the exit cleanup drains its registry entry.
+void test_case_discovery_agent_reaped_on_exit(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  const pid_t agent_pid = pid++;
+  struct ioctl_add_discovery_agent_args reg;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_pid, current->nsproxy->ipc_ns, 15, &reg), 0);
+  KUNIT_EXPECT_TRUE(test, is_agnocast_pid(agent_pid));
+
+  agnocast_enqueue_exit_pid(agent_pid);
+  msleep(20);  // let exit_worker_thread run agnocast_process_exit_cleanup
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+  KUNIT_EXPECT_FALSE(test, is_agnocast_pid(agent_pid));
+}
+
+// The orphan race the whole registry exists to close: the agent's final exit (commit) and a new
+// process's add_process are serialized, so the domain never ends up with live processes and no
+// agent. Here commit wins first, then a new process spawns a replacement that registers cleanly.
+void test_case_discovery_agent_orphan_race(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  const pid_t agent_a = pid++;
+  struct ioctl_add_discovery_agent_args reg_a;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_a, current->nsproxy->ipc_ns, 16, &reg_a), 0);
 
   bool should_exit = false;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_discovery_agent_should_exit(current->nsproxy->ipc_ns, 9, &should_exit), 0);
-  KUNIT_EXPECT_TRUE(test, should_exit);  // exited-but-not-drained must not keep the agent alive
+    test,
+    agnocast_ioctl_discovery_agent_should_exit(
+      agent_a, current->nsproxy->ipc_ns, 16, true, &should_exit),
+    0);
+  KUNIT_ASSERT_TRUE(test, should_exit);  // idle domain -> A deregisters
 
-  union ioctl_add_process_args next_args;
+  union ioctl_add_process_args p2;
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 9, &next_args), 0);
-  KUNIT_EXPECT_FALSE(
-    test, next_args.ret_discovery_agent_exist);  // exited predecessor is not counted
+    test, agnocast_ioctl_add_process(pid++, current->nsproxy->ipc_ns, false, 16, &p2), 0);
+  KUNIT_EXPECT_FALSE(test, p2.ret_discovery_agent_exist);  // A is gone -> P2 must spawn one
+
+  const pid_t agent_b = pid++;
+  struct ioctl_add_discovery_agent_args reg_b;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_b, current->nsproxy->ipc_ns, 16, &reg_b), 0);
+  KUNIT_EXPECT_FALSE(test, reg_b.ret_already_exists);            // replacement wins
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 1);  // exactly one agent, no orphan
+}
+
+// The read-only liveness ioctl (backing the CLI status verb) reflects registration per domain.
+void test_case_discovery_agent_exists_ioctl(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  bool exists = true;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_exists(current->nsproxy->ipc_ns, 17, &exists), 0);
+  KUNIT_EXPECT_FALSE(test, exists);  // none registered
+
+  struct ioctl_add_discovery_agent_args reg;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(pid++, current->nsproxy->ipc_ns, 17, &reg), 0);
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_exists(current->nsproxy->ipc_ns, 17, &exists), 0);
+  KUNIT_EXPECT_TRUE(test, exists);  // registered in domain 17
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_discovery_agent_exists(current->nsproxy->ipc_ns, 18, &exists), 0);
+  KUNIT_EXPECT_FALSE(test, exists);  // a different domain
+}
+
+// An exited-but-not-yet-drained process must not veto the commit: it lingers in proc_info_htable
+// until the unlink daemon reaps it, but get_alive_process_num_in_domain() skips ->exited entries,
+// so the domain reads empty and the agent is allowed to exit.
+void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(test, agnocast_get_discovery_agent_num(), 0);
+
+  const pid_t agent_pid = pid++;
+  struct ioctl_add_discovery_agent_args reg;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_discovery_agent(agent_pid, current->nsproxy->ipc_ns, 19, &reg), 0);
+
+  const pid_t app_pid = pid++;
+  union ioctl_add_process_args app;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(app_pid, current->nsproxy->ipc_ns, false, 19, &app), 0);
+
+  agnocast_enqueue_exit_pid(app_pid);
+  msleep(20);  // let exit_worker_thread mark it exited (still present, not yet drained)
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(app_pid));
+
+  bool should_exit = false;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_discovery_agent_should_exit(
+      agent_pid, current->nsproxy->ipc_ns, 19, true, &should_exit),
+    0);
+  KUNIT_EXPECT_TRUE(test, should_exit);                          // exited process does not veto
+  KUNIT_EXPECT_EQ(test, agnocast_get_discovery_agent_num(), 0);  // agent deregistered
 }
 
 void test_case_add_process_too_many(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -6,10 +6,16 @@
   KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
     KUNIT_CASE(test_case_add_process_twice),                                        \
     KUNIT_CASE(test_case_add_process_perf_manager_per_domain),                      \
+    KUNIT_CASE(test_case_add_process_discovery_agent_per_domain),                   \
+    KUNIT_CASE(test_case_discovery_agent_should_exit),                              \
+    KUNIT_CASE(test_case_discovery_agent_ignores_exited_process),                   \
     KUNIT_CASE(test_case_add_process_too_many)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
 void test_case_add_process_twice(struct kunit * test);
 void test_case_add_process_perf_manager_per_domain(struct kunit * test);
+void test_case_add_process_discovery_agent_per_domain(struct kunit * test);
+void test_case_discovery_agent_should_exit(struct kunit * test);
+void test_case_discovery_agent_ignores_exited_process(struct kunit * test);
 void test_case_add_process_too_many(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_process.h
@@ -6,16 +6,28 @@
   KUNIT_CASE(test_case_add_process_normal), KUNIT_CASE(test_case_add_process_many), \
     KUNIT_CASE(test_case_add_process_twice),                                        \
     KUNIT_CASE(test_case_add_process_perf_manager_per_domain),                      \
-    KUNIT_CASE(test_case_add_process_discovery_agent_per_domain),                   \
-    KUNIT_CASE(test_case_discovery_agent_should_exit),                              \
-    KUNIT_CASE(test_case_discovery_agent_ignores_exited_process),                   \
+    KUNIT_CASE(test_case_discovery_agent_register_first_wins),                      \
+    KUNIT_CASE(test_case_discovery_agent_register_duplicate_loses),                 \
+    KUNIT_CASE(test_case_discovery_agent_exist_reflects_registration),              \
+    KUNIT_CASE(test_case_discovery_agent_commit_exit_when_idle),                    \
+    KUNIT_CASE(test_case_discovery_agent_commit_exit_vetoed_when_busy),             \
+    KUNIT_CASE(test_case_discovery_agent_reaped_on_exit),                           \
+    KUNIT_CASE(test_case_discovery_agent_orphan_race),                              \
+    KUNIT_CASE(test_case_discovery_agent_exists_ioctl),                             \
+    KUNIT_CASE(test_case_discovery_agent_commit_ignores_exited_process),            \
     KUNIT_CASE(test_case_add_process_too_many)
 
 void test_case_add_process_normal(struct kunit * test);
 void test_case_add_process_many(struct kunit * test);
 void test_case_add_process_twice(struct kunit * test);
 void test_case_add_process_perf_manager_per_domain(struct kunit * test);
-void test_case_add_process_discovery_agent_per_domain(struct kunit * test);
-void test_case_discovery_agent_should_exit(struct kunit * test);
-void test_case_discovery_agent_ignores_exited_process(struct kunit * test);
+void test_case_discovery_agent_register_first_wins(struct kunit * test);
+void test_case_discovery_agent_register_duplicate_loses(struct kunit * test);
+void test_case_discovery_agent_exist_reflects_registration(struct kunit * test);
+void test_case_discovery_agent_commit_exit_when_idle(struct kunit * test);
+void test_case_discovery_agent_commit_exit_vetoed_when_busy(struct kunit * test);
+void test_case_discovery_agent_reaped_on_exit(struct kunit * test);
+void test_case_discovery_agent_orphan_race(struct kunit * test);
+void test_case_discovery_agent_exists_ioctl(struct kunit * test);
+void test_case_discovery_agent_commit_ignores_exited_process(struct kunit * test);
 void test_case_add_process_too_many(struct kunit * test);


### PR DESCRIPTION
## Description

First PR of the kmod-managed discovery-agent (auto-fork) stack. The kmod owns the agent's **singleton and liveness in a dedicated registry**, so the fork gate and the singleton claim share one source of truth — no userspace lock file. This is the redesign requested in review (see the #1428 discussion, "manage the agent fully in the kmod"); it closes the orphan race the earlier flock approach had.

The agent runs **one per (IPC namespace, ROS_DOMAIN_ID)**, started by the first Agnocast node in that scope and self-exiting when the last one leaves.

- **Registry**: `discovery_agent_htable` (RCU, keyed by pid), one entry per live agent. Unlike `proc_info` there is no `exited` flag — the entry is removed the moment the agent exits, so "registered" always means "alive".
- **`AGNOCAST_ADD_DISCOVERY_AGENT` (30)** — atomic singleton claim: the first caller for a (NS, domain) wins; a duplicate loses (`ret_already_exists`) and must exit. Replaces the userspace flock.
- **`AGNOCAST_DISCOVERY_AGENT_SHOULD_EXIT` (29)** gains a `commit` flag: `false` = read-only idle poll (userspace counts consecutive idle polls before exiting); `true` = the atomic exit gate — deregisters the agent iff the (NS, domain) is truly empty, under the same write lock `add_process` takes, so a process starting during the grace period keeps the agent running instead of orphaning the scope.
- **`AGNOCAST_DISCOVERY_AGENT_EXISTS` (31)** — read-only liveness query for the CLI status verb (#1427).
- **`add_process`** returns `ret_discovery_agent_exist = (find_discovery_agent(ns, domain) != NULL)` — the first process sees `false` and forks the agent; later ones see `true`.
- The agent has no `proc_info`, so its liveness is wired into the exit pipeline (`is_agnocast_pid` + `agnocast_process_exit_cleanup`) and module teardown.

cmd numbers 30/31 follow 28 (`ADD_DOMAIN_BRIDGE`, now merged) and 29.

## Related links

- Discovery agent lifecycle discussion (TIER IV internal link): https://tier4.atlassian.net/wiki/x/4ABEPAE

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required) - tested on `#1428`
- [x] `bash scripts/test/e2e_test_2to2.bash` (required) - tested on `#1428`
- [x] kunit tests (required) — 190/190 via the `kunit` CI path (kunit.py + QEMU, KASAN + lockdep), incl. 9 discovery-agent cases: register first-wins / duplicate-loses / exist-reflects-registration / commit-exit-when-idle / commit-vetoed-when-busy / reaped-on-exit / **orphan-race** / exists-ioctl / commit-ignores-exited-process.
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required) - tested on `#1428`
- [ ] sample application

## Notes for reviewers

This is the redesign from the #1428 review discussion. The `orphan_race` KUnit case is the one to sanity-check: agent A commits and deregisters, a new process then sees no agent and forks a replacement that wins the claim — exactly one agent ends up registered, no orphan.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

- `need-minor-update` (`add_process` ABI + new ioctls 30/31 + `commit` field on 29)
