### PR TITLE
feat(agnocast)[needs minor version update]: support topic rename (remap) in the domain bridge

### DIFF
--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -45,6 +45,9 @@ jobs:
           # COMPLEX_MACRO: the KUnit suite's TEST_CASES_* macros are comma-separated
           # KUNIT_CASE(...) lists that cannot be parenthesized; this is a false positive.
           IGNORE="$IGNORE,COMPLEX_MACRO"
+          # FILE_PATH_CHANGES: agnocast is an out-of-tree module with no entry in the
+          # kernel MAINTAINERS file, so adding or moving kmod files never needs one.
+          IGNORE="$IGNORE,FILE_PATH_CHANGES"
 
           git diff origin/${{ github.base_ref }}...HEAD -- agnocast_kmod/ \
             | ./checkpatch.pl --no-tree --show-types --ignore="$IGNORE" -

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ rm /dev/shm/agnocast@*
 
 # Remove leftover message queues
 rm /dev/mqueue/agnocast@*
-rm /dev/mqueue/agnocast_bridge_manager@*
 ```
 
 If you encounter `mq_open failed: No space left on device`, the system has reached the maximum number of message queues. Run the cleanup commands above, and if the error persists, increase the system-wide `queues_max` limit (e.g., `sudo sysctl -w fs.mqueue.queues_max=1024`). See [System Configuration](https://autowarefoundation.github.io/agnocast_doc/environment-setup/configuration/) for details.

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -280,7 +280,9 @@ struct ioctl_set_ros2_publisher_num_args
 
 struct ioctl_add_domain_bridge_args
 {
-  struct name_info topic_name;
+  // topic_name_from / topic_name_to may differ (rename); equal for a plain bridge.
+  struct name_info topic_name_from;
+  struct name_info topic_name_to;
   uint32_t from_domain;
   uint32_t to_domain;
 };
@@ -451,8 +453,8 @@ int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, bool is_r2a, const struct ipc_namespace * ipc_ns);
 
 int agnocast_ioctl_add_domain_bridge(
-  const char * topic_name, uint32_t from_domain, uint32_t to_domain,
-  const struct ipc_namespace * ipc_ns);
+  const char * topic_name_from, const char * topic_name_to, uint32_t from_domain,
+  uint32_t to_domain, const struct ipc_namespace * ipc_ns);
 
 int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret);
 
@@ -527,8 +529,8 @@ bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_names
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_namespace * ipc_ns);
 bool agnocast_get_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
-  uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain,
+  uint32_t * domain_a, uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
 // Returns the shared topic_struct's wrapper refcount for the wrapper in domain_id,
 // or 0 if no such wrapper exists. Used to observe domain-bridge grouping.
 int agnocast_topic_wrapper_refcnt(

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -278,6 +278,13 @@ struct ioctl_set_ros2_publisher_num_args
   uint32_t ros2_publisher_num;
 };
 
+struct ioctl_add_domain_bridge_args
+{
+  struct name_info topic_name;
+  uint32_t from_domain;
+  uint32_t to_domain;
+};
+
 #define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
 #define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
 #define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
@@ -301,6 +308,7 @@ struct ioctl_set_ros2_publisher_num_args
   _IOW(0xA6, 25, struct ioctl_set_ros2_subscriber_num_args)
 #define AGNOCAST_SET_ROS2_PUBLISHER_NUM_CMD _IOW(0xA6, 26, struct ioctl_set_ros2_publisher_num_args)
 #define AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD _IO(0xA6, 27)
+#define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)
 
 // ================================================
 // ros2cli ioctls
@@ -442,6 +450,10 @@ int agnocast_ioctl_add_bridge(
 int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, bool is_r2a, const struct ipc_namespace * ipc_ns);
 
+int agnocast_ioctl_add_domain_bridge(
+  const char * topic_name, uint32_t from_domain, uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns);
+
 int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret);
 
 int agnocast_ioctl_get_topic_subscriber_info(
@@ -514,4 +526,7 @@ int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns);
 bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_namespace * ipc_ns);
+bool agnocast_get_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
+  uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
 #endif

--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -529,4 +529,8 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
 bool agnocast_get_domain_rule(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
   uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
+// Returns the shared topic_struct's wrapper refcount for the wrapper in domain_id,
+// or 0 if no such wrapper exists. Used to observe domain-bridge grouping.
+int agnocast_topic_wrapper_refcnt(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id);
 #endif

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -37,10 +37,7 @@ static void remove_all_topics(void)
       kfree(sub_info);
     }
 
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+    agnocast_release_topic_wrapper(wrapper);
   }
 }
 

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -71,6 +71,19 @@ static void remove_all_bridge_info(void)
   }
 }
 
+static void remove_all_domain_rules(void)
+{
+  struct domain_bridge_rule * rule;
+  int bkt;
+  struct hlist_node * tmp;
+  hash_for_each_safe(domain_rule_htable, bkt, tmp, rule, node)
+  {
+    hash_del(&rule->node);
+    kfree(rule->topic_name);
+    kfree(rule);
+  }
+}
+
 // Called during module unload. Not an ioctl function, so we manage locks here directly.
 void agnocast_exit_free_data(void)
 {
@@ -78,6 +91,7 @@ void agnocast_exit_free_data(void)
   remove_all_topics();
   remove_all_process_info();
   remove_all_bridge_info();
+  remove_all_domain_rules();
   up_write(&global_htables_rwsem);
 }
 

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -7,36 +7,10 @@ static void remove_all_topics(void)
   struct hlist_node * tmp;
   int bkt;
 
+  // release frees the shared topic_struct (rbtree + pub/sub tables) once its
+  // last wrapper goes; for a grouped pair that is the second wrapper.
   hash_for_each_safe(topic_hashtable, bkt, tmp, wrapper, node)
   {
-    struct rb_root * root = &wrapper->topic->entries;
-    struct rb_node * node = rb_first(root);
-    while (node) {
-      struct entry_node * en = rb_entry(node, struct entry_node, node);
-      node = rb_next(node);
-      agnocast_remove_entry_node(wrapper, en);
-    }
-
-    struct publisher_info * pub_info;
-    int bkt_pub_info;
-    struct hlist_node * tmp_pub_info;
-    hash_for_each_safe(wrapper->topic->pub_info_htable, bkt_pub_info, tmp_pub_info, pub_info, node)
-    {
-      hash_del(&pub_info->node);
-      kfree(pub_info->node_name);
-      kfree(pub_info);
-    }
-
-    struct subscriber_info * sub_info;
-    int bkt_sub_info;
-    struct hlist_node * tmp_sub_info;
-    hash_for_each_safe(wrapper->topic->sub_info_htable, bkt_sub_info, tmp_sub_info, sub_info, node)
-    {
-      hash_del(&sub_info->node);
-      kfree(sub_info->node_name);
-      kfree(sub_info);
-    }
-
     agnocast_release_topic_wrapper(wrapper);
   }
 }

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -50,7 +50,8 @@ static void remove_all_domain_rules(void)
   hash_for_each_safe(domain_rule_htable, bkt, tmp, rule, node)
   {
     hash_del(&rule->node);
-    kfree(rule->topic_name);
+    kfree(rule->topic_name_a);
+    kfree(rule->topic_name_b);
     kfree(rule);
   }
 }

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -10,6 +10,7 @@ DECLARE_RWSEM(global_htables_rwsem);
 DEFINE_HASHTABLE(proc_info_htable, PROC_INFO_HASH_BITS);
 DEFINE_HASHTABLE(topic_hashtable, TOPIC_HASH_BITS);
 DEFINE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
+DEFINE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
 
 DEFINE_SPINLOCK(pid_queue_lock);
 pid_t exit_pid_queue[EXIT_QUEUE_SIZE];

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -187,6 +187,10 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
 {
   hash_del(&wrapper->node);
   kfree(wrapper->key);
+
+  // Grouped domains share one topic_struct, so it (and everything it owns) is
+  // torn down only when the last referencing wrapper is released. This is the
+  // single place that frees the shared rbtree and pub/sub tables.
   if (--wrapper->topic->wrapper_refcnt == 0) {
     struct rb_node * node = rb_first(&wrapper->topic->entries);
     while (node) {
@@ -195,6 +199,27 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
       rb_erase(&en->node, &wrapper->topic->entries);
       kfree(en);
     }
+
+    struct publisher_info * pub_info;
+    int bkt_pub;
+    struct hlist_node * tmp_pub;
+    hash_for_each_safe(wrapper->topic->pub_info_htable, bkt_pub, tmp_pub, pub_info, node)
+    {
+      hash_del(&pub_info->node);
+      kfree(pub_info->node_name);
+      kfree(pub_info);
+    }
+
+    struct subscriber_info * sub_info;
+    int bkt_sub;
+    struct hlist_node * tmp_sub;
+    hash_for_each_safe(wrapper->topic->sub_info_htable, bkt_sub, tmp_sub, sub_info, node)
+    {
+      hash_del(&sub_info->node);
+      kfree(sub_info->node_name);
+      kfree(sub_info);
+    }
+
     kfree(wrapper->topic);
   }
   kfree(wrapper);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -167,6 +167,39 @@ int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper)
   return count;
 }
 
+bool agnocast_wrapper_has_domain_endpoints(const struct topic_wrapper * wrapper)
+{
+  struct publisher_info * pub_info;
+  struct subscriber_info * sub_info;
+  int bkt;
+  hash_for_each(wrapper->topic->pub_info_htable, bkt, pub_info, node)
+  {
+    if (pub_info->domain_id == wrapper->domain_id) return true;
+  }
+  hash_for_each(wrapper->topic->sub_info_htable, bkt, sub_info, node)
+  {
+    if (sub_info->domain_id == wrapper->domain_id) return true;
+  }
+  return false;
+}
+
+void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
+{
+  hash_del(&wrapper->node);
+  kfree(wrapper->key);
+  if (--wrapper->topic->wrapper_refcnt == 0) {
+    struct rb_node * node = rb_first(&wrapper->topic->entries);
+    while (node) {
+      struct entry_node * en = rb_entry(node, struct entry_node, node);
+      node = rb_next(node);
+      rb_erase(&en->node, &wrapper->topic->entries);
+      kfree(en);
+    }
+    kfree(wrapper->topic);
+  }
+  kfree(wrapper);
+}
+
 bool agnocast_is_referenced(struct entry_node * en)
 {
   return !bitmap_empty(en->referencing_subscribers, MAX_TOPIC_LOCAL_ID);
@@ -301,14 +334,9 @@ void agnocast_process_exit_cleanup(const pid_t pid)
 
     pre_handler_subscriber_exit(wrapper, pid, proc_info);
 
-    // Check if we can release the topic_wrapper
-    if (
-      agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-      agnocast_get_size_sub_info_htable(wrapper) == 0) {
-      hash_del(&wrapper->node);
-      kfree(wrapper->key);
-      kfree(wrapper->topic);
-      kfree(wrapper);
+    // Release this wrapper once its own domain has no endpoints left.
+    if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+      agnocast_release_topic_wrapper(wrapper);
     }
   }
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -80,6 +80,9 @@ extern DECLARE_HASHTABLE(proc_info_htable, PROC_INFO_HASH_BITS);
 struct publisher_info
 {
   topic_local_id_t id;
+  // The endpoint's ROS domain. Equals the owning wrapper's domain; carried per
+  // endpoint because grouped wrappers share one htable holding both domains.
+  uint32_t domain_id;
   pid_t pid;
   char * node_name;
   uint32_t qos_depth;
@@ -92,6 +95,8 @@ struct publisher_info
 struct subscriber_info
 {
   topic_local_id_t id;
+  // The endpoint's ROS domain (see publisher_info::domain_id).
+  uint32_t domain_id;
   pid_t pid;
   uint32_t qos_depth;
   bool qos_is_transient_local;
@@ -126,6 +131,10 @@ struct topic_struct
   uint32_t ros2_publisher_num;   // Updated by Bridge Manager
   // Per-topic rwsem: read for read-only ops, write for publish/receive/modify.
   struct rw_semaphore rwsem;
+  // Number of topic_wrappers sharing this struct. 1 normally; 2 when a domain
+  // bridge rule groups two domains' wrappers onto one entry/id space. The struct
+  // is freed only when the last referencing wrapper is dropped.
+  uint32_t wrapper_refcnt;
 };
 
 struct topic_wrapper
@@ -185,6 +194,10 @@ int agnocast_get_size_sub_info_htable(struct topic_wrapper * wrapper);
 
 int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper);
 
+// True if the (possibly shared) topic_struct holds any endpoint in this wrapper's
+// own domain. Used to decide when to drop a single wrapper of a grouped pair.
+bool agnocast_wrapper_has_domain_endpoints(const struct topic_wrapper * wrapper);
+
 bool agnocast_is_referenced(struct entry_node * en);
 
 struct process_info * agnocast_find_process_info(const pid_t pid);
@@ -192,6 +205,11 @@ struct process_info * agnocast_find_process_info(const pid_t pid);
 void agnocast_free_exit_subscription_list(struct process_info * proc_info);
 
 void agnocast_remove_entry_node(struct topic_wrapper * wrapper, struct entry_node * en);
+
+// Unlink a wrapper and free it. The shared topic_struct (its rbtree and the
+// struct itself) is freed only when the last referencing wrapper is dropped, so
+// a grouped partner keeps working until it too is released.
+void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper);
 
 long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -165,6 +165,22 @@ struct bridge_info
 
 extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 
+// A domain bridge rule relays one topic between two ROS domains within one IPC
+// namespace (from_domain -> to_domain). v1 supports a single domain pair per
+// (topic, ipc_ns); see agnocast_ioctl_add_domain_bridge.
+struct domain_bridge_rule
+{
+  char * topic_name;
+  const struct ipc_namespace * ipc_ns;
+  uint32_t domain_a;  // canonical ordering: domain_a < domain_b
+  uint32_t domain_b;
+  bool a_to_b;  // deliver domain_a's publications to domain_b's subscribers
+  bool b_to_a;
+  struct hlist_node node;
+};
+
+extern DECLARE_HASHTABLE(domain_rule_htable, TOPIC_HASH_BITS);
+
 int agnocast_get_size_sub_info_htable(struct topic_wrapper * wrapper);
 
 int agnocast_get_size_pub_info_htable(struct topic_wrapper * wrapper);

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -185,7 +185,11 @@ extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 // on adding one.
 struct domain_bridge_rule
 {
-  char * topic_name;
+  // Per-domain topic names. Equal when the rule does not rename; a rename pairs
+  // topic_name_a@domain_a with topic_name_b@domain_b. Delivery stays zero-copy
+  // either way -- only the two wrappers' keys differ.
+  char * topic_name_a;
+  char * topic_name_b;
   const struct ipc_namespace * ipc_ns;
   uint32_t domain_a;  // canonical ordering: domain_a < domain_b
   uint32_t domain_b;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -120,6 +120,8 @@ static inline long copy_name_from_user(char * dst, size_t dst_size, const struct
   return 0;
 }
 
+struct domain_bridge_rule;
+
 struct topic_struct
 {
   struct rb_root entries;
@@ -135,6 +137,9 @@ struct topic_struct
   // bridge rule groups two domains' wrappers onto one entry/id space. The struct
   // is freed only when the last referencing wrapper is dropped.
   uint32_t wrapper_refcnt;
+  // The domain bridge rule covering this topic, or NULL if none. Cached here so
+  // the publish/receive hot path can check delivery direction without a lookup.
+  const struct domain_bridge_rule * rule;
 };
 
 struct topic_wrapper

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -180,8 +180,9 @@ struct bridge_info
 extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 
 // A domain bridge rule relays one topic between two ROS domains within one IPC
-// namespace (from_domain -> to_domain). v1 supports a single domain pair per
-// (topic, ipc_ns); see agnocast_ioctl_add_domain_bridge.
+// namespace. The pair is stored canonically (domain_a < domain_b) with the enabled
+// direction(s) in a_to_b / b_to_a. See agnocast_ioctl_add_domain_bridge for the rules
+// on adding one.
 struct domain_bridge_rule
 {
   char * topic_name;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1224,14 +1224,15 @@ int agnocast_ioctl_get_subscriber_num(
   uint32_t inter_count = 0;
   uint32_t intra_count = 0;
 
-  // The caller is a publisher in wrapper->domain_id; count only the subscribers
-  // it actually delivers to. For a one-way bridge rule this excludes the
-  // opposite-domain subscribers; for ungrouped topics every subscriber qualifies.
+  // Match ROS 2's get_subscription_count: report only same-domain subscribers.
+  // A bridge rule still delivers cross-domain (see the publish/receive paths),
+  // but a publisher does not count subscribers in another domain. Ungrouped
+  // topics hold only one domain, so this is a no-op for them.
   struct subscriber_info * sub_info;
   int bkt_sub;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
-    if (!domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+    if (sub_info->domain_id != wrapper->domain_id) {
       continue;
     }
     if (sub_info->is_bridge) {
@@ -1326,15 +1327,16 @@ int agnocast_ioctl_get_publisher_num(
 
   ioctl_ret->ret_ros2_publisher_num = wrapper->topic->ros2_publisher_num;
 
-  // The caller is a subscriber in wrapper->domain_id; count only the publishers
-  // that actually deliver to it. For a one-way bridge rule this excludes the
-  // opposite-domain publishers; for ungrouped topics every publisher qualifies.
+  // Match ROS 2's get_publisher_count: report only same-domain publishers.
+  // A bridge rule still delivers cross-domain (see the publish/receive paths),
+  // but a subscriber does not count publishers in another domain. Ungrouped
+  // topics hold only one domain, so this is a no-op for them.
   uint32_t publisher_num = 0;
   struct publisher_info * pub_info;
   int bkt_pub;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub, pub_info, node)
   {
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+    if (pub_info->domain_id != wrapper->domain_id) {
       continue;
     }
     publisher_num++;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -99,11 +99,18 @@ static struct topic_struct * find_grouped_topic_struct(
 }
 
 // Whether a publication in pub_domain may be delivered to a subscriber in
-// sub_domain within a (possibly grouped) topic_struct. Same domain is always
-// allowed; cross-domain delivery is opened per rule direction in a later change.
-static bool domain_delivery_allowed(uint32_t pub_domain, uint32_t sub_domain)
+// sub_domain within this topic_struct. Same domain is always allowed; crossing
+// domains requires a rule permitting that direction (from_domain -> to_domain).
+static bool domain_delivery_allowed(
+  const struct topic_struct * topic, uint32_t pub_domain, uint32_t sub_domain)
 {
-  return pub_domain == sub_domain;
+  if (pub_domain == sub_domain) return true;
+
+  const struct domain_bridge_rule * rule = topic->rule;
+  if (!rule) return false;
+  if (pub_domain == rule->domain_a && sub_domain == rule->domain_b) return rule->a_to_b;
+  if (pub_domain == rule->domain_b && sub_domain == rule->domain_a) return rule->b_to_a;
+  return false;
 }
 
 static int add_topic(
@@ -158,6 +165,7 @@ static int add_topic(
     (*wrapper)->topic->ros2_subscriber_num = 0;
     (*wrapper)->topic->ros2_publisher_num = 0;
     (*wrapper)->topic->wrapper_refcnt = 1;
+    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns);
   }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
@@ -901,7 +909,8 @@ int agnocast_ioctl_publish_msg(
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
     if (sub_info->is_take_sub) continue;
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) continue;
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id))
+      continue;
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
       continue;
     }
@@ -986,7 +995,7 @@ static int receive_msg_core(
       continue;
     }
 
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1131,7 +1140,7 @@ int agnocast_ioctl_take_msg(
       continue;
     }
 
-    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1656,10 +1665,12 @@ int agnocast_ioctl_get_topic_subscriber_info(
   struct topic_info_ret __user * user_buffer =
     (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
-  // Count actual subscribers first
+  // Count actual subscribers first. The htable may be shared with a bridged
+  // domain, so only count endpoints in the requested domain.
   uint32_t subscriber_num = 0;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
+    if (sub_info->domain_id != wrapper->domain_id) continue;
     subscriber_num++;
   }
 
@@ -1685,6 +1696,8 @@ int agnocast_ioctl_get_topic_subscriber_info(
   uint32_t idx = 0;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
+    if (sub_info->domain_id != wrapper->domain_id) continue;
+
     if (!sub_info->node_name) {
       kvfree(topic_info_mem);
       ret = -EFAULT;
@@ -1742,10 +1755,12 @@ int agnocast_ioctl_get_topic_publisher_info(
   struct topic_info_ret __user * user_buffer =
     (struct topic_info_ret __user *)topic_info_args->topic_info_ret_buffer_addr;
 
-  // Count actual publishers first
+  // Count actual publishers first. The htable may be shared with a bridged
+  // domain, so only count endpoints in the requested domain.
   uint32_t publisher_num = 0;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
   {
+    if (pub_info->domain_id != wrapper->domain_id) continue;
     publisher_num++;
   }
 
@@ -1771,6 +1786,8 @@ int agnocast_ioctl_get_topic_publisher_info(
   uint32_t idx = 0;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
   {
+    if (pub_info->domain_id != wrapper->domain_id) continue;
+
     if (!pub_info->node_name) {
       kvfree(topic_info_mem);
       ret = -EFAULT;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2164,6 +2164,9 @@ int agnocast_ioctl_add_domain_bridge(
 
   if (from_domain == to_domain) return -EINVAL;
 
+  // Store the pair canonically (domain_a < domain_b), keeping direction only as the
+  // a_to_b / b_to_a flags: grouping (find_grouped_topic_struct) cares only about the pair,
+  // while direction is enforced at delivery (domain_delivery_allowed).
   const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
   const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
   const bool lo_to_hi = (from_domain == lo);
@@ -2174,6 +2177,8 @@ int agnocast_ioctl_add_domain_bridge(
   if (existing) {
     // Re-declaring the same pair just adds the reverse direction; a third domain
     // on the same topic is rejected (v1 supports a single pair per topic).
+    // TODO: support >2 domains per topic (fan-out, e.g. 1->2 and 1->3) by storing a
+    // domain group instead of a fixed pair and grouping N wrappers onto one topic_struct.
     if (existing->domain_a != lo || existing->domain_b != hi) {
       ret = -EBUSY;
       goto unlock;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -75,26 +75,31 @@ static struct topic_wrapper * find_topic_for_current(
 }
 
 static struct domain_bridge_rule * find_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain);
 
-// If a domain bridge rule pairs this domain with another whose wrapper already
-// exists, return that partner's topic_struct so the new wrapper can share it.
+// If a domain bridge rule pairs this cell (topic_name, domain_id) with another
+// whose wrapper already exists, return that partner's topic_struct so the new
+// wrapper can share it. The partner may use a different name (rename), so look it
+// up by the rule's name for the partner domain.
 static struct topic_struct * find_grouped_topic_struct(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
-  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns, domain_id);
   if (!rule) return NULL;
 
   uint32_t partner_domain;
+  const char * partner_name;
   if (domain_id == rule->domain_a) {
     partner_domain = rule->domain_b;
+    partner_name = rule->topic_name_b;
   } else if (domain_id == rule->domain_b) {
     partner_domain = rule->domain_a;
+    partner_name = rule->topic_name_a;
   } else {
     return NULL;
   }
 
-  struct topic_wrapper * partner = find_topic(topic_name, ipc_ns, partner_domain);
+  struct topic_wrapper * partner = find_topic(partner_name, ipc_ns, partner_domain);
   return partner ? partner->topic : NULL;
 }
 
@@ -165,7 +170,7 @@ static int add_topic(
     (*wrapper)->topic->ros2_subscriber_num = 0;
     (*wrapper)->topic->ros2_publisher_num = 0;
     (*wrapper)->topic->wrapper_refcnt = 1;
-    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns);
+    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns, domain_id);
   }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
@@ -1511,10 +1516,11 @@ int agnocast_ioctl_get_topic_list(
       goto unlock;
     }
 
-    if (copy_to_user(
-          (char __user *)(topic_list_args->topic_name_buffer_addr +
-                          topic_num * TOPIC_NAME_BUFFER_SIZE),
-          wrapper->key, strlen(wrapper->key) + 1)) {
+    if (
+      copy_to_user(
+        (char
+           __user *)(topic_list_args->topic_name_buffer_addr + topic_num * TOPIC_NAME_BUFFER_SIZE),
+        wrapper->key, strlen(wrapper->key) + 1)) {
       ret = -EFAULT;
       goto unlock;
     }
@@ -1582,10 +1588,11 @@ int agnocast_ioctl_get_node_subscriber_topics(
         goto unlock;
       }
 
-      if (copy_to_user(
-            (char __user *)(node_info_args->topic_name_buffer_addr +
-                            topic_num * TOPIC_NAME_BUFFER_SIZE),
-            wrapper->key, strlen(wrapper->key) + 1)) {
+      if (
+        copy_to_user(
+          (char
+             __user *)(node_info_args->topic_name_buffer_addr + topic_num * TOPIC_NAME_BUFFER_SIZE),
+          wrapper->key, strlen(wrapper->key) + 1)) {
         ret = -EFAULT;
         goto unlock;
       }
@@ -1644,10 +1651,11 @@ int agnocast_ioctl_get_node_publisher_topics(
         goto unlock;
       }
 
-      if (copy_to_user(
-            (char __user *)(node_info_args->topic_name_buffer_addr +
-                            topic_num * TOPIC_NAME_BUFFER_SIZE),
-            wrapper->key, strlen(wrapper->key) + 1)) {
+      if (
+        copy_to_user(
+          (char
+             __user *)(node_info_args->topic_name_buffer_addr + topic_num * TOPIC_NAME_BUFFER_SIZE),
+          wrapper->key, strlen(wrapper->key) + 1)) {
         ret = -EFAULT;
         goto unlock;
       }
@@ -2163,14 +2171,19 @@ unlock:
   return ret;
 }
 
+// A rule is keyed by cell = (name, domain). Rules are few (one per bridged topic
+// pair), so a full scan is cheaper than maintaining a dual-name hash.
 static struct domain_bridge_rule * find_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain)
 {
   struct domain_bridge_rule * rule;
-  uint32_t hash_val = full_name_hash(NULL, topic_name, strlen(topic_name));
-  hash_for_each_possible(domain_rule_htable, rule, node, hash_val)
+  int bkt;
+  hash_for_each(domain_rule_htable, bkt, rule, node)
   {
-    if (ipc_ns == rule->ipc_ns && strcmp(rule->topic_name, topic_name) == 0) {
+    if (ipc_ns != rule->ipc_ns) continue;
+    if (
+      (domain == rule->domain_a && strcmp(rule->topic_name_a, topic_name) == 0) ||
+      (domain == rule->domain_b && strcmp(rule->topic_name_b, topic_name) == 0)) {
       return rule;
     }
   }
@@ -2178,42 +2191,46 @@ static struct domain_bridge_rule * find_domain_rule(
 }
 
 int agnocast_ioctl_add_domain_bridge(
-  const char * topic_name, const uint32_t from_domain, const uint32_t to_domain,
-  const struct ipc_namespace * ipc_ns)
+  const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
+  const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
 {
   int ret = 0;
 
   if (from_domain == to_domain) return -EINVAL;
 
-  // Store the pair canonically (domain_a < domain_b), keeping direction only as the
-  // a_to_b / b_to_a flags: grouping (find_grouped_topic_struct) cares only about the pair,
-  // while direction is enforced at delivery (domain_delivery_allowed).
-  const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
-  const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
-  const bool lo_to_hi = (from_domain == lo);
+  // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
+  // (they differ on rename). Direction lives only in the a_to_b / b_to_a flags; grouping
+  // (find_grouped_topic_struct) pairs the two cells and delivery direction is enforced by
+  // domain_delivery_allowed.
+  const bool from_is_a = from_domain < to_domain;
+  const uint32_t domain_a = from_is_a ? from_domain : to_domain;
+  const uint32_t domain_b = from_is_a ? to_domain : from_domain;
+  const char * name_a = from_is_a ? topic_name_from : topic_name_to;
+  const char * name_b = from_is_a ? topic_name_to : topic_name_from;
 
   down_write(&global_htables_rwsem);
 
-  struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
-  if (existing) {
-    // Re-declaring the same pair just adds the reverse direction. A third domain on a
-    // topic is rejected: the current implementation supports exactly one domain pair per
-    // topic (no fan-out such as 1->2 and 1->3 on the same topic). This is the one place
-    // that enforces it.
-    // TODO: support >2 domains per topic by storing a domain group instead of a fixed
-    // pair and grouping N wrappers onto one topic_struct.
-    if (existing->domain_a != lo || existing->domain_b != hi) {
+  // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
+  // exactly two cells. r_a == r_b (non-NULL) means an existing rule already pairs exactly
+  // these two cells -- a re-declaration or the reverse direction, so just OR in the
+  // direction. Any other overlap (a cell already paired with a different cell) is a
+  // fan-out and is rejected. This is the one place that enforces one pair per cell.
+  // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
+  struct domain_bridge_rule * r_a = find_domain_rule(name_a, ipc_ns, domain_a);
+  struct domain_bridge_rule * r_b = find_domain_rule(name_b, ipc_ns, domain_b);
+  if (r_a || r_b) {
+    if (r_a == r_b) {
+      r_a->a_to_b |= from_is_a;
+      r_a->b_to_a |= !from_is_a;
+    } else {
       ret = -EBUSY;
-      goto unlock;
     }
-    existing->a_to_b |= lo_to_hi;
-    existing->b_to_a |= !lo_to_hi;
     goto unlock;
   }
 
   // Grouping merges the two domains' id and entry_id spaces, which is only safe
   // before either side has allocated any; reject if an endpoint already joined.
-  if (find_topic(topic_name, ipc_ns, from_domain) || find_topic(topic_name, ipc_ns, to_domain)) {
+  if (find_topic(name_a, ipc_ns, domain_a) || find_topic(name_b, ipc_ns, domain_b)) {
     ret = -EBUSY;
     goto unlock;
   }
@@ -2223,23 +2240,27 @@ int agnocast_ioctl_add_domain_bridge(
     ret = -ENOMEM;
     goto unlock;
   }
-  rule->topic_name = kstrdup(topic_name, GFP_KERNEL);
-  if (!rule->topic_name) {
+  rule->topic_name_a = kstrdup(name_a, GFP_KERNEL);
+  rule->topic_name_b = kstrdup(name_b, GFP_KERNEL);
+  if (!rule->topic_name_a || !rule->topic_name_b) {
+    kfree(rule->topic_name_a);
+    kfree(rule->topic_name_b);
     kfree(rule);
     ret = -ENOMEM;
     goto unlock;
   }
   rule->ipc_ns = ipc_ns;
-  rule->domain_a = lo;
-  rule->domain_b = hi;
-  rule->a_to_b = lo_to_hi;
-  rule->b_to_a = !lo_to_hi;
+  rule->domain_a = domain_a;
+  rule->domain_b = domain_b;
+  rule->a_to_b = from_is_a;
+  rule->b_to_a = !from_is_a;
   INIT_HLIST_NODE(&rule->node);
-  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, topic_name, strlen(topic_name)));
+  // find_domain_rule scans every bucket, so the hash key is only for even distribution.
+  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
 
   dev_info(
-    agnocast_device, "Domain bridge rule added (topic=%s, %u->%u).\n", topic_name, from_domain,
-    to_domain);
+    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", topic_name_from, from_domain,
+    topic_name_to, to_domain);
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -2889,13 +2910,17 @@ static long add_domain_bridge_cmd(struct ioctl_add_domain_bridge_args __user * a
   struct ioctl_add_domain_bridge_args domain_bridge_args;
   if (copy_from_user(&domain_bridge_args, arg, sizeof(domain_bridge_args))) return -EFAULT;
 
-  char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  char from_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  char to_name_buf[TOPIC_NAME_BUFFER_SIZE];
   int ret =
-    copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &domain_bridge_args.topic_name);
+    copy_name_from_user(from_name_buf, sizeof(from_name_buf), &domain_bridge_args.topic_name_from);
+  if (ret) return ret;
+  ret = copy_name_from_user(to_name_buf, sizeof(to_name_buf), &domain_bridge_args.topic_name_to);
   if (ret) return ret;
 
   return agnocast_ioctl_add_domain_bridge(
-    topic_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain, ipc_ns);
+    from_name_buf, to_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain,
+    ipc_ns);
 }
 
 static long remove_bridge_cmd(struct ioctl_remove_bridge_args __user * arg)
@@ -3264,11 +3289,11 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
 }
 
 bool agnocast_get_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
-  uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain,
+  uint32_t * domain_a, uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
 {
   down_read(&global_htables_rwsem);
-  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns, domain);
   bool found = rule != NULL;
   if (found) {
     *domain_a = rule->domain_a;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2101,6 +2101,82 @@ unlock:
   return ret;
 }
 
+static struct domain_bridge_rule * find_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns)
+{
+  struct domain_bridge_rule * rule;
+  uint32_t hash_val = full_name_hash(NULL, topic_name, strlen(topic_name));
+  hash_for_each_possible(domain_rule_htable, rule, node, hash_val)
+  {
+    if (ipc_ns == rule->ipc_ns && strcmp(rule->topic_name, topic_name) == 0) {
+      return rule;
+    }
+  }
+  return NULL;
+}
+
+int agnocast_ioctl_add_domain_bridge(
+  const char * topic_name, const uint32_t from_domain, const uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns)
+{
+  int ret = 0;
+
+  if (from_domain == to_domain) return -EINVAL;
+
+  const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
+  const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
+  const bool lo_to_hi = (from_domain == lo);
+
+  down_write(&global_htables_rwsem);
+
+  struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
+  if (existing) {
+    // Re-declaring the same pair just adds the reverse direction; a third domain
+    // on the same topic is rejected (v1 supports a single pair per topic).
+    if (existing->domain_a != lo || existing->domain_b != hi) {
+      ret = -EBUSY;
+      goto unlock;
+    }
+    existing->a_to_b |= lo_to_hi;
+    existing->b_to_a |= !lo_to_hi;
+    goto unlock;
+  }
+
+  // Grouping merges the two domains' id and entry_id spaces, which is only safe
+  // before either side has allocated any; reject if an endpoint already joined.
+  if (find_topic(topic_name, ipc_ns, from_domain) || find_topic(topic_name, ipc_ns, to_domain)) {
+    ret = -EBUSY;
+    goto unlock;
+  }
+
+  struct domain_bridge_rule * rule = kmalloc(sizeof(*rule), GFP_KERNEL);
+  if (!rule) {
+    ret = -ENOMEM;
+    goto unlock;
+  }
+  rule->topic_name = kstrdup(topic_name, GFP_KERNEL);
+  if (!rule->topic_name) {
+    kfree(rule);
+    ret = -ENOMEM;
+    goto unlock;
+  }
+  rule->ipc_ns = ipc_ns;
+  rule->domain_a = lo;
+  rule->domain_b = hi;
+  rule->a_to_b = lo_to_hi;
+  rule->b_to_a = !lo_to_hi;
+  INIT_HLIST_NODE(&rule->node);
+  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, topic_name, strlen(topic_name)));
+
+  dev_info(
+    agnocast_device, "Domain bridge rule added (topic=%s, %u->%u).\n", topic_name, from_domain,
+    to_domain);
+
+unlock:
+  up_write(&global_htables_rwsem);
+  return ret;
+}
+
 int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, const bool is_r2a, const struct ipc_namespace * ipc_ns)
 {
@@ -2737,6 +2813,22 @@ static long add_bridge_cmd(struct ioctl_add_bridge_args __user * arg)
   return ret;
 }
 
+static long add_domain_bridge_cmd(struct ioctl_add_domain_bridge_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_add_domain_bridge_args domain_bridge_args;
+  if (copy_from_user(&domain_bridge_args, arg, sizeof(domain_bridge_args))) return -EFAULT;
+
+  char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  int ret =
+    copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &domain_bridge_args.topic_name);
+  if (ret) return ret;
+
+  return agnocast_ioctl_add_domain_bridge(
+    topic_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain, ipc_ns);
+}
+
 static long remove_bridge_cmd(struct ioctl_remove_bridge_args __user * arg)
 {
   int ret = 0;
@@ -2861,6 +2953,8 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
       return add_bridge_cmd((struct ioctl_add_bridge_args __user *)arg);
     case AGNOCAST_REMOVE_BRIDGE_CMD:
       return remove_bridge_cmd((struct ioctl_remove_bridge_args __user *)arg);
+    case AGNOCAST_ADD_DOMAIN_BRIDGE_CMD:
+      return add_domain_bridge_cmd((struct ioctl_add_domain_bridge_args __user *)arg);
     case AGNOCAST_CHECK_AND_REQUEST_BRIDGE_SHUTDOWN_CMD:
       return check_and_request_bridge_shutdown_cmd(
         (struct ioctl_check_and_request_bridge_shutdown_args __user *)arg);
@@ -3098,6 +3192,19 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
     return br_info->pid;
   }
   return -1;
+}
+
+bool agnocast_get_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
+  uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
+{
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  if (!rule) return false;
+  *domain_a = rule->domain_a;
+  *domain_b = rule->domain_b;
+  *a_to_b = rule->a_to_b;
+  *b_to_a = rule->b_to_a;
+  return true;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2175,10 +2175,12 @@ int agnocast_ioctl_add_domain_bridge(
 
   struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
   if (existing) {
-    // Re-declaring the same pair just adds the reverse direction; a third domain
-    // on the same topic is rejected (v1 supports a single pair per topic).
-    // TODO: support >2 domains per topic (fan-out, e.g. 1->2 and 1->3) by storing a
-    // domain group instead of a fixed pair and grouping N wrappers onto one topic_struct.
+    // Re-declaring the same pair just adds the reverse direction. A third domain on a
+    // topic is rejected: the current implementation supports exactly one domain pair per
+    // topic (no fan-out such as 1->2 and 1->3 on the same topic). This is the one place
+    // that enforces it.
+    // TODO: support >2 domains per topic by storing a domain group instead of a fixed
+    // pair and grouping N wrappers onto one topic_struct.
     if (existing->domain_a != lo || existing->domain_b != hi) {
       ret = -EBUSY;
       goto unlock;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -74,6 +74,38 @@ static struct topic_wrapper * find_topic_for_current(
   return find_topic(topic_name, ipc_ns, get_current_domain_id());
 }
 
+static struct domain_bridge_rule * find_domain_rule(
+  const char * topic_name, const struct ipc_namespace * ipc_ns);
+
+// If a domain bridge rule pairs this domain with another whose wrapper already
+// exists, return that partner's topic_struct so the new wrapper can share it.
+static struct topic_struct * find_grouped_topic_struct(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
+{
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  if (!rule) return NULL;
+
+  uint32_t partner_domain;
+  if (domain_id == rule->domain_a) {
+    partner_domain = rule->domain_b;
+  } else if (domain_id == rule->domain_b) {
+    partner_domain = rule->domain_a;
+  } else {
+    return NULL;
+  }
+
+  struct topic_wrapper * partner = find_topic(topic_name, ipc_ns, partner_domain);
+  return partner ? partner->topic : NULL;
+}
+
+// Whether a publication in pub_domain may be delivered to a subscriber in
+// sub_domain within a (possibly grouped) topic_struct. Same domain is always
+// allowed; cross-domain delivery is opened per rule direction in a later change.
+static bool domain_delivery_allowed(uint32_t pub_domain, uint32_t sub_domain)
+{
+  return pub_domain == sub_domain;
+}
+
 static int add_topic(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id,
   struct topic_wrapper ** wrapper)
@@ -91,36 +123,42 @@ static int add_topic(
     return -ENOMEM;
   }
 
-  (*wrapper)->topic = kmalloc(sizeof(struct topic_struct), GFP_KERNEL);
-  if (!(*wrapper)->topic) {
-    dev_warn(
-      agnocast_device,
-      "Failed to allocate topic_struct for a new topic (topic_name=%s) by kmalloc. (%s)\n",
-      topic_name, __func__);
-    kfree(*wrapper);
-    return -ENOMEM;
-  }
-
-  (*wrapper)->ipc_ns = ipc_ns;
-  (*wrapper)->domain_id = domain_id;
   (*wrapper)->key = kstrdup(topic_name, GFP_KERNEL);
   if (!(*wrapper)->key) {
     dev_warn(
       agnocast_device, "Failed to add a new topic (topic_name=%s) by kstrdup. (%s)\n", topic_name,
       __func__);
-    kfree((*wrapper)->topic);
     kfree(*wrapper);
     return -ENOMEM;
   }
+  (*wrapper)->ipc_ns = ipc_ns;
+  (*wrapper)->domain_id = domain_id;
 
-  init_rwsem(&(*wrapper)->topic->rwsem);
-  (*wrapper)->topic->entries = RB_ROOT;
-  hash_init((*wrapper)->topic->pub_info_htable);
-  hash_init((*wrapper)->topic->sub_info_htable);
-  (*wrapper)->topic->current_pubsub_id = 0;
-  (*wrapper)->topic->current_entry_id = 0;
-  (*wrapper)->topic->ros2_subscriber_num = 0;
-  (*wrapper)->topic->ros2_publisher_num = 0;
+  struct topic_struct * grouped = find_grouped_topic_struct(topic_name, ipc_ns, domain_id);
+  if (grouped) {
+    (*wrapper)->topic = grouped;
+    grouped->wrapper_refcnt++;
+  } else {
+    (*wrapper)->topic = kmalloc(sizeof(struct topic_struct), GFP_KERNEL);
+    if (!(*wrapper)->topic) {
+      dev_warn(
+        agnocast_device,
+        "Failed to allocate topic_struct for a new topic (topic_name=%s) by kmalloc. (%s)\n",
+        topic_name, __func__);
+      kfree((*wrapper)->key);
+      kfree(*wrapper);
+      return -ENOMEM;
+    }
+    init_rwsem(&(*wrapper)->topic->rwsem);
+    (*wrapper)->topic->entries = RB_ROOT;
+    hash_init((*wrapper)->topic->pub_info_htable);
+    hash_init((*wrapper)->topic->sub_info_htable);
+    (*wrapper)->topic->current_pubsub_id = 0;
+    (*wrapper)->topic->current_entry_id = 0;
+    (*wrapper)->topic->ros2_subscriber_num = 0;
+    (*wrapper)->topic->ros2_publisher_num = 0;
+    (*wrapper)->topic->wrapper_refcnt = 1;
+  }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
   dev_dbg(agnocast_device, "Topic (topic_name=%s) added. (%s)\n", topic_name, __func__);
@@ -195,6 +233,7 @@ static int insert_subscriber_info(
   wrapper->topic->current_pubsub_id++;
 
   (*new_info)->id = new_id;
+  (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = subscriber_pid;
   (*new_info)->qos_depth = qos_depth;
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
@@ -297,6 +336,7 @@ static int insert_publisher_info(
   wrapper->topic->current_pubsub_id++;
 
   (*new_info)->id = new_id;
+  (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = publisher_pid;
   (*new_info)->node_name = node_name_copy;
   (*new_info)->qos_depth = qos_depth;
@@ -861,6 +901,7 @@ int agnocast_ioctl_publish_msg(
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
   {
     if (sub_info->is_take_sub) continue;
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) continue;
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
       continue;
     }
@@ -942,6 +983,10 @@ static int receive_msg_core(
     }
 
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+      continue;
+    }
+
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1083,6 +1128,10 @@ int agnocast_ioctl_take_msg(
     }
 
     if (sub_info->ignore_local_publications && (sub_info->pid == pub_info->pid)) {
+      continue;
+    }
+
+    if (!domain_delivery_allowed(pub_info->domain_id, sub_info->domain_id)) {
       continue;
     }
 
@@ -1906,21 +1955,8 @@ int agnocast_ioctl_remove_subscriber(
     }
   }
 
-  if (
-    agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-    agnocast_get_size_sub_info_htable(wrapper) == 0) {
-    struct rb_node * n = rb_first(&wrapper->topic->entries);
-    while (n) {
-      struct entry_node * en = rb_entry(n, struct entry_node, node);
-      n = rb_next(n);
-      rb_erase(&en->node, &wrapper->topic->entries);
-      kfree(en);
-    }
-
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+  if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+    agnocast_release_topic_wrapper(wrapper);
     dev_dbg(agnocast_device, "Topic %s removed (empty).\n", topic_name);
   }
 
@@ -3205,6 +3241,13 @@ bool agnocast_get_domain_rule(
   *a_to_b = rule->a_to_b;
   *b_to_a = rule->b_to_a;
   return true;
+}
+
+int agnocast_topic_wrapper_refcnt(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
+{
+  const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, domain_id);
+  return wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2031,20 +2031,8 @@ int agnocast_ioctl_remove_publisher(
     }
   }
 
-  if (
-    agnocast_get_size_pub_info_htable(wrapper) == 0 &&
-    agnocast_get_size_sub_info_htable(wrapper) == 0) {
-    struct rb_node * n = rb_first(&wrapper->topic->entries);
-    while (n) {
-      struct entry_node * en = rb_entry(n, struct entry_node, node);
-      n = rb_next(n);
-      agnocast_remove_entry_node(wrapper, en);
-    }
-
-    hash_del(&wrapper->node);
-    kfree(wrapper->key);
-    kfree(wrapper->topic);
-    kfree(wrapper);
+  if (!agnocast_wrapper_has_domain_endpoints(wrapper)) {
+    agnocast_release_topic_wrapper(wrapper);
     dev_dbg(agnocast_device, "Topic %s removed (empty).\n", topic_name);
   }
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -550,6 +550,12 @@ static int set_publisher_shm_info(
       continue;
     }
 
+    // A subscriber only reads from publishers that deliver to it; a one-way
+    // bridge rule can exclude opposite-domain publishers, so skip mapping them.
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+      continue;
+    }
+
     const struct process_info * proc_info = agnocast_find_process_info(pub_info->pid);
     if (!proc_info || proc_info->exited) {
       continue;
@@ -1218,10 +1224,16 @@ int agnocast_ioctl_get_subscriber_num(
   uint32_t inter_count = 0;
   uint32_t intra_count = 0;
 
+  // The caller is a publisher in wrapper->domain_id; count only the subscribers
+  // it actually delivers to. For a one-way bridge rule this excludes the
+  // opposite-domain subscribers; for ungrouped topics every subscriber qualifies.
   struct subscriber_info * sub_info;
   int bkt_sub;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
+    if (!domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+      continue;
+    }
     if (sub_info->is_bridge) {
       ioctl_ret->ret_a2r_bridge_exist = true;
     }
@@ -1312,18 +1324,25 @@ int agnocast_ioctl_get_publisher_num(
 
   down_read(&wrapper->topic->rwsem);
 
-  ioctl_ret->ret_publisher_num = agnocast_get_size_pub_info_htable(wrapper);
   ioctl_ret->ret_ros2_publisher_num = wrapper->topic->ros2_publisher_num;
 
+  // The caller is a subscriber in wrapper->domain_id; count only the publishers
+  // that actually deliver to it. For a one-way bridge rule this excludes the
+  // opposite-domain publishers; for ungrouped topics every publisher qualifies.
+  uint32_t publisher_num = 0;
   struct publisher_info * pub_info;
   int bkt_pub;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub, pub_info, node)
   {
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+      continue;
+    }
+    publisher_num++;
     if (pub_info->is_bridge) {
       ioctl_ret->ret_r2a_bridge_exist = true;
-      break;
     }
   }
+  ioctl_ret->ret_publisher_num = publisher_num;
 
   struct subscriber_info * sub_info;
   int bkt_sub;
@@ -3246,20 +3265,27 @@ bool agnocast_get_domain_rule(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
   uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
 {
+  down_read(&global_htables_rwsem);
   const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
-  if (!rule) return false;
-  *domain_a = rule->domain_a;
-  *domain_b = rule->domain_b;
-  *a_to_b = rule->a_to_b;
-  *b_to_a = rule->b_to_a;
-  return true;
+  bool found = rule != NULL;
+  if (found) {
+    *domain_a = rule->domain_a;
+    *domain_b = rule->domain_b;
+    *a_to_b = rule->a_to_b;
+    *b_to_a = rule->b_to_a;
+  }
+  up_read(&global_htables_rwsem);
+  return found;
 }
 
 int agnocast_topic_wrapper_refcnt(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
+  down_read(&global_htables_rwsem);
   const struct topic_wrapper * wrapper = find_topic(topic_name, ipc_ns, domain_id);
-  return wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
+  int refcnt = wrapper ? (int)wrapper->topic->wrapper_refcnt : 0;
+  up_read(&global_htables_rwsem);
+  return refcnt;
 }
 
 #endif

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -14,6 +14,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_get_subscriber_qos.o \
   agnocast_kunit_add_bridge.o \
   agnocast_kunit_remove_bridge.o \
+  agnocast_kunit_domain_bridge.o \
   agnocast_kunit_set_ros2_subscriber_num.o \
   agnocast_kunit_set_ros2_publisher_num.o \
   agnocast_kunit_do_exit.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -8,6 +8,11 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+// A rename rule pairs two differently-named cells; RN_SRC lives in one domain and
+// RN_DST in the other.
+static const char * RN_SRC = "/kunit_test_domain_bridge_rename_src";
+static const char * RN_DST = "/kunit_test_domain_bridge_rename_dst";
+
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
 static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
@@ -22,32 +27,45 @@ static uint64_t setup_process_in_domain(
   return args.ret_addr;
 }
 
-static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+static topic_local_id_t add_publisher_named(
+  struct kunit * test, const pid_t pid, const char * topic_name)
 {
   union ioctl_add_publisher_args args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_publisher(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+      topic_name, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+    0);
+  return args.ret_id;
+}
+
+static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+{
+  return add_publisher_named(test, pid, TOPIC_NAME);
+}
+
+static topic_local_id_t add_subscriber_named(
+  struct kunit * test, const pid_t pid, const char * topic_name)
+{
+  union ioctl_add_subscriber_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      topic_name, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
+      &args),
     0);
   return args.ret_id;
 }
 
 static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
 {
-  union ioctl_add_subscriber_args args;
-  KUNIT_ASSERT_EQ(
-    test,
-    agnocast_ioctl_add_subscriber(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
-      &args),
-    0);
-  return args.ret_id;
+  return add_subscriber_named(test, pid, TOPIC_NAME);
 }
 
 void test_case_add_domain_bridge_normal(struct kunit * test)
 {
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
 
@@ -55,7 +73,7 @@ void test_case_add_domain_bridge_normal(struct kunit * test)
   bool a_to_b = false, b_to_a = false;
   KUNIT_ASSERT_TRUE(
     test, agnocast_get_domain_rule(
-            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+            TOPIC_NAME, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
   KUNIT_EXPECT_EQ(test, domain_a, 1);
   KUNIT_EXPECT_EQ(test, domain_b, 2);
   KUNIT_EXPECT_TRUE(test, a_to_b);
@@ -64,7 +82,8 @@ void test_case_add_domain_bridge_normal(struct kunit * test)
 
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test)
 {
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
 }
 
@@ -73,15 +92,17 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
   // Re-declaring the same pair in reverse records the reverse direction on the
   // existing rule rather than creating a second one.
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
 
   uint32_t domain_a = 0, domain_b = 0;
   bool a_to_b = false, b_to_a = false;
   KUNIT_ASSERT_TRUE(
     test, agnocast_get_domain_rule(
-            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+            TOPIC_NAME, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
   KUNIT_EXPECT_TRUE(test, a_to_b);
   KUNIT_EXPECT_TRUE(test, b_to_a);
 }
@@ -89,9 +110,11 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
   // A different domain pair on the same topic is rejected (one pair per topic).
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
@@ -101,14 +124,16 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
   add_publisher_for(test, 1000);
 
   // The topic's domain-1 id space is already allocated, so grouping is unsafe.
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
 void test_case_domain_bridge_groups_wrappers(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, 1000, 1);
   add_publisher_for(test, 1000);
@@ -123,7 +148,8 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test)
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   // publish resolves the wrapper by the caller's domain, so the caller and the
   // publisher are both in domain 1.
@@ -148,7 +174,8 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 {
   // Only 1 -> 2 is declared; the reverse direction must not deliver.
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
   const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
@@ -169,7 +196,8 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   // remove_publisher resolves the wrapper by the caller's domain, so the caller
   // is in domain 1 alongside the publisher being removed.
@@ -192,7 +220,8 @@ void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
@@ -209,7 +238,8 @@ void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, 1000, 1);
   add_publisher_for(test, 1000);
@@ -233,7 +263,8 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   add_publisher_for(test, current->tgid);
@@ -258,7 +289,8 @@ void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 2);
   add_subscriber_for(test, current->tgid);
@@ -280,7 +312,8 @@ void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
@@ -300,4 +333,89 @@ void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit *
 
   KUNIT_EXPECT_EQ(test, receive_args.ret_pub_shm_num, (uint32_t)1);
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, (pid_t)1000);
+}
+
+// A rename rule pairs two differently-named cells onto one shared topic_struct:
+// the rule is found from either name, and the partner is resolved by the partner's
+// name (RN_SRC@1 and RN_DST@2 end up sharing a struct, refcnt 2).
+void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_named(test, 1001, RN_DST);
+
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_DST, current->nsproxy->ipc_ns, 2), 2);
+}
+
+// A domain-1 publication on the source name reaches the domain-2 subscriber on the
+// renamed target name (rule RN_SRC@1 -> RN_DST@2).
+void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_named(test, 1001, RN_DST);
+
+  union ioctl_publish_msg_args publish_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      RN_SRC, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+      ARRAY_SIZE(subscriber_ids_buf), &publish_args),
+    0);
+
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
+}
+
+// Renaming two different sources onto the same (name, domain) target is a 3-cell
+// fan-out and must be rejected (one pair per cell).
+void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test)
+{
+  const char * other_src = "/kunit_test_domain_bridge_rename_src2";
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+  // RN_DST@2 is already paired with RN_SRC@1; a second source onto it is rejected.
+  KUNIT_EXPECT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(other_src, RN_DST, 1, 2, current->nsproxy->ipc_ns),
+    -EBUSY);
+}
+
+// The bridged source need not be the only publisher: with a second publisher on the
+// source name and a native publisher on the (renamed) target name sharing the struct,
+// a domain-1 publication is still delivered exactly once to the domain-2 subscriber.
+void test_case_domain_bridge_rename_multi_publisher(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, RN_SRC);
+  // A second publisher on the source name, and a native publisher on the target name.
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1002, 2);
+  add_publisher_named(test, 1002, RN_DST);
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_named(test, 1001, RN_DST);
+
+  union ioctl_publish_msg_args publish_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      RN_SRC, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+      ARRAY_SIZE(subscriber_ids_buf), &publish_args),
+    0);
+
+  // Delivered exactly once to the domain-2 subscriber, regardless of the other publishers.
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -227,49 +227,50 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
 }
 
-// A publisher's subscriber count must include only the subscribers it delivers to:
-// same-domain ones always, opposite-domain ones only in the rule's direction. With
-// a 1 -> 2 rule, a domain-2 publisher reaches the domain-2 subscriber but not the
-// domain-1 one.
+// A publisher reports only same-domain subscribers, matching ROS 2's
+// get_subscription_count. With a 1 -> 2 rule a domain-1 publisher still delivers
+// to the domain-2 subscriber, but must not count it.
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
 
-  setup_process_in_domain(test, current->tgid, 2);
+  setup_process_in_domain(test, current->tgid, 1);
   add_publisher_for(test, current->tgid);
-  setup_process_in_domain(test, 1002, 2);
-  add_subscriber_for(test, 1002);
   setup_process_in_domain(test, 1001, 1);
   add_subscriber_for(test, 1001);
+  setup_process_in_domain(test, 1002, 2);
+  add_subscriber_for(test, 1002);
 
   union ioctl_get_subscriber_num_args args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, current->tgid, &args),
     0);
+  // Only the domain-1 subscriber is counted; the cross-domain (domain-2) one is not.
   KUNIT_EXPECT_EQ(test, args.ret_other_process_subscriber_num, (uint32_t)1);
   KUNIT_EXPECT_EQ(test, args.ret_same_process_subscriber_num, (uint32_t)0);
 }
 
-// A subscriber's publisher count must include only the publishers that deliver to
-// it. With a 1 -> 2 rule, a domain-1 subscriber sees the domain-1 publisher but not
-// the domain-2 one (2 -> 1 is not allowed).
+// A subscriber reports only same-domain publishers, matching ROS 2's
+// get_publisher_count. With a 1 -> 2 rule a domain-2 subscriber still receives
+// from the domain-1 publisher, but must not count it.
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
 
-  setup_process_in_domain(test, current->tgid, 1);
+  setup_process_in_domain(test, current->tgid, 2);
   add_subscriber_for(test, current->tgid);
-  setup_process_in_domain(test, 1000, 1);
+  setup_process_in_domain(test, 1000, 2);
   add_publisher_for(test, 1000);
-  setup_process_in_domain(test, 1001, 2);
+  setup_process_in_domain(test, 1001, 1);
   add_publisher_for(test, 1001);
 
   union ioctl_get_publisher_num_args args;
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns, &args), 0);
+  // Only the domain-2 publisher is counted; the cross-domain (domain-1) one is not.
   KUNIT_EXPECT_EQ(test, args.ret_publisher_num, (uint32_t)1);
 }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_domain_bridge.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
+
+void test_case_add_domain_bridge_normal(struct kunit * test)
+{
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_EQ(test, domain_a, 1);
+  KUNIT_EXPECT_EQ(test, domain_b, 2);
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_FALSE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test)
+{
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
+{
+  // Re-declaring the same pair in reverse records the reverse direction on the
+  // existing rule rather than creating a second one.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns), 0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_TRUE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+  // A different domain pair on the same topic is rejected (v1 is pair-only).
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -8,6 +8,8 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+#define KUNIT_PUB_SHM_BUF_SIZE 4
+
 static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
 
 // Returns the process's mempool base address, used as a valid publish address.
@@ -223,4 +225,78 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
+}
+
+// A publisher's subscriber count must include only the subscribers it delivers to:
+// same-domain ones always, opposite-domain ones only in the rule's direction. With
+// a 1 -> 2 rule, a domain-2 publisher reaches the domain-2 subscriber but not the
+// domain-1 one.
+void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 2);
+  add_publisher_for(test, current->tgid);
+  setup_process_in_domain(test, 1002, 2);
+  add_subscriber_for(test, 1002);
+  setup_process_in_domain(test, 1001, 1);
+  add_subscriber_for(test, 1001);
+
+  union ioctl_get_subscriber_num_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_get_subscriber_num(TOPIC_NAME, current->nsproxy->ipc_ns, current->tgid, &args),
+    0);
+  KUNIT_EXPECT_EQ(test, args.ret_other_process_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, args.ret_same_process_subscriber_num, (uint32_t)0);
+}
+
+// A subscriber's publisher count must include only the publishers that deliver to
+// it. With a 1 -> 2 rule, a domain-1 subscriber sees the domain-1 publisher but not
+// the domain-2 one (2 -> 1 is not allowed).
+void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+
+  union ioctl_get_publisher_num_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_get_publisher_num(TOPIC_NAME, current->nsproxy->ipc_ns, &args), 0);
+  KUNIT_EXPECT_EQ(test, args.ret_publisher_num, (uint32_t)1);
+}
+
+// A subscriber maps only the mempools of publishers that deliver to it. With a
+// 1 -> 2 rule, the domain-1 subscriber maps the domain-1 publisher but skips the
+// domain-2 one, so the opposite-domain mempool is never referenced.
+void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+
+  union ioctl_receive_msg_args receive_args;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_receive_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, sub_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+      &receive_args),
+    0);
+
+  KUNIT_EXPECT_EQ(test, receive_args.ret_pub_shm_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, (pid_t)1000);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -7,11 +7,16 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
-static void setup_process_in_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
+
+// Returns the process's mempool base address, used as a valid publish address.
+static uint64_t setup_process_in_domain(
+  struct kunit * test, const pid_t pid, const uint32_t domain_id)
 {
   union ioctl_add_process_args args;
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+  return args.ret_addr;
 }
 
 static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
@@ -110,4 +115,50 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test)
   // Both domains' wrappers point at one shared topic_struct (refcnt 2).
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 2);
+}
+
+void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // publish resolves the wrapper by the caller's domain, so the caller and the
+  // publisher are both in domain 1.
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_for(test, 1001);
+
+  union ioctl_publish_msg_args publish_args;
+  int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+    ARRAY_SIZE(subscriber_ids_buf), &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // The domain-2 subscriber receives the domain-1 publication (rule 1 -> 2).
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
+}
+
+void test_case_domain_bridge_direction_respected(struct kunit * test)
+{
+  // Only 1 -> 2 is declared; the reverse direction must not deliver.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 1);
+  add_subscriber_for(test, 1001);
+
+  union ioctl_publish_msg_args publish_args;
+  int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+    ARRAY_SIZE(subscriber_ids_buf), &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // The domain-1 subscriber must not receive a domain-2 publication (no 2 -> 1).
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -185,6 +185,25 @@ void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
   KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
 }
 
+// Same as above, but the dropped endpoint is a subscriber: remove_subscriber must
+// release only its own domain's wrapper and keep the shared struct for domain 2.
+void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_subscriber(TOPIC_NAME, current->nsproxy->ipc_ns, sub_id), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
+}
+
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -4,6 +4,7 @@
 #include "../agnocast.h"
 
 #include <kunit/test.h>
+#include <linux/delay.h>
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
@@ -161,4 +162,46 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 
   // The domain-1 subscriber must not receive a domain-2 publication (no 2 -> 1).
   KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)0);
+}
+
+void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // remove_publisher resolves the wrapper by the caller's domain, so the caller
+  // is in domain 1 alongside the publisher being removed.
+  setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  // Dropping domain 1's last endpoint drops its wrapper, but the shared struct
+  // must survive for domain 2 (refcnt 2 -> 1); freeing it here would be a UAF.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_publisher(TOPIC_NAME, current->nsproxy->ipc_ns, pub_id), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 1);
+}
+
+void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+
+  // Both domains' processes exit: each wrapper is dropped as its domain empties,
+  // and the shared struct is freed only with the last one (KASAN checks the free).
+  agnocast_enqueue_exit_pid(1000);
+  agnocast_enqueue_exit_pid(1001);
+  msleep(20);  // let exit_worker_thread drain both pids
+
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -88,7 +88,7 @@ void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
-  // A different domain pair on the same topic is rejected (v1 is pair-only).
+  // A different domain pair on the same topic is rejected (one pair per topic).
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -7,6 +7,36 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+static void setup_process_in_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+}
+
+static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_publisher_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+    0);
+  return args.ret_id;
+}
+
+static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_subscriber_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
+      &args),
+    0);
+  return args.ret_id;
+}
+
 void test_case_add_domain_bridge_normal(struct kunit * test)
 {
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
@@ -55,4 +85,29 @@ void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
   // A different domain pair on the same topic is rejected (v1 is pair-only).
   int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test)
+{
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+
+  // The topic's domain-1 id space is already allocated, so grouping is unsafe.
+  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_domain_bridge_groups_wrappers(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_for(test, 1000);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_for(test, 1001);
+
+  // Both domains' wrappers point at one shared topic_struct (refcnt 2).
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(TOPIC_NAME, current->nsproxy->ipc_ns, 2), 2);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -2,13 +2,17 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_DOMAIN_BRIDGE                                  \
-  KUNIT_CASE(test_case_add_domain_bridge_normal),                 \
-    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected), \
-    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),    \
-    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected)
+#define TEST_CASES_DOMAIN_BRIDGE                                           \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                          \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),          \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),             \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),         \
+    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
 void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);
+void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test);
+void test_case_domain_bridge_groups_wrappers(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -13,7 +13,10 @@
     KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),   \
-    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),          \
+    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),       \
+    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),        \
+    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -26,3 +29,6 @@ void test_case_domain_bridge_direction_respected(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);
+void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test);
+void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test);
+void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -8,7 +8,9 @@
     KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),             \
     KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),         \
     KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
-    KUNIT_CASE(test_case_domain_bridge_groups_wrappers)
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                   \
+    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
+    KUNIT_CASE(test_case_domain_bridge_direction_respected)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -16,3 +18,5 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);
 void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * test);
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
+void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
+void test_case_domain_bridge_direction_respected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -16,7 +16,11 @@
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),          \
     KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),       \
     KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),        \
-    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher)
+    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher), \
+    KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),            \
+    KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),      \
+    KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),            \
+    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -32,3 +36,7 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test);
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test);
 void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test);
+void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test);
+void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
+void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
+void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -12,6 +12,7 @@
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
     KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),   \
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
@@ -23,4 +24,5 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
+void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_DOMAIN_BRIDGE                                  \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                 \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected), \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),    \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected)
+
+void test_case_add_domain_bridge_normal(struct kunit * test);
+void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
+void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
+void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -10,7 +10,9 @@
     KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
     KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                   \
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
-    KUNIT_CASE(test_case_domain_bridge_direction_respected)
+    KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -20,3 +22,5 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
+void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
+void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -7,6 +7,7 @@
 #include "agnocast_kunit/agnocast_kunit_bridge_shutdown.h"
 #include "agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h"
 #include "agnocast_kunit/agnocast_kunit_do_exit.h"
+#include "agnocast_kunit/agnocast_kunit_domain_bridge.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_publisher_num.h"
@@ -50,6 +51,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_GET_PUBLISHER_QOS,
   TEST_CASES_ADD_BRIDGE,
   TEST_CASES_REMOVE_BRIDGE,
+  TEST_CASES_DOMAIN_BRIDGE,
   TEST_CASES_SET_ROS2_SUBSCRIBER_NUM,
   TEST_CASES_SET_ROS2_PUBLISHER_NUM,
   TEST_CASES_DO_EXIT,

--- a/docs/message_queue.md
+++ b/docs/message_queue.md
@@ -32,26 +32,3 @@ The restrictions of the naming are
 
 The first rule is satisfied because all topic names start with `/`.
 To satisfy the second rule, all the occurrence of `/` in topic names are replaced for `_`.
-
-## How message queue is used in Agnocast Bridge?
-
-The message queue is also used for communication between Agnocast processes and Bridge Manager processes. When an Agnocast publisher or subscriber is created, it sends a bridge request to the Bridge Manager via message queue.
-
-The message queue is used as follows:
-
-- The first Agnocast process spawns a global Bridge Manager that opens `/agnocast_bridge_manager@-1` (optionally with a `_d<ROS_DOMAIN_ID>` suffix when `ROS_DOMAIN_ID` is set) as a receiver.
-- All Agnocast processes send bridge requests to this shared message queue.
-- Upon receiving the request, the Bridge Manager creates the appropriate bridge if conditions are met.
-
-The message definition is:
-
-```cpp
-struct BridgeMsg {
-  BridgeMsgType type;  // PubSub, Service, or DaemonPubSub
-  union {
-    BridgeMsgPubSubPayload pubsub;
-    BridgeMsgServicePayload service;
-    BridgeMsgDaemonPubSubPayload daemon_pubsub;
-  } payload;
-};
-```

--- a/scripts/test/e2e_test_2to2.bash
+++ b/scripts/test/e2e_test_2to2.bash
@@ -87,11 +87,6 @@ if [ "$LOWER_BRIDGE_MODE" != "off" ] && [ "$LOWER_BRIDGE_MODE" != "0" ]; then
     fi
 
     sleep 1
-    # Verify stale bridge manager mqueue does not remain.
-    if [ -e "/dev/mqueue/agnocast_bridge_manager@-1" ]; then
-        echo "ERROR: stale mqueue exists: /dev/mqueue/agnocast_bridge_manager@-1" | sudo tee /dev/kmsg
-        exit 1
-    fi
 fi
 
 # Run test

--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Case 2 (same IPC namespace, cross-domain) zero-copy e2e.
+#
+# Registers a domain bridge rule for the sample topic, then runs the sample
+# talker in FROM_DOMAIN and the sample listener in TO_DOMAIN as SEPARATE launches
+# and asserts the listener received the talker's messages — cross-domain delivery
+# through the kmod with no DDS / bridge node.
+#
+# Two separate launches (not one launch file) are required: each `ros2 launch`
+# runs entirely under one ROS_DOMAIN_ID, including the composable-node loader. A
+# single launch can't load nodes into containers on two different domains.
+#
+# Each launch is run under `timeout` so it self-terminates (SIGINT, then SIGKILL
+# after a grace period) — Agnocast container shutdown can stall on SIGINT, so we
+# never block on a graceful exit.
+#
+# Run on a freshly loaded kmod — the rule must be registered before any endpoint
+# for the topic joins. Pure Case 2 uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
+
+set -uo pipefail
+
+if ! grep -q "^agnocast " /proc/modules; then
+    echo "ERROR: agnocast kernel module is not loaded." >&2
+    echo "Load it first: sudo insmod agnocast_kmod/agnocast.ko" >&2
+    exit 1
+fi
+
+TOPIC="${E2E_TOPIC_NAME:-/my_topic}"   # the sample app's topic
+FROM_DOMAIN="${E2E_FROM_DOMAIN:-1}"
+TO_DOMAIN="${E2E_TO_DOMAIN:-2}"
+RUN_SECONDS="${E2E_RUN_SECONDS:-10}"
+
+echo "Registering domain bridge rule: ${TOPIC} ${FROM_DOMAIN}->${TO_DOMAIN}"
+if ! python3 - "$TOPIC" "$FROM_DOMAIN" "$TO_DOMAIN" <<'PY'
+import ctypes, sys
+lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+lib.add_agnocast_domain_bridge_rule.argtypes = [ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
+rc = lib.add_agnocast_domain_bridge_rule(sys.argv[1].encode(), int(sys.argv[2]), int(sys.argv[3]))
+if rc != 0:
+    sys.stderr.write(f"add_agnocast_domain_bridge_rule failed (rc={rc})\n")
+sys.exit(0 if rc == 0 else 1)
+PY
+then
+    echo "Rule registration failed (was the kmod freshly loaded?)." >&2
+    exit 1
+fi
+
+SUBLOG="$(mktemp)"; PUBLOG="$(mktemp)"
+LISTEN_SECS=$((5 + RUN_SECONDS + 3))   # listener: startup + run + drain
+TALK_SECS=$((RUN_SECONDS + 3))         # talker: starts 5 s later
+
+echo "Starting listener in domain ${TO_DOMAIN} (subscriber first), ~${LISTEN_SECS}s ..."
+timeout -s INT -k 5 "$LISTEN_SECS" \
+    env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$TO_DOMAIN" \
+    ros2 launch agnocast_sample_application listener.launch.xml > "$SUBLOG" 2>&1 &
+SUB_PID=$!
+sleep 5
+
+echo "Starting talker in domain ${FROM_DOMAIN}, ~${TALK_SECS}s ..."
+timeout -s INT -k 5 "$TALK_SECS" \
+    env AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID="$FROM_DOMAIN" \
+    ros2 launch agnocast_sample_application talker.launch.xml > "$PUBLOG" 2>&1 &
+PUB_PID=$!
+
+echo "Running (auto-stop via timeout) ..."
+wait "$SUB_PID" "$PUB_PID" 2>/dev/null || true
+sleep 1
+
+echo "--- talker log (tail) ---";   tail -n 3 "$PUBLOG"
+echo "--- listener log (tail) ---"; tail -n 3 "$SUBLOG"
+
+pub_count=$(grep -c "publish message: id=" "$PUBLOG" || true)
+sub_count=$(grep -c "subscribe message: id=" "$SUBLOG" || true)
+echo "published=${pub_count}  received(cross-domain)=${sub_count}"
+
+if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then
+    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (Case 2 zero-copy)."
+    exit 0
+fi
+echo "FAIL: cross-domain delivery not observed (published=${pub_count}, received=${sub_count})." >&2
+exit 1

--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -31,20 +31,20 @@ TO_DOMAIN="${E2E_TO_DOMAIN:-2}"
 RUN_SECONDS="${E2E_RUN_SECONDS:-10}"
 
 echo "Registering domain bridge rule: ${TOPIC} ${FROM_DOMAIN}->${TO_DOMAIN}"
-if ! python3 - "$TOPIC" "$FROM_DOMAIN" "$TO_DOMAIN" <<'PY'
-import ctypes, sys
-lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
-lib.add_agnocast_domain_bridge_rule.argtypes = [ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
-rc = lib.add_agnocast_domain_bridge_rule(sys.argv[1].encode(), int(sys.argv[2]), int(sys.argv[3]))
-if rc != 0:
-    sys.stderr.write(f"add_agnocast_domain_bridge_rule failed (rc={rc})\n")
-sys.exit(0 if rc == 0 else 1)
-PY
-then
+# Register through the same tool production uses, not an inline ioctl call.
+BRIDGE_CONFIG="$(mktemp --suffix=.yaml)"
+cat > "$BRIDGE_CONFIG" <<YAML
+from_domain: ${FROM_DOMAIN}
+to_domain: ${TO_DOMAIN}
+topics:
+  "${TOPIC}":
+YAML
+if ! ros2 run ros2agnocast_discovery_agent register_domain_bridge --config "$BRIDGE_CONFIG"; then
     echo "Rule registration failed (was the kmod freshly loaded?)." >&2
+    rm -f "$BRIDGE_CONFIG"
     exit 1
 fi
+rm -f "$BRIDGE_CONFIG"
 
 SUBLOG="$(mktemp)"; PUBLOG="$(mktemp)"
 LISTEN_SECS=$((5 + RUN_SECONDS + 3))   # listener: startup + run + drain

--- a/scripts/test/e2e_test_domain_bridge.bash
+++ b/scripts/test/e2e_test_domain_bridge.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Case 2 (same IPC namespace, cross-domain) zero-copy e2e.
+# Same-IPC-namespace cross-domain zero-copy e2e (two ROS domains, one mempool).
 #
 # Registers a domain bridge rule for the sample topic, then runs the sample
 # talker in FROM_DOMAIN and the sample listener in TO_DOMAIN as SEPARATE launches
@@ -15,7 +15,7 @@
 # never block on a graceful exit.
 #
 # Run on a freshly loaded kmod — the rule must be registered before any endpoint
-# for the topic joins. Pure Case 2 uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
+# for the topic joins. This path uses no bridge, so AGNOCAST_BRIDGE_MODE=off.
 
 set -uo pipefail
 
@@ -75,7 +75,7 @@ sub_count=$(grep -c "subscribe message: id=" "$SUBLOG" || true)
 echo "published=${pub_count}  received(cross-domain)=${sub_count}"
 
 if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then
-    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (Case 2 zero-copy)."
+    echo "PASS: domain ${FROM_DOMAIN} publisher reached domain ${TO_DOMAIN} subscriber (cross-domain zero-copy)."
     exit 0
 fi
 echo "FAIL: cross-domain delivery not observed (published=${pub_count}, received=${sub_count})." >&2

--- a/src/agnocast_ioctl_wrapper/CMakeLists.txt
+++ b/src/agnocast_ioctl_wrapper/CMakeLists.txt
@@ -4,7 +4,7 @@ project(agnocast_ioctl_wrapper)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
-add_library(agnocast_ioctl_wrapper SHARED src/topic_list.cpp src/node_info.cpp src/topic_info.cpp src/version.cpp)
+add_library(agnocast_ioctl_wrapper SHARED src/topic_list.cpp src/node_info.cpp src/topic_info.cpp src/version.cpp src/domain_bridge.cpp)
 
 ament_target_dependencies(agnocast_ioctl_wrapper rclcpp)
 

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -82,7 +82,9 @@ struct ioctl_get_version_args
 // Mirrors agnocast_kmod/agnocast.h so _IOW encodes the same size.
 struct ioctl_add_domain_bridge_args
 {
-  struct name_info topic_name;
+  // topic_name_from / topic_name_to may differ (rename); equal for a plain bridge.
+  struct name_info topic_name_from;
+  struct name_info topic_name_to;
   uint32_t from_domain;
   uint32_t to_domain;
 };

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -79,9 +79,18 @@ struct ioctl_get_version_args
   char ret_version[VERSION_BUFFER_LEN];
 };
 
+// Mirrors agnocast_kmod/agnocast.h so _IOW encodes the same size.
+struct ioctl_add_domain_bridge_args
+{
+  struct name_info topic_name;
+  uint32_t from_domain;
+  uint32_t to_domain;
+};
+
 #define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
 #define AGNOCAST_GET_TOPIC_LIST_CMD _IOWR(0xA6, 20, union ioctl_topic_list_args)
 #define AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD _IOWR(0xA6, 21, union ioctl_topic_info_args)
 #define AGNOCAST_GET_TOPIC_PUBLISHER_INFO_CMD _IOWR(0xA6, 22, union ioctl_topic_info_args)
 #define AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD _IOWR(0xA6, 23, union ioctl_node_info_args)
 #define AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD _IOWR(0xA6, 24, union ioctl_node_info_args)
+#define AGNOCAST_ADD_DOMAIN_BRIDGE_CMD _IOW(0xA6, 28, struct ioctl_add_domain_bridge_args)

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -16,6 +16,13 @@ extern "C" {
 int add_agnocast_domain_bridge_rule(
   const char * topic_name, uint32_t from_domain, uint32_t to_domain)
 {
+  // Exported C symbol: guard the pointer so a null from a caller returns an
+  // error instead of segfaulting in strlen() below.
+  if (topic_name == nullptr) {
+    errno = EINVAL;
+    return -1;
+  }
+
   int fd = open("/dev/agnocast", O_RDONLY);
   if (fd < 0) {
     if (errno == ENOENT) {

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -1,0 +1,43 @@
+#include "agnocast_ioctl.hpp"
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+extern "C" {
+
+// Register a domain bridge rule with the kmod so it relays the topic between
+// from_domain and to_domain within this process's IPC namespace. Returns 0 on
+// success, -1 on failure.
+int add_agnocast_domain_bridge_rule(
+  const char * topic_name, uint32_t from_domain, uint32_t to_domain)
+{
+  int fd = open("/dev/agnocast", O_RDONLY);
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      fprintf(stderr, "%s", AGNOCAST_DEVICE_NOT_FOUND_MSG);
+    } else {
+      perror("Failed to open /dev/agnocast");
+    }
+    return -1;
+  }
+
+  ioctl_add_domain_bridge_args args = {};
+  args.topic_name = {topic_name, strlen(topic_name)};
+  args.from_domain = from_domain;
+  args.to_domain = to_domain;
+
+  if (ioctl(fd, AGNOCAST_ADD_DOMAIN_BRIDGE_CMD, &args) < 0) {
+    perror("AGNOCAST_ADD_DOMAIN_BRIDGE_CMD failed");
+    close(fd);
+    return -1;
+  }
+
+  close(fd);
+  return 0;
+}
+}

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -10,15 +10,17 @@
 
 extern "C" {
 
-// Register a domain bridge rule with the kmod so it relays the topic between
-// from_domain and to_domain within this process's IPC namespace. Returns 0 on
-// success, -1 on failure.
+// Register a domain bridge rule with the kmod so it relays the topic from
+// (topic_name_from, from_domain) to (topic_name_to, to_domain) within this
+// process's IPC namespace. The two names may differ (rename) or be equal (plain
+// bridge). Returns 0 on success, -1 on failure.
 int add_agnocast_domain_bridge_rule(
-  const char * topic_name, uint32_t from_domain, uint32_t to_domain)
+  const char * topic_name_from, const char * topic_name_to, uint32_t from_domain,
+  uint32_t to_domain)
 {
-  // Exported C symbol: guard the pointer so a null from a caller returns an
+  // Exported C symbol: guard the pointers so a null from a caller returns an
   // error instead of segfaulting in strlen() below.
-  if (topic_name == nullptr) {
+  if (topic_name_from == nullptr || topic_name_to == nullptr) {
     errno = EINVAL;
     return -1;
   }
@@ -34,7 +36,8 @@ int add_agnocast_domain_bridge_rule(
   }
 
   ioctl_add_domain_bridge_args args = {};
-  args.topic_name = {topic_name, strlen(topic_name)};
+  args.topic_name_from = {topic_name_from, strlen(topic_name_from)};
+  args.topic_name_to = {topic_name_to, strlen(topic_name_to)};
   args.from_domain = from_domain;
   args.to_domain = to_domain;
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -157,7 +157,8 @@ if(BUILD_TESTING)
     test/unit/test_type_registry_writer.cpp
     test/unit/test_agnocast_generic_callback.cpp
     test/unit/test_agnocast_generic_publisher.cpp
-    test/unit/test_daemon_bridge_mq.cpp)
+    test/unit/test_daemon_bridge_uds.cpp
+    test/unit/test_agnocast_bridge_uds.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)

--- a/src/agnocastlib/include/agnocast/agnocast_mq.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_mq.hpp
@@ -1,20 +1,7 @@
 #pragma once
 
-#include "agnocast/agnocast_ioctl.hpp"
-
-#include <cstddef>
-#include <cstdint>
-
 namespace agnocast
 {
-
-inline constexpr pid_t PERFORMANCE_BRIDGE_VIRTUAL_PID = -1;
-
-inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
-inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
-inline constexpr size_t SERVICE_TYPE_BUFFER_SIZE = 256;
-
-enum class BridgeDirection : uint32_t { ROS2_TO_AGNOCAST = 0, AGNOCAST_TO_ROS2 = 1 };
 
 struct MqMsgAgnocast
 {
@@ -24,62 +11,5 @@ struct MqMsgROS2Publish
 {
   bool should_terminate;
 };
-
-enum class BridgeMsgType : uint32_t {
-  PubSub = 0,
-  Service = 1,
-  DaemonPubSub = 2,
-};
-
-struct BridgeMsgPubSubPayload
-{
-  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
-  char topic_name[TOPIC_NAME_BUFFER_SIZE];
-  topic_local_id_t target_id;
-  BridgeDirection direction;
-};
-
-struct BridgeMsgServicePayload
-{
-  char service_type[SERVICE_TYPE_BUFFER_SIZE];
-  char service_name[SERVICE_NAME_BUFFER_SIZE];
-  bool create_shadow_node;
-  BridgeDirection direction;
-  char shadow_node_namespace[NODE_NAME_BUFFER_SIZE];
-  char shadow_node_name[NODE_NAME_BUFFER_SIZE];
-};
-
-struct BridgeMsgDaemonPubSubPayload
-{
-  char topic_name[TOPIC_NAME_BUFFER_SIZE];
-  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
-  BridgeDirection direction;
-  uint32_t qos_depth;
-  bool qos_is_transient_local;
-  bool qos_is_reliable;
-};
-
-struct BridgeMsg
-{
-  BridgeMsgType type;
-  union Payload {
-    BridgeMsgPubSubPayload pubsub;
-    BridgeMsgServicePayload service;
-    BridgeMsgDaemonPubSubPayload daemon_pubsub;
-  } payload;
-};
-
-constexpr int64_t BRIDGE_MQ_MAX_MESSAGES = 256;
-constexpr int64_t BRIDGE_MQ_MESSAGE_SIZE = sizeof(BridgeMsg);
-constexpr mode_t BRIDGE_MQ_PERMS = 0600;
-
-// Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
-// just the active variant's bytes. Used both for `mq_send` and for sizing
-// auxiliary buffers.
-template <typename PayloadT>
-constexpr size_t bridge_msg_wire_size()
-{
-  return offsetof(BridgeMsg, payload) + sizeof(PayloadT);
-}
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -241,6 +241,85 @@ public:
 };
 
 /**
+ * @brief A type-erased Agnocast publisher.
+ *
+ * There are four differences between this and Publisher:
+ *
+ * 1. borrow_loaned_message() takes a size and returns an ipc_shared_ptr<void> that points to a
+ *    shared memory block of the requested size.
+ * 2. publish() takes a deleter as well as the message. Because the message is type-erased, the
+ *    publisher cannot know how to free it, so the caller must provide a deleter.
+ * 3. If a user decides not to publish a borrowed message, they must call cancel_message() with a
+ *    deleter to free the memory.
+ * 4. The constructor is just a thin wrapper around init_base(). As this class is intended for
+ *    internal use only, flexibility is prioritized.
+ */
+class TypeErasedPublisher : public PublisherBase
+{
+public:
+  using SharedPtr = std::shared_ptr<TypeErasedPublisher>;
+
+  TypeErasedPublisher(
+    rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
+
+  TypeErasedPublisher(
+    agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+    const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
+
+  ipc_shared_ptr<void> borrow_loaned_message(size_t size);
+
+  template <typename Deleter>
+  void cancel_message(ipc_shared_ptr<void> && message, Deleter && deleter)
+  {
+    if (!message || topic_name_ != message.get_topic_name()) {
+      RCLCPP_ERROR(logger, "Invalid message to cancel.");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    void * delete_ptr = message.get();
+
+    message.invalidate_all_references();
+
+    decrement_borrowed_publisher_num();
+
+    deleter(delete_ptr);
+
+    message.reset();
+  }
+
+  template <typename Deleter>
+  void publish(ipc_shared_ptr<void> && message, Deleter && deleter)
+  {
+    if (!message || topic_name_ != message.get_topic_name()) {
+      RCLCPP_ERROR(logger, "Invalid message to publish.");
+      close(agnocast_fd);
+      exit(EXIT_FAILURE);
+    }
+
+    const uint64_t msg_virtual_address = reinterpret_cast<uint64_t>(message.get());
+
+    message.invalidate_all_references();
+
+    decrement_borrowed_publisher_num();
+
+    union ioctl_publish_msg_args publish_msg_args;
+    {
+      std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
+      publish_msg_args = publish_core(this, topic_name_, id_, msg_virtual_address, opened_mqs_);
+    }
+
+    for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
+      void * release_ptr = reinterpret_cast<void *>(publish_msg_args.ret_released_addrs[i]);
+      deleter(release_ptr);
+    }
+
+    message.reset();
+  }
+};
+
+/**
  * @brief Mirrors `rclcpp::GenericPublisher` semantics: the topic type is supplied as a
  * runtime string (e.g. "std_msgs/msg/String") rather than a compile-time
  * template argument. The typesupport library is loaded eagerly in the
@@ -250,7 +329,7 @@ public:
  * and are deserialized into Agnocast shared memory within the `publish()` call.
  */
 AGNOCAST_PUBLIC
-class GenericPublisher : public PublisherBase
+class GenericPublisher : public TypeErasedPublisher
 {
   // Keeps the dynamically loaded typesupport and introspection shared libraries
   // (.so) alongside their handles for the lifetime of the publisher.
@@ -259,10 +338,7 @@ class GenericPublisher : public PublisherBase
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
   const rosidl_typesupport_introspection_cpp::MessageMembers * members_{nullptr};
 
-  template <typename NodeT>
-  rclcpp::QoS constructor_impl(
-    NodeT * node, const std::string & topic_name, const std::string & topic_type,
-    const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role);
+  void load_type_support(const std::string & topic_type);
 
 public:
   using SharedPtr = std::shared_ptr<GenericPublisher>;

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -44,6 +44,8 @@ constexpr int64_t ENTRY_ID_NOT_ASSIGNED = -1;
 template <typename MessageT>
 class Publisher;
 
+class TypeErasedPublisher;
+
 namespace detail
 {
 
@@ -101,9 +103,11 @@ AGNOCAST_PUBLIC
 template <typename T>
 class ipc_shared_ptr
 {
-  // Allow Publisher to call invalidate_all_references()
+  // Allow Publisher and TypeErasedPublisher to call invalidate_all_references()
   template <typename MessageT>
   friend class Publisher;
+
+  friend class TypeErasedPublisher;
 
   // Allow converting constructors to access private members of ipc_shared_ptr<U>
   template <typename U>
@@ -299,7 +303,8 @@ public:
   /// by publish().
   /// @return Reference to the managed message.
   AGNOCAST_PUBLIC
-  T & operator*() const noexcept
+  template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+  U & operator*() const noexcept
   {
     if (AGNOCAST_UNLIKELY(is_invalidated_())) {
       std::fprintf(
@@ -316,7 +321,8 @@ public:
   /// invalidated by publish().
   /// @return Pointer to the managed message.
   AGNOCAST_PUBLIC
-  T * operator->() const noexcept
+  template <typename U = T, typename = std::enable_if_t<!std::is_void_v<U>>>
+  U * operator->() const noexcept
   {
     if (AGNOCAST_UNLIKELY(is_invalidated_())) {
       std::fprintf(
@@ -361,12 +367,23 @@ public:
         // Publisher side, last reference, not published: delete the memory.
         // This handles the case where borrow_loaned_message() was called but publish() was not.
         decrement_borrowed_publisher_num();
-        delete ptr_;
+        if constexpr (!std::is_void_v<T>) {
+          delete ptr_;
+        } else {
+          std::fprintf(
+            stderr,
+            "[agnocast] FATAL: Type-erased message was dropped before being published.\n"
+            "This is not allowed because there is no well-defined way to free a type-erased "
+            "message.\n");
+          std::terminate();
+        }
       }
       delete control_;
     }
 
     ptr_ = nullptr;
+    // Suppress false positive from clang-tidy: atomic reference counting ensures no leak.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     control_ = nullptr;
   }
 };

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -83,7 +83,7 @@ void validate_ld_preload();
 uint32_t get_ros_domain_id();
 std::string create_mq_name_for_agnocast_publish(
   const std::string & topic_name, const topic_local_id_t id);
-std::string create_mq_name_for_bridge(const pid_t pid);
+std::string create_uds_addr_for_bridge();
 std::string create_shm_name(const pid_t pid);
 // Return the inode number of the calling process's IPC namespace
 // (`/proc/self/ns/ipc`). Used by the type registry writer/reader as the

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
 #include <sys/socket.h>
@@ -17,6 +16,8 @@
 #include <array>
 #include <cerrno>
 #include <csignal>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <string>
@@ -30,12 +31,12 @@ namespace agnocast
 class IpcEventLoopBase
 {
 public:
-  using EventCallback = std::function<void(int)>;
+  using MessageCallback = std::function<void(const void * data, std::size_t size)>;
   using SignalCallback = std::function<void()>;
   using SocketCallback = std::function<std::string()>;
 
   IpcEventLoopBase(
-    const rclcpp::Logger & logger, const std::string & mq_name, long mq_msg_size,
+    const rclcpp::Logger & logger, const std::string & uds_addr, std::size_t max_msg_size,
     const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore);
 
   virtual ~IpcEventLoopBase();
@@ -45,11 +46,11 @@ public:
 
   bool spin_once(int timeout_ms);
 
-  void set_mq_handler(EventCallback cb);
+  void set_message_handler(MessageCallback cb);
   void set_signal_handler(SignalCallback cb);
   void set_socket_handler(SocketCallback cb);
 
-  const std::string & get_mq_name() const { return mq_name_; }
+  const std::string & get_uds_addr() const { return uds_addr_; }
 
 protected:
   rclcpp::Logger logger_;
@@ -61,36 +62,35 @@ private:
   int signal_fd_ = -1;
   int socket_fd_ = -1;
 
-  mqd_t mq_fd_ = (mqd_t)-1;
-  std::string mq_name_;
+  int listener_fd_ = -1;
+  std::string uds_addr_;
+  std::vector<uint8_t> recv_buf_;
 
-  long mq_msg_size_;
-
-  EventCallback mq_cb_;
+  MessageCallback message_cb_;
   SignalCallback signal_cb_;
   SocketCallback socket_cb_;
 
-  void setup_mq();
+  void setup_listener();
   void setup_signals(
     const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore);
   void setup_socket();
   void setup_epoll();
   void cleanup_resources();
 
-  mqd_t create_and_open_mq(const std::string & name) const;
   void add_fd_to_epoll(int fd, const std::string & label) const;
+  void drain_listener();
 
   static void ignore_signals_impl(const std::vector<int> & signals);
   static sigset_t block_signals_impl(const std::vector<int> & signals);
 };
 
 inline IpcEventLoopBase::IpcEventLoopBase(
-  const rclcpp::Logger & logger, const std::string & mq_name, long mq_msg_size,
+  const rclcpp::Logger & logger, const std::string & uds_addr, std::size_t max_msg_size,
   const std::vector<int> & signals_to_block, const std::vector<int> & signals_to_ignore)
-: logger_(logger), mq_name_(mq_name), mq_msg_size_(mq_msg_size)
+: logger_(logger), uds_addr_(uds_addr), recv_buf_(max_msg_size)
 {
   try {
-    setup_mq();
+    setup_listener();
     setup_signals(signals_to_block, signals_to_ignore);
     setup_socket();
     setup_epoll();
@@ -123,10 +123,8 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
   }
   for (int event_index = 0; event_index < event_count; ++event_index) {
     int fd = events[event_index].data.fd;
-    if (fd == mq_fd_) {
-      if (mq_cb_) {
-        mq_cb_(fd);
-      }
+    if (fd == listener_fd_) {
+      drain_listener();
     } else if (fd == signal_fd_) {
       struct signalfd_siginfo fdsi
       {
@@ -139,7 +137,7 @@ inline bool IpcEventLoopBase::spin_once(int timeout_ms)
       int client_fd = accept4(socket_fd_, nullptr, nullptr, SOCK_CLOEXEC | SOCK_NONBLOCK);
       if (client_fd == -1) {
         if (errno != EAGAIN && errno != EWOULDBLOCK) {
-          RCLCPP_WARN(logger_, "accept4 on socket failed: %s", strerror(errno));
+          RCLCPP_WARN(logger_, "accept4 on debug socket failed: %s", strerror(errno));
         }
       } else {
         handle_socket(client_fd);
@@ -190,7 +188,7 @@ inline void IpcEventLoopBase::handle_socket(int client_fd)
       } else if (errno == EINTR) {
         // EINTR is harmless; retry without counting it as a failure
       } else {
-        RCLCPP_WARN(logger_, "send on socket failed: %s", strerror(errno));
+        RCLCPP_WARN(logger_, "send on debug socket failed: %s", strerror(errno));
         return;
       }
     }
@@ -198,14 +196,14 @@ inline void IpcEventLoopBase::handle_socket(int client_fd)
 
   if (sent < response.size()) {
     RCLCPP_WARN(
-      logger_, "send on socket incomplete after retries: sent %zu of %zu bytes", sent,
+      logger_, "send on debug socket incomplete after retries: sent %zu of %zu bytes", sent,
       response.size());
   }
 }
 
-inline void IpcEventLoopBase::set_mq_handler(EventCallback cb)
+inline void IpcEventLoopBase::set_message_handler(MessageCallback cb)
 {
-  mq_cb_ = std::move(cb);
+  message_cb_ = std::move(cb);
 }
 
 inline void IpcEventLoopBase::set_signal_handler(SignalCallback cb)
@@ -218,9 +216,25 @@ inline void IpcEventLoopBase::set_socket_handler(SocketCallback cb)
   socket_cb_ = std::move(cb);
 }
 
-inline void IpcEventLoopBase::setup_mq()
+inline void IpcEventLoopBase::drain_listener()
 {
-  mq_fd_ = create_and_open_mq(mq_name_);
+  while (true) {
+    ssize_t n = recv(listener_fd_, recv_buf_.data(), recv_buf_.size(), 0);
+    if (n < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+      if (errno == EINTR) continue;
+      RCLCPP_WARN(logger_, "bridge UDS recv() failed: %s", strerror(errno));
+      break;
+    }
+    if (message_cb_) {
+      message_cb_(recv_buf_.data(), static_cast<size_t>(n));
+    }
+  }
+}
+
+inline void IpcEventLoopBase::setup_listener()
+{
+  listener_fd_ = create_bridge_uds_listener(uds_addr_);
 }
 
 inline void IpcEventLoopBase::setup_signals(
@@ -303,27 +317,11 @@ inline void IpcEventLoopBase::setup_epoll()
     throw std::runtime_error("epoll_create1 failed: " + std::string(strerror(errno)));
   }
 
-  add_fd_to_epoll(mq_fd_, "MQ");
+  add_fd_to_epoll(listener_fd_, "BridgeUDS");
   add_fd_to_epoll(signal_fd_, "Signal");
   if (socket_fd_ != -1) {
-    add_fd_to_epoll(socket_fd_, "Socket");
+    add_fd_to_epoll(socket_fd_, "DebugSocket");
   }
-}
-
-inline mqd_t IpcEventLoopBase::create_and_open_mq(const std::string & name) const
-{
-  struct mq_attr attr = {};
-  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
-  attr.mq_msgsize = mq_msg_size_;
-
-  mqd_t fd =
-    mq_open(name.c_str(), O_CREAT | O_RDONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
-
-  if (fd == -1) {
-    throw std::system_error(errno, std::generic_category(), "MQ open failed: " + name);
-  }
-
-  return fd;
 }
 
 inline void IpcEventLoopBase::add_fd_to_epoll(int fd, const std::string & label) const
@@ -379,7 +377,7 @@ inline void IpcEventLoopBase::cleanup_resources()
 
   if (socket_fd_ != -1) {
     if (close(socket_fd_) == -1) {
-      RCLCPP_WARN(logger_, "Failed to close socket_fd: %s", strerror(errno));
+      RCLCPP_WARN(logger_, "Failed to close debug socket_fd: %s", strerror(errno));
     }
     socket_fd_ = -1;
   }
@@ -391,17 +389,11 @@ inline void IpcEventLoopBase::cleanup_resources()
     signal_fd_ = -1;
   }
 
-  if (mq_fd_ != -1) {
-    if (mq_close(mq_fd_) == -1) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to close mq_fd for mq_name='" << mq_name_ << "': " << strerror(errno));
+  if (listener_fd_ != -1) {
+    if (close(listener_fd_) == -1) {
+      RCLCPP_WARN(logger_, "Failed to close bridge UDS listener_fd: %s", strerror(errno));
     }
-    mq_fd_ = -1;
-
-    if (mq_unlink(mq_name_.c_str()) == -1 && errno != ENOENT) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to unlink mq for mq_name='" << mq_name_ << "': " << strerror(errno));
-    }
+    listener_fd_ = -1;
   }
 }
 

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_msg.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "agnocast/agnocast_ioctl.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace agnocast
+{
+
+inline constexpr size_t SERVICE_NAME_BUFFER_SIZE = 256;
+inline constexpr size_t MESSAGE_TYPE_BUFFER_SIZE = 256;
+inline constexpr size_t SERVICE_TYPE_BUFFER_SIZE = 256;
+
+enum class BridgeDirection : uint32_t { ROS2_TO_AGNOCAST = 0, AGNOCAST_TO_ROS2 = 1 };
+
+enum class BridgeMsgType : uint32_t {
+  PubSub = 0,
+  Service = 1,
+  DaemonPubSub = 2,
+};
+
+struct BridgeMsgPubSubPayload
+{
+  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  topic_local_id_t target_id;
+  BridgeDirection direction;
+};
+
+struct BridgeMsgServicePayload
+{
+  char service_type[SERVICE_TYPE_BUFFER_SIZE];
+  char service_name[SERVICE_NAME_BUFFER_SIZE];
+  bool create_shadow_node;
+  BridgeDirection direction;
+  char shadow_node_namespace[NODE_NAME_BUFFER_SIZE];
+  char shadow_node_name[NODE_NAME_BUFFER_SIZE];
+};
+
+struct BridgeMsgDaemonPubSubPayload
+{
+  char topic_name[TOPIC_NAME_BUFFER_SIZE];
+  char type_name[MESSAGE_TYPE_BUFFER_SIZE];
+  BridgeDirection direction;
+  uint32_t qos_depth;
+  bool qos_is_transient_local;
+  bool qos_is_reliable;
+};
+
+struct BridgeMsg
+{
+  BridgeMsgType type;
+  union Payload {
+    BridgeMsgPubSubPayload pubsub;
+    BridgeMsgServicePayload service;
+    BridgeMsgDaemonPubSubPayload daemon_pubsub;
+  } payload;
+};
+
+constexpr size_t BRIDGE_MSG_MAX_SIZE = sizeof(BridgeMsg);
+
+// Wire size of a BridgeMsg carrying a specific payload variant: the tag plus
+// just the active variant's bytes. Used both to size the datagram sent over
+// the abstract-namespace UDS transport and to size auxiliary buffers.
+template <typename PayloadT>
+constexpr size_t bridge_msg_wire_size()
+{
+  return offsetof(BridgeMsg, payload) + sizeof(PayloadT);
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_node.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "agnocast/agnocast_client.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/version.h"
 
 #include <fcntl.h>
-#include <mqueue.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -78,47 +78,6 @@ struct RosToAgnocastServiceRegistrationPolicy
   }
 };
 
-inline void send_mq_message(
-  const std::string & mq_name, const BridgeMsg & msg, size_t send_size,
-  const rclcpp::Logger & logger)
-{
-  struct mq_attr attr = {};
-  attr.mq_maxmsg = BRIDGE_MQ_MAX_MESSAGES;
-  attr.mq_msgsize = BRIDGE_MQ_MESSAGE_SIZE;
-
-  mqd_t mq =
-    mq_open(mq_name.c_str(), O_CREAT | O_WRONLY | O_NONBLOCK | O_CLOEXEC, BRIDGE_MQ_PERMS, &attr);
-
-  if (mq == (mqd_t)-1) {
-    RCLCPP_ERROR(
-      logger, "mq_open failed for name '%s': %s (errno: %d)", mq_name.c_str(), strerror(errno),
-      errno);
-    return;
-  }
-
-  constexpr int BRIDGE_MQ_SEND_MAX_RETRIES = 100;
-  constexpr useconds_t BRIDGE_MQ_SEND_RETRY_INTERVAL_US = 100000;  // 100ms
-
-  int send_result = -1;
-  int last_errno = 0;
-  for (int retry = 0; retry <= BRIDGE_MQ_SEND_MAX_RETRIES; ++retry) {
-    send_result = mq_send(mq, reinterpret_cast<const char *>(&msg), send_size, 0);
-    if (send_result == 0) break;
-    last_errno = errno;
-    if (last_errno != EAGAIN) break;
-    if (retry < BRIDGE_MQ_SEND_MAX_RETRIES) {
-      usleep(BRIDGE_MQ_SEND_RETRY_INTERVAL_US);
-    }
-  }
-  if (send_result < 0) {
-    RCLCPP_ERROR(
-      logger, "mq_send failed for name '%s': %s (errno: %d)", mq_name.c_str(), strerror(last_errno),
-      last_errno);
-  }
-
-  mq_close(mq);
-}
-
 inline void send_performance_pubsub_bridge_registration_by_type_name(
   const std::string & topic_name, topic_local_id_t id, const std::string & message_type_name,
   BridgeDirection direction)
@@ -139,8 +98,8 @@ inline void send_performance_pubsub_bridge_registration_by_type_name(
     exit(EXIT_FAILURE);
   }
 
-  std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgPubSubPayload>(), logger);
+  const std::string uds_addr = create_uds_addr_for_bridge();
+  send_bridge_uds_message(uds_addr, &msg, bridge_msg_wire_size<BridgeMsgPubSubPayload>(), logger);
 }
 
 template <typename ServiceT>
@@ -166,8 +125,8 @@ void send_performance_service_bridge_registration(
     exit(EXIT_FAILURE);
   }
 
-  std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-  send_mq_message(mq_name, msg, bridge_msg_wire_size<BridgeMsgServicePayload>(), logger);
+  const std::string uds_addr = create_uds_addr_for_bridge();
+  send_bridge_uds_message(uds_addr, &msg, bridge_msg_wire_size<BridgeMsgServicePayload>(), logger);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace agnocast
+{
+
+inline constexpr int BRIDGE_UDS_SEND_MAX_RETRIES = 100;
+inline constexpr useconds_t BRIDGE_UDS_SEND_RETRY_INTERVAL_US = 100000;
+
+namespace detail
+{
+
+// Abstract-namespace addresses are length-scoped: leading NUL + name bytes,
+// no trailing NUL. Returns the socklen_t bind()/sendto() expect.
+inline socklen_t fill_abstract_sockaddr(const std::string & addr, sockaddr_un & out)
+{
+  out = {};
+  out.sun_family = AF_UNIX;
+  if (addr.empty() || addr[0] != '\0') {
+    throw std::invalid_argument("abstract UDS address must start with NUL");
+  }
+  if (addr.size() > sizeof(out.sun_path)) {
+    throw std::length_error("abstract UDS address too long for sun_path");
+  }
+  std::memcpy(out.sun_path, addr.data(), addr.size());
+  return static_cast<socklen_t>(offsetof(struct sockaddr_un, sun_path) + addr.size());
+}
+
+}  // namespace detail
+
+inline int create_bridge_uds_listener(const std::string & addr)
+{
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+  if (fd == -1) {
+    throw std::system_error(errno, std::generic_category(), "bridge UDS socket() failed");
+  }
+
+  try {
+    sockaddr_un sa{};
+    const socklen_t alen = detail::fill_abstract_sockaddr(addr, sa);
+    if (bind(fd, reinterpret_cast<sockaddr *>(&sa), alen) == -1) {
+      throw std::system_error(errno, std::generic_category(), "bridge UDS bind() failed");
+    }
+  } catch (...) {
+    close(fd);
+    throw;
+  }
+  return fd;
+}
+
+// Send `data`/`size` as a single datagram to `addr`.
+// Retries on ECONNREFUSED/EAGAIN/EWOULDBLOCK/ENOBUFS up to
+// BRIDGE_UDS_SEND_MAX_RETRIES * BRIDGE_UDS_SEND_RETRY_INTERVAL_US.
+inline bool send_bridge_uds_message(
+  const std::string & addr, const void * data, size_t size, const rclcpp::Logger & logger)
+{
+  int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+  if (fd == -1) {
+    RCLCPP_ERROR(logger, "bridge UDS socket() failed: %s (errno: %d)", strerror(errno), errno);
+    return false;
+  }
+
+  sockaddr_un sa{};
+  socklen_t alen = 0;
+  try {
+    alen = detail::fill_abstract_sockaddr(addr, sa);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger, "bridge UDS address invalid: %s", e.what());
+    close(fd);
+    return false;
+  }
+
+  const std::string display_name = (!addr.empty() && addr.front() == '\0') ? addr.substr(1) : addr;
+
+  ssize_t send_result = -1;
+  int last_errno = 0;
+  for (int retry = 0; retry <= BRIDGE_UDS_SEND_MAX_RETRIES; ++retry) {
+    send_result = sendto(fd, data, size, MSG_NOSIGNAL, reinterpret_cast<sockaddr *>(&sa), alen);
+    if (send_result >= 0) break;
+    last_errno = errno;
+    if (
+      last_errno != ECONNREFUSED && last_errno != EAGAIN && last_errno != EWOULDBLOCK &&
+      last_errno != ENOBUFS) {
+      break;
+    }
+    if (retry < BRIDGE_UDS_SEND_MAX_RETRIES) {
+      usleep(BRIDGE_UDS_SEND_RETRY_INTERVAL_US);
+    }
+  }
+
+  if (send_result < 0) {
+    RCLCPP_ERROR(
+      logger, "bridge UDS sendto() failed for '%s': %s (errno: %d)", display_name.c_str(),
+      strerror(last_errno), last_errno);
+    close(fd);
+    return false;
+  }
+  if (static_cast<size_t>(send_result) != size) {
+    // SOCK_DGRAM is atomic; a short send would indicate a kernel/API bug.
+    RCLCPP_ERROR(
+      logger, "bridge UDS sendto() short send to '%s': sent %zd of %zu bytes", display_name.c_str(),
+      send_result, size);
+    close(fd);
+    return false;
+  }
+
+  close(fd);
+  return true;
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/performance/agnocast_performance_bridge_manager.hpp
@@ -75,7 +75,7 @@ private:
 
   void start_ros_execution();
 
-  void on_mq_request(int fd);
+  void on_bridge_message(const void * data, std::size_t size);
   void on_signal();
   std::string on_socket_request() const;
 

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -204,11 +204,6 @@ void poll_for_unlink()
         const std::string shm_name = create_shm_name(get_exit_process_args.ret_pid);
         shm_unlink(shm_name.c_str());
 
-        // We don't need to call mq_unlink for non BridgeManager processes. However, we do it for
-        // all exited processes to avoid the complexity of checking the process type.
-        const std::string mq_name = create_mq_name_for_bridge(get_exit_process_args.ret_pid);
-        mq_unlink(mq_name.c_str());
-
         // Unlink subscription MQs that the exited process owned
         for (uint32_t i = 0; i < get_exit_process_args.ret_subscription_mq_info_num; i++) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
@@ -221,11 +216,6 @@ void poll_for_unlink()
     } while (get_exit_process_args.ret_pid > 0);
 
     if (get_exit_process_args.ret_daemon_should_exit) {
-      auto bridge_mode = get_bridge_mode();
-      if (bridge_mode == BridgeMode::On) {
-        const std::string mq_name = create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID);
-        mq_unlink(mq_name.c_str());
-      }
       break;
     }
   }

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -311,10 +311,38 @@ PublisherBase::~PublisherBase()
   }
 }
 
-template <typename NodeT>
-rclcpp::QoS GenericPublisher::constructor_impl(
-  NodeT * node, const std::string & topic_name, const std::string & topic_type,
+TypeErasedPublisher::TypeErasedPublisher(
+  rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
+{
+  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
+    topic_name_.c_str(), actual_qos.depth());
+}
+
+TypeErasedPublisher::TypeErasedPublisher(
+  agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
+  const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
+{
+  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
+
+  TRACEPOINT(
+    agnocast_publisher_init, static_cast<const void *>(this),
+    static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
+    actual_qos.depth());
+}
+
+ipc_shared_ptr<void> TypeErasedPublisher::borrow_loaned_message(size_t size)
+{
+  increment_borrowed_publisher_num();
+  void * ptr = ::operator new(size);
+  return ipc_shared_ptr<void>(ptr, topic_name_, id_);
+}
+
+void GenericPublisher::load_type_support(const std::string & topic_type)
 {
   // The typesupport functions may throw exceptions if the shared libraries
   // fail to load or an invalid message type name is provided. These
@@ -337,32 +365,22 @@ rclcpp::QoS GenericPublisher::constructor_impl(
 #endif
   members_ = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
     introspection_handle->data);
-
-  return this->init_base(node, topic_name, topic_type, qos, options, role);
 }
 
 GenericPublisher::GenericPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
+: TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
-  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
-
-  TRACEPOINT(
-    agnocast_publisher_init, static_cast<const void *>(this),
-    static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
-    topic_name_.c_str(), actual_qos.depth());
+  load_type_support(topic_type);
 }
 
 GenericPublisher::GenericPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const PublisherOptions & options, PublisherRole role)
+: TypeErasedPublisher(node, topic_name, topic_type, qos, options, role)
 {
-  const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, topic_type, qos, options, role);
-
-  TRACEPOINT(
-    agnocast_publisher_init, static_cast<const void *>(this),
-    static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
-    actual_qos.depth());
+  load_type_support(topic_type);
 }
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
@@ -381,8 +399,8 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
     return;
   }
 
-  increment_borrowed_publisher_num();
-  void * ptr = ::operator new(members_->size_of_);
+  ipc_shared_ptr<void> message = borrow_loaned_message(members_->size_of_);
+  void * ptr = message.get();
 
   // Invoke the constructor of the message type at ptr.
   // Type-specific initialization is unnecessary because the message object
@@ -393,34 +411,20 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & serialized_msg)
   const rmw_ret_t ret =
     rmw_deserialize(&serialized_msg.get_rcl_serialized_message(), type_support_handle_, ptr);
 
-  decrement_borrowed_publisher_num();
+  auto deleter = [this](void * release_ptr) {
+    members_->fini_function(release_ptr);
+    ::operator delete(release_ptr);
+  };
 
   if (ret != RMW_RET_OK) {
-    members_->fini_function(ptr);
-    ::operator delete(ptr);
+    cancel_message(std::move(message), deleter);
     RCLCPP_ERROR(
       logger, "rmw_deserialize failed in GenericPublisher (rmw_ret=%d); dropping message",
       static_cast<int>(ret));
     return;
   }
 
-  const auto va = reinterpret_cast<uint64_t>(ptr);
-  union ioctl_publish_msg_args publish_msg_args {
-  };
-  {
-    std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
-    publish_msg_args = publish_core(this, topic_name_, id_, va, opened_mqs_);
-  }
-
-  // Release entries that all subscribers have finished reading.
-  // Only the addresses previously passed to the kernel by this publisher are returned here.
-  // Therefore, the message type is guaranteed to match members_ and it's safe to call
-  // fini_function on the pointer.
-  for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
-    void * rptr = reinterpret_cast<void *>(publish_msg_args.ret_released_addrs[i]);
-    members_->fini_function(rptr);
-    ::operator delete(rptr);
-  }
+  TypeErasedPublisher::publish(std::move(message), deleter);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -1,6 +1,5 @@
 #include "agnocast/agnocast_utils.hpp"
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
 #include <sys/stat.h>
@@ -80,10 +79,10 @@ std::string create_mq_name_for_agnocast_publish(
   return create_mq_name("/agnocast", topic_name, id);
 }
 
-// MQ-name suffix that scopes the per-IPC-namespace performance bridge by domain.
+// UDS-address suffix that scopes the per-IPC-namespace bridge listener by domain.
 // An unset OR empty ROS_DOMAIN_ID means "no domain" (no suffix), keeping this in
-// sync with the Python discovery agent (bridge_decider._bridge_mq_name).
-static std::string performance_domain_suffix()
+// sync with the Python discovery agent (bridge_decider._bridge_uds_addr).
+static std::string bridge_domain_suffix()
 {
   const char * domain_id = getenv("ROS_DOMAIN_ID");
   if (domain_id == nullptr || *domain_id == '\0') {
@@ -109,13 +108,16 @@ uint32_t get_ros_domain_id()
   return static_cast<uint32_t>(value);
 }
 
-std::string create_mq_name_for_bridge(const pid_t pid)
+std::string create_uds_addr_for_bridge()
 {
-  std::string name = "/agnocast_bridge_manager@" + std::to_string(pid);
-  if (pid == PERFORMANCE_BRIDGE_VIRTUAL_PID) {
-    name += performance_domain_suffix();
-  }
-  return name;
+  // Abstract-namespace UDS address is prefixed with '\0' and its length is
+  // scoped by the socklen_t passed to bind()/sendto() (no trailing NUL).
+  std::string addr;
+  addr.push_back('\0');
+  addr += "agnocast_bridge_manager_";
+  addr += std::to_string(get_self_ipc_ns_inode());
+  addr += bridge_domain_suffix();
+  return addr;
 }
 
 uint64_t get_self_ipc_ns_inode()

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp
@@ -1,7 +1,7 @@
 #include "agnocast/bridge/performance/agnocast_performance_bridge_ipc_event_loop.hpp"
 
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 
 #include <utility>
 #include <vector>
@@ -12,10 +12,10 @@ namespace agnocast
 PerformanceBridgeIpcEventLoop::PerformanceBridgeIpcEventLoop(const rclcpp::Logger & logger)
 : IpcEventLoopBase(
     logger,
-    // 1. MQ Name
-    create_mq_name_for_bridge(PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    // 2. Message Size
-    BRIDGE_MQ_MESSAGE_SIZE,
+    // 1. Abstract-namespace UDS address
+    create_uds_addr_for_bridge(),
+    // 2. Upper bound on any single received message
+    BRIDGE_MSG_MAX_SIZE,
     // 3. Block Signals
     {SIGTERM, SIGINT},
     // 4. Ignore Signals

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -3,15 +3,16 @@
 
 #include "agnocast/agnocast_callback_isolated_executor.hpp"
 #include "agnocast/agnocast_ioctl.hpp"
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
-#include <mqueue.h>
 #include <sys/prctl.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 
 namespace agnocast
 {
@@ -55,7 +56,8 @@ void PerformanceBridgeManager::run()
 
   start_ros_execution();
 
-  event_loop_.set_mq_handler([this](int fd) { this->on_mq_request(fd); });
+  event_loop_.set_message_handler(
+    [this](const void * data, std::size_t size) { this->on_bridge_message(data, size); });
   event_loop_.set_signal_handler([this]() { this->on_signal(); });
   event_loop_.set_socket_handler([this]() { return this->on_socket_request(); });
 
@@ -98,33 +100,25 @@ void PerformanceBridgeManager::start_ros_execution()
   });
 }
 
-void PerformanceBridgeManager::on_mq_request(int fd)
+void PerformanceBridgeManager::on_bridge_message(const void * data, std::size_t size)
 {
-  BridgeMsg msg{};
-
-  ssize_t bytes_read = mq_receive(fd, reinterpret_cast<char *>(&msg), sizeof(msg), nullptr);
-  if (bytes_read < 0) {
-    if (errno != EAGAIN) {
-      RCLCPP_WARN_STREAM(
-        logger_, "mq_receive failed for mq_name='" << event_loop_.get_mq_name() << "' (fd=" << fd
-                                                   << "): " << strerror(errno));
-    }
-    return;
-  }
-
-  if (static_cast<size_t>(bytes_read) < offsetof(BridgeMsg, payload)) {
+  if (size < offsetof(BridgeMsg, payload)) {
     RCLCPP_WARN(
       logger_,
-      "bridge msg too small to carry a discriminator: got %zd bytes, expected at least %zu",
-      bytes_read, offsetof(BridgeMsg, payload));
+      "bridge msg too small to carry a discriminator: got %zu bytes, expected at least %zu", size,
+      offsetof(BridgeMsg, payload));
     return;
   }
 
+  BridgeMsg msg{};
+  const size_t copy_size = std::min(size, sizeof(BridgeMsg));
+  std::memcpy(&msg, data, copy_size);
+
   const auto validate_variant_size = [&](size_t expected) -> bool {
-    if (static_cast<size_t>(bytes_read) < expected) {
+    if (size < expected) {
       RCLCPP_WARN(
-        logger_, "bridge msg (type=%u) truncated: got %zd bytes, expected at least %zu",
-        static_cast<uint32_t>(msg.type), bytes_read, expected);
+        logger_, "bridge msg (type=%u) truncated: got %zu bytes, expected at least %zu",
+        static_cast<uint32_t>(msg.type), size, expected);
       return false;
     }
     return true;

--- a/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
@@ -1,0 +1,167 @@
+#include "agnocast/bridge/agnocast_bridge_uds.hpp"
+
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace
+{
+
+// Abstract-namespace address unique to this process + test-provided suffix, so
+// parallel test binaries and repeated runs never collide with a live socket.
+std::string make_unique_abstract_addr(const std::string & tag)
+{
+  std::string addr;
+  addr.push_back('\0');
+  addr += "agnocast_bridge_uds_test_";
+  addr += std::to_string(getpid());
+  addr += "_";
+  addr += tag;
+  return addr;
+}
+
+// RAII owner so a failed EXPECT doesn't leak the fd into later tests.
+class ScopedFd
+{
+public:
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ~ScopedFd()
+  {
+    if (fd_ != -1) {
+      close(fd_);
+    }
+  }
+  ScopedFd(const ScopedFd &) = delete;
+  ScopedFd & operator=(const ScopedFd &) = delete;
+  int get() const { return fd_; }
+
+private:
+  int fd_;
+};
+
+}  // namespace
+
+// ---- detail::fill_abstract_sockaddr ---------------------------------------
+
+TEST(BridgeUdsAddrTest, EmptyAddressRejected)
+{
+  sockaddr_un sa{};
+  EXPECT_THROW(agnocast::detail::fill_abstract_sockaddr("", sa), std::invalid_argument);
+}
+
+TEST(BridgeUdsAddrTest, NonNulPrefixedAddressRejected)
+{
+  sockaddr_un sa{};
+  EXPECT_THROW(
+    agnocast::detail::fill_abstract_sockaddr("agnocast_bridge_no_nul", sa), std::invalid_argument);
+}
+
+TEST(BridgeUdsAddrTest, OverlongAddressRejected)
+{
+  sockaddr_un sa{};
+  // Leading NUL + (sizeof(sun_path)) bytes = one byte too many for sun_path.
+  std::string too_long(sizeof(sa.sun_path) + 1, 'x');
+  too_long[0] = '\0';
+  EXPECT_THROW(agnocast::detail::fill_abstract_sockaddr(too_long, sa), std::length_error);
+}
+
+TEST(BridgeUdsAddrTest, ValidAddressPopulatesSockaddr)
+{
+  const std::string addr = std::string("\0hello", 6);  // NUL + "hello"
+
+  sockaddr_un sa{};
+  // Poison the padding to prove fill_abstract_sockaddr zeroes the whole struct.
+  std::memset(&sa, 0xAB, sizeof(sa));
+
+  const socklen_t alen = agnocast::detail::fill_abstract_sockaddr(addr, sa);
+
+  EXPECT_EQ(sa.sun_family, AF_UNIX);
+  EXPECT_EQ(alen, static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + addr.size()));
+  EXPECT_EQ(std::memcmp(sa.sun_path, addr.data(), addr.size()), 0);
+  // Bytes past the address must remain zero (i.e. no trailing NUL is required
+  // and no leftover poison bits leak to the kernel).
+  for (size_t i = addr.size(); i < sizeof(sa.sun_path); ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(sa.sun_path[i]), 0u) << "byte " << i;
+  }
+}
+
+TEST(BridgeUdsAddrTest, MaxLengthAddressAccepted)
+{
+  sockaddr_un probe{};
+  // Boundary: exactly sizeof(sun_path) bytes (leading NUL + sizeof-1 name bytes).
+  std::string boundary(sizeof(probe.sun_path), 'y');
+  boundary[0] = '\0';
+
+  sockaddr_un sa{};
+  const socklen_t alen = agnocast::detail::fill_abstract_sockaddr(boundary, sa);
+  EXPECT_EQ(alen, static_cast<socklen_t>(offsetof(sockaddr_un, sun_path) + boundary.size()));
+  EXPECT_EQ(std::memcmp(sa.sun_path, boundary.data(), boundary.size()), 0);
+}
+
+// ---- create_bridge_uds_listener -------------------------------------------
+
+TEST(BridgeUdsListenerTest, RejectsInvalidAddress)
+{
+  EXPECT_THROW(agnocast::create_bridge_uds_listener(""), std::invalid_argument);
+  EXPECT_THROW(agnocast::create_bridge_uds_listener("no-leading-nul"), std::invalid_argument);
+}
+
+TEST(BridgeUdsListenerTest, DuplicateBindFailsWithAddrInUse)
+{
+  const std::string addr = make_unique_abstract_addr("dup");
+  ScopedFd first(agnocast::create_bridge_uds_listener(addr));
+  ASSERT_NE(first.get(), -1);
+
+  try {
+    ScopedFd second(agnocast::create_bridge_uds_listener(addr));
+    FAIL() << "second listener on the same abstract address must fail";
+  } catch (const std::system_error & e) {
+    EXPECT_EQ(e.code().value(), EADDRINUSE)
+      << "expected EADDRINUSE, got " << e.code().value() << " (" << e.what() << ")";
+  }
+}
+
+// ---- send_bridge_uds_message ----------------------------------------------
+
+TEST(BridgeUdsSendTest, RoundTripDeliversPayload)
+{
+  const std::string addr = make_unique_abstract_addr("roundtrip");
+  ScopedFd listener(agnocast::create_bridge_uds_listener(addr));
+  ASSERT_NE(listener.get(), -1);
+
+  const std::array<std::uint8_t, 4> payload = {0xDE, 0xAD, 0xBE, 0xEF};
+  const auto logger = rclcpp::get_logger("BridgeUdsSendTest");
+  EXPECT_TRUE(agnocast::send_bridge_uds_message(addr, payload.data(), payload.size(), logger));
+
+  std::array<std::uint8_t, 32> buf{};
+  const ssize_t n = recv(listener.get(), buf.data(), buf.size(), 0);
+  ASSERT_EQ(n, static_cast<ssize_t>(payload.size()))
+    << "recv failed or short read: " << (n < 0 ? strerror(errno) : "size mismatch");
+  EXPECT_EQ(std::memcmp(buf.data(), payload.data(), payload.size()), 0);
+}
+
+TEST(BridgeUdsSendTest, InvalidAddressFailsFast)
+{
+  const auto logger = rclcpp::get_logger("BridgeUdsSendTest");
+  const std::uint8_t byte = 0;
+  // Empty and non-NUL-prefixed addresses are rejected inside
+  // send_bridge_uds_message before any sendto()/retry loop runs, so this must
+  // return false immediately rather than spending
+  // BRIDGE_UDS_SEND_MAX_RETRIES * BRIDGE_UDS_SEND_RETRY_INTERVAL_US retrying.
+  EXPECT_FALSE(agnocast::send_bridge_uds_message("", &byte, sizeof(byte), logger));
+  EXPECT_FALSE(agnocast::send_bridge_uds_message("no-nul", &byte, sizeof(byte), logger));
+}

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -69,9 +69,14 @@ TEST(AgnocastUtilsTest, create_mq_name_invalid_topic)
     ::testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(AgnocastUtilsTest, create_mq_name_bridge_manager)
+TEST(AgnocastUtilsTest, create_uds_addr_bridge_manager)
 {
-  EXPECT_EQ(agnocast::create_mq_name_for_bridge(12345), "/agnocast_bridge_manager@12345");
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
 }
 
 TEST(AgnocastUtilsTest, validate_ld_preload_normal)

--- a/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
@@ -1,5 +1,5 @@
-#include "agnocast/agnocast_mq.hpp"
 #include "agnocast/agnocast_utils.hpp"
+#include "agnocast/bridge/agnocast_bridge_msg.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <gtest/gtest.h>
@@ -42,7 +42,7 @@ private:
 // The discovery daemon (Python) packs BridgeMsgDaemonPubSubPayload by hand inside a
 // BridgeMsg, mirroring this layout. These checks fail loudly if the C++ struct
 // drifts from the daemon's `_MSG_PACK_FORMAT`.
-TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
+TEST(DaemonBridgeUdsTest, DaemonPayloadWireLayout)
 {
   using agnocast::BridgeMsgDaemonPubSubPayload;
   EXPECT_EQ(sizeof(BridgeMsgDaemonPubSubPayload), 524u);
@@ -54,14 +54,14 @@ TEST(DaemonBridgeMqTest, DaemonPayloadWireLayout)
   EXPECT_EQ(offsetof(BridgeMsgDaemonPubSubPayload, qos_is_reliable), 521u);
 }
 
-TEST(DaemonBridgeMqTest, BridgeMsgTypeNumeric)
+TEST(DaemonBridgeUdsTest, BridgeMsgTypeNumeric)
 {
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::PubSub), 0u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::Service), 1u);
   EXPECT_EQ(static_cast<uint32_t>(agnocast::BridgeMsgType::DaemonPubSub), 2u);
 }
 
-TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
+TEST(DaemonBridgeUdsTest, BridgeMsgWireLayout)
 {
   EXPECT_EQ(offsetof(agnocast::BridgeMsg, type), 0u);
   EXPECT_EQ(offsetof(agnocast::BridgeMsg, payload), 4u);
@@ -77,18 +77,45 @@ TEST(DaemonBridgeMqTest, BridgeMsgWireLayout)
 }
 
 // An empty ROS_DOMAIN_ID (set but "") means "no domain": no `_d` suffix.
-TEST(DaemonBridgeMqTest, BridgeMqNameEmptyDomainIdHasNoSuffix)
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrEmptyDomainIdHasNoSuffix)
 {
   const ScopedRosDomainId guard;
   setenv("ROS_DOMAIN_ID", "", 1);
-  EXPECT_EQ(
-    agnocast::create_mq_name_for_bridge(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID),
-    "/agnocast_bridge_manager@" + std::to_string(agnocast::PERFORMANCE_BRIDGE_VIRTUAL_PID));
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
+}
+
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrAppendsDomainId)
+{
+  const ScopedRosDomainId guard;
+  setenv("ROS_DOMAIN_ID", "7", 1);
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode()) + "_d7";
+  EXPECT_EQ(addr.substr(1), expected);
+}
+
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
+{
+  const ScopedRosDomainId guard;
+  unsetenv("ROS_DOMAIN_ID");
+  const auto addr = agnocast::create_uds_addr_for_bridge();
+  ASSERT_FALSE(addr.empty());
+  EXPECT_EQ(addr[0], '\0');
+  const auto expected =
+    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
+  EXPECT_EQ(addr.substr(1), expected);
 }
 
 // Performance-mode daemon bridges have no local endpoint to query, so the QoS
 // must be rebuilt faithfully from the request's explicit fields.
-TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
+TEST(DaemonBridgeUdsTest, DaemonRequestQosReliableTransientLocal)
 {
   agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 10;
@@ -101,7 +128,7 @@ TEST(DaemonBridgeMqTest, DaemonRequestQosReliableTransientLocal)
   EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
 }
 
-TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
+TEST(DaemonBridgeUdsTest, DaemonRequestQosBestEffortVolatile)
 {
   agnocast::BridgeMsgDaemonPubSubPayload req{};
   req.qos_depth = 1;
@@ -117,7 +144,7 @@ TEST(DaemonBridgeMqTest, DaemonRequestQosBestEffortVolatile)
 // The daemon-forced lease (used by the performance bridge_manager to keep a
 // cross-NS bridge alive without a same-graph DDS counterpart) is active for the
 // half-open window [registered, registered + DAEMON_FORCE_TTL).
-TEST(DaemonBridgeMqTest, DaemonForceLeaseWindowIsHalfOpen)
+TEST(DaemonBridgeUdsTest, DaemonForceLeaseWindowIsHalfOpen)
 {
   const std::chrono::steady_clock::time_point t0{};
   const auto deadline = agnocast::daemon_force_deadline(t0);
@@ -136,7 +163,7 @@ TEST(DaemonBridgeMqTest, DaemonForceLeaseWindowIsHalfOpen)
 
 // Re-asserting the request (the daemon does so every tick) pushes the deadline
 // out, so a continuously-requested bridge never lapses.
-TEST(DaemonBridgeMqTest, DaemonForceLeaseRenewalExtendsDeadline)
+TEST(DaemonBridgeUdsTest, DaemonForceLeaseRenewalExtendsDeadline)
 {
   const std::chrono::steady_clock::time_point t0{};
   const auto first = agnocast::daemon_force_deadline(t0);

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -56,6 +56,8 @@ BridgeMode get_bridge_mode()
 {
   return BridgeMode::Off;  // Skip MQ sending in tests
 }
+
+PublisherBase::~PublisherBase() = default;
 }  // namespace agnocast
 
 // =========================================
@@ -209,6 +211,52 @@ TEST_F(AgnocastPublisherTest, test_multiple_borrows_mixed_publish_and_drop)
 }
 
 // =========================================
+// TypeErasedPublisher tests
+// =========================================
+
+class AgnocastTypeErasedPublisherTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node = std::make_shared<rclcpp::Node>("dummy_node");
+    dummy_publisher = std::make_shared<agnocast::TypeErasedPublisher>(
+      node.get(), "/dummy", "/std_msgs/msg/Int32", rclcpp::QoS{10}, agnocast::PublisherOptions{},
+      agnocast::PublisherRole::Default);
+
+    publish_core_mock_called_count = 0;
+    mock_borrowed_publisher_num = 0;
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<rclcpp::Node> node;
+  std::shared_ptr<agnocast::TypeErasedPublisher> dummy_publisher;
+};
+
+TEST_F(AgnocastTypeErasedPublisherTest, test_cancel)
+{
+  // Arrange
+  agnocast::ipc_shared_ptr<void> message = dummy_publisher->borrow_loaned_message(4);
+  void * message_ptr = message.get();
+  void * delete_ptr = nullptr;
+  auto deleter = [&delete_ptr](void * p) {
+    delete_ptr = p;
+    ::operator delete(p);
+  };
+
+  // Act
+  dummy_publisher->cancel_message(std::move(message), deleter);
+
+  // Assert
+  EXPECT_EQ(publish_core_mock_called_count, 0);
+  EXPECT_EQ(agnocast_get_borrowed_publisher_num(), 0);
+  EXPECT_NE(message_ptr, nullptr);
+  EXPECT_EQ(delete_ptr, message_ptr);
+}
+
+// =========================================
 // ipc_shared_ptr tests
 // =========================================
 
@@ -253,6 +301,18 @@ TEST_F(AgnocastSmartPointerTest, reset_nullptr)
 
   // Assert
   EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+}
+
+void drop_unpublished_void_message(const std::string & tn, topic_local_id_t pubsub_id)
+{
+  void * ptr = ::operator new(4);
+  agnocast::ipc_shared_ptr<void> sut{ptr, tn, pubsub_id, ENTRY_ID_NOT_ASSIGNED};
+  return;
+}
+
+TEST_F(AgnocastSmartPointerTest, reset_void)
+{
+  EXPECT_DEATH(drop_unpublished_void_message(dummy_tn, dummy_pubsub_id), "");
 }
 
 TEST_F(AgnocastSmartPointerTest, copy_constructor_normal)

--- a/src/ros2agnocast/ros2agnocast/_bridged_ros2cli.py
+++ b/src/ros2agnocast/ros2agnocast/_bridged_ros2cli.py
@@ -75,7 +75,7 @@ def resolve_type_name(topic_name: str, gossip_timeout: float):
         if not type_name:
             # If not found, fall back to /_agnocast_discovery to look up the Agnocast topic.
             snapshots, used_fallback = collect_announcements_with_fallback(proxy_node, timeout_sec=gossip_timeout)
-            warn_if_using_fallback(proxy_node, used_fallback, gossip_timeout)
+            warn_if_using_fallback(proxy_node, used_fallback, gossip_timeout, snapshots)
             type_name = next(
                 (topic.type_name
                  for snap in snapshots

--- a/src/ros2agnocast/ros2agnocast/_ioctl.py
+++ b/src/ros2agnocast/ros2agnocast/_ioctl.py
@@ -28,7 +28,11 @@ class _TopicInfoRet(ctypes.Structure):
 
 
 def _load_lib() -> Optional[ctypes.CDLL]:
-    """Return the configured ioctl wrapper, or None on absent kmod."""
+    """Return the ioctl wrapper CDLL, or None if its shared library is missing.
+
+    This does not depend on the kmod: when the library loads but the kmod is
+    absent, the ioctls still succeed and simply return empty results.
+    """
     try:
         lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
     except OSError:

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -15,7 +15,7 @@ from rclpy.qos import (
 
 from ros2agnocast._ioctl import self_ns_snapshot
 
-from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState, AgnocastEndpoint
 
 
 GOSSIP_TOPIC = '/_agnocast_discovery'
@@ -66,8 +66,12 @@ def gossip_qos() -> QoSProfile:
 def collect_announcements(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
-) -> list:
-    """Collect one latest snapshot per ``(host_uuid, ipc_ns_inode)`` from gossip."""
+) -> list[AgnocastDaemonState]:
+    """Collect one latest snapshot per ``(host_uuid, ipc_ns_inode)`` from gossip.
+
+    Returns one ``AgnocastDaemonState`` per gossiping agent, or ``[]`` when no
+    agent is reachable within ``timeout_sec``.
+    """
     snapshots = {}
 
     def on_msg(msg: AgnocastDaemonState) -> None:
@@ -99,8 +103,16 @@ def collect_announcements(
 def collect_announcements_with_fallback(
     node,
     timeout_sec: float = DEFAULT_COLLECT_TIMEOUT_SEC,
-) -> tuple:
-    """Gossip first; ioctl fallback. Returns ``(snapshots, used_fallback)``."""
+) -> tuple[list[AgnocastDaemonState], bool]:
+    """Gossip first, then ioctl fallback. Returns ``(snapshots, used_fallback)``.
+
+    - ``used_fallback`` is False when at least one agent gossiped; ``snapshots``
+      is then every reachable agent's state.
+    - Otherwise it is True and ``snapshots`` is the local-NS ioctl view: a
+      single-element ``[state]`` whose ``topics`` may be empty (kmod absent or
+      nothing registered), or ``[]`` only if the ioctl wrapper library itself
+      cannot be loaded.
+    """
     snapshots = collect_announcements(node, timeout_sec)
     if snapshots:
         return snapshots, False
@@ -120,8 +132,16 @@ def _resolve_spin_node(node):
     return getattr(direct, 'node', direct)
 
 
-def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> None:
-    """Best-effort stderr note when gossip was unavailable and ioctl fallback ran."""
+def warn_if_using_fallback(
+    node, used_fallback: bool, timeout_sec: float, snapshots: list[AgnocastDaemonState]
+) -> None:
+    """Best-effort stderr note when gossip was unavailable and ioctl fallback ran.
+
+    ``snapshots`` is the fallback result from ``collect_announcements_with_fallback``.
+    The local ioctl fallback returns a ``[state]`` with empty ``topics`` (not ``[]``)
+    when the kmod is absent or nothing is registered, so "no Agnocast here" is
+    detected by the absence of topics, not by an empty list.
+    """
     if not used_fallback or timeout_sec <= 0:
         return
 
@@ -132,6 +152,11 @@ def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> Non
         publishers = []
 
     if not publishers:
+        # No agent is gossiping. Only worth a note when this namespace actually
+        # has Agnocast endpoints to show: ros2 CLI runs constantly in namespaces
+        # without Agnocast, where "no agent" would be misleading noise.
+        if not any(snap.topics for snap in snapshots):
+            return
         print(
             'NOTE: no /_agnocast_discovery agent visible; showing local '
             'NS only via ioctl. Start one with '
@@ -148,12 +173,12 @@ def warn_if_using_fallback(node, used_fallback: bool, timeout_sec: float) -> Non
             file=sys.stderr)
 
 
-def all_topic_names(snapshots: list) -> set:
+def all_topic_names(snapshots: list[AgnocastDaemonState]) -> set[str]:
     """Union of topic names across all snapshots."""
     return {topic.topic_name for snap in snapshots for topic in snap.topics}
 
 
-def all_nodes(snapshots: list) -> set:
+def all_nodes(snapshots: list[AgnocastDaemonState]) -> set[str]:
     """Union of node names across all snapshots."""
     nodes = set()
     for snap in snapshots:
@@ -165,7 +190,9 @@ def all_nodes(snapshots: list) -> set:
     return nodes
 
 
-def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
+def topic_endpoints(
+    snapshots: list[AgnocastDaemonState], topic_name: str
+) -> tuple[list[AgnocastEndpoint], list[AgnocastEndpoint]]:
     """Return (publishers, subscribers) for ``topic_name`` across all snapshots."""
     publishers = []
     subscribers = []
@@ -178,7 +205,9 @@ def topic_endpoints(snapshots: list, topic_name: str) -> tuple:
     return publishers, subscribers
 
 
-def topics_of_node(snapshots: list, node_name: str) -> tuple:
+def topics_of_node(
+    snapshots: list[AgnocastDaemonState], node_name: str
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
     """Return (pub topics, sub topics) for ``node_name`` as {topic_name, type_name} dicts."""
     pubs, subs = [], []
     for snap in snapshots:
@@ -206,7 +235,9 @@ BRIDGE_LABEL_TEXT = {
 }
 
 
-def collect_bridge_roles(snapshots: list) -> dict:
+def collect_bridge_roles(
+    snapshots: list[AgnocastDaemonState],
+) -> dict[str, list[tuple[bool, bool, bool, bool]]]:
     """Map ``topic_name -> per-NS bridge roles`` in a single pass over snapshots.
 
     Each value is a list with one entry per NS that has a real (non-bridge)

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -44,7 +44,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             bridge_roles = collect_bridge_roles(snapshots)
 
             def get_agnocast_label(topic_name, ros2_sub_topics, ros2_pub_topics):

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -36,7 +36,7 @@ class ListAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
 
             # Get node names which contains Agnocast topics from gossip.
             agnocast_node_name = all_nodes(snapshots)

--- a/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_info_agnocast.py
@@ -133,7 +133,7 @@ class TopicInfoAgnocastVerb(VerbExtension):
 
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             pub_endpoints, sub_endpoints = topic_endpoints(snapshots, topic_name)
 
             def to_info_ret(ep):

--- a/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
@@ -24,7 +24,7 @@ class ListAgnocastVerb(VerbExtension):
         with NodeStrategy(None) as node:
             snapshots, used_fallback = collect_announcements_with_fallback(
                 node, timeout_sec=args.gossip_timeout)
-            warn_if_using_fallback(node, used_fallback, args.gossip_timeout)
+            warn_if_using_fallback(node, used_fallback, args.gossip_timeout, snapshots)
             bridge_roles = collect_bridge_roles(snapshots)
 
             def divide_ros2_topic_into_pubsub(topic_names):

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -178,22 +178,38 @@ def _plain_node(publishers=None):
 
 
 def test_warn_if_using_fallback_silent_when_no_fallback_or_timeout_zero(capsys):
-    warn_if_using_fallback(_plain_node(), used_fallback=False, timeout_sec=2.0)
-    warn_if_using_fallback(_plain_node(), used_fallback=True, timeout_sec=0)
+    warn_if_using_fallback(_plain_node(), used_fallback=False, timeout_sec=2.0, snapshots=[])
+    warn_if_using_fallback(_plain_node(), used_fallback=True, timeout_sec=0, snapshots=[])
     assert capsys.readouterr().err == ''
 
 
 def test_warn_if_using_fallback_says_no_agent_when_dds_sees_no_publisher(capsys):
+    # Local Agnocast state exists (a topic), but no agent is gossiping.
     warn_if_using_fallback(
-        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0)
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[_state('h', 1, topics=[_topic('/chatter')])])
     err = capsys.readouterr().err
     assert 'NOTE' in err
     assert 'no /_agnocast_discovery agent visible' in err
 
 
+def test_warn_if_using_fallback_silent_when_no_publisher_and_no_local_state(capsys):
+    # No agent and no local Agnocast: stay quiet rather than nag the many ros2 CLI
+    # invocations in namespaces without Agnocast. The ioctl fallback yields a single
+    # state with empty ``topics`` (not an empty list) when nothing is registered, so
+    # emptiness is judged by topics, not list length.
+    warn_if_using_fallback(
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[_state('h', 1)])
+    warn_if_using_fallback(
+        _plain_node(publishers=[]), used_fallback=True, timeout_sec=2.0, snapshots=[])
+    assert capsys.readouterr().err == ''
+
+
 def test_warn_if_using_fallback_says_qos_or_pythonpath_when_publisher_visible(capsys):
     warn_if_using_fallback(
-        _plain_node(publishers=[MagicMock()]), used_fallback=True, timeout_sec=2.0)
+        _plain_node(publishers=[MagicMock()]), used_fallback=True, timeout_sec=2.0,
+        snapshots=[])
     err = capsys.readouterr().err
     assert 'WARNING' in err
     assert 'falling back to ioctl' in err

--- a/src/ros2agnocast_discovery_agent/package.xml
+++ b/src/ros2agnocast_discovery_agent/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2agnocast_discovery_msgs</exec_depend>
   <exec_depend>agnocast_ioctl_wrapper</exec_depend>
+  <!-- Parsing the domain_bridge YAML; rosdep/bloom installs ignore setup.py's
+       install_requires, so the runtime dep must be declared here too. -->
+  <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -414,7 +414,8 @@ class DiscoveryAgent(Node):
         remote_states = {key: msg for key, (msg, _received_at) in self._remote_states.items()}
         requests = bridge_decider.decide_bridges(local_state, remote_states)
         if requests:
-            bridge_decider.dispatch_requests(requests, logger=self.get_logger())
+            bridge_decider.dispatch_requests(
+                requests, self._ipc_ns_inode, logger=self.get_logger())
 
     def build_state(self) -> AgnocastDaemonState:
         msg = AgnocastDaemonState()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -43,8 +43,10 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastEndpoint,
     AgnocastTopic,
 )
+import yaml
 
 from . import bridge_decider
+from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
 
 
@@ -104,6 +106,10 @@ def _load_ioctl_wrapper():
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
+
+    lib.add_agnocast_domain_bridge_rule.argtypes = [
+        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
 
     return lib
 
@@ -372,10 +378,33 @@ class DiscoveryAgent(Node):
 
         self._timer = self.create_timer(PUBLISH_INTERVAL_SEC, self._on_tick)
 
+        # Inject domain bridge rules at startup, before application endpoints can
+        # join (the kmod rejects a rule once a domain has allocated ids).
+        self._register_domain_bridge_rules()
+
         self.get_logger().info(
             f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode} '
             f'version={self._agnocast_version}')
+
+    def _register_domain_bridge_rules(self) -> None:
+        path = os.environ.get(domain_bridge_config.CONFIG_ENV)
+        if not path:
+            return
+        try:
+            rules = domain_bridge_config.load_domain_bridge_rules(path)
+        except (OSError, yaml.YAMLError) as e:
+            self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
+            return
+        for topic, from_domain, to_domain in rules:
+            # Idempotent in the kmod, so every per-domain agent in this namespace
+            # may register the same rule without conflict.
+            ret = self._lib.add_agnocast_domain_bridge_rule(
+                topic.encode('utf-8'), from_domain, to_domain)
+            if ret != 0:
+                self.get_logger().warning(
+                    f'failed to register domain bridge rule '
+                    f'{topic} {from_domain}->{to_domain} (ret={ret})')
 
     def _on_tick(self) -> None:
         self._registry.rebuild()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -43,10 +43,8 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastEndpoint,
     AgnocastTopic,
 )
-import yaml
 
 from . import bridge_decider
-from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
 
 
@@ -106,10 +104,6 @@ def _load_ioctl_wrapper():
     lib.get_agnocast_pub_nodes.restype = ctypes.POINTER(TopicInfoRet)
     lib.free_agnocast_topic_info_ret.argtypes = [ctypes.POINTER(TopicInfoRet)]
     lib.free_agnocast_topic_info_ret.restype = None
-
-    lib.add_agnocast_domain_bridge_rule.argtypes = [
-        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
-    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
 
     return lib
 
@@ -378,34 +372,10 @@ class DiscoveryAgent(Node):
 
         self._timer = self.create_timer(PUBLISH_INTERVAL_SEC, self._on_tick)
 
-        # Inject domain bridge rules at startup, before application endpoints can
-        # join (the kmod rejects a rule once a domain has allocated ids).
-        self._register_domain_bridge_rules()
-
         self.get_logger().info(
             f'agnocast_discovery_agent up: host_uuid={self._host_uuid} '
             f'hostname={self._host_hostname} ipc_ns_inode={self._ipc_ns_inode} '
             f'version={self._agnocast_version}')
-
-    def _register_domain_bridge_rules(self) -> None:
-        path = os.environ.get(domain_bridge_config.CONFIG_ENV)
-        if not path:
-            return
-        try:
-            rules = domain_bridge_config.load_domain_bridge_rules(path)
-        except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
-            # A bad config must not take the daemon down: warn and run without rules.
-            self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
-            return
-        for topic, from_domain, to_domain in rules:
-            # Idempotent in the kmod, so every per-domain agent in this namespace
-            # may register the same rule without conflict.
-            ret = self._lib.add_agnocast_domain_bridge_rule(
-                topic.encode('utf-8'), from_domain, to_domain)
-            if ret != 0:
-                self.get_logger().warning(
-                    f'failed to register domain bridge rule '
-                    f'{topic} {from_domain}->{to_domain} (ret={ret})')
 
     def _on_tick(self) -> None:
         self._registry.rebuild()

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -393,7 +393,8 @@ class DiscoveryAgent(Node):
             return
         try:
             rules = domain_bridge_config.load_domain_bridge_rules(path)
-        except (OSError, yaml.YAMLError) as e:
+        except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+            # A bad config must not take the daemon down: warn and run without rules.
             self.get_logger().warning(f'could not load domain bridge config {path}: {e}')
             return
         for topic, from_domain, to_domain in rules:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -8,17 +8,18 @@ so the two reach each other through ROS 2 (DDS):
   * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
   * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
 
-The request is sent as a ``BridgeMsg`` (type=Daemon) to the per-namespace
-bridge_manager MQ (``/agnocast_bridge_manager@-1[_d<domain>]``).
+The request is sent as a ``BridgeMsg`` (type=DaemonPubSub) to the per-namespace
+bridge_manager over an abstract-namespace UNIX domain socket
+(``\\0agnocast_bridge_manager_<ipc_ns_inode>[_d<domain>]``).
 The struct layout is mirrored here so the daemon stays decoupled from
-libagnocast's C++ headers; ``agnocast_mq.hpp`` owns the source of truth and a
-test asserts the size stays in sync.
+libagnocast's C++ headers; ``agnocast_bridge_msg.hpp`` owns the source of
+truth and a test asserts the size stays in sync.
 """
 
-import ctypes
 from dataclasses import dataclass
 import errno
 import os
+import socket
 import struct
 from typing import Iterable, Optional
 
@@ -50,26 +51,7 @@ _MSG_PACK_FORMAT = '=I256s256sIIBB2x'
 DIRECTION_ROS2_TO_AGNOCAST = 0
 DIRECTION_AGNOCAST_TO_ROS2 = 1
 
-# One bridge_manager per IPC namespace listens on this MQ.
-_BRIDGE_MQ_BASE = '/agnocast_bridge_manager@-1'
-
-# librt mq_* loaded lazily to keep the daemon's deps at "rclpy + stdlib".
-_librt = None
-
-
-def _load_librt():
-    global _librt
-    if _librt is not None:
-        return _librt
-    lib = ctypes.CDLL('librt.so.1', use_errno=True)
-    lib.mq_open.argtypes = [ctypes.c_char_p, ctypes.c_int]
-    lib.mq_open.restype = ctypes.c_int
-    lib.mq_send.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_uint]
-    lib.mq_send.restype = ctypes.c_int
-    lib.mq_close.argtypes = [ctypes.c_int]
-    lib.mq_close.restype = ctypes.c_int
-    _librt = lib
-    return _librt
+_BRIDGE_UDS_BASE = 'agnocast_bridge_manager'
 
 
 @dataclass(frozen=True)
@@ -80,7 +62,7 @@ class BridgeRequest:
     qos_depth: int
     qos_is_transient_local: bool
     qos_is_reliable: bool
-    # Selects the target bridge_manager's MQ (one manager per domain); not part
+    # Selects the target bridge_manager's UDS (one manager per domain); not part
     # of the wire payload, since that manager already runs in this domain.
     domain_id: int = 0
 
@@ -176,46 +158,51 @@ def decide_bridges(local_state, remote_states) -> list:
     return list(requests.values())
 
 
-def _bridge_mq_name(domain_id: int) -> str:
-    name = _BRIDGE_MQ_BASE
+def _bridge_uds_addr(ipc_ns_inode: int, domain_id: int) -> str:
+    name = '\x00' + _BRIDGE_UDS_BASE + '_' + str(ipc_ns_inode)
     if domain_id:
         name += '_d' + str(domain_id)
     return name
 
 
-def send_request(mq_name: str, payload: bytes) -> Optional[str]:
-    """Send ``payload`` to ``mq_name``; return an error string or None.
+def send_request(uds_addr: str, payload: bytes) -> Optional[str]:
+    """Send ``payload`` to ``uds_addr``; return an error string or None.
 
-    O_NONBLOCK keeps a full or absent queue from stalling the daemon: the
-    request is re-issued idempotently next tick.
+    Transient failures (bridge_manager not yet bound, receiver buffer full)
+    are swallowed since the request is re-issued idempotently next tick.
     """
-    lib = _load_librt()
-    fd = lib.mq_open(mq_name.encode('utf-8'), os.O_WRONLY | os.O_NONBLOCK)
-    if fd == -1:
-        err = ctypes.get_errno()
-        if err == errno.ENOENT:
-            return None
-        return f'mq_open({mq_name}): {os.strerror(err)}'
+    transient_errnos = (
+        errno.ECONNREFUSED,
+        errno.ENOENT,
+        errno.EAGAIN,
+        errno.EWOULDBLOCK,
+        errno.ENOBUFS,
+    )
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.setblocking(False)
     try:
-        if lib.mq_send(fd, payload, len(payload), 0) == -1:
-            err = ctypes.get_errno()
-            if err == errno.EAGAIN:
+        try:
+            sock.sendto(payload, uds_addr)
+        except OSError as e:
+            if e.errno in transient_errnos:
                 return None
-            return f'mq_send({mq_name}): {os.strerror(err)}'
+            return f'sendto({uds_addr!r}): {os.strerror(e.errno) if e.errno else str(e)}'
     finally:
-        lib.mq_close(fd)
+        sock.close()
     return None
 
 
-def dispatch_requests(requests: Iterable[BridgeRequest], logger=None) -> None:
-    """Deliver each request to the per-namespace bridge_manager MQ.
+def dispatch_requests(
+        requests: Iterable[BridgeRequest], ipc_ns_inode: int, logger=None) -> None:
+    """Deliver each request to the per-namespace bridge_manager UDS.
 
-    Each request goes to the manager that owns its domain (one per domain). The
-    MQ is absent until that bridge_manager is up; ``send_request`` skips
-    ENOENT/EAGAIN so a missing or full queue never stalls the daemon, and the
-    request is re-issued idempotently next tick.
+    Each request goes to the manager that owns its (IPC namespace, domain).
+    The listener UDS is absent until that bridge_manager is up;
+    ``send_request`` swallows ECONNREFUSED/ENOENT so a missing peer never
+    stalls the daemon, and the request is re-issued idempotently next tick.
     """
     for req in requests:
-        err = send_request(_bridge_mq_name(req.domain_id), serialize_request(req))
+        err = send_request(
+            _bridge_uds_addr(ipc_ns_inode, req.domain_id), serialize_request(req))
         if err is not None and logger is not None:
             logger.warn('daemon bridge dispatch failed: %s', err)

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,9 +1,9 @@
 """Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
 rules the Agnocast daemon registers with the kmod.
 
-The same YAML drives both the external ``domain_bridge`` node (cross-ECU, Case 8)
-and the daemon's kmod rule injection that opens same-namespace zero-copy
-cross-domain delivery (Case 2). Only the topic name and domain pair matter here;
+The same YAML drives both the external ``domain_bridge`` node (cross-ECU, via DDS)
+and the daemon's kmod rule injection that opens same-IPC-namespace zero-copy
+cross-domain delivery. Only the topic name and domain pair matter here;
 ``type`` and other fields are ignored.
 """
 import yaml

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,10 +1,10 @@
-"""Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
-rules the Agnocast daemon registers with the kmod.
+"""Parse a ROS 2 ``domain_bridge`` YAML into kmod rule tuples.
 
-The same YAML drives both the external ``domain_bridge`` node (cross-ECU, via DDS)
-and the daemon's kmod rule injection that opens same-IPC-namespace zero-copy
-cross-domain delivery. Only the topic name and domain pair matter here;
-``type`` and other fields are ignored.
+Each rule is ``(from_topic, to_topic, from_domain, to_domain)``. The same YAML
+drives both the external ``domain_bridge`` node (cross-ECU, via DDS) and the kmod
+rule injection that opens same-IPC-namespace zero-copy cross-domain delivery. The
+topic name, its ``remap`` target, and the domain pair matter here; ``type`` and
+other fields are ignored.
 """
 import yaml
 
@@ -25,14 +25,17 @@ def _as_domain_id(value):
 
 
 def parse_domain_bridge_config(text):
-    """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
+    """Return a list of ``(from_topic, to_topic, from_domain, to_domain)`` tuples.
 
+    ``to_topic`` is the per-topic ``remap`` target (same ``domain_bridge`` field
+    the external node honors), or the source name when ``remap`` is absent.
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
     overridden per topic. Topics without a resolvable domain pair are skipped.
 
     Raises ``ValueError`` / ``TypeError`` on a structurally malformed document
-    (non-mapping root, ``topics``, or topic spec) or an out-of-range domain id.
-    The daemon catches both and runs without rules rather than crashing.
+    (non-mapping root, ``topics``, or topic spec), a non-string ``remap``, or an
+    out-of-range domain id. The caller catches these and skips the config rather
+    than crashing.
     """
     doc = yaml.safe_load(text) or {}
     if not isinstance(doc, dict):
@@ -57,7 +60,11 @@ def parse_domain_bridge_config(text):
         to_domain = spec.get('to_domain', default_to)
         if from_domain is None or to_domain is None:
             continue
-        rules.append((str(topic_name), _as_domain_id(from_domain), _as_domain_id(to_domain)))
+        to_topic = spec.get('remap', topic_name)
+        if not isinstance(to_topic, str):
+            raise ValueError(f"'remap' for topic {topic_name!r} must be a string")
+        rules.append(
+            (str(topic_name), to_topic, _as_domain_id(from_domain), _as_domain_id(to_domain)))
     return rules
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -1,0 +1,39 @@
+"""Parse a ROS 2 ``domain_bridge`` YAML into the (topic, from_domain, to_domain)
+rules the Agnocast daemon registers with the kmod.
+
+The same YAML drives both the external ``domain_bridge`` node (cross-ECU, Case 8)
+and the daemon's kmod rule injection that opens same-namespace zero-copy
+cross-domain delivery (Case 2). Only the topic name and domain pair matter here;
+``type`` and other fields are ignored.
+"""
+import yaml
+
+# Operators point the daemon at the config by setting this to the YAML path.
+CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
+
+
+def parse_domain_bridge_config(text):
+    """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
+
+    ``from_domain`` / ``to_domain`` are taken from the top level and may be
+    overridden per topic. Entries without a resolvable domain pair are skipped.
+    """
+    doc = yaml.safe_load(text) or {}
+    default_from = doc.get('from_domain')
+    default_to = doc.get('to_domain')
+
+    rules = []
+    for topic_name, spec in (doc.get('topics') or {}).items():
+        spec = spec or {}
+        from_domain = spec.get('from_domain', default_from)
+        to_domain = spec.get('to_domain', default_to)
+        if from_domain is None or to_domain is None:
+            continue
+        rules.append((str(topic_name), int(from_domain), int(to_domain)))
+    return rules
+
+
+def load_domain_bridge_rules(path):
+    """Read and parse the ``domain_bridge`` YAML at ``path``."""
+    with open(path, encoding='utf-8') as f:
+        return parse_domain_bridge_config(f.read())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -11,25 +11,53 @@ import yaml
 # Operators point the daemon at the config by setting this to the YAML path.
 CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
 
+# Domain ids cross the ioctl boundary as ctypes.c_uint32, so an out-of-range
+# value would wrap silently; reject it here instead.
+_UINT32_MAX = 0xFFFFFFFF
+
+
+def _as_domain_id(value):
+    """Coerce a YAML domain value to a uint32, raising ``ValueError`` if invalid."""
+    domain = int(value)  # ValueError on non-numeric, TypeError on a list/dict
+    if not 0 <= domain <= _UINT32_MAX:
+        raise ValueError(f'domain id {domain} out of range [0, {_UINT32_MAX}]')
+    return domain
+
 
 def parse_domain_bridge_config(text):
     """Return a list of ``(topic_name, from_domain, to_domain)`` tuples.
 
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
-    overridden per topic. Entries without a resolvable domain pair are skipped.
+    overridden per topic. Topics without a resolvable domain pair are skipped.
+
+    Raises ``ValueError`` / ``TypeError`` on a structurally malformed document
+    (non-mapping root, ``topics``, or topic spec) or an out-of-range domain id.
+    The daemon catches both and runs without rules rather than crashing.
     """
     doc = yaml.safe_load(text) or {}
+    if not isinstance(doc, dict):
+        raise ValueError('domain bridge config root must be a mapping')
+
+    topics = doc.get('topics')
+    if topics is None:
+        topics = {}
+    if not isinstance(topics, dict):
+        raise ValueError("'topics' must be a mapping")
+
     default_from = doc.get('from_domain')
     default_to = doc.get('to_domain')
 
     rules = []
-    for topic_name, spec in (doc.get('topics') or {}).items():
-        spec = spec or {}
+    for topic_name, spec in topics.items():
+        if spec is None:
+            spec = {}
+        elif not isinstance(spec, dict):
+            raise ValueError(f'spec for topic {topic_name!r} must be a mapping')
         from_domain = spec.get('from_domain', default_from)
         to_domain = spec.get('to_domain', default_to)
         if from_domain is None or to_domain is None:
             continue
-        rules.append((str(topic_name), int(from_domain), int(to_domain)))
+        rules.append((str(topic_name), _as_domain_id(from_domain), _as_domain_id(to_domain)))
     return rules
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -1,0 +1,72 @@
+"""Register Agnocast domain bridge rules with the kernel module.
+
+Reads a ROS 2 ``domain_bridge`` YAML and registers each
+``(topic, from_domain, to_domain)`` rule through the ioctl wrapper.
+
+Run this once, before any application node for the bridged topics starts: the
+kmod rejects a rule once an endpoint exists in either domain. The tool is
+standalone and idempotent (the kmod folds duplicate rules), so it can run from
+a boot-time one-shot, a launch file, or by hand. It is independent of the
+discovery agent, which is observability-only and never registers rules.
+"""
+import argparse
+import ctypes
+import os
+import sys
+
+import yaml
+
+from . import domain_bridge_config
+
+
+def _load_add_rule_symbol():
+    """Load the ioctl wrapper and return the bound add_agnocast_domain_bridge_rule."""
+    lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
+    lib.add_agnocast_domain_bridge_rule.argtypes = [
+        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+    lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
+    return lib.add_agnocast_domain_bridge_rule
+
+
+def main(argv=None) -> int:
+    """Register every rule in the config; return non-zero if any is rejected."""
+    parser = argparse.ArgumentParser(
+        description='Register Agnocast domain bridge rules with the kernel module.')
+    parser.add_argument(
+        '--config',
+        default=os.environ.get(domain_bridge_config.CONFIG_ENV),
+        help='path to the domain_bridge YAML '
+             f'(default: ${domain_bridge_config.CONFIG_ENV})')
+    args = parser.parse_args(argv)
+
+    if not args.config:
+        parser.error(
+            f'no config given; pass --config or set {domain_bridge_config.CONFIG_ENV}')
+
+    try:
+        rules = domain_bridge_config.load_domain_bridge_rules(args.config)
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+        print(f'error: cannot load {args.config}: {e}', file=sys.stderr)
+        return 1
+
+    add_rule = _load_add_rule_symbol()
+    failures = 0
+    for topic, from_domain, to_domain in rules:
+        if add_rule(topic.encode('utf-8'), from_domain, to_domain) == 0:
+            print(f'registered: {topic} {from_domain}->{to_domain}')
+            continue
+        # A non-zero return most likely means an endpoint for the topic already
+        # exists in one of the domains; the rule must precede every node.
+        failures += 1
+        print(
+            f'error: failed to register {topic} {from_domain}->{to_domain}; '
+            'was a publisher/subscriber already started?', file=sys.stderr)
+
+    if failures:
+        print(f'error: {failures} of {len(rules)} rule(s) rejected', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -1,7 +1,8 @@
 """Register Agnocast domain bridge rules with the kernel module.
 
 Reads a ROS 2 ``domain_bridge`` YAML and registers each
-``(topic, from_domain, to_domain)`` rule through the ioctl wrapper.
+``(from_topic, to_topic, from_domain, to_domain)`` rule through the ioctl wrapper
+(``to_topic`` is the per-topic ``remap`` target, or the source name if absent).
 
 Run this once, before any application node for the bridged topics starts: the
 kmod rejects a rule once an endpoint exists in either domain. The tool is
@@ -23,7 +24,7 @@ def _load_add_rule_symbol():
     """Load the ioctl wrapper and return the bound add_agnocast_domain_bridge_rule."""
     lib = ctypes.CDLL('libagnocast_ioctl_wrapper.so')
     lib.add_agnocast_domain_bridge_rule.argtypes = [
-        ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
+        ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint32]
     lib.add_agnocast_domain_bridge_rule.restype = ctypes.c_int
     return lib.add_agnocast_domain_bridge_rule
 
@@ -51,15 +52,18 @@ def main(argv=None) -> int:
 
     add_rule = _load_add_rule_symbol()
     failures = 0
-    for topic, from_domain, to_domain in rules:
-        if add_rule(topic.encode('utf-8'), from_domain, to_domain) == 0:
-            print(f'registered: {topic} {from_domain}->{to_domain}')
+    for from_topic, to_topic, from_domain, to_domain in rules:
+        label = f'{from_topic}@{from_domain} -> {to_topic}@{to_domain}'
+        if add_rule(
+                from_topic.encode('utf-8'), to_topic.encode('utf-8'),
+                from_domain, to_domain) == 0:
+            print(f'registered: {label}')
             continue
         # A non-zero return most likely means an endpoint for the topic already
         # exists in one of the domains; the rule must precede every node.
         failures += 1
         print(
-            f'error: failed to register {topic} {from_domain}->{to_domain}; '
+            f'error: failed to register {label}; '
             'was a publisher/subscriber already started?', file=sys.stderr)
 
     if failures:

--- a/src/ros2agnocast_discovery_agent/scripts/register_domain_bridge
+++ b/src/ros2agnocast_discovery_agent/scripts/register_domain_bridge
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Wrapper so `ros2 run ros2agnocast_discovery_agent register_domain_bridge` works.
+
+ament_python's `entry_points` would normally produce a binary in `bin/`, but
+`ros2 run` looks in `lib/<pkg>/`. The setup.py installs this file to
+`lib/<pkg>/register_domain_bridge` so the standard ros2 run discovery rule finds it.
+"""
+import sys
+
+from ros2agnocast_discovery_agent.register_domain_bridge import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -13,7 +13,7 @@ setup(
         ('share/' + package_name + '/launch', ['launch/discovery_agent.launch.xml']),
         ('lib/' + package_name, ['scripts/discovery_agent']),
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
     extras_require={'test': ['pytest']},
     maintainer='Keita Morisaki, Takahiro Ishikawa-Aso, Koichi Imai, Takumi Jin',

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -11,7 +11,10 @@ setup(
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/launch', ['launch/discovery_agent.launch.xml']),
-        ('lib/' + package_name, ['scripts/discovery_agent']),
+        ('share/' + package_name + '/systemd',
+            ['systemd/agnocast-domain-bridge.service.example', 'systemd/README.md']),
+        ('lib/' + package_name,
+            ['scripts/discovery_agent', 'scripts/register_domain_bridge']),
     ],
     install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
@@ -27,6 +30,8 @@ setup(
     entry_points={
         'console_scripts': [
             'discovery_agent = ros2agnocast_discovery_agent.agent:main',
+            'register_domain_bridge = '
+            'ros2agnocast_discovery_agent.register_domain_bridge:main',
         ],
     },
 )

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -1,0 +1,31 @@
+# Registering domain bridge rules at boot
+
+Agnocast domain bridge rules must be registered **before any publisher or
+subscriber for the bridged topics exists** — the kernel module rejects a rule
+once a domain has allocated endpoint ids. Registration is therefore a one-time
+boot step, independent of the discovery agent (which is observability-only and
+never registers rules).
+
+`register_domain_bridge` (a console script in this package) reads a ROS 2
+`domain_bridge` YAML and registers each rule:
+
+```bash
+ros2 run ros2agnocast_discovery_agent register_domain_bridge --config /etc/agnocast/domain_bridge.yaml
+# or set AGNOCAST_DOMAIN_BRIDGE_CONFIG and run it with no arguments
+```
+
+Run it once, ordered so that it:
+
+1. runs **after** the Agnocast kernel module is loaded (so `/dev/agnocast` exists),
+2. runs **after** the filesystem holding the config is mounted, and
+3. completes **before** any application node for the bridged topics starts.
+
+`agnocast-domain-bridge.service.example` is a reference systemd one-shot that
+expresses exactly this ordering (`After=` the kmod, `RequiresMountsFor=` the
+config, `Before=` your application target). Agnocast does not ship an installed
+unit or assume systemd — an init script or a container entrypoint that
+satisfies the same ordering works just as well.
+
+The tool is idempotent (the kmod folds duplicate rules) and exits non-zero if
+any rule is rejected, so a misordering — a node started first — fails loudly
+instead of silently leaving topics unbridged.

--- a/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
+++ b/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
@@ -1,0 +1,29 @@
+# Example systemd unit: register Agnocast domain bridge rules before applications.
+#
+# This is a REFERENCE, not an installed unit. Agnocast does not assume systemd
+# (see README.md). Copy it to /etc/systemd/system/, adjust the unit names,
+# paths, and target for your deployment, then `systemctl enable` it.
+#
+# What matters is the ordering (see README.md): register AFTER the kmod is
+# loaded and the config filesystem is mounted, and BEFORE any node that uses
+# the bridged topics starts. The dependencies below express exactly that.
+
+[Unit]
+Description=Register Agnocast domain bridge rules
+# /dev/agnocast must exist first. Point this at whatever loads the kmod.
+After=agnocast-kmod.service
+Requires=agnocast-kmod.service
+# The partition holding the config must be mounted before we read it.
+RequiresMountsFor=/etc/agnocast
+# Rules must be in place before any application node comes up.
+Before=my-robot-apps.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=AGNOCAST_DOMAIN_BRIDGE_CONFIG=/etc/agnocast/domain_bridge.yaml
+# Source ROS 2 and the workspace so `ros2 run` resolves, then register.
+ExecStart=/bin/bash -lc 'source /opt/ros/$ROS_DISTRO/setup.bash && ros2 run ros2agnocast_discovery_agent register_domain_bridge'
+
+[Install]
+WantedBy=multi-user.target

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -3,7 +3,7 @@
 These need neither the kmod, DDS, nor a POSIX MQ: ``decide_bridges`` is pure
 logic, and the wire format is checked against the hand-built byte layout that
 mirrors a Daemon-variant ``BridgeMsg`` (4-byte tag + 524-byte payload = 528
-bytes) in ``agnocast_mq.hpp``.
+bytes) in ``agnocast_bridge_msg.hpp``.
 """
 
 import struct
@@ -199,26 +199,28 @@ def test_serialize_packs_direction_qos_at_expected_offsets():
     assert (direction, depth, transient, reliable) == (DIRECTION_ROS2_TO_AGNOCAST, 7, 1, 1)
 
 
-def test_dispatch_targets_per_namespace_mq(monkeypatch):
+def test_dispatch_targets_per_namespace_uds(monkeypatch):
     from ros2agnocast_discovery_agent import bridge_decider as bd
     sent = []
-    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: sent.append(addr) or None)
 
     req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
-    dispatch_requests([req])
+    dispatch_requests([req], ipc_ns_inode=12345)
 
-    assert all(name.startswith('/agnocast_bridge_manager@-1') for name in sent)
-    assert len(sent) == 1
+    assert sent == ['\x00agnocast_bridge_manager_12345']
 
 
-def test_dispatch_routes_to_per_domain_mq(monkeypatch):
+def test_dispatch_routes_to_per_domain_uds(monkeypatch):
     from ros2agnocast_discovery_agent import bridge_decider as bd
     sent = []
-    monkeypatch.setattr(bd, 'send_request', lambda mq, payload: sent.append(mq) or None)
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: sent.append(addr) or None)
 
     dispatch_requests([
         BridgeRequest('/a', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=0),
         BridgeRequest('/b', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True, domain_id=5),
-    ])
+    ], ipc_ns_inode=12345)
 
-    assert sent == ['/agnocast_bridge_manager@-1', '/agnocast_bridge_manager@-1_d5']
+    assert sent == [
+        '\x00agnocast_bridge_manager_12345',
+        '\x00agnocast_bridge_manager_12345_d5',
+    ]

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -61,3 +61,58 @@ topics:
 """
     with pytest.raises(ValueError):
         parse_domain_bridge_config(text)
+
+
+def test_out_of_range_domain_raises():
+    # uint32 overflow would wrap silently at the ioctl boundary, so reject it.
+    text = """
+from_domain: 1
+to_domain: 4294967296
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)
+
+
+def test_negative_domain_raises():
+    text = """
+from_domain: -1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)
+
+
+# Malformed structure must raise a caught exception (ValueError/TypeError), not
+# AttributeError, so the daemon runs without rules instead of crashing.
+
+def test_non_mapping_root_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('- a\n- b\n')
+
+
+def test_non_mapping_topics_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('topics:\n  - chatter\n  - special\n')
+
+
+def test_non_mapping_topic_spec_raises():
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config('from_domain: 1\nto_domain: 2\ntopics:\n  chatter: oops\n')
+
+
+def test_null_topic_spec_with_top_level_domains_is_used():
+    # `chatter:` with no body is a None spec; it should fall back to the
+    # top-level domains, not crash.
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+"""
+    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -1,0 +1,47 @@
+"""Unit tests for parsing the domain_bridge YAML into kmod rule tuples.
+
+These exercise the pure parser only; no kmod, DDS, or file I/O is involved.
+"""
+
+from ros2agnocast_discovery_agent.domain_bridge_config import parse_domain_bridge_config
+
+
+def test_top_level_domains_apply_to_each_topic():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+
+
+def test_per_topic_domains_override_top_level():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+  special:
+    from_domain: 3
+    to_domain: 4
+"""
+    rules = parse_domain_bridge_config(text)
+    assert ('chatter', 1, 2) in rules
+    assert ('special', 3, 4) in rules
+
+
+def test_topic_without_resolvable_domain_pair_is_skipped():
+    text = """
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    assert parse_domain_bridge_config(text) == []
+
+
+def test_empty_or_topicless_config_yields_no_rules():
+    assert parse_domain_bridge_config('') == []
+    assert parse_domain_bridge_config('topics:') == []

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -16,7 +16,7 @@ topics:
   chatter:
     type: std_msgs/msg/String
 """
-    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+    assert parse_domain_bridge_config(text) == [('chatter', 'chatter', 1, 2)]
 
 
 def test_per_topic_domains_override_top_level():
@@ -31,8 +31,44 @@ topics:
     to_domain: 4
 """
     rules = parse_domain_bridge_config(text)
-    assert ('chatter', 1, 2) in rules
-    assert ('special', 3, 4) in rules
+    assert ('chatter', 'chatter', 1, 2) in rules
+    assert ('special', 'special', 3, 4) in rules
+
+
+def test_remap_sets_the_target_topic_name():
+    # The `remap` field becomes the to_topic; the source name stays the from_topic.
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /in_sub/chatter:
+    type: std_msgs/msg/String
+    remap: /chatter
+"""
+    assert parse_domain_bridge_config(text) == [('/in_sub/chatter', '/chatter', 1, 2)]
+
+
+def test_absent_remap_reuses_the_source_name():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    assert parse_domain_bridge_config(text) == [('chatter', 'chatter', 1, 2)]
+
+
+def test_non_string_remap_raises():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  chatter:
+    remap: [not, a, string]
+"""
+    with pytest.raises((ValueError, TypeError)):
+        parse_domain_bridge_config(text)
 
 
 def test_topic_without_resolvable_domain_pair_is_skipped():
@@ -115,4 +151,4 @@ to_domain: 2
 topics:
   chatter:
 """
-    assert parse_domain_bridge_config(text) == [('chatter', 1, 2)]
+    assert parse_domain_bridge_config(text) == [('chatter', 'chatter', 1, 2)]

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -3,6 +3,8 @@
 These exercise the pure parser only; no kmod, DDS, or file I/O is involved.
 """
 
+import pytest
+
 from ros2agnocast_discovery_agent.domain_bridge_config import parse_domain_bridge_config
 
 
@@ -45,3 +47,17 @@ topics:
 def test_empty_or_topicless_config_yields_no_rules():
     assert parse_domain_bridge_config('') == []
     assert parse_domain_bridge_config('topics:') == []
+
+
+def test_non_integer_domain_raises():
+    # A non-integer domain raises; the agent catches this and runs without rules
+    # rather than crashing at startup.
+    text = """
+from_domain: not_a_number
+to_domain: 2
+topics:
+  chatter:
+    type: std_msgs/msg/String
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -12,10 +12,11 @@ class FakeAddRule:
         self.calls = []
         self._codes = codes or {}
 
-    def __call__(self, topic, from_domain, to_domain):
-        name = topic.decode('utf-8')
-        self.calls.append((name, from_domain, to_domain))
-        return self._codes.get(name, 0)
+    def __call__(self, from_topic, to_topic, from_domain, to_domain):
+        from_name = from_topic.decode('utf-8')
+        to_name = to_topic.decode('utf-8')
+        self.calls.append((from_name, to_name, from_domain, to_domain))
+        return self._codes.get(from_name, 0)
 
 
 def _write_config(tmp_path, text):
@@ -35,7 +36,17 @@ def test_registers_every_rule(tmp_path, monkeypatch):
     monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
     cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
     assert register_domain_bridge.main(['--config', cfg]) == 0
-    assert fake.calls == [('chatter', 1, 2)]
+    assert fake.calls == [('chatter', 'chatter', 1, 2)]
+
+
+def test_registers_remapped_rule_with_both_names(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(
+        tmp_path,
+        'from_domain: 1\nto_domain: 2\ntopics:\n  /in_sub/chatter:\n    remap: /chatter\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    assert fake.calls == [('/in_sub/chatter', '/chatter', 1, 2)]
 
 
 def test_returns_nonzero_when_a_rule_is_rejected(tmp_path, monkeypatch):
@@ -59,4 +70,4 @@ def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
     cfg = _write_config(tmp_path, 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n')
     monkeypatch.setenv(CONFIG_ENV, cfg)
     assert register_domain_bridge.main([]) == 0
-    assert fake.calls == [('image', 3, 4)]
+    assert fake.calls == [('image', 'image', 3, 4)]

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -1,0 +1,62 @@
+"""Tests for the standalone domain bridge rule injector."""
+import pytest
+
+from ros2agnocast_discovery_agent import register_domain_bridge
+from ros2agnocast_discovery_agent.domain_bridge_config import CONFIG_ENV
+
+
+class FakeAddRule:
+    """Stand-in for the ioctl wrapper symbol: records calls, returns a code per topic."""
+
+    def __init__(self, codes=None):
+        self.calls = []
+        self._codes = codes or {}
+
+    def __call__(self, topic, from_domain, to_domain):
+        name = topic.decode('utf-8')
+        self.calls.append((name, from_domain, to_domain))
+        return self._codes.get(name, 0)
+
+
+def _write_config(tmp_path, text):
+    path = tmp_path / 'bridge.yaml'
+    path.write_text(text)
+    return str(path)
+
+
+def test_no_config_is_usage_error(monkeypatch):
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    with pytest.raises(SystemExit):
+        register_domain_bridge.main([])
+
+
+def test_registers_every_rule(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 0
+    assert fake.calls == [('chatter', 1, 2)]
+
+
+def test_returns_nonzero_when_a_rule_is_rejected(tmp_path, monkeypatch):
+    fake = FakeAddRule(codes={'chatter': -16})  # -EBUSY: an endpoint already exists
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    assert register_domain_bridge.main(['--config', cfg]) == 1
+
+
+def test_returns_nonzero_on_unreadable_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        register_domain_bridge, '_load_add_rule_symbol',
+        lambda: pytest.fail('the wrapper must not load when the config is unreadable'))
+    missing = str(tmp_path / 'does_not_exist.yaml')
+    assert register_domain_bridge.main(['--config', missing]) == 1
+
+
+def test_config_path_falls_back_to_env(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    cfg = _write_config(tmp_path, 'from_domain: 3\nto_domain: 4\ntopics:\n  image:\n')
+    monkeypatch.setenv(CONFIG_ENV, cfg)
+    assert register_domain_bridge.main([]) == 0
+    assert fake.calls == [('image', 3, 4)]


### PR DESCRIPTION
## What

Adds **topic rename (remap)** to the domain bridge. The bridge previously required identical topic names on both domains; redundant-Autoware setups need renaming (e.g. prefixing a sub-ECU topic so it can be logged under the main domain without a name collision). The rename target is the standard ROS 2 `domain_bridge` `remap:` field — previously parsed and dropped, now honored.

Stacked on #1418 (base branch `feat/domain-bridge-userspace`); reviewing just this PR's diff shows only the rename change.

## Design

The merged `topic_struct`, `domain_delivery_allowed`, and the refcnt lifetime are **name-agnostic and untouched**. The change is confined to rule matching:

- `domain_bridge_rule` stores a name **per domain** (`topic_name_a` / `topic_name_b`; equal when there's no rename).
- rules are keyed by the **cell `(name, domain)`**; `find_grouped_topic_struct` resolves the partner by the **partner's** name.
- **Invariant enforced in `add_domain_bridge`:** each cell belongs to at most one rule, and a rule pairs exactly two cells. `r_a == r_b` (non-NULL) → re-declaration/reverse direction (OR the flags); any other overlap (e.g. **two sources remapped onto one target**, or a 3-cell chain) → `-EBUSY`. The "rule before any endpoint" guard applies to both names.
- Same-name bridging is the special case `name_a == name_b`, so existing a2a and same-name bridge behavior is **byte-identical**.

Userspace: the config parser reads `remap` → `(from_topic, to_topic, from_domain, to_domain)`; the wrapper symbol and the `ADD_DOMAIN_BRIDGE` ioctl carry both names.

Cross-ECU rename already works via the external ROS 2 `domain_bridge` (a2r/r2a are name-local); this PR adds the same-IPC-namespace **zero-copy (Case 2)** side.

## Manual testing

### 1. kmod KUnit — rename logic incl. corner cases (automated)

The suite (`agnocast_kunit_domain_bridge.c`) gains 4 rename cases. Runs in the `kunit` CI job (QEMU); locally on a `CONFIG_KUNIT=y` kernel:

```bash
bash scripts/test/run_kunit.bash
```

Ran the CI-equivalent (`kunit.py --arch=x86_64`) locally: **185/185 pass**, including:
- `test_case_domain_bridge_rename_groups_wrappers` — two differently-named cells share one `topic_struct` (found from either name, partner by partner name).
- `test_case_domain_bridge_rename_cross_domain_delivery` — `/src@1` publish reaches the `/dst@2` subscriber.
- `test_case_domain_bridge_rename_fanout_rejected` — two sources onto one target → `-EBUSY`.
- `test_case_domain_bridge_rename_multi_publisher` — extra publisher on the source + a native publisher on the renamed target still deliver exactly once (the "the bridged node isn't the only publisher" case).

All pre-existing domain-bridge tests still pass (same-name backward compat).

### 2. userspace config → ioctl plumbing (automated)

```bash
cd src/ros2agnocast_discovery_agent && python3 -m pytest test/
```

Covers `remap` parsing (`test_remap_sets_the_target_topic_name`) and the tool passing both names to the ioctl wrapper.

### 3. full-stack cross-domain renamed delivery — Case 2 zero-copy (manual)

On a **freshly loaded** kmod (the rule must precede any endpoint for the topic):

```bash
bash scripts/dev/build_all.bash
sudo rmmod agnocast 2>/dev/null; sudo insmod agnocast_kmod/agnocast.ko

# Register a RENAME rule: /my_topic@1  ->  /renamed@2
cat > /tmp/bridge.yaml <<'YAML'
from_domain: 1
to_domain: 2
topics:
  "/my_topic":
    remap: "/renamed"
YAML
ros2 run ros2agnocast_discovery_agent register_domain_bridge --config /tmp/bridge.yaml
#   expect: "registered: /my_topic@1 -> /renamed@2"
```

This alone exercises the whole new userspace path (YAML `remap` → parser → tool → wrapper → `ADD_DOMAIN_BRIDGE` ioctl → kmod rule with two names). For **live delivery**, publish on the source name in domain 1 and subscribe the renamed name in domain 2 — the stock samples both use `/my_topic`, so remap the listener's subscription to `/renamed` (Agnocast resolves topic names through the node, so a ROS remap `/my_topic:=/renamed` on the listener node applies):

```bash
# domain-2 listener, its /my_topic subscription remapped to /renamed:
AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID=2 \
  ros2 run agnocast_sample_application <listener_node> --ros-args -r /my_topic:=/renamed &
sleep 5
# domain-1 talker on the source name /my_topic (stock):
AGNOCAST_BRIDGE_MODE=off ROS_DOMAIN_ID=1 \
  ros2 launch agnocast_sample_application talker.launch.xml
```

Expected: the domain-2 listener receives the domain-1 talker's messages under the renamed topic — cross-domain delivery **with rename**, zero-copy, no bridge node. (The renamed cross-domain delivery itself is also proven deterministically by the KUnit case in method 1.)

Regression — the existing same-name path still works:

```bash
bash scripts/test/e2e_test_domain_bridge.bash
```

## Notes

- `[needs minor version update]`: extends the `ADD_DOMAIN_BRIDGE` ioctl struct (a second name). The bump lives with the domain-bridge stack; labeled `need-minor-update`.
- Service domain bridge is still out of scope (see the design doc): services are request/response topics, so the rule mechanism would extend, but full support is gated on the unimplemented A2R service bridge (Case 8) and dynamic rules for the per-client response topics (Case 2).
