### PR TITLE
refactor(agnocastlib): replace bridge MQ with UDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ rm /dev/shm/agnocast@*
 
 # Remove leftover message queues
 rm /dev/mqueue/agnocast@*
-rm /dev/mqueue/agnocast_bridge_manager@*
 ```
 
 If you encounter `mq_open failed: No space left on device`, the system has reached the maximum number of message queues. Run the cleanup commands above, and if the error persists, increase the system-wide `queues_max` limit (e.g., `sudo sysctl -w fs.mqueue.queues_max=1024`). See [System Configuration](https://autowarefoundation.github.io/agnocast_doc/environment-setup/configuration/) for details.

--- a/docs/message_queue.md
+++ b/docs/message_queue.md
@@ -32,26 +32,3 @@ The restrictions of the naming are
 
 The first rule is satisfied because all topic names start with `/`.
 To satisfy the second rule, all the occurrence of `/` in topic names are replaced for `_`.
-
-## How message queue is used in Agnocast Bridge?
-
-The message queue is also used for communication between Agnocast processes and Bridge Manager processes. When an Agnocast publisher or subscriber is created, it sends a bridge request to the Bridge Manager via message queue.
-
-The message queue is used as follows:
-
-- The first Agnocast process spawns a global Bridge Manager that opens `/agnocast_bridge_manager@-1` (optionally with a `_d<ROS_DOMAIN_ID>` suffix when `ROS_DOMAIN_ID` is set) as a receiver.
-- All Agnocast processes send bridge requests to this shared message queue.
-- Upon receiving the request, the Bridge Manager creates the appropriate bridge if conditions are met.
-
-The message definition is:
-
-```cpp
-struct BridgeMsg {
-  BridgeMsgType type;  // PubSub, Service, or DaemonPubSub
-  union {
-    BridgeMsgPubSubPayload pubsub;
-    BridgeMsgServicePayload service;
-    BridgeMsgDaemonPubSubPayload daemon_pubsub;
-  } payload;
-};
-```

--- a/scripts/test/e2e_test_2to2.bash
+++ b/scripts/test/e2e_test_2to2.bash
@@ -87,11 +87,6 @@ if [ "$LOWER_BRIDGE_MODE" != "off" ] && [ "$LOWER_BRIDGE_MODE" != "0" ]; then
     fi
 
     sleep 1
-    # Verify stale bridge manager mqueue does not remain.
-    if [ -e "/dev/mqueue/agnocast_bridge_manager@-1" ]; then
-        echo "ERROR: stale mqueue exists: /dev/mqueue/agnocast_bridge_manager@-1" | sudo tee /dev/kmsg
-        exit 1
-    fi
 fi
 
 # Run test

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -157,7 +157,8 @@ if(BUILD_TESTING)
     test/unit/test_type_registry_writer.cpp
     test/unit/test_agnocast_generic_callback.cpp
     test/unit/test_agnocast_generic_publisher.cpp
-    test/unit/test_daemon_bridge_mq.cpp)
+    test/unit/test_daemon_bridge_uds.cpp
+    test/unit/test_agnocast_bridge_uds.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -8,8 +8,6 @@
 namespace agnocast
 {
 
-inline constexpr pid_t PERFORMANCE_BRIDGE_VIRTUAL_PID = -1;
-
 inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
 inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
 inline constexpr size_t SERVICE_TYPE_BUFFER_SIZE = 256;
@@ -69,13 +67,11 @@ struct BridgeMsg
   } payload;
 };
 
-constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 256;
-constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(BridgeMsg);
-constexpr mode_t BRIDGE_MQ_PERMS = 0600;
+constexpr int64_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
 
 // Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
-// just the active variant's bytes. Used both for `mq_send` and for sizing
-// auxiliary buffers.
+// just the active variant's bytes. Used both to size the datagram sent over
+// the abstract-namespace UDS transport and to size auxiliary buffers.
 template <typename PayloadT>
 constexpr size_t bridge_msg_wire_size()
 {

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -1,18 +1,7 @@
 #pragma once
 
-#include "agnocast/agnocast_ioctl.hpp"
-
-#include <cstddef>
-#include <cstdint>
-
 namespace agnocast
 {
-
-inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
-inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
-inline constexpr size_t SERVICE_TYPE_BUFFER_SIZE = 256;
-
-enum class BridgeDirection : uint32_t { ROS2_TO_AGNOCAST = 0, AGNOCAST_TO_ROS2 = 1 };
 
 struct MqMsgAgnocast
 {
@@ -22,60 +11,5 @@ struct MqMsgROS2Publish
 {
   bool should_terminate;
 };
-
-enum class BridgeMsgType : uint32_t {
-  PubSub = 0,
-  Service = 1,
-  DaemonPubSub = 2,
-};
-
-struct BridgeMsgPubSubPayload
-{
-  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
-  char topic_name[TOPIC_NAME_BUFFER_SIZE];
-  topic_local_id_t target_id;
-  BridgeDirection direction;
-};
-
-struct BridgeMsgServicePayload
-{
-  char service_type[SERVICE_TYPE_BUFFER_SIZE];
-  char service_name[SERVICE_NAME_BUFFER_SIZE];
-  bool create_shadow_node;
-  BridgeDirection direction;
-  char shadow_node_namespace[NODE_NAME_BUFFER_SIZE];
-  char shadow_node_name[NODE_NAME_BUFFER_SIZE];
-};
-
-struct BridgeMsgDaemonPubSubPayload
-{
-  char topic_name[TOPIC_NAME_BUFFER_SIZE];
-  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
-  BridgeDirection direction;
-  uint32_t qos_depth;
-  bool qos_is_transient_local;
-  bool qos_is_reliable;
-};
-
-struct BridgeMsg
-{
-  BridgeMsgType type;
-  union Payload {
-    BridgeMsgPubSubPayload pubsub;
-    BridgeMsgServicePayload service;
-    BridgeMsgDaemonPubSubPayload daemon_pubsub;
-  } payload;
-};
-
-constexpr int64_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
-
-// Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
-// just the active variant's bytes. Used both to size the datagram sent over
-// the abstract-namespace UDS transport and to size auxiliary buffers.
-template <typename PayloadT>
-constexpr size_t bridge_msg_wire_size()
-{
-  return offsetof(BridgeMsg, payload) + sizeof(PayloadT);
-}
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -83,7 +83,7 @@ void validate_ld_preload();
 uint32_t get_ros_domain_id();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
-std::string create_mq_name_for_bridge(const pid_t pid);
+std::string create_uds_addr_for_bridge();
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
 #include <sys/socket.h>
@@ -17,6 +16,8 @@
 #include <array>
 #include <cerrno>
 #include <csignal>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <string>
@@ -30,12 +31,12 @@ namespace agnocast
 class IpcEventLoopBase
 {
 public:
-  using EventCallback = std::function<void(int)>;
+  using MessageCallback = std::function<void(const void * data, std::size_t size)>;
   using SignalCallback = std::function<void()>;
   using SocketCallback = std::function<std::string()>;
 
   IpcEventLoopBase(
-    const rclcpp::Logger & logger, const std::string & mq_name, long mq_msg_size,
+    const rclcpp::Logger & logger, const std::string & uds_addr, long max_msg_size,
     const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore);
 
   virtual ~IpcEventLoopBase();
@@ -45,11 +46,11 @@ public:
 
   bool spin_once(int timeout_ms);
 
-  void set_mq_handler(EventCallback cb);
+  void set_message_handler(MessageCallback cb);
   void set_signal_handler(SignalCallback cb);
   void set_socket_handler(SocketCallback cb);
 
-  const std::string & get_mq_name() const { return mq_name_; }
+  const std::string & get_uds_addr() const { return uds_addr_; }
 
 protected:
   rclcpp::Logger logger_;
@@ -61,36 +62,35 @@ private:
   int signal_fd_ = -1;
   int socket_fd_ = -1;
 
-  mqd_t mq_fd_ = (mqd_t)-1;
-  std::string mq_name_;
+  int listener_fd_ = -1;
+  std::string uds_addr_;
+  long max_msg_size_;
 
-  long mq_msg_size_;
-
-  EventCallback mq_cb_;
+  MessageCallback message_cb_;
   SignalCallback signal_cb_;
   SocketCallback socket_cb_;
 
-  void setup_mq();
+  void setup_listener();
   void setup_signals(
     const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore);
   void setup_socket();
   void setup_epoll();
   void cleanup_resources();
 
-  mqd_t create_and_open_mq(const std::string & name) const;
   void add_fd_to_epoll(int fd, const std::string & label) const;
+  void drain_listener();
 
   static void ignore_signals_impl(const std::vector<int> & signals);
   static sigset_t block_signals_impl(const std::vector<int> & signals);
 };
 
 inline IpcEventLoopBase::IpcEventLoopBase(
-  const rclcpp::Logger & logger, const std::string & mq_name, long mq_msg_size,
+  const rclcpp::Logger & logger, const std::string & uds_addr, long max_msg_size,
   const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore)
-: logger_(logger), mq_name_(mq_name), mq_msg_size_(mq_msg_size)
+: logger_(logger), uds_addr_(uds_addr), max_msg_size_(max_msg_size)
 {
   try {
-    setup_mq();
+    setup_listener();
     setup_signals(signals_to_block, signals_to_ignore);
     setup_socket();
     setup_epoll();
@@ -123,10 +123,8 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
   }
   for (int event_index = 0; event_index < event_count; ++event_index) {
     int fd = events[event_index].data.fd;
-    if (fd == mq_fd_) {
-      if (mq_cb_) {
-        mq_cb_(fd);
-      }
+    if (fd == listener_fd_) {
+      drain_listener();
     } else if (fd == signal_fd_) {
       struct signalfd_siginfo fdsi
       {
@@ -139,7 +137,7 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
       int client_fd = accept4(socket_fd_, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
       if (client_fd == -1) {
         if (errno != EAGAIN && errno != EWOULDBLOCK) {
-          RCLCPP_WARN(logger_, "accept4 on socket failed: %s", strerror(errno));
+          RCLCPP_WARN(logger_, "accept4 on debug socket failed: %s", strerror(errno));
         }
       } else {
         handle_socket(client_fd);
@@ -190,7 +188,7 @@ inline void IpcEventLoopBase::handle_socket(int client_fd)
       } else if (errno == EINTR) {
         // EINTR is harmless; retry without counting it as a failure
       } else {
-        RCLCPP_WARN(logger_, "send on socket failed: %s", strerror(errno));
+        RCLCPP_WARN(logger_, "send on debug socket failed: %s", strerror(errno));
         return;
       }
     }
@@ -198,14 +196,14 @@ inline void IpcEventLoopBase::handle_socket(int client_fd)
 
   if (sent < response.size()) {
     RCLCPP_WARN(
-      logger_, "send on socket incomplete after retries: sent %zu of %zu bytes", sent,
+      logger_, "send on debug socket incomplete after retries: sent %zu of %zu bytes", sent,
       response.size());
   }
 }
 
-inline void IpcEventLoopBase::set_mq_handler(EventCallback cb)
+inline void IpcEventLoopBase::set_message_handler(MessageCallback cb)
 {
-  mq_cb_ = std::move(cb);
+  message_cb_ = std::move(cb);
 }
 
 inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
@@ -218,9 +216,26 @@ inline void IpcEventLoopBase::set_socket_handler(SocketCallback cb)
   socket_cb_ = std::move(cb);
 }
 
-inline void IpcEventLoopBase::setup_mq()
+inline void IpcEventLoopBase::drain_listener()
 {
-  mq_fd_ = create_and_open_mq(mq_name_);
+  std::vector<uint8_t> buf(static_cast<size_t>(max_msg_size_));
+  while (true) {
+    ssize_t n = recv(listener_fd_, buf.data(), buf.size(), 0);
+    if (n < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+      if (errno == EINTR) continue;
+      RCLCPP_WARN(logger_, "bridge UDS recv() failed: %s", strerror(errno));
+      break;
+    }
+    if (message_cb_) {
+      message_cb_(buf.data(), static_cast<size_t>(n));
+    }
+  }
+}
+
+inline void IpcEventLoopBase::setup_listener()
+{
+  listener_fd_ = create_bridge_uds_listener(uds_addr_);
 }
 
 inline void IpcEventLoopBase::setup_signals(
@@ -303,27 +318,11 @@ inline void IpcEventLoopBase::setup_epoll()
     throw std::runtime_error("epoll_create1 failed: " + std::string(strerror(errno)));
   }
 
-  add_fd_to_epoll(mq_fd_, "MQ");
+  add_fd_to_epoll(listener_fd_, "BridgeUDS");
   add_fd_to_epoll(signal_fd_, "Signal");
   if (socket_fd_ != -1) {
-    add_fd_to_epoll(socket_fd_, "Socket");
+    add_fd_to_epoll(socket_fd_, "DebugSocket");
   }
-}
-
-inline mqd_t IpcEventLoopBase::create_and_open_mq(const std::string & name) const
-{
-  struct mq_attr attr = {};
-  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
-  attr.mq_msgsize = mq_msg_size_;
-
-  mqd_t fd =
-    mq_open(name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
-
-  if (fd == -1) {
-    throw std::system_error(errno, std::generic_category(), "MQ open failed: " + name);
-  }
-
-  return fd;
 }
 
 inline void IpcEventLoopBase::add_fd_to_epoll(int fd, const std::string & label) const
@@ -379,7 +378,7 @@ inline void IpcEventLoopBase::cleanup_resources()
 
   if (socket_fd_ != -1) {
     if (close(socket_fd_) == -1) {
-      RCLCPP_WARN(logger_, "Failed to close socket_fd: %s", strerror(errno));
+      RCLCPP_WARN(logger_, "Failed to close debug socket_fd: %s", strerror(errno));
     }
     socket_fd_ = -1;
   }
@@ -391,17 +390,11 @@ inline void IpcEventLoopBase::cleanup_resources()
     signal_fd_ = -1;
   }
 
-  if (mq_fd_ != -1) {
-    if (mq_close(mq_fd_) == -1) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to close mq_fd for mq_name='" << mq_name_ << "': " << strerror(errno));
+  if (listener_fd_ != -1) {
+    if (close(listener_fd_) == -1) {
+      RCLCPP_WARN(logger_, "Failed to close bridge UDS listener_fd: %s", strerror(errno));
     }
-    mq_fd_ = -1;
-
-    if (mq_unlink(mq_name_.c_str()) == -1 && errno != ENOENT) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
-    }
+    listener_fd_ = -1;
   }
 }
 

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -36,7 +36,7 @@ public:
   using SocketCallback = std::function<std::string()>;
 
   IpcEventLoopBase(
-    const rclcpp::Logger & logger, const std::string & uds_addr, long max_msg_size,
+    const rclcpp::Logger & logger, const std::string & uds_addr, std::size_t max_msg_size,
     const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore);
 
   virtual ~IpcEventLoopBase();
@@ -64,7 +64,7 @@ private:
 
   int listener_fd_ = -1;
   std::string uds_addr_;
-  long max_msg_size_;
+  std::vector<uint8_t> recv_buf_;
 
   MessageCallback message_cb_;
   SignalCallback signal_cb_;
@@ -85,9 +85,9 @@ private:
 };
 
 inline IpcEventLoopBase::IpcEventLoopBase(
-  const rclcpp::Logger & logger, const std::string & uds_addr, long max_msg_size,
+  const rclcpp::Logger & logger, const std::string & uds_addr, std::size_t max_msg_size,
   const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore)
-: logger_(logger), uds_addr_(uds_addr), max_msg_size_(max_msg_size)
+: logger_(logger), uds_addr_(uds_addr), recv_buf_(max_msg_size)
 {
   try {
     setup_listener();
@@ -218,9 +218,8 @@ inline void IpcEventLoopBase::set_socket_handler(SocketCallback cb)
 
 inline void IpcEventLoopBase::drain_listener()
 {
-  std::vector<uint8_t> buf(static_cast<size_t>(max_msg_size_));
   while (true) {
-    ssize_t n = recv(listener_fd_, buf.data(), buf.size(), 0);
+    ssize_t n = recv(listener_fd_, recv_buf_.data(), recv_buf_.size(), 0);
     if (n < 0) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) break;
       if (errno == EINTR) continue;
@@ -228,7 +227,7 @@ inline void IpcEventLoopBase::drain_listener()
       break;
     }
     if (message_cb_) {
-      message_cb_(buf.data(), static_cast<size_t>(n));
+      message_cb_(recv_buf_.data(), static_cast<size_t>(n));
     }
   }
 }

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
@@ -58,7 +58,7 @@ struct BridgeMsg
   } payload;
 };
 
-constexpr int64_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
+constexpr size_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
 
 // Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
 // just the active variant's bytes. Used both to size the datagram sent over

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "agnocast/agnocast_ioctl.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace agnocast
+{
+
+inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
+inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
+inline constexpr size_t SERVICE_TYPE_BUFFER_SIZE = 256;
+
+enum class BridgeDirection : uint32_t { ROS2_TO_AGNOCAST = 0, AGNOCAST_TO_ROS2 = 1 };
+
+enum class BridgeMsgType : uint32_t {
+  PubSub = 0,
+  Service = 1,
+  DaemonPubSub = 2,
+};
+
+struct BridgeMsgPubSubPayload
+{
+  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  topic_local_id_t target_id;
+  BridgeDirection direction;
+};
+
+struct BridgeMsgServicePayload
+{
+  char service_type[SERVICE_TYPE_BUFFER_SIZE];
+  char service_name[SERVICE_NAME_BUFFER_SIZE];
+  bool create_shadow_node;
+  BridgeDirection direction;
+  char shadow_node_namespace[NODE_NAME_BUFFER_SIZE];
+  char shadow_node_name[NODE_NAME_BUFFER_SIZE];
+};
+
+struct BridgeMsgDaemonPubSubPayload
+{
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
+  BridgeDirection direction;
+  uint32_t qos_depth;
+  bool qos_is_transient_local;
+  bool qos_is_reliable;
+};
+
+struct BridgeMsg
+{
+  BridgeMsgType type;
+  union Payload {
+    BridgeMsgPubSubPayload pubsub;
+    BridgeMsgServicePayload service;
+    BridgeMsgDaemonPubSubPayload daemon_pubsub;
+  } payload;
+};
+
+constexpr int64_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
+
+// Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
+// just the active variant's bytes. Used both to size the datagram sent over
+// the abstract-namespace UDS transport and to size auxiliary buffers.
+template <typename PayloadT>
+constexpr size_t bridge_msg_wire_size()
+{
+  return offsetof(BridgeMsg, payload) + sizeof(PayloadT);
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "agnocast/agnocast_client.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 #include "agnocast/bridge/agnocast_bridge_uds.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -4,12 +4,12 @@
 #include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/version.h"
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -78,47 +78,6 @@ struct RosToAgnocastServiceRegistrationPolicy
   }
 };
 
-inline void send_mq_message(
-  const std::string & mq_name, const BridgeMsg & msg, size_t send_size,
-  const rclcpp::Logger & logger)
-{
-  struct mq_attr attr = {};
-  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
-  attr.mq_msgsize = BRIDGE_MQ_MESSAGE_SIZE;
-
-  mqd_t mq =
-    mq_open(mq_name.c_str(), O_CREAT | O_WRONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
-
-  if (mq == (mqd_t)-1) {
-    RCLCPP_ERROR(
-      logger, "mq_open failed for name '%s': %s (errno: %d)", mq_name.c_str(), strerror(errno),
-      errno);
-    return;
-  }
-
-  constexpr int BRIDGE_MQ_SEND_MAX_RETRIES = 100;
-  constexpr useconds_t BRIDGE_MQ_SEND_RETRY_INTERVAL_US = 100000;  // 100ms
-
-  int send_result = -1;
-  int last_errno = 0;
-  for (int retry = 0; retry <= BRIDGE_MQ_SEND_MAX_RETRIES; ++retry) {
-    send_result = mq_send(mq, reinterpret_cast<const char *>(&msg), send_size, 0);
-    if (send_result == 0) break;
-    last_errno = errno;
-    if (last_errno != EAGAIN) break;
-    if (retry < BRIDGE_MQ_SEND_MAX_RETRIES) {
-      usleep(BRIDGE_MQ_SEND_RETRY_INTERVAL_US);
-    }
-  }
-  if (send_result < 0) {
-    RCLCPP_ERROR(
-      logger, "mq_send failed for name '%s': %s (errno: %d)", mq_name.c_str(), strerror(last_errno),
-      last_errno);
-  }
-
-  mq_close(mq);
-}
-
 inline void send_performance_pubsub_bridge_registration_by_type_name(
   const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
   BridgeDirection direction)
@@ -139,8 +98,8 @@ inline void send_performance_pubsub_bridge_registration_by_type_name(
     exit(EXIT_FAILURE);
   }
 
-  std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgPubSubPayload>(), logger);
+  const std::string uds_addr = create_uds_addr_for_bridge();
+  send_bridge_uds_message(uds_addr, &msg, bridge_msg_wire_size<BridgeMsgPubSubPayload>(), logger);
 }
 
 template <typename ServiceT>
@@ -166,8 +125,8 @@ void send_performance_service_bridge_registration(
     exit(EXIT_FAILURE);
   }
 
-  std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgServicePayload>(), logger);
+  const std::string uds_addr = create_uds_addr_for_bridge();
+  send_bridge_uds_message(uds_addr, &msg, bridge_msg_wire_size<BridgeMsgServicePayload>(), logger);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace agnocast
+{
+
+inline constexpr int BRIDGE_UDS_SEND_MAX_RETRIES = 100;
+inline constexpr useconds_t BRIDGE_UDS_SEND_RETRY_INTERVAL_US = 100000;
+
+namespace detail
+{
+
+// Abstract-namespace addresses are length-scoped: leading NUL + name bytes,
+// no trailing NUL. Returns the socklen_t bind()/sendto() expect.
+inline socklen_t fill_abstract_sockaddr(const std::string & addr, sockaddr_un & out)
+{
+  out = {};
+  out.sun_family = AF_UNIX;
+  if (addr.empty() || addr[0] != '\0') {
+    throw std::invalid_argument("abstract UDS address must start with NUL");
+  }
+  if (addr.size() > sizeof(out.sun_path)) {
+    throw std::length_error("abstract UDS address too long for sun_path");
+  }
+  std::memcpy(out.sun_path, addr.data(), addr.size());
+  return static_cast<socklen_t>(offsetof(struct sockaddr_un, sun_path) + addr.size());
+}
+
+}  // namespace detail
+
+inline int create_bridge_uds_listener(const std::string & addr)
+{
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+  if (fd == -1) {
+    throw std::system_error(errno, std::generic_category(), "bridge UDS socket() failed");
+  }
+
+  try {
+    sockaddr_un sa{};
+    const socklen_t alen = detail::fill_abstract_sockaddr(addr, sa);
+    if (bind(fd, reinterpret_cast<sockaddr *>(&sa), alen) == -1) {
+      throw std::system_error(errno, std::generic_category(), "bridge UDS bind() failed");
+    }
+  } catch (...) {
+    close(fd);
+    throw;
+  }
+  return fd;
+}
+
+// Send `data`/`size` as a single datagram to `addr`.
+// Retries on ECONNREFUSED/ENOENT/EAGAIN/EWOULDBLOCK/ENOBUFS up to
+// BRIDGE_UDS_SEND_MAX_RETRIES * BRIDGE_UDS_SEND_RETRY_INTERVAL_US.
+inline bool send_bridge_uds_message(
+  const std::string & addr, const void * data, size_t size, const rclcpp::Logger & logger)
+{
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+  if (fd == -1) {
+    RCLCPP_ERROR(logger, "bridge UDS socket() failed: %s (errno: %d)", strerror(errno), errno);
+    return false;
+  }
+
+  sockaddr_un sa{};
+  socklen_t alen = 0;
+  try {
+    alen = detail::fill_abstract_sockaddr(addr, sa);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger, "bridge UDS address invalid: %s", e.what());
+    close(fd);
+    return false;
+  }
+
+  const std::string display_name = (!addr.empty() && addr.front() == '\0') ? addr.substr(1) : addr;
+
+  ssize_t send_result = -1;
+  int last_errno = 0;
+  for (int retry = 0; retry <= BRIDGE_UDS_SEND_MAX_RETRIES; ++retry) {
+    send_result = sendto(fd, data, size, MSG_NOSIGNAL, reinterpret_cast<sockaddr *>(&sa), alen);
+    if (send_result >= 0) break;
+    last_errno = errno;
+    if (
+      last_errno != ECONNREFUSED && last_errno != ENOENT && last_errno != EAGAIN &&
+      last_errno != EWOULDBLOCK && last_errno != ENOBUFS) {
+      break;
+    }
+    if (retry < BRIDGE_UDS_SEND_MAX_RETRIES) {
+      usleep(BRIDGE_UDS_SEND_RETRY_INTERVAL_US);
+    }
+  }
+
+  if (send_result < 0) {
+    RCLCPP_ERROR(
+      logger, "bridge UDS sendto() failed for '%s': %s (errno: %d)", display_name.c_str(),
+      strerror(last_errno), last_errno);
+    close(fd);
+    return false;
+  }
+  if (static_cast<size_t>(send_result) != size) {
+    // SOCK_DGRAM is atomic; a short send would indicate a kernel/API bug.
+    RCLCPP_ERROR(
+      logger, "bridge UDS sendto() short send to '%s': sent %zd of %zu bytes", display_name.c_str(),
+      send_result, size);
+    close(fd);
+    return false;
+  }
+
+  close(fd);
+  return true;
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
@@ -63,7 +63,7 @@ inline int create_bridge_uds_listener(const std::string & addr)
 }
 
 // Send `data`/`size` as a single datagram to `addr`.
-// Retries on ECONNREFUSED/ENOENT/EAGAIN/EWOULDBLOCK/ENOBUFS up to
+// Retries on ECONNREFUSED/EAGAIN/EWOULDBLOCK/ENOBUFS up to
 // BRIDGE_UDS_SEND_MAX_RETRIES * BRIDGE_UDS_SEND_RETRY_INTERVAL_US.
 inline bool send_bridge_uds_message(
   const std::string & addr, const void * data, size_t size, const rclcpp::Logger & logger)
@@ -93,8 +93,8 @@ inline bool send_bridge_uds_message(
     if (send_result >= 0) break;
     last_errno = errno;
     if (
-      last_errno != ECONNREFUSED && last_errno != ENOENT && last_errno != EAGAIN &&
-      last_errno != EWOULDBLOCK && last_errno != ENOBUFS) {
+      last_errno != ECONNREFUSED && last_errno != EAGAIN && last_errno != EWOULDBLOCK &&
+      last_errno != ENOBUFS) {
       break;
     }
     if (retry < BRIDGE_UDS_SEND_MAX_RETRIES) {

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -75,7 +75,7 @@ private:
 
   void start_ros_execution();
 
-  void on_mq_request(int fd);
+  void on_bridge_message(const void * data, std::size_t size);
   void on_signal();
   std::string on_socket_request() const;
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -204,11 +204,6 @@ void poll_for_unlink()
         const std::string shm_name = create_shm_name(get_exit_process_args.ret_pid);
         shm_unlink(shm_name.c_str());
 
-        // We don't need to call mq_unlink for non BridgeManager processes. However, we do it for
-        // all exited processes to avoid the complexity of checking the process type.
-        const std::string mq_name = create_mq_name_for_bridge(get_exit_process_args.ret_pid);
-        mq_unlink(mq_name.c_str());
-
         // Unlink subscription MQs that the exited process owned
         for (uint32_t i = 0; i < get_exit_process_args.ret_subscription_mq_info_num; i++) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
@@ -221,11 +216,6 @@ void poll_for_unlink()
     } while (get_exit_process_args.ret_pid > 0);
 
     if (get_exit_process_args.ret_daemon_should_exit) {
-      auto bridge_mode = get_bridge_mode();
-      if (bridge_mode == BridgeMode::On) {
-        const std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-        mq_unlink(mq_name.c_str());
-      }
       break;
     }
   }

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -1,6 +1,5 @@
 #include "agnocast/agnocast_utils.hpp"
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
 #include <sys/stat.h>
@@ -80,10 +79,10 @@ std::string create_mq_name_for_agnocast_publish(
   return create_mq_name("/agnocast", topic_name, id);
 }
 
-// MQ-name suffix that scopes the per-IPC-namespace performance bridge by domain.
+// UDS-address suffix that scopes the per-IPC-namespace bridge listener by domain.
 // An unset OR empty ROS_DOMAIN_ID means "no domain" (no suffix), keeping this in
-// sync with the Python discovery agent (bridge_decider._bridge_mq_name).
-static std::string performance_domain_suffix()
+// sync with the Python discovery agent (bridge_decider._bridge_uds_addr).
+static std::string bridge_domain_suffix()
 {
   const char * domain_id = getenv("ROS_DOMAIN_ID");
   if (domain_id == nullptr || *domain_id == '\0') {
@@ -109,13 +108,16 @@ uint32_t get_ros_domain_id()
   return static_cast<uint32_t>(value);
 }
 
-std::string create_mq_name_for_bridge(const pid_t pid)
+std::string create_uds_addr_for_bridge()
 {
-  std::string name = "/agnocast_bridge_manager@" + std::to_string(pid);
-  if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
-    name += performance_domain_suffix();
-  }
-  return name;
+  // Abstract-namespace UDS address is prefixed with '\0' and its length is
+  // scoped by the socklen_t passed to bind()/sendto() (no trailing NUL).
+  std::string addr;
+  addr.push_back('\0');
+  addr += "agnocast_bridge_manager_";
+  addr += std::to_string(get_self_ipc_ns_inode());
+  addr += bridge_domain_suffix();
+  return addr;
 }
 
 uint64_t get_self_ipc_ns_inode()

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
@@ -1,7 +1,7 @@
 #include "agnocast/bridge/performance/agnocast_performance_bridge_ipc_event_loop.hpp"
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 
 #include <utility>
 #include <vector>

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
@@ -12,10 +12,10 @@ namespace agnocast
 PerformanceBridgeIpcEventLoop::PerformanceBridgeIpcEventLoop(const rclcpp::Logger & logger)
 : IpcEventLoopBase(
     logger,
-    // 1. MQ Name
-    create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    // 2. Message Size
-    BRIDGE_MQ_MESSAGE_SIZE,
+    // 1. Abstract-namespace UDS address
+    create_uds_addr_for_bridge(),
+    // 2. Upper bound on any single received message
+    BRIDGE_MSG_MAX_SIZE,
     // 3. Block Signals
     {SIGTERM, SIGINT},
     // 4. Ignore Signals

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -7,11 +7,12 @@
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
-#include <mqueue.h>
 #include <sys/prctl.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 
 namespace agnocast
 {
@@ -55,7 +56,8 @@ void PerformanceBridgeManager::run()
 
   start_ros_execution();
 
-  event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
+  event_loop_.set_message_handler(
+    [this](const void * data, std::size_t size) { this->on_bridge_message(data, size); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
 
@@ -98,33 +100,25 @@ void PerformanceBridgeManager::start_ros_execution()
   });
 }
 
-void PerformanceBridgeManager::on_mq_request(int fd)
+void PerformanceBridgeManager::on_bridge_message(const void * data, std::size_t size)
 {
-  BridgeMsg msg{};
-
-  ssize_t bytes_read = mq_receive(fd, reinterpret_cast<char *>(&msg), sizeof(msg), nullptr);
-  if (bytes_read < 0) {
-    if (errno != EAGAIN) {
-      RCLCPP_WARN_STREAM(
-        logger_, "mq_receive failed for mq_name='" << event_loop_.get_mq_name() << "' (fd=" << fd
-                                                   << "): " << strerror(errno));
-    }
-    return;
-  }
-
-  if (static_cast<size_t>(bytes_read) < offsetof(BridgeMsg, payload)) {
+  if (size < offsetof(BridgeMsg, payload)) {
     RCLCPP_WARN(
       logger_,
-      "bridge msg too small to carry a discriminator: got %zd bytes, expected at least %zu",
-      bytes_read, offsetof(BridgeMsg, payload));
+      "bridge msg too small to carry a discriminator: got %zu bytes, expected at least %zu", size,
+      offsetof(BridgeMsg, payload));
     return;
   }
 
+  BridgeMsg msg{};
+  const size_t copy_size = std::min(size, sizeof(BridgeMsg));
+  std::memcpy(&msg, data, copy_size);
+
   const auto validate_variant_size = [&](size_t expected) -> bool {
-    if (static_cast<size_t>(bytes_read) < expected) {
+    if (size < expected) {
       RCLCPP_WARN(
-        logger_, "bridge msg (type=%u) truncated: got %zd bytes, expected at least %zu",
-        static_cast<uint32_t>(msg.type), bytes_read, expected);
+        logger_, "bridge msg (type=%u) truncated: got %zu bytes, expected at least %zu",
+        static_cast<uint32_t>(msg.type), size, expected);
       return false;
     }
     return true;

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -3,8 +3,8 @@
 
 #include "agnocast/agnocast_callback_isolated_executor.hpp"
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <sys/prctl.h>

--- a/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
@@ -1,0 +1,167 @@
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace
+{
+
+// Abstract-namespace address unique to this process + test-provided suffix, so
+// parallel test binaries and repeated runs never collide with a live socket.
+std::string make_unique_abstract_addr(const std::string & tag)
+{
+  std::string addr;
+  addr.push_back('\0');
+  addr += "agnocast_bridge_uds_test_";
+  addr += std::to_string(getpid());
+  addr += "_";
+  addr += tag;
+  return addr;
+}
+
+// RAII owner so a failed EXPECT doesn't leak the fd into later tests.
+class ScopedFd
+{
+public:
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ~ScopedFd()
+  {
+    if (fd_ != -1) {
+      close(fd_);
+    }
+  }
+  ScopedFd(const ScopedFd &) = delete;
+  ScopedFd & operator=(const ScopedFd &) = delete;
+  int get() const { return fd_; }
+
+private:
+  int fd_;
+};
+
+}  // namespace
+
+// ---- detail::fill_abstract_sockaddr ---------------------------------------
+
+TEST(BridgeUdsAddrTest, EmptyAddressRejected)
+{
+  sockaddr_un sa{};
+  EXPECT_THROW(agnocast::detail::fill_abstract_sockaddr("", sa), std::invalid_argument);
+}
+
+TEST(BridgeUdsAddrTest, NonNulPrefixedAddressRejected)
+{
+  sockaddr_un sa{};
+  EXPECT_THROW(
+    agnocast::detail::fill_abstract_sockaddr("agnocast_bridge_no_nul", sa), std::invalid_argument);
+}
+
+TEST(BridgeUdsAddrTest, OverlongAddressRejected)
+{
+  sockaddr_un sa{};
+  // Leading NUL + (sizeof(sun_path)) bytes = one byte too many for sun_path.
+  std::string too_long(sizeof(sa.sun_path) + 1, 'x');
+  too_long[0] = '\0';
+  EXPECT_THROW(agnocast::detail::fill_abstract_sockaddr(too_long, sa), std::length_error);
+}
+
+TEST(BridgeUdsAddrTest, ValidAddressPopulatesSockaddr)
+{
+  const std::string addr = std::string("\0hello", 6);  // NUL + "hello"
+
+  sockaddr_un sa{};
+  // Poison the padding to prove fill_abstract_sockaddr zeroes the whole struct.
+  std::memset(&sa, 0xAB, sizeof(sa));
+
+  const socklen_t alen = agnocast::detail::fill_abstract_sockaddr(addr, sa);
+
+  EXPECT_EQ(sa.sun_family, AF_UNIX);
+  EXPECT_EQ(alen, static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + addr.size()));
+  EXPECT_EQ(std::memcmp(sa.sun_path, addr.data(), addr.size()), 0);
+  // Bytes past the address must remain zero (i.e. no trailing NUL is required
+  // and no leftover poison bits leak to the kernel).
+  for (size_t i = addr.size(); i < sizeof(sa.sun_path); ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(sa.sun_path[i]), 0u) << "byte " << i;
+  }
+}
+
+TEST(BridgeUdsAddrTest, MaxLengthAddressAccepted)
+{
+  sockaddr_un probe{};
+  // Boundary: exactly sizeof(sun_path) bytes (leading NUL + sizeof-1 name bytes).
+  std::string boundary(sizeof(probe.sun_path), 'y');
+  boundary[0] = '\0';
+
+  sockaddr_un sa{};
+  const socklen_t alen = agnocast::detail::fill_abstract_sockaddr(boundary, sa);
+  EXPECT_EQ(alen, static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + boundary.size()));
+  EXPECT_EQ(std::memcmp(sa.sun_path, boundary.data(), boundary.size()), 0);
+}
+
+// ---- create_bridge_uds_listener -------------------------------------------
+
+TEST(BridgeUdsListenerTest, RejectsInvalidAddress)
+{
+  EXPECT_THROW(agnocast::create_bridge_uds_listener(""), std::invalid_argument);
+  EXPECT_THROW(agnocast::create_bridge_uds_listener("no-leading-nul"), std::invalid_argument);
+}
+
+TEST(BridgeUdsListenerTest, DuplicateBindFailsWithAddrInUse)
+{
+  const std::string addr = make_unique_abstract_addr("dup");
+  ScopedFd first(agnocast::create_bridge_uds_listener(addr));
+  ASSERT_NE(first.get(), -1);
+
+  try {
+    ScopedFd second(agnocast::create_bridge_uds_listener(addr));
+    FAIL() << "second listener on the same abstract address must fail";
+  } catch (const std::system_error & e) {
+    EXPECT_EQ(e.code().value(), EADDRINUSE)
+      << "expected EADDRINUSE, got " << e.code().value() << " (" << e.what() << ")";
+  }
+}
+
+// ---- send_bridge_uds_message ----------------------------------------------
+
+TEST(BridgeUdsSendTest, RoundTripDeliversPayload)
+{
+  const std::string addr = make_unique_abstract_addr("roundtrip");
+  ScopedFd listener(agnocast::create_bridge_uds_listener(addr));
+  ASSERT_NE(listener.get(), -1);
+
+  const std::array<std::uint8_t, 4> payload = {0xDE, 0xAD, 0xBE, 0xEF};
+  const auto logger = rclcpp::get_logger("BridgeUdsSendTest");
+  EXPECT_TRUE(agnocast::send_bridge_uds_message(addr, payload.data(), payload.size(), logger));
+
+  std::array<std::uint8_t, 32> buf{};
+  const ssize_t n = recv(listener.get(), buf.data(), buf.size(), 0);
+  ASSERT_EQ(n, static_cast<ssize_t>(payload.size()))
+    << "recv failed or short read: " << (n < 0 ? strerror(errno) : "size mismatch");
+  EXPECT_EQ(std::memcmp(buf.data(), payload.data(), payload.size()), 0);
+}
+
+TEST(BridgeUdsSendTest, InvalidAddressFailsFast)
+{
+  const auto logger = rclcpp::get_logger("BridgeUdsSendTest");
+  const std::uint8_t byte = 0;
+  // Empty and non-NUL-prefixed addresses are rejected inside
+  // send_bridge_uds_message before any sendto()/retry loop runs, so this must
+  // return false immediately rather than spending
+  // BRIDGE_UDS_SEND_MAX_RETRIES * BRIDGE_UDS_SEND_RETRY_INTERVAL_US retrying.
+  EXPECT_FALSE(agnocast::send_bridge_uds_message("", &byte, sizeof(byte), logger));
+  EXPECT_FALSE(agnocast::send_bridge_uds_message("no-nul", &byte, sizeof(byte), logger));
+}

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -69,9 +69,14 @@ TEST(AgnocastUtilsTest, create_mq_name_invalid_topic)
     ::testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(AgnocastUtilsTest, create_mq_name_bridge_manager)
+TEST(AgnocastUtilsTest, create_uds_addr_bridge_manager)
 {
-  EXPECT_EQ(agnocast::create_mq_name_for_bridge(12345), "/agnocast_bridge_manager@12345");
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
 }
 
 TEST(AgnocastUtilsTest, validate_ld_preload_normal)

--- a/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_mq.cpp
@@ -77,13 +77,40 @@ TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
 }
 
 // An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix.
-TEST(DaemonBridgeMqTest, BridgeMqNameEmptyDomainIdHasNoSuffix)
+TEST(DaemonBridgeMqTest, BridgeUdsAddrEmptyDomainIdHasNoSuffix)
 {
   const ScopedRosDomainId guard;
   setenv("ROS_DOMAIN_ID", "", 1);
-  EXPECT_EQ(
-    agnocast::create_mq_name_for_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    "/agnocast_bridge_manager@" + std::to_string(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID));
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
+}
+
+TEST(DaemonBridgeMqTest, BridgeUdsAddrAppendsDomainId)
+{
+  const ScopedRosDomainId guard;
+  setenv("ROS_DOMAIN_ID", "7", 1);
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode()) + "_d7";
+  EXPECT_EQ(addr.substr(1), expected);
+}
+
+TEST(DaemonBridgeMqTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
+{
+  const ScopedRosDomainId guard;
+  unsetenv("ROS_DOMAIN_ID");
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
 }
 
 // Performance-mode daemon bridges have no local endpoint to query, so the QoS

--- a/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
@@ -42,7 +42,7 @@ private:
 // The discovery daemon (Python) packs BridgeMsgDaemonPubSubPayload by hand inside a
 // BridgeMsg, mirroring this layout. These checks fail loudly if the C++ struct
 // drifts from the daemon's `_MSG_PACK_FORMAT`.
-TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
+TEST(DaemonBridgeUdsTest, DaemonPayloadWireLayout)
 {
   using agnocast::BridgeMsgDaemonPubSubPayload;
   EXPECT_EQ(sizeof(BridgeMsgDaemonPubSubPayload), 524u);
@@ -54,14 +54,14 @@ TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
   EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_reliable), 521u);
 }
 
-TEST(DaemonBridgeMqTest, BridgeMsgTypeNumeric)
+TEST(DaemonBridgeUdsTest, BridgeMsgTypeNumeric)
 {
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::PubSub), 0u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::Service), 1u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::DaemonPubSub), 2u);
 }
 
-TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
+TEST(DaemonBridgeUdsTest, BridgeMsgWireLayout)
 {
   EXPECT_EQ(offsetof(agnocast::BridgeMsg, type), 0u);
   EXPECT_EQ(offsetof(agnocast::BridgeMsg, payload), 4u);
@@ -77,7 +77,7 @@ TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
 }
 
 // An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix.
-TEST(DaemonBridgeMqTest, BridgeUdsAddrEmptyDomainIdHasNoSuffix)
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrEmptyDomainIdHasNoSuffix)
 {
   const ScopedRosDomainId guard;
   setenv("ROS_DOMAIN_ID", "", 1);
@@ -89,7 +89,7 @@ TEST(DaemonBridgeMqTest, BridgeUdsAddrEmptyDomainIdHasNoSuffix)
   EXPECT_EQ(addr.substr(1), expected);
 }
 
-TEST(DaemonBridgeMqTest, BridgeUdsAddrAppendsDomainId)
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrAppendsDomainId)
 {
   const ScopedRosDomainId guard;
   setenv("ROS_DOMAIN_ID", "7", 1);
@@ -101,7 +101,7 @@ TEST(DaemonBridgeMqTest, BridgeUdsAddrAppendsDomainId)
   EXPECT_EQ(addr.substr(1), expected);
 }
 
-TEST(DaemonBridgeMqTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
 {
   const ScopedRosDomainId guard;
   unsetenv("ROS_DOMAIN_ID");
@@ -115,7 +115,7 @@ TEST(DaemonBridgeMqTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
 
 // Performance-mode daemon bridges have no local endpoint to query, so the QoS
 // must be rebuilt faithfully from the request's explicit fields.
-TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
+TEST(DaemonBridgeUdsTest, DaemonRequestQosReliableTransientLocal)
 {
   agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 10;
@@ -128,7 +128,7 @@ TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
   EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
 }
 
-TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
+TEST(DaemonBridgeUdsTest, DaemonRequestQosBestEffortVolatile)
 {
   agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 1;
@@ -144,7 +144,7 @@ TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
 // The daemon-forced lease (used by the performance bridge_manager to keep a
 // cross-NS bridge alive without a same-graph DDS counterpart) is active for the
 // half-open window [registered, registered + DAEMON_FORCE_TTL).
-TEST(DaemonBridgeMqTest, DaemonForceLeaseWindowIsHalfOpen)
+TEST(DaemonBridgeUdsTest, DaemonForceLeaseWindowIsHalfOpen)
 {
   const std::chrono::steady_clock::time_point t0{};
   const auto deadline = agnocast::daemon_force_deadline(t0);
@@ -163,7 +163,7 @@ TEST(DaemonBridgeMqTest, DaemonForceLeaseWindowIsHalfOpen)
 
 // Re-asserting the request (the daemon does so every tick) pushes the deadline
 // out, so a continuously-requested bridge never lapses.
-TEST(DaemonBridgeMqTest, DaemonForceLeaseRenewalExtendsDeadline)
+TEST(DaemonBridgeUdsTest, DaemonForceLeaseRenewalExtendsDeadline)
 {
   const std::chrono::steady_clock::time_point t0{};
   const auto first = agnocast::daemon_force_deadline(t0);

--- a/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
@@ -1,5 +1,5 @@
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <gtest/gtest.h>

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -414,7 +414,8 @@ class DiscoveryAgent(Node):
         remote_states = {key: msg for key, (msg, _received_at) in self._remote_states.items()}
         requests = bridge_decider.decide_bridges(local_state, remote_states)
         if requests:
-            bridge_decider.dispatch_requests(requests, logger=self.get_logger())
+            bridge_decider.dispatch_requests(
+                requests, self._ipc_ns_inode, logger=self.get_logger())
 
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -8,17 +8,18 @@ so the two reach each other through ROS 2 (DDS):
   * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
   * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
 
-The request is sent as a ``BridgeMsg`` (type=Daemon) to the per-namespace
-bridge_manager MQ (``/agnocast_bridge_manager@-1[_d<domain>]``).
+The request is sent as a ``BridgeMsg`` (type=DaemonPubSub) to the per-namespace
+bridge_manager over an abstract-namespace UNIX domain socket
+(``\\0agnocast_bridge_manager_<ipc_ns_inode>[_d<domain>]``).
 The struct layout is mirrored here so the daemon stays decoupled from
 libagnocast's C++ headers; ``agnocast_mq.hpp`` owns the source of truth and a
 test asserts the size stays in sync.
 """
 
-import ctypes
 from dataclasses import dataclass
 import errno
 import os
+import socket
 import struct
 from typing import Iterable, Optional
 
@@ -50,26 +51,7 @@ _MSG_PACK_FORMAT = '=I256s256sIIBB2x'
 DIRECTION_ROS2_TO_AGNOCAST = 0
 DIRECTION_AGNOCAST_TO_ROS2 = 1
 
-# One bridge_manager per IPC namespace listens on this MQ.
-_BRIDGE_MQ_BASE = '/agnocast_bridge_manager@-1'
-
-# librt mq_* loaded lazily to keep the daemon's deps at "rclpy + stdlib".
-_librt = None
-
-
-def _load_librt():
-    global _librt
-    if _librt is not None:
-        return _librt
-    lib = ctypes.CDLL('librt.so.1', use_errno=True)
-    lib.mq_open.argtypes = [ctypes.c_char_p, ctypes.c_int]
-    lib.mq_open.restype = ctypes.c_int
-    lib.mq_send.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint]
-    lib.mq_send.restype = ctypes.c_int
-    lib.mq_close.argtypes = [ctypes.c_int]
-    lib.mq_close.restype = ctypes.c_int
-    _librt = lib
-    return _librt
+_BRIDGE_UDS_BASE = 'agnocast_bridge_manager'
 
 
 @dataclass(frozen=True)
@@ -80,7 +62,7 @@ class BridgeRequest:
     qos_depth: int
     qos_is_transient_local: bool
     qos_is_reliable: bool
-    # Selects the target bridge_manager's MQ (one manager per domain); not part
+    # Selects the target bridge_manager's UDS (one manager per domain); not part
     # of the wire payload, since that manager already runs in this domain.
     domain_id: int = 0
 
@@ -176,46 +158,51 @@ def decide_bridges(local_state, remote_states) -> list:
     return list(requests.values())
 
 
-def _bridge_mq_name(domain_id: int) -> str:
-    name = _BRIDGE_MQ_BASE
+def _bridge_uds_addr(ipc_ns_inode: int, domain_id: int) -> str:
+    name = '\x00' + _BRIDGE_UDS_BASE + '_' + str(ipc_ns_inode)
     if domain_id:
         name += '_d' + str(domain_id)
     return name
 
 
-def send_request(mq_name: str, payload: bytes) -> Optional[str]:
-    """Send ``payload`` to ``mq_name``; return an error string or None.
+def send_request(uds_addr: str, payload: bytes) -> Optional[str]:
+    """Send ``payload`` to ``uds_addr``; return an error string or None.
 
-    O_NONBLOCK keeps a full or absent queue from stalling the daemon: the
-    request is re-issued idempotently next tick.
+    Transient failures (bridge_manager not yet bound, receiver buffer full)
+    are swallowed since the request is re-issued idempotently next tick.
     """
-    lib = _load_librt()
-    fd = lib.mq_open(mq_name.encode('utf-8'), os.O_WRONLY | os.O_NONBLOCK)
-    if fd == -1:
-        err = ctypes.get_errno()
-        if err == errno.ENOENT:
-            return None
-        return f'mq_open({mq_name}): {os.strerror(err)}'
+    transient_errnos = (
+        errno.ECONNREFUSED,
+        errno.ENOENT,
+        errno.EAGAIN,
+        errno.EWOULDBLOCK,
+        errno.ENOBUFS,
+    )
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.setblocking(False)
     try:
-        if lib.mq_send(fd, payload, len(payload), 0) == -1:
-            err = ctypes.get_errno()
-            if err == errno.EAGAIN:
+        try:
+            sock.sendto(payload, uds_addr)
+        except OSError as e:
+            if e.errno in transient_errnos:
                 return None
-            return f'mq_send({mq_name}): {os.strerror(err)}'
+            return f'sendto({uds_addr!r}): {os.strerror(e.errno) if e.errno else str(e)}'
     finally:
-        lib.mq_close(fd)
+        sock.close()
     return None
 
 
-def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
-    """Deliver each request to the per-namespace bridge_manager MQ.
+def dispatch_requests(
+        requests: Iterable[BridgeRequest], ipc_ns_inode: int, logger=None) -> None:
+    """Deliver each request to the per-namespace bridge_manager UDS.
 
-    Each request goes to the manager that owns its domain (one per domain). The
-    MQ is absent until that bridge_manager is up; ``send_request`` skips
-    ENOENT/EAGAIN so a missing or full queue never stalls the daemon, and the
-    request is re-issued idempotently next tick.
+    Each request goes to the manager that owns its (IPC namespace, domain).
+    The listener UDS is absent until that bridge_manager is up;
+    ``send_request`` swallows ECONNREFUSED/ENOENT so a missing peer never
+    stalls the daemon, and the request is re-issued idempotently next tick.
     """
     for req in requests:
-        err = send_request(_bridge_mq_name(req.domain_id), serialize_request(req))
+        err = send_request(
+            _bridge_uds_addr(ipc_ns_inode, req.domain_id), serialize_request(req))
         if err is not None and logger is not None:
             logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -12,8 +12,8 @@ The request is sent as a ``BridgeMsg`` (type=DaemonPubSub) to the per-namespace
 bridge_manager over an abstract-namespace UNIX domain socket
 (``\\0agnocast_bridge_manager_<ipc_ns_inode>[_d<domain>]``).
 The struct layout is mirrored here so the daemon stays decoupled from
-libagnocast's C++ headers; ``agnocast_mq.hpp`` owns the source of truth and a
-test asserts the size stays in sync.
+libagnocast's C++ headers; ``agnocast_bridge_msg.hpp`` owns the source of
+truth and a test asserts the size stays in sync.
 """
 
 from dataclasses import dataclass

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -3,7 +3,7 @@
 These need neither the kmod, DDS, nor a POSIX MQ: ``decide_bridges`` is pure
 logic, and the wire format is checked against the hand-built byte layout that
 mirrors a Daemon-variant ``BridgeMsg`` (4-byte tag + 524-byte payload = 528
-bytes) in ``agnocast_mq.hpp``.
+bytes) in ``agnocast_bridge_msg.hpp``.
 """
 
 import struct

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -199,26 +199,28 @@ def test_serialize_packs_direction_qos_at_expected_offsets():
     assert (direction, depth, transient, reliable) == (DIRECTION_ROS2_TO_AGNOCAST, 7, 1, 1)
 
 
-def test_dispatch_targets_per_namespace_mq(monkeypatch):
+def test_dispatch_targets_per_namespace_uds(monkeypatch):
     from ros2agnocast_discovery_agent import bridge_decider as bd
     sent = []
-    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: sent.append(addr) or None)
 
     req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
-    dispatch_requests([req])
+    dispatch_requests([req], ipc_ns_inode=12345)
 
-    assert all(name.startswith('/agnocast_bridge_manager@-1') for name in sent)
-    assert len(sent) == 1
+    assert sent == ['\x00agnocast_bridge_manager_12345']
 
 
-def test_dispatch_routes_to_per_domain_mq(monkeypatch):
+def test_dispatch_routes_to_per_domain_uds(monkeypatch):
     from ros2agnocast_discovery_agent import bridge_decider as bd
     sent = []
-    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: sent.append(addr) or None)
 
     dispatch_requests([
         BridgeRequest('/a', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=0),
         BridgeRequest('/b', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=5),
-    ])
+    ], ipc_ns_inode=12345)
 
-    assert sent == ['/agnocast_bridge_manager@-1', '/agnocast_bridge_manager@-1_d5']
+    assert sent == [
+        '\x00agnocast_bridge_manager_12345',
+        '\x00agnocast_bridge_manager_12345_d5',
+    ]


### PR DESCRIPTION
## Description

This PR replaces the POSIX message queue (MQ) used by the bridge with **an abstract-namespace UNIX Domain Socket (UDS)**.

Previously, the bridge manager used POSIX MQ to interact with Agnocast endpoints and the discovery agent. However, a POSIX MQ is not owned by any particular process, so it is not cleaned up by the OS on process exit. This leads to an MQ leak when the bridge manager crashes unexpectedly, which has been a serious pain point for Agnocast users developing Agnocast applications.

An abstract-namespace UNIX domain socket, on the other hand, is bound to a specific process and released by the OS automatically when that process exits.

Main changes:

* POSIX MQ `/dev/mqueue/agnocast_bridge_manager@-1[_d<domain ID>]` -> Abstract-namespace UDS **`\0agnocast_bridge_manager_<IPC-namespace-inode>[_d<domain ID>]`**
* Renamed "MQ" to "UDS" in the corresponding filenames, data structures, comments, etc.
* Added tests for the newly introduced UDS helpers.
* Updated the related documentation.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

### Namespace scope

We include the IPC namespace inode in the UDS name because the bridge manager runs one instance per IPC namespace.

During testing, we often use `unshare --ipc` to split only the IPC namespace, leaving the network namespace shared. If we used a fixed name like `\0agnocast_bridge_manager`, a second instance would fail to bind with an "address already in use" error.

If applications always split both namespaces together, the fixed name would be fine. However, to make testing easier and avoid conflicts, I chose to add the inode to the UDS name.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.