### PR TITLE
refactor(agnocastlib): add TypeErasedPublisher

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -274,6 +274,85 @@ public:
 };
 
 /**
+ * @brief A type-erased Agnocast publisher.
+ *
+ * There are four differences between this and BasicPublisher:
+ *
+ * 1. borrow_loaned_message() takes a size and returns an ipc_shared_ptr<void> that points to a
+ *    shared memory block of the requested size.
+ * 2. publish() takes a deleter as well as the message. Because the message is type-erased, the
+ *    publisher cannot know how to free it, so the caller must provide a deleter.
+ * 3. If a user decides not to publish a borrowed message, they must call cancel_message() with a
+ *    deleter to free the memory.
+ * 4. The constructor is just a thin wrapper around init_base(). As this class is intended for
+ *    internal use only, flexibility is prioritized.
+ */
+class TypeErasedPublisher : public PublisherBase
+{
+public:
+  using SharedPtr = std::shared_ptr<TypeErasedPublisher>;
+
+  TypeErasedPublisher(
+    rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge);
+
+  TypeErasedPublisher(
+    agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge);
+
+  ipc_shared_ptr<void> borrow_loaned_message(size_t size);
+
+  template <typename Deleter>
+  void cancel_message(ipc_shared_ptr<void> && message, Deleter && deleter)
+  {
+    if (!message || topic_name_ != message.get_topic_name()) {
+      RCLCPP_ERROR(logger, "Invalid message to cancel.");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    message.invalidate_all_references();
+
+    decrement_borrowed_publisher_num();
+
+    deleter(message.get());
+
+    message.reset();
+  }
+
+  template <typename Deleter>
+  void publish(ipc_shared_ptr<void> && message, Deleter && deleter)
+  {
+    if (!message || topic_name_ != message.get_topic_name()) {
+      RCLCPP_ERROR(logger, "Invalid message to publish.");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    const uint64_t msg_virtual_address = reinterpret_cast<uint64_t>(message.get());
+
+    message.invalidate_all_references();
+
+    decrement_borrowed_publisher_num();
+
+    union ioctl_publish_msg_args publish_msg_args;
+    {
+      std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
+      publish_msg_args = publish_core(this, topic_name_, id_, msg_virtual_address, opened_mqs_);
+    }
+
+    for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
+      void * release_ptr = reinterpret_cast<void *>(publish_msg_args.ret_released_addrs[i]);
+      deleter(release_ptr);
+    }
+
+    message.reset();
+  }
+};
+
+// TOOD(bdm-k): Incorporate TypeErasedPublisher into GenericPublisher to increase code reuse.
+
+/**
  * @brief Mirrors `rclcpp::GenericPublisher` semantics: the topic type is supplied as a
  * runtime string (e.g. "std_msgs/msg/String") rather than a compile-time
  * template argument. The typesupport library is loaded eagerly in the

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -350,8 +351,6 @@ public:
   }
 };
 
-// TOOD(bdm-k): Incorporate TypeErasedPublisher into GenericPublisher to increase code reuse.
-
 /**
  * @brief Mirrors `rclcpp::GenericPublisher` semantics: the topic type is supplied as a
  * runtime string (e.g. "std_msgs/msg/String") rather than a compile-time
@@ -362,7 +361,7 @@ public:
  * and are deserialized into Agnocast shared memory within the `publish()` call.
  */
 AGNOCAST_PUBLIC
-class GenericPublisher : public PublisherBase
+class GenericPublisher : public TypeErasedPublisher
 {
   // Keeps the dynamically loaded typesupport and introspection shared libraries
   // (.so) alongside their handles for the lifetime of the publisher.
@@ -371,10 +370,7 @@ class GenericPublisher : public PublisherBase
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
   const rosidl_typesupport_introspection_cpp::MessageMembers * members_{nullptr};
 
-  template <typename NodeT>
-  rclcpp::QoS constructor_impl(
-    NodeT * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role);
+  void load_type_support(const std::string & topic_type);
 
 public:
   using SharedPtr = std::shared_ptr<GenericPublisher>;

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -278,11 +278,13 @@ public:
       exit(EXIT_FAILURE);
     }
 
+    void * delete_ptr = message.get();
+
     message.invalidate_all_references();
 
     decrement_borrowed_publisher_num();
 
-    deleter(message.get());
+    deleter(delete_ptr);
 
     message.reset();
   }

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -261,11 +261,11 @@ public:
 
   TypeErasedPublisher(
     rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge);
+    const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
 
   TypeErasedPublisher(
     agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, const PublisherOptions & options, const bool is_bridge);
+    const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
 
   ipc_shared_ptr<void> borrow_loaned_message(size_t size);
 

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -243,7 +243,7 @@ public:
 /**
  * @brief A type-erased Agnocast publisher.
  *
- * There are four differences between this and BasicPublisher:
+ * There are four differences between this and Publisher:
  *
  * 1. borrow_loaned_message() takes a size and returns an ipc_shared_ptr<void> that points to a
  *    shared memory block of the requested size.

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -382,6 +382,8 @@ public:
     }
 
     ptr_ = nullptr;
+    // Suppress false positive from clang-tidy: atomic reference counting ensures no leak.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     control_ = nullptr;
   }
 };

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -44,6 +44,8 @@ constexpr int64_t ENTRY_ID_NOT_ASSIGNED = -1;
 template <typename MessageT, typename BridgeRegistrationPolicy>
 class BasicPublisher;
 
+class TypeErasedPublisher;
+
 namespace detail
 {
 
@@ -101,9 +103,11 @@ AGNOCAST_PUBLIC
 template <typename T>
 class ipc_shared_ptr
 {
-  // Allow BasicPublisher to call invalidate_all_references()
+  // Allow BasicPublisher and TypeErasedPublisher to call invalidate_all_references()
   template <typename MessageT, typename BridgeRegistrationPolicy>
   friend class BasicPublisher;
+
+  friend class TypeErasedPublisher;
 
   // Allow converting constructors to access private members of ipc_shared_ptr<U>
   template <typename U>
@@ -299,7 +303,8 @@ public:
   /// by publish().
   /// @return Reference to the managed message.
   AGNOCAST_PUBLIC
-  T & operator*() const noexcept
+  template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+  U & operator*() const noexcept
   {
     if (AGNOCAST_UNLIKELY(is_invalidated_())) {
       std::fprintf(
@@ -316,7 +321,8 @@ public:
   /// invalidated by publish().
   /// @return Pointer to the managed message.
   AGNOCAST_PUBLIC
-  T * operator->() const noexcept
+  template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+  U * operator->() const noexcept
   {
     if (AGNOCAST_UNLIKELY(is_invalidated_())) {
       std::fprintf(
@@ -361,7 +367,16 @@ public:
         // Publisher side, last reference, not published: delete the memory.
         // This handles the case where borrow_loaned_message() was called but publish() was not.
         decrement_borrowed_publisher_num();
-        delete ptr_;
+        if constexpr (!std::is_void_v<T>) {
+          delete ptr_;
+        } else {
+          std::fprintf(
+            stderr,
+            "[agnocast] FATAL: Type-erased message was dropped before being published.\n"
+            "This is not allowed because there is no well-defined way to free a type-erased "
+            "message.\n");
+          std::terminate();
+        }
       }
       delete control_;
     }

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -339,7 +339,7 @@ ipc_shared_ptr<void> TypeErasedPublisher::borrow_loaned_message(size_t size)
 {
   increment_borrowed_publisher_num();
   void * ptr = ::operator new(size);
-  return ipc_shared_ptr<void>(ptr, topic_name_.c_str(), id_);
+  return ipc_shared_ptr<void>(ptr, topic_name_, id_);
 }
 
 void GenericPublisher::load_type_support(const std::string & topic_type)

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -373,11 +373,6 @@ GenericPublisher::GenericPublisher(
 : TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
   load_type_support(topic_type);
-
-  if (role == PublisherRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
-  }
 }
 
 GenericPublisher::GenericPublisher(
@@ -386,11 +381,6 @@ GenericPublisher::GenericPublisher(
 : TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
   load_type_support(topic_type);
-
-  if (role == PublisherRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
-  }
 }
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -292,10 +292,7 @@ ipc_shared_ptr<void> TypeErasedPublisher::borrow_loaned_message(size_t size)
   return ipc_shared_ptr<void>(ptr, topic_name_.c_str(), id_);
 }
 
-template <typename NodeT>
-rclcpp::QoS GenericPublisher::constructor_impl(
-  NodeT * node, const std::string & topic_name, const std::string & topic_type,
-  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
+void GenericPublisher::load_type_support(const std::string & topic_type)
 {
   // The typesupport functions may throw exceptions if the shared libraries
   // fail to load or an invalid message type name is provided. These
@@ -318,41 +315,34 @@ rclcpp::QoS GenericPublisher::constructor_impl(
 #endif
   members_ = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
     introspection_handle->data);
-
-  const bool is_bridge = (role == PublisherRole::BridgeInternal);
-  const rclcpp::QoS actual_qos =
-    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
-
-  if (role == PublisherRole::Default) {
-    register_pubsub_bridge_by_type_name(
-      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
-  }
-
-  return actual_qos;
 }
 
 GenericPublisher::GenericPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
+: TypeErasedPublisher(
+    node, topic_name, topic_type, qos, options, role == PublisherRole::BridgeInternal)
 {
-  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
+  load_type_support(topic_type);
 
-  TRACEPOINT(
-    agnocast_publisher_init, static_cast<const void *>(this),
-    static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
-    topic_name_.c_str(), actual_qos.depth());
+  if (role == PublisherRole::Default) {
+    register_pubsub_bridge_by_type_name(
+      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
+  }
 }
 
 GenericPublisher::GenericPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
+: TypeErasedPublisher(
+    node, topic_name, topic_type, qos, options, role == PublisherRole::BridgeInternal)
 {
-  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
+  load_type_support(topic_type);
 
-  TRACEPOINT(
-    agnocast_publisher_init, static_cast<const void *>(this),
-    static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
-    actual_qos.depth());
+  if (role == PublisherRole::Default) {
+    register_pubsub_bridge_by_type_name(
+      topic_name_, id_, topic_type, BridgeDirection::AGNOCAST_TO_ROS2);
+  }
 }
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
@@ -371,8 +361,8 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
     return;
   }
 
-  increment_borrowed_publisher_num();
-  void * ptr = ::operator new(members_->size_of_);
+  ipc_shared_ptr<void> message = borrow_loaned_message(members_->size_of_);
+  void * ptr = message.get();
 
   // Invoke the constructor of the message type at ptr.
   // Type-specific initialization is unnecessary because the message object
@@ -383,34 +373,20 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
   const rmw_ret_t ret =
     rmw_deserialize(&serialized_msg.get_rcl_serialized_message(), type_support_handle_, ptr);
 
-  decrement_borrowed_publisher_num();
+  auto deleter = [this](void * release_ptr) {
+    members_->fini_function(release_ptr);
+    ::operator delete(release_ptr);
+  };
 
   if (ret != RMW_RET_OK) {
-    members_->fini_function(ptr);
-    ::operator delete(ptr);
+    cancel_message(std::move(message), deleter);
     RCLCPP_ERROR(
       logger, "rmw_deserialize failed in GenericPublisher (rmw_ret=%d); dropping message",
       static_cast<int>(ret));
     return;
   }
 
-  const auto va = reinterpret_cast<uint64_t>(ptr);
-  union ioctl_publish_msg_args publish_msg_args {
-  };
-  {
-    std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
-    publish_msg_args = publish_core(this, topic_name_, id_, va, opened_mqs_);
-  }
-
-  // Release entries that all subscribers have finished reading.
-  // Only the addresses previously passed to the kernel by this publisher are returned here.
-  // Therefore, the message type is guaranteed to match members_ and it's safe to call
-  // fini_function on the pointer.
-  for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
-    void * rptr = reinterpret_cast<void *>(publish_msg_args.ret_released_addrs[i]);
-    members_->fini_function(rptr);
-    ::operator delete(rptr);
-  }
+  TypeErasedPublisher::publish(std::move(message), deleter);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -313,10 +313,9 @@ PublisherBase::~PublisherBase()
 
 TypeErasedPublisher::TypeErasedPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
-  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const bool is_bridge)
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
 {
-  const rclcpp::QoS actual_qos =
-    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
+  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
 
   TRACEPOINT(
     agnocast_publisher_init, static_cast<const void *>(this),
@@ -326,10 +325,9 @@ TypeErasedPublisher::TypeErasedPublisher(
 
 TypeErasedPublisher::TypeErasedPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
-  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const bool is_bridge)
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
 {
-  const rclcpp::QoS actual_qos =
-    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
+  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
 
   TRACEPOINT(
     agnocast_publisher_init, static_cast<const void *>(this),
@@ -372,8 +370,7 @@ void GenericPublisher::load_type_support(const std::string & topic_type)
 GenericPublisher::GenericPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
-: TypeErasedPublisher(
-    node, topic_name, topic_type, qos, options, role == PublisherRole::BridgeInternal)
+: TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
   load_type_support(topic_type);
 
@@ -386,8 +383,7 @@ GenericPublisher::GenericPublisher(
 GenericPublisher::GenericPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
-: TypeErasedPublisher(
-    node, topic_name, topic_type, qos, options, role == PublisherRole::BridgeInternal)
+: TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
   load_type_support(topic_type);
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -259,6 +259,39 @@ PublisherBase::~PublisherBase()
   }
 }
 
+TypeErasedPublisher::TypeErasedPublisher(
+  rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const bool is_bridge)
+{
+  const rclcpp::QoS actual_qos =
+    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
+    topic_name_.c_str(), actual_qos.depth());
+}
+
+TypeErasedPublisher::TypeErasedPublisher(
+  agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const bool is_bridge)
+{
+  const rclcpp::QoS actual_qos =
+    this->init_base(node, topic_name, topic_type, qos, options, is_bridge);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
+    actual_qos.depth());
+}
+
+ipc_shared_ptr<void> TypeErasedPublisher::borrow_loaned_message(size_t size)
+{
+  increment_borrowed_publisher_num();
+  void * ptr = ::operator new(size);
+  return ipc_shared_ptr<void>(ptr, topic_name_.c_str(), id_);
+}
+
 template <typename NodeT>
 rclcpp::QoS GenericPublisher::constructor_impl(
   NodeT * node, const std::string & topic_name, const std::string & topic_type,

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -237,11 +237,12 @@ protected:
 
 TEST_F(AgnocastTypeErasedPublisherTest, test_cancel)
 {
-  // Arrarnge
+  // Arrange
   agnocast::ipc_shared_ptr<void> message = dummy_publisher->borrow_loaned_message(4);
-  bool deleter_invoked = false;
-  auto deleter = [&deleter_invoked](void * p) {
-    deleter_invoked = true;
+  void * message_ptr = message.get();
+  void * delete_ptr = nullptr;
+  auto deleter = [&delete_ptr](void * p) {
+    delete_ptr = p;
     ::operator delete(p);
   };
 
@@ -251,7 +252,8 @@ TEST_F(AgnocastTypeErasedPublisherTest, test_cancel)
   // Assert
   EXPECT_EQ(publish_core_mock_called_count, 0);
   EXPECT_EQ(agnocast_get_borrowed_publisher_num(), 0);
-  EXPECT_TRUE(deleter_invoked);
+  EXPECT_NE(message_ptr, nullptr);
+  EXPECT_EQ(delete_ptr, message_ptr);
 }
 
 // =========================================

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -56,6 +56,8 @@ BridgeMode get_bridge_mode()
 {
   return BridgeMode::Off;  // Skip MQ sending in tests
 }
+
+PublisherBase::~PublisherBase() = default;
 }  // namespace agnocast
 
 // =========================================
@@ -209,6 +211,50 @@ TEST_F(AgnocastPublisherTest, test_multiple_borrows_mixed_publish_and_drop)
 }
 
 // =========================================
+// TypeErasedPublisher tests
+// =========================================
+
+class AgnocastTypeErasedPublisherTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node = std::make_shared<rclcpp::Node>("dummy_node");
+    dummy_publisher = std::make_shared<agnocast::TypeErasedPublisher>(
+      node.get(), "/dummy", "/std_msgs/msg/Int32", rclcpp::QoS{10}, agnocast::PublisherOptions{},
+      agnocast::PublisherRole::Default);
+
+    publish_core_mock_called_count = 0;
+    mock_borrowed_publisher_num = 0;
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<rclcpp::Node> node;
+  std::shared_ptr<agnocast::TypeErasedPublisher> dummy_publisher;
+};
+
+TEST_F(AgnocastTypeErasedPublisherTest, test_cancel)
+{
+  // Arrarnge
+  agnocast::ipc_shared_ptr<void> message = dummy_publisher->borrow_loaned_message(4);
+  bool deleter_invoked = false;
+  auto deleter = [&deleter_invoked](void * p) {
+    deleter_invoked = true;
+    ::operator delete(p);
+  };
+
+  // Act
+  dummy_publisher->cancel_message(std::move(message), deleter);
+
+  // Assert
+  EXPECT_EQ(publish_core_mock_called_count, 0);
+  EXPECT_EQ(agnocast_get_borrowed_publisher_num(), 0);
+  EXPECT_TRUE(deleter_invoked);
+}
+
+// =========================================
 // ipc_shared_ptr tests
 // =========================================
 
@@ -253,6 +299,18 @@ TEST_F(AgnocastSmartPointerTest, reset_nullptr)
 
   // Assert
   EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+}
+
+void drop_unpublished_void_message(const std::string & tn, topic_local_id_t pubsub_id)
+{
+  void * ptr = ::operator new(4);
+  agnocast::ipc_shared_ptr<void> sut{ptr, tn, pubsub_id, ENTRY_ID_NOT_ASSIGNED};
+  return;
+}
+
+TEST_F(AgnocastSmartPointerTest, reset_void)
+{
+  EXPECT_DEATH(drop_unpublished_void_message(dummy_tn, dummy_pubsub_id), "");
 }
 
 TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)


### PR DESCRIPTION
## Description

This PR introduces a new internal `TypeErasedPublisher` abstraction and refactors `GenericPublisher` to inherit from it. This low-level abstraction will be needed when we implement `GenericClient` in the future.

### What is `TypeErasedPublisher`

Please refer to the doc comment for information about what `TypeErasedPublisher` is. The comment summarizes the differences from `BasicPublisher`.

`TypeErasedPublisher` will be used to implement `GenericClient` in the near future. The interface of `GenericClient` has nothing to do with message serialization and is similar to the standard `Client`. In Agnocast, therefore, `GenericClient` would need to provide an API to allocate requests in shared memory (i.e., `borrow_loaned_request()`). In order to provide such an API, `GenericPublisher` is too specialized, and we need `TypeErasedPublisher` instead.

### `ipc_shared_ptr` updates for type-erased safety

`TypeErasedPublisher` uses `ipc_shared_ptr<void>` for its interface. A few changes are made to allow usage of `ipc_shared_ptr<void>`

- Guarded `operator*` and `oeprator->` for non-void specialization only.
- Added fatal behavior if an `ipc_shared_ptr<void>` is dropped before it is either publisher or canceled. We need this assertion because `ipc_shared_ptr<void>` cannot know how to free the message it points to.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application (`minimal_generic_publisher` works fine)

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

