### PR TITLE
fix(agnocast_sample_application): graceful shutdown on service wait interruption

### DIFF
--- a/src/agnocast_sample_application/src/minimal_client.cpp
+++ b/src/agnocast_sample_application/src/minimal_client.cpp
@@ -26,6 +26,7 @@ int main(int argc, char * argv[])
   while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
+      spin_thread.join();
       return 0;
     }
     RCLCPP_INFO(node->get_logger(), "Service not available, waiting again...");

--- a/src/agnocast_sample_application/src/minimal_client.cpp
+++ b/src/agnocast_sample_application/src/minimal_client.cpp
@@ -27,6 +27,7 @@ int main(int argc, char * argv[])
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
       spin_thread.join();
+      rclcpp::shutdown();
       return 0;
     }
     RCLCPP_INFO(node->get_logger(), "Service not available, waiting again...");

--- a/src/agnocast_sample_application/src/no_rclcpp_client.cpp
+++ b/src/agnocast_sample_application/src/no_rclcpp_client.cpp
@@ -25,6 +25,7 @@ int main(int argc, char * argv[])
     if (!agnocast::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
       spin_thread.join();
+      agnocast::shutdown();
       return 0;
     }
     RCLCPP_INFO(node->get_logger(), "Service not available, waiting again...");

--- a/src/agnocast_sample_application/src/no_rclcpp_client.cpp
+++ b/src/agnocast_sample_application/src/no_rclcpp_client.cpp
@@ -21,8 +21,12 @@ int main(int argc, char * argv[])
   using ServiceT = agnocast_sample_interfaces::srv::SumIntArray;
   auto client = node->create_client<ServiceT>("sum_int_array");
 
-  // TODO(Koichi98): Add agnocast::ok() check here
   while (!client->wait_for_service(1s)) {
+    if (!agnocast::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
+      spin_thread.join();
+      return 0;
+    }
     RCLCPP_INFO(node->get_logger(), "Service not available, waiting again...");
   }
 


### PR DESCRIPTION
## Description

This PR improves the shutdown behavior of sample clients when they are waiting for the service. The change ensures that the `spin_thread` is properly joined before the application exits, preventing `std::terminate()` from being called.

As for `no_rclcpp_client`, a context check with `agnocast::ok()` is also added.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
