### PR TITLE
fix(ros2agnocast): don't flag a missing discovery agent when there is no Agnocast

### DIFF
--- a/src/ros2agnocast/ros2agnocast/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/_bridged_ros2cli.py
@@ -75,7 +75,7 @@ def resolve_type_name(topic_name: str, gossip_timeout: float):
         if not type_name:
             # If not found, fall back to /_agnocast_discovery to look up the Agnocast topic.
             snapshots, used_fallback = collect_announcements_with_fallback(proxy_node, timeout_sec=gossip_timeout)
-            warn_if_using_fallback(proxy_node, used_fallback, gossip_timeout)
+            warn_if_using_fallback(proxy_node, used_fallback, gossip_timeout, snapshots)
             type_name = next(
                 (topic.type_name
                  for snap in snapshots

--- a/src/ros2agnocast/ros2agnocast/_ioctl.py
+++ b/src/ros2agnocast/ros2agnocast/_ioctl.py
@@ -28,7 +28,11 @@ class _TopicInfoRet(ctypes.Structure):
 
 
 def _load_lib() -> Optional[ctypes.CDLL]:
-    """Return the configured ioctl wrapper, or None on absent kmod."""
+    """Return the ioctl wrapper CDLL, or None if its shared library is missing.
+
+    This does not depend on the kmod: when the library loads but the kmod is
+    absent, the ioctls still succeed and simply return empty results.
+    """
     try:
         lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
     except OSError:

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -15,7 +15,7 @@ from rclpy.qos import (
 
 from ros2agnocast._ioctl import self_ns_snapshot
 
-from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState, AgnocastEndpoint
 
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
@@ -66,8 +66,12 @@ def gossip_qos() -> QoSProfile:
 def collect_announcements(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
-) -> list:
-    """Collect one latest snapshot per ``(host_uuid, ipc_ns_inode)`` from gossip."""
+) -> list[AgnocastDaemonState]:
+    """Collect one latest snapshot per ``(host_uuid, ipc_ns_inode)`` from gossip.
+
+    Returns one ``AgnocastDaemonState`` per gossiping agent, or ``[]`` when no
+    agent is reachable within ``timeout_sec``.
+    """
     snapshots = {}
 
     def on_msg(msg: AgnocastDaemonState) -> None:
@@ -99,8 +103,16 @@ def collect_announcements(
 def collect_announcements_with_fallback(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
-) -> tuple:
-    """Gossip first; ioctl fallback. Returns ``(snapshots, used_fallback)``."""
+) -> tuple[list[AgnocastDaemonState], bool]:
+    """Gossip first, then ioctl fallback. Returns ``(snapshots, used_fallback)``.
+
+    - ``used_fallback`` is False when at least one agent gossiped; ``snapshots``
+      is then every reachable agent's state.
+    - Otherwise it is True and ``snapshots`` is the local-NS ioctl view: a
+      single-element ``[state]`` whose ``topics`` may be empty (kmod absent or
+      nothing registered), or ``[]`` only if the ioctl wrapper library itself
+      cannot be loaded.
+    """
     snapshots = collect_announcements(node, timeout_sec)
     if snapshots:
         return snapshots, False
@@ -120,8 +132,16 @@ def _resolve_spin_node(node):
     return getattr(direct, 'node', direct)
 
 
-def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> None:
-    """Best-effort stderr note when gossip was unavailable and ioctl fallback ran."""
+def warn_if_using_fallback(
+    node, used_fallback: bool, timeout_sec: float, snapshots: list[AgnocastDaemonState]
+) -> None:
+    """Best-effort stderr note when gossip was unavailable and ioctl fallback ran.
+
+    ``snapshots`` is the fallback result from ``collect_announcements_with_fallback``.
+    The local ioctl fallback returns a ``[state]`` with empty ``topics`` (not ``[]``)
+    when the kmod is absent or nothing is registered, so "no Agnocast here" is
+    detected by the absence of topics, not by an empty list.
+    """
     if not used_fallback or timeout_sec <= 0:
         return
 
@@ -132,6 +152,11 @@ def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> Non
         publishers = []
 
     if not publishers:
+        # No agent is gossiping. Only worth a note when this namespace actually
+        # has Agnocast endpoints to show: ros2 CLI runs constantly in namespaces
+        # without Agnocast, where "no agent" would be misleading noise.
+        if not any(snap.topics for snap in snapshots):
+            return
         print(
             'NOTE: no /_agnocast_discovery agent visible; showing local '
             'NS only via ioctl. Start one with '
@@ -148,12 +173,12 @@ def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> Non
             file=sys.stderr)
 
 
-def all_topic_names(snapshots: list) -> set:
+def all_topic_names(snapshots: list[AgnocastDaemonState]) -> set[str]:
     """Union of topic names across all snapshots."""
     return {topic.topic_name for snap in snapshots for topic in snap.topics}
 
 
-def all_nodes(snapshots: list) -> set:
+def all_nodes(snapshots: list[AgnocastDaemonState]) -> set[str]:
     """Union of node names across all snapshots."""
     nodes = set()
     for snap in snapshots:
@@ -165,7 +190,9 @@ def all_nodes(snapshots: list) -> set:
     return nodes
 
 
-def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
+def topic_endpoints(
+    snapshots: list[AgnocastDaemonState], topic_name: str
+) -> tuple[list[AgnocastEndpoint], list[AgnocastEndpoint]]:
     """Return (publishers, subscribers) for ``topic_name`` across all snapshots."""
     publishers = []
     subscribers = []
@@ -178,7 +205,9 @@ def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
     return publishers, subscribers
 
 
-def topics_of_node(snapshots: list, node_name: str) -> tuple:
+def topics_of_node(
+    snapshots: list[AgnocastDaemonState], node_name: str
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
     """Return (pub topics, sub topics) for ``node_name`` as {topic_name, type_name} dicts."""
     pubs, subs = [], []
     for snap in snapshots:
@@ -206,7 +235,9 @@ BRIDGE_LABEL_TEXT = {
 }
 
 
-def collect_bridge_roles(snapshots: list) -> dict:
+def collect_bridge_roles(
+    snapshots: list[AgnocastDaemonState],
+) -> dict[str, list[tuple[bool, bool, bool, bool]]]:
     """Map ``topic_name -> per-NS bridge roles`` in a single pass over snapshots.
 
     Each value is a list with one entry per NS that has a real (non-bridge)

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -44,7 +44,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             bridge_roles = collect_bridge_roles(snapshots)
 
             def get_agnocast_label(topic_name, ros2_sub_topics, ros2_pub_topics):

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -36,7 +36,7 @@ class ListAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
 
             # Get node names which contains Agnocast topics from gossip.
             agnocast_node_name = all_nodes(snapshots)

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -133,7 +133,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
 
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             pub_endpoints, sub_endpoints = topic_endpoints(snapshots, topic_name)
 
             def to_info_ret(ep):

--- a/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
@@ -24,7 +24,7 @@ class ListAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             bridge_roles = collect_bridge_roles(snapshots)
 
             def divide_ros2_topic_into_pubsub(topic_names):

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -178,22 +178,38 @@ def _plain_node(publishers=None):
 
 
 def test_warn_if_using_fallback_silent_when_no_fallback_or_timeout_zero(capsys):
-    warn_if_using_fallback(_plain_node(), used_fallback=False, timeout_sec=2.0)
-    warn_if_using_fallback(_plain_node(), used_fallback=True, timeout_sec=0)
+    warn_if_using_fallback(_plain_node(), used_fallback=False, timeout_sec=2.0, snapshots=[])
+    warn_if_using_fallback(_plain_node(), used_fallback=True, timeout_sec=0, snapshots=[])
     assert capsys.readouterr().err == ''
 
 
 def test_warn_if_using_fallback_says_no_agent_when_dds_sees_no_publisher(capsys):
+    # Local Agnocast state exists (a topic), but no agent is gossiping.
     warn_if_using_fallback(
-        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0)
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[_state('h', 1, topics=[_topic('/chatter')])])
     err = capsys.readouterr().err
     assert 'NOTE' in err
     assert 'no /_agnocast_discovery agent visible' in err
 
 
+def test_warn_if_using_fallback_silent_when_no_publisher_and_no_local_state(capsys):
+    # No agent and no local Agnocast: stay quiet rather than nag the many ros2 CLI
+    # invocations in namespaces without Agnocast. The ioctl fallback yields a single
+    # state with empty ``topics`` (not an empty list) when nothing is registered, so
+    # emptiness is judged by topics, not list length.
+    warn_if_using_fallback(
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[_state('h', 1)])
+    warn_if_using_fallback(
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0, snapshots=[])
+    assert capsys.readouterr().err == ''
+
+
 def test_warn_if_using_fallback_says_qos_or_pythonpath_when_publisher_visible(capsys):
     warn_if_using_fallback(
-        _plain_node(publishers=[MagicMock()]), used_fallback=True, timeout_sec=2.0)
+        _plain_node(publishers=[MagicMock()]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[])
     err = capsys.readouterr().err
     assert 'WARNING' in err
     assert 'falling back to ioctl' in err


### PR DESCRIPTION
## Description

The `_agnocast` CLI verbs printed `NOTE: no /_agnocast_discovery agent visible; start one ...` whenever gossip was empty and they fell back to ioctl. In a namespace with no Agnocast at all that note is misleading. It is now emitted only when the ioctl fallback actually found local Agnocast state; the publisher-visible diagnostic is unchanged.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Python-only CLI change (no kmod / data-plane impact): `colcon test --packages-select ros2agnocast` → 81 passed, including the updated and added `warn_if_using_fallback` cases.

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` (bug fix).
