### PR TITLE
feat(agnocast_kmod)[needs minor version update]: support cross-domain topic rename in the domain bridge

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -310,7 +310,9 @@ struct ioctl_set_ros2_publisher_num_args
 
 struct ioctl_add_domain_bridge_args
 {
-  struct name_info topic_name;
+  // topic_name_from / topic_name_to may differ (rename); equal for a plain bridge.
+  struct name_info topic_name_from;
+  struct name_info topic_name_to;
   uint32_t from_domain;
   uint32_t to_domain;
 };
@@ -486,8 +488,8 @@ int agnocast_ioctl_remove_bridge(
   const char * topic_name, const pid_t pid, bool is_r2a, const struct ipc_namespace * ipc_ns);
 
 int agnocast_ioctl_add_domain_bridge(
-  const char * topic_name, uint32_t from_domain, uint32_t to_domain,
-  const struct ipc_namespace * ipc_ns);
+  const char * topic_name_from, const char * topic_name_to, uint32_t from_domain,
+  uint32_t to_domain, const struct ipc_namespace * ipc_ns);
 
 int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret);
 
@@ -574,8 +576,8 @@ bool agnocast_is_in_topic_htable(const char * topic_name, const struct ipc_names
 bool agnocast_is_in_bridge_htable(const char * topic_name, const struct ipc_namespace * ipc_ns);
 pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_namespace * ipc_ns);
 bool agnocast_get_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
-  uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain,
+  uint32_t * domain_a, uint32_t * domain_b, bool * a_to_b, bool * b_to_a);
 // Returns the shared topic_struct's wrapper refcount for the wrapper in domain_id,
 // or 0 if no such wrapper exists. Used to observe domain-bridge grouping.
 int agnocast_topic_wrapper_refcnt(

--- a/agnocast_kmod/agnocast_exit.c
+++ b/agnocast_kmod/agnocast_exit.c
@@ -62,7 +62,8 @@ static void remove_all_domain_rules(void)
   hash_for_each_safe(domain_rule_htable, bkt, tmp, rule, node)
   {
     hash_del(&rule->node);
-    kfree(rule->topic_name);
+    kfree(rule->topic_name_a);
+    kfree(rule->topic_name_b);
     kfree(rule);
   }
 }

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -187,7 +187,11 @@ extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 // on adding one.
 struct domain_bridge_rule
 {
-  char * topic_name;
+  // Per-domain topic names. Equal when the rule does not rename; a rename pairs
+  // topic_name_a@domain_a with topic_name_b@domain_b. Delivery stays zero-copy
+  // either way -- only the two wrappers' keys differ.
+  char * topic_name_a;
+  char * topic_name_b;
   const struct ipc_namespace * ipc_ns;
   uint32_t domain_a;  // canonical ordering: domain_a < domain_b
   uint32_t domain_b;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -75,26 +75,31 @@ static struct topic_wrapper * find_topic_for_current(
 }
 
 static struct domain_bridge_rule * find_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns);
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id);
 
-// If a domain bridge rule pairs this domain with another whose wrapper already
-// exists, return that partner's topic_struct so the new wrapper can share it.
+// If a domain bridge rule pairs this cell (topic_name, domain_id) with another
+// whose wrapper already exists, return that partner's topic_struct so the new
+// wrapper can share it. The partner may use a different name (rename), so look it
+// up by the rule's name for the partner domain.
 static struct topic_struct * find_grouped_topic_struct(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
-  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns, domain_id);
   if (!rule) return NULL;
 
   uint32_t partner_domain;
+  const char * partner_name;
   if (domain_id == rule->domain_a) {
     partner_domain = rule->domain_b;
+    partner_name = rule->topic_name_b;
   } else if (domain_id == rule->domain_b) {
     partner_domain = rule->domain_a;
+    partner_name = rule->topic_name_a;
   } else {
     return NULL;
   }
 
-  struct topic_wrapper * partner = find_topic(topic_name, ipc_ns, partner_domain);
+  struct topic_wrapper * partner = find_topic(partner_name, ipc_ns, partner_domain);
   return partner ? partner->topic : NULL;
 }
 
@@ -165,7 +170,7 @@ static int add_topic(
     (*wrapper)->topic->ros2_subscriber_num = 0;
     (*wrapper)->topic->ros2_publisher_num = 0;
     (*wrapper)->topic->wrapper_refcnt = 1;
-    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns);
+    (*wrapper)->topic->rule = find_domain_rule(topic_name, ipc_ns, domain_id);
   }
   hash_add(topic_hashtable, &(*wrapper)->node, get_topic_hash(topic_name));
 
@@ -2167,14 +2172,19 @@ unlock:
   return ret;
 }
 
+// A rule is keyed by cell = (name, domain). Rules are few (one per bridged topic
+// pair), so a full scan is cheaper than maintaining a dual-name hash.
 static struct domain_bridge_rule * find_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
   struct domain_bridge_rule * rule;
-  uint32_t hash_val = full_name_hash(NULL, topic_name, strlen(topic_name));
-  hash_for_each_possible(domain_rule_htable, rule, node, hash_val)
+  int bkt;
+  hash_for_each(domain_rule_htable, bkt, rule, node)
   {
-    if (ipc_ns == rule->ipc_ns && strcmp(rule->topic_name, topic_name) == 0) {
+    if (ipc_ns != rule->ipc_ns) continue;
+    if (
+      (domain_id == rule->domain_a && strcmp(rule->topic_name_a, topic_name) == 0) ||
+      (domain_id == rule->domain_b && strcmp(rule->topic_name_b, topic_name) == 0)) {
       return rule;
     }
   }
@@ -2182,42 +2192,46 @@ static struct domain_bridge_rule * find_domain_rule(
 }
 
 int agnocast_ioctl_add_domain_bridge(
-  const char * topic_name, const uint32_t from_domain, const uint32_t to_domain,
-  const struct ipc_namespace * ipc_ns)
+  const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
+  const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
 {
   int ret = 0;
 
   if (from_domain == to_domain) return -EINVAL;
 
-  // Store the pair canonically (domain_a < domain_b), keeping direction only as the
-  // a_to_b / b_to_a flags: grouping (find_grouped_topic_struct) cares only about the pair,
-  // while direction is enforced at delivery (domain_delivery_allowed).
-  const uint32_t lo = from_domain < to_domain ? from_domain : to_domain;
-  const uint32_t hi = from_domain < to_domain ? to_domain : from_domain;
-  const bool lo_to_hi = (from_domain == lo);
+  // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
+  // (they differ on rename). Direction lives only in the a_to_b / b_to_a flags; grouping
+  // (find_grouped_topic_struct) pairs the two cells and delivery direction is enforced by
+  // domain_delivery_allowed.
+  const bool from_is_a = from_domain < to_domain;
+  const uint32_t domain_a = from_is_a ? from_domain : to_domain;
+  const uint32_t domain_b = from_is_a ? to_domain : from_domain;
+  const char * name_a = from_is_a ? topic_name_from : topic_name_to;
+  const char * name_b = from_is_a ? topic_name_to : topic_name_from;
 
   down_write(&global_htables_rwsem);
 
-  struct domain_bridge_rule * existing = find_domain_rule(topic_name, ipc_ns);
-  if (existing) {
-    // Re-declaring the same pair just adds the reverse direction. A third domain on a
-    // topic is rejected: the current implementation supports exactly one domain pair per
-    // topic (no fan-out such as 1->2 and 1->3 on the same topic). This is the one place
-    // that enforces it.
-    // TODO: support >2 domains per topic by storing a domain group instead of a fixed
-    // pair and grouping N wrappers onto one topic_struct.
-    if (existing->domain_a != lo || existing->domain_b != hi) {
+  // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
+  // exactly two cells. r_a == r_b (non-NULL) means an existing rule already pairs exactly
+  // these two cells -- a re-declaration or the reverse direction, so just OR in the
+  // direction. Any other overlap (a cell already paired with a different cell) is a
+  // fan-out and is rejected. This is the one place that enforces one pair per cell.
+  // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
+  struct domain_bridge_rule * r_a = find_domain_rule(name_a, ipc_ns, domain_a);
+  struct domain_bridge_rule * r_b = find_domain_rule(name_b, ipc_ns, domain_b);
+  if (r_a || r_b) {
+    if (r_a == r_b) {
+      r_a->a_to_b |= from_is_a;
+      r_a->b_to_a |= !from_is_a;
+    } else {
       ret = -EBUSY;
-      goto unlock;
     }
-    existing->a_to_b |= lo_to_hi;
-    existing->b_to_a |= !lo_to_hi;
     goto unlock;
   }
 
   // Grouping merges the two domains' id and entry_id spaces, which is only safe
   // before either side has allocated any; reject if an endpoint already joined.
-  if (find_topic(topic_name, ipc_ns, from_domain) || find_topic(topic_name, ipc_ns, to_domain)) {
+  if (find_topic(name_a, ipc_ns, domain_a) || find_topic(name_b, ipc_ns, domain_b)) {
     ret = -EBUSY;
     goto unlock;
   }
@@ -2227,23 +2241,27 @@ int agnocast_ioctl_add_domain_bridge(
     ret = -ENOMEM;
     goto unlock;
   }
-  rule->topic_name = kstrdup(topic_name, GFP_KERNEL);
-  if (!rule->topic_name) {
+  rule->topic_name_a = kstrdup(name_a, GFP_KERNEL);
+  rule->topic_name_b = kstrdup(name_b, GFP_KERNEL);
+  if (!rule->topic_name_a || !rule->topic_name_b) {
+    kfree(rule->topic_name_a);
+    kfree(rule->topic_name_b);
     kfree(rule);
     ret = -ENOMEM;
     goto unlock;
   }
   rule->ipc_ns = ipc_ns;
-  rule->domain_a = lo;
-  rule->domain_b = hi;
-  rule->a_to_b = lo_to_hi;
-  rule->b_to_a = !lo_to_hi;
+  rule->domain_a = domain_a;
+  rule->domain_b = domain_b;
+  rule->a_to_b = from_is_a;
+  rule->b_to_a = !from_is_a;
   INIT_HLIST_NODE(&rule->node);
-  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, topic_name, strlen(topic_name)));
+  // find_domain_rule scans every bucket, so the hash key is only for even distribution.
+  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
 
   dev_info(
-    agnocast_device, "Domain bridge rule added (topic=%s, %u->%u).\n", topic_name, from_domain,
-    to_domain);
+    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", topic_name_from, from_domain,
+    topic_name_to, to_domain);
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -3000,13 +3018,17 @@ static long add_domain_bridge_cmd(struct ioctl_add_domain_bridge_args __user * a
   struct ioctl_add_domain_bridge_args domain_bridge_args;
   if (copy_from_user(&domain_bridge_args, arg, sizeof(domain_bridge_args))) return -EFAULT;
 
-  char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  char from_name_buf[TOPIC_NAME_BUFFER_SIZE];
+  char to_name_buf[TOPIC_NAME_BUFFER_SIZE];
   int ret =
-    copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &domain_bridge_args.topic_name);
+    copy_name_from_user(from_name_buf, sizeof(from_name_buf), &domain_bridge_args.topic_name_from);
+  if (ret) return ret;
+  ret = copy_name_from_user(to_name_buf, sizeof(to_name_buf), &domain_bridge_args.topic_name_to);
   if (ret) return ret;
 
   return agnocast_ioctl_add_domain_bridge(
-    topic_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain, ipc_ns);
+    from_name_buf, to_name_buf, domain_bridge_args.from_domain, domain_bridge_args.to_domain,
+    ipc_ns);
 }
 
 static long remove_bridge_cmd(struct ioctl_remove_bridge_args __user * arg)
@@ -3437,11 +3459,11 @@ pid_t agnocast_get_bridge_owner_pid(const char * topic_name, const struct ipc_na
 }
 
 bool agnocast_get_domain_rule(
-  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t * domain_a,
-  uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
+  const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain,
+  uint32_t * domain_a, uint32_t * domain_b, bool * a_to_b, bool * b_to_a)
 {
   down_read(&global_htables_rwsem);
-  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns);
+  const struct domain_bridge_rule * rule = find_domain_rule(topic_name, ipc_ns, domain);
   bool found = rule != NULL;
   if (found) {
     *domain_a = rule->domain_a;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -8,6 +8,11 @@
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
+// A rename rule pairs two differently-named cells; RN_SRC lives in one domain and
+// RN_DST in the other.
+static const char * RN_SRC = "/kunit_test_domain_bridge_rename_src";
+static const char * RN_DST = "/kunit_test_domain_bridge_rename_dst";
+
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
 static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
@@ -22,32 +27,45 @@ static uint64_t setup_process_in_domain(
   return args.ret_addr;
 }
 
-static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+static topic_local_id_t add_publisher_named(
+  struct kunit * test, const pid_t pid, const char * topic_name)
 {
   union ioctl_add_publisher_args args;
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_publisher(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+      topic_name, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+    0);
+  return args.ret_id;
+}
+
+static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
+{
+  return add_publisher_named(test, pid, TOPIC_NAME);
+}
+
+static topic_local_id_t add_subscriber_named(
+  struct kunit * test, const pid_t pid, const char * topic_name)
+{
+  union ioctl_add_subscriber_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      topic_name, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
+      &args),
     0);
   return args.ret_id;
 }
 
 static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
 {
-  union ioctl_add_subscriber_args args;
-  KUNIT_ASSERT_EQ(
-    test,
-    agnocast_ioctl_add_subscriber(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
-      &args),
-    0);
-  return args.ret_id;
+  return add_subscriber_named(test, pid, TOPIC_NAME);
 }
 
 void test_case_add_domain_bridge_normal(struct kunit * test)
 {
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
 
   KUNIT_EXPECT_EQ(test, ret, 0);
 
@@ -55,7 +73,7 @@ void test_case_add_domain_bridge_normal(struct kunit * test)
   bool a_to_b = false, b_to_a = false;
   KUNIT_ASSERT_TRUE(
     test, agnocast_get_domain_rule(
-            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+            TOPIC_NAME, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
   KUNIT_EXPECT_EQ(test, domain_a, 1);
   KUNIT_EXPECT_EQ(test, domain_b, 2);
   KUNIT_EXPECT_TRUE(test, a_to_b);
@@ -64,7 +82,8 @@ void test_case_add_domain_bridge_normal(struct kunit * test)
 
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test)
 {
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 3, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
 }
 
@@ -73,15 +92,17 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
   // Re-declaring the same pair in reverse records the reverse direction on the
   // existing rule rather than creating a second one.
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
 
   uint32_t domain_a = 0, domain_b = 0;
   bool a_to_b = false, b_to_a = false;
   KUNIT_ASSERT_TRUE(
     test, agnocast_get_domain_rule(
-            TOPIC_NAME, current->nsproxy->ipc_ns, &domain_a, &domain_b, &a_to_b, &b_to_a));
+            TOPIC_NAME, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
   KUNIT_EXPECT_TRUE(test, a_to_b);
   KUNIT_EXPECT_TRUE(test, b_to_a);
 }
@@ -89,9 +110,11 @@ void test_case_add_domain_bridge_reverse_direction(struct kunit * test)
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
   // A different domain pair on the same topic is rejected (one pair per topic).
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 3, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
@@ -101,14 +124,16 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
   add_publisher_for(test, 1000);
 
   // The topic's domain-1 id space is already allocated, so grouping is unsafe.
-  int ret = agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+  int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
 void test_case_domain_bridge_groups_wrappers(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, 1000, 1);
   add_publisher_for(test, 1000);
@@ -123,7 +148,8 @@ void test_case_domain_bridge_groups_wrappers(struct kunit * test)
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   // publish resolves the wrapper by the caller's domain, so the caller and the
   // publisher are both in domain 1.
@@ -148,7 +174,8 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 {
   // Only 1 -> 2 is declared; the reverse direction must not deliver.
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
   const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
@@ -169,7 +196,8 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   // remove_publisher resolves the wrapper by the caller's domain, so the caller
   // is in domain 1 alongside the publisher being removed.
@@ -192,7 +220,8 @@ void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
@@ -209,7 +238,8 @@ void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, 1000, 1);
   add_publisher_for(test, 1000);
@@ -233,7 +263,8 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test)
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   add_publisher_for(test, current->tgid);
@@ -258,7 +289,8 @@ void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test)
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 2);
   add_subscriber_for(test, current->tgid);
@@ -280,7 +312,8 @@ void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test)
 void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns), 0);
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
 
   setup_process_in_domain(test, current->tgid, 1);
   const topic_local_id_t sub_id = add_subscriber_for(test, current->tgid);
@@ -300,4 +333,89 @@ void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit *
 
   KUNIT_EXPECT_EQ(test, receive_args.ret_pub_shm_num, (uint32_t)1);
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, (pid_t)1000);
+}
+
+// A rename rule pairs two differently-named cells onto one shared topic_struct:
+// the rule is found from either name, and the partner is resolved by the partner's
+// name (RN_SRC@1 and RN_DST@2 end up sharing a struct, refcnt 2).
+void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_named(test, 1001, RN_DST);
+
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_DST, current->nsproxy->ipc_ns, 2), 2);
+}
+
+// A domain-1 publication on the source name reaches the domain-2 subscriber on the
+// renamed target name (rule RN_SRC@1 -> RN_DST@2).
+void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_named(test, 1001, RN_DST);
+
+  union ioctl_publish_msg_args publish_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      RN_SRC, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+      ARRAY_SIZE(subscriber_ids_buf), &publish_args),
+    0);
+
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
+}
+
+// Renaming two different sources onto the same (name, domain) target is a 3-cell
+// fan-out and must be rejected (one pair per cell).
+void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test)
+{
+  const char * other_src = "/kunit_test_domain_bridge_rename_src2";
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+  // RN_DST@2 is already paired with RN_SRC@1; a second source onto it is rejected.
+  KUNIT_EXPECT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(other_src, RN_DST, 1, 2, current->nsproxy->ipc_ns),
+    -EBUSY);
+}
+
+// The bridged source need not be the only publisher: with a second publisher on the
+// source name and a native publisher on the (renamed) target name sharing the struct,
+// a domain-1 publication is still delivered exactly once to the domain-2 subscriber.
+void test_case_domain_bridge_rename_multi_publisher(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, RN_SRC);
+  // A second publisher on the source name, and a native publisher on the target name.
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1002, 2);
+  add_publisher_named(test, 1002, RN_DST);
+  setup_process_in_domain(test, 1001, 2);
+  const topic_local_id_t sub_d2 = add_subscriber_named(test, 1001, RN_DST);
+
+  union ioctl_publish_msg_args publish_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      RN_SRC, current->nsproxy->ipc_ns, pub_id, msg_addr, subscriber_ids_buf,
+      ARRAY_SIZE(subscriber_ids_buf), &publish_args),
+    0);
+
+  // Delivered exactly once to the domain-2 subscriber, regardless of the other publishers.
+  KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
+  KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -2,21 +2,25 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_DOMAIN_BRIDGE                                           \
-  KUNIT_CASE(test_case_add_domain_bridge_normal),                          \
-    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),          \
-    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),             \
-    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),         \
-    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists), \
-    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                   \
-    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),          \
-    KUNIT_CASE(test_case_domain_bridge_direction_respected),               \
-    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),       \
-    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),   \
-    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),          \
-    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),       \
-    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),        \
-    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher)
+#define TEST_CASES_DOMAIN_BRIDGE                                              \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                             \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),             \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),                \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),            \
+    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists),    \
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                      \
+    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),             \
+    KUNIT_CASE(test_case_domain_bridge_direction_respected),                  \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),          \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),      \
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),             \
+    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),          \
+    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),           \
+    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher), \
+    KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),               \
+    KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),         \
+    KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),               \
+    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -32,3 +36,7 @@ void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);
 void test_case_domain_bridge_get_subscriber_num_filtered(struct kunit * test);
 void test_case_domain_bridge_get_publisher_num_filtered(struct kunit * test);
 void test_case_domain_bridge_shm_info_skips_undelivered_publisher(struct kunit * test);
+void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test);
+void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
+void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
+void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -82,7 +82,9 @@ struct ioctl_get_version_args
 // Mirrors agnocast_kmod/agnocast.h so _IOW encodes the same size.
 struct ioctl_add_domain_bridge_args
 {
-  struct name_info topic_name;
+  // topic_name_from / topic_name_to may differ (rename); equal for a plain bridge.
+  struct name_info topic_name_from;
+  struct name_info topic_name_to;
   uint32_t from_domain;
   uint32_t to_domain;
 };

--- a/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
+++ b/src/agnocast_ioctl_wrapper/src/domain_bridge.cpp
@@ -34,7 +34,10 @@ int add_agnocast_domain_bridge_rule(
   }
 
   ioctl_add_domain_bridge_args args = {};
-  args.topic_name = {topic_name, strlen(topic_name)};
+  // Same-name bridge: source and target names are identical here. The distinct-target
+  // (rename) path is wired through the two-name form in a later PR.
+  args.topic_name_from = {topic_name, strlen(topic_name)};
+  args.topic_name_to = {topic_name, strlen(topic_name)};
   args.from_domain = from_domain;
   args.to_domain = to_domain;
 


### PR DESCRIPTION
## Description

Adds cross-domain **topic rename** to the domain bridge (kmod side). The bridge required identical topic names on both domains; this lets a rule map a source topic in one domain to a differently-named topic in the other (the ROS 2 `domain_bridge` `remap` target) — e.g. prefixing a sub-ECU topic so it can be logged under the main domain without a name collision.

The merged `topic_struct`, `domain_delivery_allowed`, and the refcnt lifetime are **name-agnostic and untouched**. The change is confined to rule matching:

- `domain_bridge_rule` stores a name **per domain** (`topic_name_a` / `topic_name_b`; equal when there's no rename).
- Rules are keyed by the **cell `(name, domain)`**; `find_grouped_topic_struct` resolves the partner by the **partner's** name.
- **Invariant in `add_domain_bridge`:** each cell belongs to at most one rule, and a rule pairs exactly two cells. `r_a == r_b` (non-NULL) → re-declaration / reverse direction; any other overlap — e.g. two sources remapped onto one target, or a 3-cell chain — → `-EBUSY`. The "rule before any endpoint" guard applies to both names.
- Same-name bridging is the special case `name_a == name_b`, so existing a2a and same-name bridge behavior is **byte-identical**.
- The `ADD_DOMAIN_BRIDGE` ioctl struct now carries a topic name per domain.

Base of the rename stack: **#1436 (this)** → #1443 (canonical notification MQ) → #1437 (userspace YAML `remap` → wrapper → ioctl).

## Related links

- Prior (merged) domain-bridge stack: #1417 (kmod) → #1418 (userspace).
- Rename stack (bottom-up): **#1436 (this)** → #1443 (canonical notification MQ) → #1437 (userspace `remap`).

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

KUnit: ran the full suite via the `kunit` CI path (`kunit.py --arch=x86_64` under QEMU) — **185/185 pass**, including 4 new rename cases:

- `test_case_domain_bridge_rename_groups_wrappers` — two differently-named cells share one `topic_struct`.
- `test_case_domain_bridge_rename_cross_domain_delivery` — `/src@1` publish reaches the `/dst@2` subscriber.
- `test_case_domain_bridge_rename_fanout_rejected` — two sources onto one target → `-EBUSY`.
- `test_case_domain_bridge_rename_multi_publisher` — an extra publisher on the source + a native publisher on the renamed target still deliver exactly once.

All pre-existing domain-bridge tests still pass (same-name backward compat). The `(required)` e2e / `run_requires_kernel_module` boxes are left for the run-build-test pass.

## Notes for reviewers

- kmod half of the rename, split from the (now-closed) single PR. The core sharing/lifetime code is unchanged; the diff is the rule table + matching + KUnit.
- The one-pair-per-cell invariant (`r_a == r_b` in `add_domain_bridge`) handles all the conflict cases uniformly — the main thing to sanity-check.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (the domain-bridge guide should note rename support)

## Version Update Label

`need-minor-update` — kmod internal ABI change (the `ADD_DOMAIN_BRIDGE` ioctl struct gains a per-domain name); reflected in the PR title.

