### PR TITLE
refactor(agnocastlib): merge two MQs of the bridge manager into one

### DIFF
--- a/docs/message_queue.md
+++ b/docs/message_queue.md
@@ -46,12 +46,12 @@ The message queue is used as follows:
 The message definition is:
 
 ```cpp
-struct MqMsgPerformanceBridge {
-  char message_type[256];     // e.g., "std_msgs/msg/String"
-  BridgeTargetInfo target;    // topic name, target ID
-  BridgeDirection direction;  // ROS2_TO_AGNOCAST or AGNOCAST_TO_ROS2
+struct BridgeMsg {
+  BridgeMsgType type;  // PubSub, Service, or DaemonPubSub
+  union {
+    BridgeMsgPubSubPayload pubsub;
+    BridgeMsgServicePayload service;
+    BridgeMsgDaemonPubSubPayload daemon_pubsub;
+  } payload;
 };
 ```
-
-> [!NOTE]
-> The struct is named `MqMsgPerformanceBridge` for historical reasons. Before the bridge implementation was unified, this message format was specific to the "Performance Bridge" as opposed to the "Standard Bridge". The Standard Bridge has since been removed, but the struct name has been kept as-is to minimize churn.

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -25,39 +25,31 @@ struct MqMsgROS2Publish
   bool should_terminate;
 };
 
-struct PubsubBridgeTargetInfoWithType
+enum class BridgeMsgType : uint32_t {
+  PubSub = 0,
+  Service = 1,
+  DaemonPubSub = 2,
+};
+
+struct BridgeMsgPubSubPayload
 {
   char message_type[MESSAGE_TYPE_BUFFER_SIZE];
   char topic_name[TOPIC_NAME_BUFFER_SIZE];
   topic_local_id_t target_id;
+  BridgeDirection direction;
 };
 
-struct ServiceBridgeTargetInfoWithType
+struct BridgeMsgServicePayload
 {
   char service_type[SERVICE_TYPE_BUFFER_SIZE];
   char service_name[SERVICE_NAME_BUFFER_SIZE];
   bool create_shadow_node;
+  BridgeDirection direction;
   char shadow_node_namespace[NODE_NAME_BUFFER_SIZE];
   char shadow_node_name[NODE_NAME_BUFFER_SIZE];
 };
 
-struct MqMsgPerformanceBridge
-{
-  union {
-    PubsubBridgeTargetInfoWithType pubsub_target;
-    ServiceBridgeTargetInfoWithType srv_target;
-  };
-  BridgeDirection direction;
-  bool is_service;
-};
-
-// Cross-IPC-namespace bridge request from the per-NS daemon to a same-NS
-// bridge_manager. The daemon holds no process-local factory pointers, so it
-// names the target by topic (standard mode reuses the factory the manager
-// already cached from this process's intra-NS requests) and by type
-// (performance mode resolves a plugin). QoS is sent explicitly since the
-// bridge_manager cannot query the originating endpoint's QoS on its own.
-struct MqMsgDaemonBridge
+struct BridgeMsgDaemonPubSubPayload
 {
   char topic_name[TOPIC_NAME_BUFFER_SIZE];
   char type_name[MESSAGE_TYPE_BUFFER_SIZE];
@@ -67,19 +59,27 @@ struct MqMsgDaemonBridge
   bool qos_is_reliable;
 };
 
-constexpr int64_t PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES = 256;
-// The discovery agent bursts one request per (cross-NS topic, direction) each tick,
-// so a shallow queue would throttle startup convergence to a few bridges per second.
-// The bridge_manager already opens the 256-deep performance MQ, so matching it needs
-// no extra fs.mqueue.msg_max headroom.
-constexpr int64_t DAEMON_BRIDGE_MQ_MAX_MESSAGES = 256;
-constexpr int64_t PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgPerformanceBridge);
-constexpr int64_t DAEMON_BRIDGE_MQ_MESSAGE_SIZE = sizeof(MqMsgDaemonBridge);
+struct BridgeMsg
+{
+  BridgeMsgType type;
+  union Payload {
+    BridgeMsgPubSubPayload pubsub;
+    BridgeMsgServicePayload service;
+    BridgeMsgDaemonPubSubPayload daemon_pubsub;
+  } payload;
+};
+
+constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 256;
+constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(BridgeMsg);
 constexpr mode_t BRIDGE_MQ_PERMS = 0600;
 
-// Standard mode: one MQ per user process, `/agnocast_daemon_bridge@<pid>`.
-// Performance mode: one MQ per IPC namespace, `/agnocast_daemon_bridge_perf`.
-inline constexpr const char * DAEMON_BRIDGE_MQ_PREFIX = "/agnocast_daemon_bridge";
-inline constexpr const char * PERFORMANCE_DAEMON_BRIDGE_MQ_NAME = "/agnocast_daemon_bridge_perf";
+// Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
+// just the active variant's bytes. Used both for `mq_send` and for sizing
+// auxiliary buffers.
+template <typename PayloadT>
+constexpr size_t bridge_msg_wire_size()
+{
+  return offsetof(BridgeMsg, payload) + sizeof(PayloadT);
+}
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -84,10 +84,6 @@ uint32_t get_ros_domain_id();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
 std::string create_mq_name_for_bridge(const pid_t pid);
-// Name of the MQ a per-NS daemon uses to ask a bridge_manager to create a
-// cross-NS bridge. Standard mode keys on the owning user process's pid;
-// performance mode is per-NS (see impl).
-std::string create_mq_name_for_daemon_bridge(const pid_t pid);
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -14,7 +14,6 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <csignal>
@@ -50,13 +49,6 @@ public:
   void set_signal_handler(SignalCallback cb);
   void set_socket_handler(SocketCallback cb);
 
-  // Register a secondary MQ on this event loop (e.g. the daemon-originated
-  // cross-NS bridge request MQ). Call before `spin_once`; may be called more
-  // than once, each registration keeping its own fd-dispatched handler.
-  // Throws on failure.
-  void register_aux_mq(
-    const std::string & name, long max_messages, long msg_size, EventCallback cb);
-
   const std::string & get_mq_name() const { return mq_name_; }
 
 protected:
@@ -73,17 +65,6 @@ private:
   std::string mq_name_;
 
   long mq_msg_size_;
-
-  // One per `register_aux_mq()` call; matched by fd in `spin_once`.
-  struct AuxMq
-  {
-    mqd_t fd = (mqd_t)-1;
-    std::string name;
-    EventCallback cb;
-  };
-  // Expected to hold only a handful of entries (~5), so a flat vector is both
-  // simpler and faster to scan than a hash map would be at this size.
-  std::vector<AuxMq> aux_mqs_;
 
   EventCallback mq_cb_;
   SignalCallback signal_cb_;
@@ -164,12 +145,6 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
         handle_socket(client_fd);
         close(client_fd);
       }
-    } else {
-      auto it = std::find_if(
-        aux_mqs_.begin(), aux_mqs_.end(), [fd](const AuxMq & aux) { return fd == aux.fd; });
-      if (it != aux_mqs_.end() && it->cb) {
-        it->cb(fd);
-      }
     }
   }
   return true;
@@ -241,34 +216,6 @@ inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
 inline void IpcEventLoopBase::set_socket_handler(SocketCallback cb)
 {
   socket_cb_ = std::move(cb);
-}
-
-inline void IpcEventLoopBase::register_aux_mq(
-  const std::string & name, long max_messages, long msg_size, EventCallback cb)
-{
-  struct mq_attr attr = {};
-  attr.mq_maxmsg = max_messages;
-  attr.mq_msgsize = msg_size;
-
-  mqd_t fd =
-    mq_open(name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
-  if (fd == -1) {
-    throw std::system_error(errno, std::generic_category(), "aux MQ open failed: " + name);
-  }
-
-  try {
-    add_fd_to_epoll(fd, "AuxMQ");
-  } catch (...) {
-    if (mq_close(fd) == -1) {
-      RCLCPP_WARN(logger_, "Failed to close aux mq_fd: %s", strerror(errno));
-    }
-    if (mq_unlink(name.c_str()) == -1 && errno != ENOENT) {
-      RCLCPP_WARN(logger_, "Failed to unlink aux mq: %s", strerror(errno));
-    }
-    throw;
-  }
-
-  aux_mqs_.push_back(AuxMq{fd, name, std::move(cb)});
 }
 
 inline void IpcEventLoopBase::setup_mq()
@@ -366,7 +313,7 @@ inline void IpcEventLoopBase::setup_epoll()
 inline mqd_t IpcEventLoopBase::create_and_open_mq(const std::string & name) const
 {
   struct mq_attr attr = {};
-  attr.mq_maxmsg = PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES;
+  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
   attr.mq_msgsize = mq_msg_size_;
 
   mqd_t fd =
@@ -456,21 +403,6 @@ inline void IpcEventLoopBase::cleanup_resources()
         logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
     }
   }
-
-  for (auto & aux : aux_mqs_) {
-    if (aux.fd != (mqd_t)-1) {
-      if (mq_close(aux.fd) == -1) {
-        RCLCPP_WARN_STREAM(
-          logger_,
-          "Failed to close aux mq_fd for mq_name='" << aux.name << "': " << strerror(errno));
-      }
-      if (mq_unlink(aux.name.c_str()) == -1 && errno != ENOENT) {
-        RCLCPP_WARN_STREAM(
-          logger_, "Failed to unlink aux mq for mq_name='" << aux.name << "': " << strerror(errno));
-      }
-    }
-  }
-  aux_mqs_.clear();
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -78,14 +78,13 @@ struct RosToAgnocastServiceRegistrationPolicy
   }
 };
 
-template <typename MsgStruct>
-void send_mq_message(
-  const std::string & mq_name, const MsgStruct & msg, long msg_size_limit,
+inline void send_mq_message(
+  const std::string & mq_name, const BridgeMsg & msg, size_t send_size,
   const rclcpp::Logger & logger)
 {
   struct mq_attr attr = {};
-  attr.mq_maxmsg = PERFORMANCE_BRIDGE_MQ_MAX_MESSAGES;
-  attr.mq_msgsize = msg_size_limit;
+  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
+  attr.mq_msgsize = BRIDGE_MQ_MESSAGE_SIZE;
 
   mqd_t mq =
     mq_open(mq_name.c_str(), O_CREAT | O_WRONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
@@ -103,7 +102,7 @@ void send_mq_message(
   int send_result = -1;
   int last_errno = 0;
   for (int retry = 0; retry <= BRIDGE_MQ_SEND_MAX_RETRIES; ++retry) {
-    send_result = mq_send(mq, reinterpret_cast<const char *>(&msg), sizeof(msg), 0);
+    send_result = mq_send(mq, reinterpret_cast<const char *>(&msg), send_size, 0);
     if (send_result == 0) break;
     last_errno = errno;
     if (last_errno != EAGAIN) break;
@@ -132,7 +131,7 @@ inline void send_performance_pubsub_bridge_registration_by_type_name(
                          .set_message_type(message_type_name.c_str())
                          .set_topic_name(topic_name.c_str())
                          .set_pubsub_target_id(id)
-                         .build_performance_message();
+                         .build_message();
   if (!reason.empty()) {
     RCLCPP_ERROR(
       logger, "Failed to build performance pubsub bridge registration: %s", reason.c_str());
@@ -141,7 +140,7 @@ inline void send_performance_pubsub_bridge_registration_by_type_name(
   }
 
   std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE, logger);
+  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgPubSubPayload>(), logger);
 }
 
 template <typename ServiceT>
@@ -159,7 +158,7 @@ void send_performance_service_bridge_registration(
                          .set_service_type(service_type_name.c_str())
                          .set_service_name(service_name.c_str())
                          .set_shadow_node_identity(shadow_node_identity)
-                         .build_performance_message();
+                         .build_message();
   if (!reason.empty()) {
     RCLCPP_ERROR(
       logger, "Failed to build performance service bridge registration: %s", reason.c_str());
@@ -168,7 +167,7 @@ void send_performance_service_bridge_registration(
   }
 
   std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE, logger);
+  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgServicePayload>(), logger);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -58,7 +58,7 @@ rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t p
 // Rebuild a QoS profile from the fields a daemon cross-NS request carries. The
 // daemon has no local endpoint to query, so reliability / durability / depth are
 // reconstructed from the request rather than from the kernel.
-rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req);
+rclcpp::QoS daemon_request_qos(const BridgeMsgDaemonPubSubPayload & req);
 PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name);
 SubscriberCountResult get_agnocast_subscriber_count(const std::string & topic_name);
 bool update_ros2_subscriber_num(const rclcpp::Node * node, const std::string & topic_name);
@@ -71,12 +71,15 @@ bool is_agnocast_service_alive(const std::string & service_name, std::string & r
 /// @brief A builder class for creating bridge registration messages.
 ///
 /// It detects errors such as string truncation when copying string fields, and
-/// `build_performance_message()` returns the error reason. However, it does not check whether
+/// `build_message()` returns the error reason. However, it does not check whether
 /// the computed message as a whole is valid. It's the caller's responsibility to invoke a correct
 /// set of setters to build a valid message.
 class BridgeRegistrationMsgBuilder
 {
-  MqMsgPerformanceBridge msg_{};
+  BridgeMsgPubSubPayload pubsub_{};
+  BridgeMsgServicePayload service_{};
+  BridgeDirection direction_{BridgeDirection::ROS2_TO_AGNOCAST};
+  bool is_service_{false};
   bool failed_;
   std::string reason_;
 
@@ -97,7 +100,7 @@ public:
   BridgeRegistrationMsgBuilder & set_shadow_node_identity(
     const std::optional<std::pair<std::string, std::string>> & shadow_node_identity);
 
-  std::pair<MqMsgPerformanceBridge, std::string> build_performance_message();
+  std::pair<BridgeMsg, std::string> build_message();
 };
 
 template <typename MapT>

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -26,7 +26,7 @@ public:
   void run();
 
 private:
-  using RequestMap = std::unordered_map<topic_local_id_t, MqMsgPerformanceBridge>;
+  using RequestMap = std::unordered_map<topic_local_id_t, BridgeMsgPubSubPayload>;
 
   // A cross-NS bridge request from the per-NS daemon. Unlike an intra-NS request,
   // there is no local endpoint to resolve the plugin / QoS from, so the type and
@@ -76,11 +76,10 @@ private:
   void start_ros_execution();
 
   void on_mq_request(int fd);
-  void on_daemon_mq_request(int fd);
   void on_signal();
   std::string on_socket_request() const;
 
-  void register_daemon_pubsub_request(const MqMsgDaemonBridge & req);
+  void register_daemon_pubsub_request(const BridgeMsgDaemonPubSubPayload & req);
   bool is_daemon_forced(const std::string & topic_name, BridgeDirection direction) const;
   void create_daemon_forced_bridges();
   void activate_daemon_forced_bridge(
@@ -100,7 +99,7 @@ private:
   static void remove_invalid_requests(const std::string & topic_name, RequestMap & request_map);
 
   void create_service_bridge_if_needed(
-    const ServiceBridgeTargetInfoWithType & target, BridgeDirection direction);
+    const BridgeMsgServicePayload & target, BridgeDirection direction);
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -82,7 +82,7 @@ std::string create_mq_name_for_agnocast_publish(
 
 // MQ-name suffix that scopes the per-IPC-namespace performance bridge by domain.
 // An unset OR empty ROS_DOMAIN_ID means "no domain" (no suffix), keeping this in
-// sync with the Python discovery agent (bridge_decider._performance_mq_name).
+// sync with the Python discovery agent (bridge_decider._bridge_mq_name).
 static std::string performance_domain_suffix()
 {
   const char * domain_id = getenv("ROS_DOMAIN_ID");
@@ -116,14 +116,6 @@ std::string create_mq_name_for_bridge(const pid_t pid)
     name += performance_domain_suffix();
   }
   return name;
-}
-
-std::string create_mq_name_for_daemon_bridge(const pid_t pid)
-{
-  if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
-    return std::string(PERFORMANCE_DAEMON_BRIDGE_MQ_NAME) + performance_domain_suffix();
-  }
-  return std::string(DAEMON_BRIDGE_MQ_PREFIX) + "@" + std::to_string(pid);
 }
 
 uint64_t get_self_ipc_ns_inode()

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -82,7 +82,7 @@ rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t p
                                                     : rclcpp::DurabilityPolicy::Volatile);
 }
 
-rclcpp::QoS daemon_request_qos(const MqMsgDaemonBridge & req)
+rclcpp::QoS daemon_request_qos(const BridgeMsgDaemonPubSubPayload & req)
 {
   return rclcpp::QoS(req.qos_depth)
     .durability(
@@ -305,13 +305,13 @@ int BridgeRegistrationMsgBuilder::checked_snprintf(
 BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_direction(
   BridgeDirection direction)
 {
-  msg_.direction = direction;
+  direction_ = direction;
   return *this;
 }
 
 BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_is_service(bool is_service)
 {
-  msg_.is_service = is_service;
+  is_service_ = is_service;
   return *this;
 }
 
@@ -319,15 +319,15 @@ BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_message_type(
   const char * message_type)
 {
   checked_snprintf(
-    "message_type", static_cast<char *>(msg_.pubsub_target.message_type), MESSAGE_TYPE_BUFFER_SIZE,
-    "%s", message_type);
+    "message_type", static_cast<char *>(pubsub_.message_type), MESSAGE_TYPE_BUFFER_SIZE, "%s",
+    message_type);
   return *this;
 }
 
 BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_topic_name(const char * topic_name)
 {
   checked_snprintf(
-    "topic_name", static_cast<char *>(msg_.pubsub_target.topic_name), TOPIC_NAME_BUFFER_SIZE, "%s",
+    "topic_name", static_cast<char *>(pubsub_.topic_name), TOPIC_NAME_BUFFER_SIZE, "%s",
     topic_name);
   return *this;
 }
@@ -335,7 +335,7 @@ BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_topic_name(cons
 BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_pubsub_target_id(
   topic_local_id_t target_id)
 {
-  msg_.pubsub_target.target_id = target_id;
+  pubsub_.target_id = target_id;
   return *this;
 }
 
@@ -343,8 +343,8 @@ BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_service_type(
   const char * service_type)
 {
   checked_snprintf(
-    "service_type", static_cast<char *>(msg_.srv_target.service_type), SERVICE_TYPE_BUFFER_SIZE,
-    "%s", service_type);
+    "service_type", static_cast<char *>(service_.service_type), SERVICE_TYPE_BUFFER_SIZE, "%s",
+    service_type);
   return *this;
 }
 
@@ -352,15 +352,15 @@ BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_service_name(
   const char * service_name)
 {
   checked_snprintf(
-    "service_name", static_cast<char *>(msg_.srv_target.service_name), SERVICE_NAME_BUFFER_SIZE,
-    "%s", service_name);
+    "service_name", static_cast<char *>(service_.service_name), SERVICE_NAME_BUFFER_SIZE, "%s",
+    service_name);
   return *this;
 }
 
 BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_shadow_node_identity(
   const std::optional<std::pair<std::string, std::string>> & shadow_node_identity)
 {
-  msg_.srv_target.create_shadow_node = shadow_node_identity.has_value();
+  service_.create_shadow_node = shadow_node_identity.has_value();
 
   const char * shadow_node_namespace =
     shadow_node_identity.has_value() ? shadow_node_identity->first.c_str() : "";
@@ -368,19 +368,28 @@ BridgeRegistrationMsgBuilder & BridgeRegistrationMsgBuilder::set_shadow_node_ide
     shadow_node_identity.has_value() ? shadow_node_identity->second.c_str() : "";
 
   checked_snprintf(
-    "shadow_node_namespace", static_cast<char *>(msg_.srv_target.shadow_node_namespace),
+    "shadow_node_namespace", static_cast<char *>(service_.shadow_node_namespace),
     NODE_NAME_BUFFER_SIZE, "%s", shadow_node_namespace);
   checked_snprintf(
-    "shadow_node_name", static_cast<char *>(msg_.srv_target.shadow_node_name),
-    NODE_NAME_BUFFER_SIZE, "%s", shadow_node_name);
+    "shadow_node_name", static_cast<char *>(service_.shadow_node_name), NODE_NAME_BUFFER_SIZE, "%s",
+    shadow_node_name);
 
   return *this;
 }
 
-std::pair<MqMsgPerformanceBridge, std::string>
-BridgeRegistrationMsgBuilder::build_performance_message()
+std::pair<BridgeMsg, std::string> BridgeRegistrationMsgBuilder::build_message()
 {
-  return {msg_, failed_ ? std::move(reason_) : std::string{}};
+  BridgeMsg msg{};
+  if (is_service_) {
+    msg.type = BridgeMsgType::Service;
+    service_.direction = direction_;
+    msg.payload.service = service_;
+  } else {
+    msg.type = BridgeMsgType::PubSub;
+    pubsub_.direction = direction_;
+    msg.payload.pubsub = pubsub_;
+  }
+  return {msg, failed_ ? std::move(reason_) : std::string{}};
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
@@ -15,7 +15,7 @@ PerformanceBridgeIpcEventLoop::PerformanceBridgeIpcEventLoop(const rclcpp::Logge
     // 1. MQ Name
     create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID),
     // 2. Message Size
-    PERFORMANCE_BRIDGE_MQ_MESSAGE_SIZE,
+    BRIDGE_MQ_MESSAGE_SIZE,
     // 3. Block Signals
     {SIGTERM, SIGINT},
     // 4. Ignore Signals

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -58,10 +58,6 @@ void PerformanceBridgeManager::run()
   event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
-  // One bridge manager runs per IPC namespace, so its daemon request MQ is per-NS too.
-  event_loop_.register_aux_mq(
-    create_mq_name_for_daemon_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID), DAEMON_BRIDGE_MQ_MAX_MESSAGES,
-    DAEMON_BRIDGE_MQ_MESSAGE_SIZE, [this](int fd) { this->on_daemon_mq_request(fd); });
 
   while (!shutdown_requested_) {
     if (!event_loop_.spin_once(EVENT_LOOP_TIMEOUT_MS)) {
@@ -104,7 +100,7 @@ void PerformanceBridgeManager::start_ros_execution()
 
 void PerformanceBridgeManager::on_mq_request(int fd)
 {
-  MqMsgPerformanceBridge msg{};
+  BridgeMsg msg{};
 
   ssize_t bytes_read = mq_receive(fd, reinterpret_cast<char *>(&msg), sizeof(msg), nullptr);
   if (bytes_read < 0) {
@@ -116,39 +112,64 @@ void PerformanceBridgeManager::on_mq_request(int fd)
     return;
   }
 
-  if (msg.is_service) {
-    create_service_bridge_if_needed(msg.srv_target, msg.direction);
-  } else {
-    std::string topic_name = static_cast<const char *>(msg.pubsub_target.topic_name);
-    topic_local_id_t target_id = msg.pubsub_target.target_id;
-    std::string message_type = static_cast<const char *>(msg.pubsub_target.message_type);
-
-    request_cache_[topic_name][target_id] = msg;
-
-    create_pubsub_bridge_if_needed(
-      topic_name, request_cache_[topic_name], message_type, msg.direction);
+  if (static_cast<size_t>(bytes_read) < offsetof(BridgeMsg, payload)) {
+    RCLCPP_WARN(
+      logger_,
+      "bridge msg too small to carry a discriminator: got %zd bytes, expected at least %zu",
+      bytes_read, offsetof(BridgeMsg, payload));
+    return;
   }
-}
 
-void PerformanceBridgeManager::on_daemon_mq_request(int fd)
-{
-  MqMsgDaemonBridge req{};
-  while (!shutdown_requested_) {
-    ssize_t bytes_read = mq_receive(fd, reinterpret_cast<char *>(&req), sizeof(req), nullptr);
-    if (bytes_read < 0) {
-      // EAGAIN just means the queue is drained; anything else is unexpected and
-      // would otherwise silently drop a daemon bridge request.
-      if (errno != EAGAIN) {
-        RCLCPP_WARN_STREAM(
-          logger_, "mq_receive failed for daemon bridge mq (fd=" << fd << "): " << strerror(errno));
+  const auto validate_variant_size = [&](size_t expected) -> bool {
+    if (static_cast<size_t>(bytes_read) < expected) {
+      RCLCPP_WARN(
+        logger_, "bridge msg (type=%u) truncated: got %zd bytes, expected at least %zu",
+        static_cast<uint32_t>(msg.type), bytes_read, expected);
+      return false;
+    }
+    return true;
+  };
+
+  switch (msg.type) {
+    case BridgeMsgType::Service: {
+      if (!validate_variant_size(bridge_msg_wire_size<BridgeMsgServicePayload>())) {
+        return;
       }
+      const auto & payload = msg.payload.service;
+      create_service_bridge_if_needed(payload, payload.direction);
       break;
     }
-    register_daemon_pubsub_request(req);
+    case BridgeMsgType::PubSub: {
+      if (!validate_variant_size(bridge_msg_wire_size<BridgeMsgPubSubPayload>())) {
+        return;
+      }
+      const auto & payload = msg.payload.pubsub;
+      std::string topic_name = static_cast<const char *>(payload.topic_name);
+      topic_local_id_t target_id = payload.target_id;
+      std::string message_type = static_cast<const char *>(payload.message_type);
+
+      request_cache_[topic_name][target_id] = payload;
+
+      create_pubsub_bridge_if_needed(
+        topic_name, request_cache_[topic_name], message_type, payload.direction);
+      break;
+    }
+    case BridgeMsgType::DaemonPubSub: {
+      if (!validate_variant_size(bridge_msg_wire_size<BridgeMsgDaemonPubSubPayload>())) {
+        return;
+      }
+      register_daemon_pubsub_request(msg.payload.daemon_pubsub);
+      break;
+    }
+    default:
+      RCLCPP_WARN(
+        logger_, "Received bridge message with unknown type: %u", static_cast<uint32_t>(msg.type));
+      break;
   }
 }
 
-void PerformanceBridgeManager::register_daemon_pubsub_request(const MqMsgDaemonBridge & req)
+void PerformanceBridgeManager::register_daemon_pubsub_request(
+  const BridgeMsgDaemonPubSubPayload & req)
 {
   const std::string topic_name = static_cast<const char *>(req.topic_name);
   const std::string message_type = static_cast<const char *>(req.type_name);
@@ -260,7 +281,7 @@ void PerformanceBridgeManager::check_and_create_pubsub_bridges()
     }
 
     const std::string message_type =
-      static_cast<const char *>(requests.begin()->second.pubsub_target.message_type);
+      static_cast<const char *>(requests.begin()->second.message_type);
 
     create_pubsub_bridge_if_needed(
       topic_name, requests, message_type, BridgeDirection::ROS2_TO_AGNOCAST);
@@ -484,7 +505,7 @@ void PerformanceBridgeManager::create_pubsub_bridge_if_needed(
 }
 
 void PerformanceBridgeManager::create_service_bridge_if_needed(
-  const ServiceBridgeTargetInfoWithType & target, BridgeDirection direction)
+  const BridgeMsgServicePayload & target, BridgeDirection direction)
 {
   std::string service_name = static_cast<const char *>(target.service_name);
   std::string service_type = static_cast<const char *>(target.service_type);

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -54,6 +54,13 @@ TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
   EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_reliable), 521u);
 }
 
+TEST(DaemonBridgeMqTest, BridgeMsgTypeNumeric)
+{
+  EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::PubSub), 0u);
+  EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::Service), 1u);
+  EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::DaemonPubSub), 2u);
+}
+
 TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
 {
   EXPECT_EQ(offsetof(agnocast::BridgeMsg, type), 0u);

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -39,53 +39,41 @@ private:
 };
 }  // namespace
 
-// The discovery daemon (Python) packs MqMsgDaemonBridge by hand, mirroring
-// this layout. These checks fail loudly if the C++ struct drifts from the
-// daemon's `_MSG_PACK_FORMAT` ('=256s256sIIBB2x', 524 bytes).
-TEST(DaemonBridgeMqTest, WireLayoutMatchesDaemonPackFormat)
+// The discovery daemon (Python) packs BridgeMsgDaemonPubSubPayload by hand inside a
+// BridgeMsg, mirroring this layout. These checks fail loudly if the C++ struct
+// drifts from the daemon's `_MSG_PACK_FORMAT`.
+TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
 {
-  using agnocast::MqMsgDaemonBridge;
-  EXPECT_EQ(sizeof(MqMsgDaemonBridge), 524u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, topic_name), 0u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, type_name), 256u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, direction), 512u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_depth), 516u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_is_transient_local), 520u);
-  EXPECT_EQ(offsetof(MqMsgDaemonBridge, qos_is_reliable), 521u);
+  using agnocast::BridgeMsgDaemonPubSubPayload;
+  EXPECT_EQ(sizeof(BridgeMsgDaemonPubSubPayload), 524u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, topic_name), 0u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, type_name), 256u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, direction), 512u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_depth), 516u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_transient_local), 520u);
+  EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_reliable), 521u);
 }
 
-TEST(DaemonBridgeMqTest, StandardMqNameIsKeyedByPid)
+TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
 {
-  EXPECT_EQ(agnocast::create_mq_name_for_daemon_bridge(4242), "/agnocast_daemon_bridge@4242");
-}
-
-TEST(DaemonBridgeMqTest, PerformanceMqNameIsPerNamespace)
-{
-  const ScopedRosDomainId guard;
-  unsetenv("ROS_DOMAIN_ID");
+  EXPECT_EQ(offsetof(agnocast::BridgeMsg, type), 0u);
+  EXPECT_EQ(offsetof(agnocast::BridgeMsg, payload), 4u);
   EXPECT_EQ(
-    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    "/agnocast_daemon_bridge_perf");
-}
-
-TEST(DaemonBridgeMqTest, PerformanceMqNameAppendsDomainId)
-{
-  const ScopedRosDomainId guard;
-  setenv("ROS_DOMAIN_ID", "7", 1);
+    agnocast::bridge_msg_wire_size<agnocast::BridgeMsgDaemonPubSubPayload>(),
+    4u + sizeof(agnocast::BridgeMsgDaemonPubSubPayload));
   EXPECT_EQ(
-    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    "/agnocast_daemon_bridge_perf_d7");
+    agnocast::bridge_msg_wire_size<agnocast::BridgeMsgPubSubPayload>(),
+    4u + sizeof(agnocast::BridgeMsgPubSubPayload));
+  EXPECT_EQ(
+    agnocast::bridge_msg_wire_size<agnocast::BridgeMsgServicePayload>(),
+    4u + sizeof(agnocast::BridgeMsgServicePayload));
 }
 
-// An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix. Both
-// name builders must agree on this and with the Python agent.
-TEST(DaemonBridgeMqTest, PerformanceMqNameEmptyDomainIdHasNoSuffix)
+// An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix.
+TEST(DaemonBridgeMqTest, BridgeMqNameEmptyDomainIdHasNoSuffix)
 {
   const ScopedRosDomainId guard;
   setenv("ROS_DOMAIN_ID", "", 1);
-  EXPECT_EQ(
-    agnocast::create_mq_name_for_daemon_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    "/agnocast_daemon_bridge_perf");
   EXPECT_EQ(
     agnocast::create_mq_name_for_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
     "/agnocast_bridge_manager@" + std::to_string(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID));
@@ -95,7 +83,7 @@ TEST(DaemonBridgeMqTest, PerformanceMqNameEmptyDomainIdHasNoSuffix)
 // must be rebuilt faithfully from the request's explicit fields.
 TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
 {
-  agnocast::MqMsgDaemonBridge req{};
+  agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 10;
   req.qos_is_reliable = true;
   req.qos_is_transient_local = true;
@@ -108,7 +96,7 @@ TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
 
 TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
 {
-  agnocast::MqMsgDaemonBridge req{};
+  agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 1;
   req.qos_is_reliable = false;
   req.qos_is_transient_local = false;

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -8,8 +8,9 @@ so the two reach each other through ROS 2 (DDS):
   * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
   * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
 
-The request is sent as ``MqMsgDaemonBridge`` to the per-namespace bridge_manager
-MQ. The struct layout is mirrored here so the daemon stays decoupled from
+The request is sent as a ``BridgeMsg`` (type=Daemon) to the per-namespace
+bridge_manager MQ (``/agnocast_bridge_manager@-1[_d<domain>]``).
+The struct layout is mirrored here so the daemon stays decoupled from
 libagnocast's C++ headers; ``agnocast_mq.hpp`` owns the source of truth and a
 test asserts the size stays in sync.
 """
@@ -24,16 +25,33 @@ from typing import Iterable, Optional
 TOPIC_NAME_BUFFER_SIZE = 256
 MESSAGE_TYPE_BUFFER_SIZE = 256
 
-# char topic_name[256]; char type_name[256]; uint32 direction; uint32 qos_depth;
-# bool qos_is_transient_local; bool qos_is_reliable; + 2 bytes tail padding so
-# the total matches sizeof(MqMsgDaemonBridge) == 524 on the C++ side.
-_MSG_PACK_FORMAT = '=256s256sIIBB2x'
+# BridgeMsgType::DaemonPubSub discriminator value (matches the C++ enum).
+_BRIDGE_MSG_TYPE_DAEMON_PUBSUB = 2
+
+# BridgeMsg wire format for a DaemonPubSub-variant message (528 bytes total).
+# The C++ BridgeMsg is `uint32_t type` + union { pubsub | service | daemon_pubsub }.
+# All payload variants are 4-byte aligned so no padding precedes the union.
+# Senders transmit only the bytes for the active variant, so a DaemonPubSub
+# message is 4 (tag) + 524 (BridgeMsgDaemonPubSubPayload) = 528 bytes.
+#
+#   uint32 type                             [0..3]   = _BRIDGE_MSG_TYPE_DAEMON_PUBSUB
+#   BridgeMsgDaemonPubSubPayload at union offset 4..527:
+#     char[256] topic_name                  [4..259]
+#     char[256] type_name                   [260..515]
+#     uint32    direction                   [516..519]
+#     uint32    qos_depth                   [520..523]
+#     bool      qos_is_transient_local      [524]
+#     bool      qos_is_reliable             [525]
+#     2 bytes   padding                     [526..527]
+#
+# Must stay in sync with bridge_msg_wire_size<BridgeMsgDaemonPubSubPayload>() == 528.
+_MSG_PACK_FORMAT = '=I256s256sIIBB2x'
 
 DIRECTION_ROS2_TO_AGNOCAST = 0
 DIRECTION_AGNOCAST_TO_ROS2 = 1
 
 # One bridge_manager per IPC namespace listens on this MQ.
-_PERFORMANCE_MQ_NAME = '/agnocast_daemon_bridge_perf'
+_BRIDGE_MQ_BASE = '/agnocast_bridge_manager@-1'
 
 # librt mq_* loaded lazily to keep the daemon's deps at "rclpy + stdlib".
 _librt = None
@@ -72,6 +90,7 @@ def serialize_request(req: BridgeRequest) -> bytes:
     type_name = req.type_name.encode('utf-8')[: MESSAGE_TYPE_BUFFER_SIZE - 1]
     return struct.pack(
         _MSG_PACK_FORMAT,
+        _BRIDGE_MSG_TYPE_DAEMON_PUBSUB,
         topic,
         type_name,
         req.direction,
@@ -157,8 +176,8 @@ def decide_bridges(local_state, remote_states) -> list:
     return list(requests.values())
 
 
-def _performance_mq_name(domain_id: int) -> str:
-    name = _PERFORMANCE_MQ_NAME
+def _bridge_mq_name(domain_id: int) -> str:
+    name = _BRIDGE_MQ_BASE
     if domain_id:
         name += '_d' + str(domain_id)
     return name
@@ -197,6 +216,6 @@ def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
     request is re-issued idempotently next tick.
     """
     for req in requests:
-        err = send_request(_performance_mq_name(req.domain_id), serialize_request(req))
+        err = send_request(_bridge_mq_name(req.domain_id), serialize_request(req))
         if err is not None and logger is not None:
             logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -176,7 +176,11 @@ def test_decide_collapses_duplicates_across_remotes():
 def test_serialize_matches_cpp_struct_size():
     req = BridgeRequest('/x', 'std_msgs/msg/Int32', DIRECTION_AGNOCAST_TO_ROS2,
                         10, False, True)
-    assert len(serialize_request(req)) == 528
+    msg = serialize_request(req)
+    assert len(msg) == 528
+    # First uint32 must be BridgeMsgType::DaemonPubSub (=2)
+    (tag,) = struct.unpack_from('=I', msg, 0)
+    assert tag == 2
 
 
 def test_serialize_nul_terminates_truncated_topic():

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -2,7 +2,8 @@
 
 These need neither the kmod, DDS, nor a POSIX MQ: ``decide_bridges`` is pure
 logic, and the wire format is checked against the hand-built byte layout that
-mirrors ``sizeof(MqMsgDaemonBridge) == 524`` in ``agnocast_mq.hpp``.
+mirrors a Daemon-variant ``BridgeMsg`` (4-byte tag + 524-byte payload = 528
+bytes) in ``agnocast_mq.hpp``.
 """
 
 import struct
@@ -175,17 +176,20 @@ def test_decide_collapses_duplicates_across_remotes():
 def test_serialize_matches_cpp_struct_size():
     req = BridgeRequest('/x', 'std_msgs/msg/Int32', DIRECTION_AGNOCAST_TO_ROS2,
                         10, False, True)
-    assert len(serialize_request(req)) == 524
+    assert len(serialize_request(req)) == 528
 
 
 def test_serialize_nul_terminates_truncated_topic():
     req = BridgeRequest('/' + 'a' * 1000, 'T', DIRECTION_AGNOCAST_TO_ROS2, 10, False, True)
-    assert serialize_request(req)[255] == 0
+    msg = serialize_request(req)
+    payload = msg[4:]
+    assert payload[255] == 0
 
 
 def test_serialize_packs_direction_qos_at_expected_offsets():
     req = BridgeRequest('/x', 'T', DIRECTION_ROS2_TO_AGNOCAST, 7, True, True)
-    payload = serialize_request(req)
+    msg = serialize_request(req)
+    payload = msg[4:]
     direction, depth = struct.unpack_from('=II', payload, 512)
     transient, reliable = struct.unpack_from('=BB', payload, 520)
     assert (direction, depth, transient, reliable) == (DIRECTION_ROS2_TO_AGNOCAST, 7, 1, 1)
@@ -199,7 +203,7 @@ def test_dispatch_targets_per_namespace_mq(monkeypatch):
     req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
     dispatch_requests([req])
 
-    assert all(name.startswith('/agnocast_daemon_bridge_perf') for name in sent)
+    assert all(name.startswith('/agnocast_bridge_manager@-1') for name in sent)
     assert len(sent) == 1
 
 
@@ -213,4 +217,4 @@ def test_dispatch_routes_to_per_domain_mq(monkeypatch):
         BridgeRequest('/b', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=5),
     ])
 
-    assert sent == ['/agnocast_daemon_bridge_perf', '/agnocast_daemon_bridge_perf_d5']
+    assert sent == ['/agnocast_bridge_manager@-1', '/agnocast_bridge_manager@-1_d5']


### PR DESCRIPTION
## Description

Merge the bridge manager's two POSIX message queues into one.

Before, the bridge manager listened on two MQs:
- `/agnocast_bridge_manager@-1[_d<domain>]` for endpoint registrations from Agnocast processes.
- `/agnocast_daemon_bridge_perf[_d<domain>]` (an auxiliary MQ) for cross-namespace bridge requests from the discovery agent.

This PR removes the auxiliary MQ. All bridge requests now flow through the single `/agnocast_bridge_manager@-1[_d<domain>]` MQ using a new tagged-union wire format.

Main changes:
- Remove the auxiliary MQ. All bridge requests now flow through a single MQ.
- Redefine the wire format as a tagged union `BridgeMsg`, with three variants: pub/sub, service, and daemon pub/sub. Senders write only the bytes of the active variant.
- Drop the aux-MQ support code (`register_aux_mq`, `create_mq_name_for_daemon_bridge`, `on_daemon_mq_request`, and the old per-purpose message structs).
- Collapse the two MQ-size constant sets into one `BRIDGE_MQ_*` set.
- Rename `BridgeRegistrationMsgBuilder::build_performance_message()` → `build_message()`.
- Validate `mq_receive` byte counts against the selected variant's expected wire size.
- Mirror the wire-format change in `bridge_decider.py` and update the affected unit tests.
- Update `docs/message_queue.md` to describe the unified MQ and new layout.

## Related links

This PR is a follow-up PR for #1389 

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) — N/A, no kmod change
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

### Why a tagged union with independent per-variant payloads

An alternative was to put every message field into a single flat union. We rejected it because the Python discovery agent addresses the wire buffer by absolute byte offsets, and a shared union would leak the C++ layout of every variant into that offset math. Adding or refactoring one variant would then silently shift the offsets of the others. With a tagged union of independent payload structs, only the tag is common to all variants, and each variant's layout can evolve without touching the others.

### Why the payload structs reuse the existing layouts

Each payload struct keeps the same fields as the pre-refactor per-purpose message (`MqMsgPerformanceBridge` → `BridgeMsgPubSub` / `BridgeMsgService`, `MqMsgDaemonBridge` → `BridgeMsgDaemonPubSub`). This keeps the diff in the `BridgeManager` dispatch logic as small as possible.
## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`