### PR TITLE
feat(agnocastlib): add vendored GenericService

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -54,7 +54,8 @@ add_library(agnocast SHARED
   src/bridge/agnocast_bridge_utils.cpp src/bridge/agnocast_service_bridge.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
-  src/node/diagnostic_updater/diagnostic_updater.cpp)
+  src/node/diagnostic_updater/diagnostic_updater.cpp
+  src/vendor/rclcpp/generic_service.cpp)
 
 ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_introspection_cpp)
 

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <rclcpp/expand_topic_or_service_name.hpp>
+#include <rclcpp/function_traits.hpp>
+#include <rclcpp/macros.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/service.hpp>
+#include <rcpputils/shared_library.hpp>
+#include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
+
+#include <rcl/node.h>
+#include <rcl/service.h>
+#include <rclcpp/version.h>
+#include <rmw/types.h>
+
+#include <memory>
+#include <type_traits>
+#include <variant>
+
+namespace agnocast::vendor_rclcpp
+{
+
+#if RCLCPP_VERSION_MAJOR < 28
+
+const rosidl_service_type_support_t * get_service_typesupport_handle(
+  const std::string & type, const std::string & typesupport_identifier,
+  rcpputils::SharedLibrary & library);
+
+#endif
+
+class GenericService;
+
+class GenericServiceCallback
+{
+  using BasicCallback = std::function<void(std::shared_ptr<void>, std::shared_ptr<void>)>;
+  using DeferredCallback = std::function<void(
+    std::shared_ptr<GenericService>, std::shared_ptr<rmw_request_id_t>, std::shared_ptr<void>)>;
+
+  std::variant<BasicCallback, DeferredCallback> callback_;
+
+public:
+  template <typename Func>
+  GenericServiceCallback(Func && callback)
+  {
+    if constexpr (::rclcpp::detail::can_be_nullptr<std::decay_t<Func>>::value) {
+      if (!callback) {
+        throw std::invalid_argument("GenericServiceCallback cannot be initialized with nullptr");
+      }
+    }
+
+    if constexpr (::rclcpp::function_traits::same_arguments<Func, BasicCallback>::value) {
+      callback_.template emplace<BasicCallback>(std::forward<Func>(callback));
+    } else if constexpr (::rclcpp::function_traits::same_arguments<Func, DeferredCallback>::value) {
+      callback_.template emplace<DeferredCallback>(std::forward<Func>(callback));
+    }
+  }
+
+  std::shared_ptr<void> dispatch(
+    const std::shared_ptr<GenericService> & service_handle,
+    const std::shared_ptr<rmw_request_id_t> & request_header, std::shared_ptr<void> request,
+    const std::function<std::shared_ptr<void>()> & create_response)
+  {
+    if (std::holds_alternative<BasicCallback>(callback_)) {
+      const auto & cb = std::get<BasicCallback>(callback_);
+      std::shared_ptr<void> response = create_response();
+      cb(std::move(request), response);
+      return response;
+    }
+
+    // deferred callback
+    const auto & cb = std::get<DeferredCallback>(callback_);
+    cb(service_handle, request_header, std::move(request));
+    return nullptr;
+  }
+};
+
+class GenericService : public ::rclcpp::ServiceBase,
+                       public std::enable_shared_from_this<GenericService>
+{
+public:
+  template <typename Func>
+  GenericService(
+    ::rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    Func && callback, const ::rclcpp::QoS & qos = ::rclcpp::ServicesQoS())
+  : ServiceBase(node->get_node_base_interface()->get_shared_rcl_node_handle()),
+    any_callback_(std::forward<Func>(callback)),
+    service_name_(node->get_node_services_interface()->resolve_service_name(service_name))
+  {
+    static const std::string ts_identifier = "rosidl_typesupport_cpp";
+    static const std::string ts_introspection_identifier = "rosidl_typesupport_introspection_cpp";
+
+    const std::string request_type = service_type + "_Request";
+    const std::string response_type = service_type + "_Response";
+
+    const rosidl_service_type_support_t * service_ts = nullptr;
+    try {
+      ts_lib_ = ::rclcpp::get_typesupport_library(service_type, ts_identifier);
+      ts_lib_introspection_ =
+        ::rclcpp::get_typesupport_library(service_type, ts_introspection_identifier);
+
+#if RCLCPP_VERSION_MAJOR >= 28
+      service_ts = ::rclcpp::get_service_typesupport_handle(service_type, ts_identifier, *ts_lib_);
+
+      const rosidl_message_type_support_t * request_ts = ::rclcpp::get_message_typesupport_handle(
+        request_type, ts_introspection_identifier, *ts_lib_introspection_);
+      const rosidl_message_type_support_t * response_ts = ::rclcpp::get_message_typesupport_handle(
+        response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#else
+      service_ts = get_service_typesupport_handle(service_type, ts_identifier, *ts_lib_);
+
+      const rosidl_message_type_support_t * request_ts = ::rclcpp::get_typesupport_handle(
+        request_type, ts_introspection_identifier, *ts_lib_introspection_);
+      const rosidl_message_type_support_t * response_ts = ::rclcpp::get_typesupport_handle(
+        response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#endif
+
+      request_members_ =
+        static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(request_ts->data);
+      response_members_ = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+        response_ts->data);
+    } catch (std::runtime_error & err) {
+      RCLCPP_ERROR(
+        node_logger_.get_child("agnocast.rclcpp"), "Invalid service type: %s", err.what());
+      throw;
+    }
+
+    service_handle_ =
+      std::shared_ptr<rcl_service_t>(new rcl_service_t, [this](rcl_service_t * service) {
+        if (rcl_service_fini(service, node_handle_.get()) != RCL_RET_OK) {
+          RCLCPP_ERROR(
+            node_logger_.get_child("agnocast.rclcpp"),
+            "Error in destruction of rcl service handle '%s': %s", service_name_.c_str(),
+            rcl_get_error_string().str);
+          rcl_reset_error();
+        }
+        delete service;
+      });
+    *service_handle_.get() = rcl_get_zero_initialized_service();
+
+    rcl_service_options_t service_options = rcl_service_get_default_options();
+    service_options.qos = qos.get_rmw_qos_profile();
+
+    rcl_ret_t ret = rcl_service_init(
+      service_handle_.get(), node_handle_.get(), service_ts, service_name.c_str(),
+      &service_options);
+    if (ret != RCL_RET_OK) {
+      if (ret == RCL_RET_SERVICE_NAME_INVALID) {
+        auto rcl_node_handle = get_rcl_node_handle();
+        // this will throw on any validation problem
+        rcl_reset_error();
+        ::rclcpp::expand_topic_or_service_name(
+          service_name, rcl_node_get_name(rcl_node_handle), rcl_node_get_namespace(rcl_node_handle),
+          true);
+      }
+
+      ::rclcpp::exceptions::throw_from_rcl_error(ret, "could not create service");
+    }
+  }
+
+  template <typename Func>
+  static std::shared_ptr<GenericService> create_generic_service(
+    ::rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    Func && callback, const ::rclcpp::QoS & qos = ::rclcpp::ServicesQoS(),
+    const ::rclcpp::CallbackGroup::SharedPtr & group = nullptr)
+  {
+    auto service = std::make_shared<GenericService>(
+      node, service_name, service_type, std::forward<Func>(callback), qos);
+
+    std::shared_ptr<::rclcpp::ServiceBase> base_sp = service;
+    node->get_node_services_interface()->add_service(std::move(base_sp), group);
+
+    return service;
+  }
+
+  GenericService() = delete;
+  virtual ~GenericService() = default;
+
+  // --- rclcpp::ServiceBase overrides (driven by the executor) ---
+  std::shared_ptr<void> create_request() override;
+  std::shared_ptr<rmw_request_id_t> create_request_header() override;
+  void handle_request(
+    std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<void> request) override;
+
+  std::shared_ptr<void> create_response();
+
+  void send_response(rmw_request_id_t & req_id, std::shared_ptr<void> & response);
+
+private:
+  RCLCPP_DISABLE_COPY(GenericService)
+
+  GenericServiceCallback any_callback_;
+
+  std::string service_name_;
+
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * request_members_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_;
+};
+
+}  // namespace agnocast::vendor_rclcpp

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
@@ -14,6 +14,9 @@
 //
 // This file has been modified from the original.
 
+// GenericService is not available in ROS 2 Humble/Jazzy, so it is vendored here to implement
+// Agnocast's service bridging feature.
+
 #pragma once
 
 #include <rclcpp/expand_topic_or_service_name.hpp>

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file has been modified from the original.
+
 #pragma once
 
 #include <rclcpp/expand_topic_or_service_name.hpp>

--- a/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
@@ -28,15 +28,15 @@ namespace
 
 std::string string_trim(std::string_view str_v)
 {
-  auto begin =
+  const auto * begin =
     std::find_if_not(str_v.begin(), str_v.end(), [](unsigned char ch) { return std::isspace(ch); });
-  auto end = std::find_if_not(str_v.rbegin(), str_v.rend(), [](unsigned char ch) {
-               return std::isspace(ch);
-             }).base();
+  const auto * end = std::find_if_not(str_v.rbegin(), str_v.rend(), [](unsigned char ch) {
+                       return std::isspace(ch);
+                     }).base();
   if (begin >= end) {
     return {};
   }
-  return std::string(begin, end);
+  return {begin, end};
 }
 
 std::tuple<std::string, std::string, std::string> extract_type_identifier(
@@ -53,7 +53,7 @@ std::tuple<std::string, std::string, std::string> extract_type_identifier(
   }
 
   std::string package_name = full_type.substr(0, sep_position_front);
-  std::string middle_module = "";
+  std::string middle_module;
   if (sep_position_back - sep_position_front > 0) {
     middle_module =
       full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
@@ -119,10 +119,10 @@ std::shared_ptr<void> GenericService::create_request()
 {
   void * request = new uint8_t[request_members_->size_of_];
   request_members_->init_function(request, rosidl_runtime_cpp::MessageInitialization::ZERO);
-  return std::shared_ptr<void>(request, [this](void * p) {
-    request_members_->fini_function(p);
-    delete[] reinterpret_cast<uint8_t *>(p);
-  });
+  return {request, [this](void * p) {
+            request_members_->fini_function(p);
+            delete[] static_cast<uint8_t *>(p);  // NOLINT(cppcoreguidelines-owning-memory)
+          }};
 }
 
 std::shared_ptr<rmw_request_id_t> GenericService::create_request_header()
@@ -145,10 +145,10 @@ std::shared_ptr<void> GenericService::create_response()
 {
   void * response = new uint8_t[response_members_->size_of_];
   response_members_->init_function(response, rosidl_runtime_cpp::MessageInitialization::ZERO);
-  return std::shared_ptr<void>(response, [this](void * p) {
-    response_members_->fini_function(p);
-    delete[] reinterpret_cast<uint8_t *>(p);
-  });
+  return {response, [this](void * p) {
+            response_members_->fini_function(p);
+            delete[] static_cast<uint8_t *>(p);  // NOLINT(cppcoreguidelines-owning-memory)
+          }};
 }
 
 void GenericService::send_response(rmw_request_id_t & req_id, std::shared_ptr<void> & response)

--- a/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
@@ -164,7 +164,7 @@ void GenericService::send_response(rmw_request_id_t & req_id, std::shared_ptr<vo
     return;
   }
   if (ret != RCL_RET_OK) {
-    ::rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send rensponse");
+    ::rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
   }
 }
 

--- a/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file has been modified from the original.
+
 #include "agnocast/vendor/rclcpp/generic_service.hpp"
 
 #include <rclcpp/exceptions.hpp>

--- a/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_service.cpp
@@ -1,0 +1,155 @@
+#include "agnocast/vendor/rclcpp/generic_service.hpp"
+
+#include <rclcpp/exceptions.hpp>
+
+namespace agnocast::vendor_rclcpp
+{
+
+#if RCLCPP_VERSION_MAJOR < 28
+
+namespace
+{
+
+std::string string_trim(std::string_view str_v)
+{
+  auto begin =
+    std::find_if_not(str_v.begin(), str_v.end(), [](unsigned char ch) { return std::isspace(ch); });
+  auto end = std::find_if_not(str_v.rbegin(), str_v.rend(), [](unsigned char ch) {
+               return std::isspace(ch);
+             }).base();
+  if (begin >= end) {
+    return {};
+  }
+  return std::string(begin, end);
+}
+
+std::tuple<std::string, std::string, std::string> extract_type_identifier(
+  const std::string & full_type)
+{
+  char type_separator = '/';
+  auto sep_position_back = full_type.find_last_of(type_separator);
+  auto sep_position_front = full_type.find_first_of(type_separator);
+  if (
+    sep_position_back == std::string::npos || sep_position_front == 0 || sep_position_back == 0 ||
+    sep_position_back == full_type.length() - 1) {
+    throw std::runtime_error(
+      "Message type is not of the form package/type and cannot be processed");
+  }
+
+  std::string package_name = full_type.substr(0, sep_position_front);
+  std::string middle_module = "";
+  if (sep_position_back - sep_position_front > 0) {
+    middle_module =
+      full_type.substr(sep_position_front + 1, sep_position_back - sep_position_front - 1);
+  }
+  std::string type_name = full_type.substr(sep_position_back + 1);
+
+  return std::make_tuple(
+    string_trim(package_name), string_trim(middle_module), string_trim(type_name));
+}
+
+const void * get_typesupport_handle_impl(
+  const std::string & type, const std::string & typesupport_identifier,
+  const std::string & typesupport_name, const std::string & symbol_part_name,
+  const std::string & middle_module_additional, rcpputils::SharedLibrary & library)
+{
+  std::string package_name;
+  std::string middle_module;
+  std::string type_name;
+  std::tie(package_name, middle_module, type_name) = extract_type_identifier(type);
+
+  if (middle_module.empty()) {
+    middle_module = middle_module_additional;
+  }
+
+  auto mk_error = [&package_name, &type_name, &typesupport_name](auto reason) {
+    std::stringstream rcutils_dynamic_loading_error;
+    rcutils_dynamic_loading_error << "Something went wrong loading the typesupport library for "
+                                  << typesupport_name << " type " << package_name << "/"
+                                  << type_name << ". " << reason;
+    return rcutils_dynamic_loading_error.str();
+  };
+
+  try {
+    std::string symbol_name = typesupport_identifier + symbol_part_name + package_name + "__" +
+                              middle_module + "__" + type_name;
+    const void * (*get_ts)() = nullptr;
+    // This will throw runtime_error if the symbol was not found.
+    get_ts = reinterpret_cast<decltype(get_ts)>(library.get_symbol(symbol_name));
+    return get_ts();
+  } catch (std::runtime_error &) {
+    throw std::runtime_error{mk_error("Library could not be found.")};
+  }
+}
+
+}  // namespace
+
+const rosidl_service_type_support_t * get_service_typesupport_handle(
+  const std::string & type, const std::string & typesupport_identifier,
+  rcpputils::SharedLibrary & library)
+{
+  static const std::string typesupport_name = "service";
+  static const std::string symbol_part_name = "__get_service_type_support_handle__";
+  static const std::string middle_module_additional = "srv";
+
+  return static_cast<const rosidl_service_type_support_t *>(get_typesupport_handle_impl(
+    type, typesupport_identifier, typesupport_name, symbol_part_name, middle_module_additional,
+    library));
+}
+
+#endif
+
+std::shared_ptr<void> GenericService::create_request()
+{
+  void * request = new uint8_t[request_members_->size_of_];
+  request_members_->init_function(request, rosidl_runtime_cpp::MessageInitialization::ZERO);
+  return std::shared_ptr<void>(request, [this](void * p) {
+    request_members_->fini_function(p);
+    delete[] reinterpret_cast<uint8_t *>(p);
+  });
+}
+
+std::shared_ptr<rmw_request_id_t> GenericService::create_request_header()
+{
+  return std::make_shared<rmw_request_id_t>();
+}
+
+void GenericService::handle_request(
+  std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<void> request)
+{
+  std::shared_ptr<void> response = any_callback_.dispatch(
+    this->shared_from_this(), request_header, std::move(request),
+    [this]() { return create_response(); });
+  if (response) {
+    send_response(*request_header, response);
+  }
+}
+
+std::shared_ptr<void> GenericService::create_response()
+{
+  void * response = new uint8_t[response_members_->size_of_];
+  response_members_->init_function(response, rosidl_runtime_cpp::MessageInitialization::ZERO);
+  return std::shared_ptr<void>(response, [this](void * p) {
+    response_members_->fini_function(p);
+    delete[] reinterpret_cast<uint8_t *>(p);
+  });
+}
+
+void GenericService::send_response(rmw_request_id_t & req_id, std::shared_ptr<void> & response)
+{
+  rcl_ret_t ret = rcl_send_response(get_service_handle().get(), &req_id, response.get());
+
+  if (ret == RCL_RET_TIMEOUT) {
+    RCLCPP_WARN(
+      node_logger_.get_child("agnocast.rclcpp"),
+      "failed to send response in service '%s' (timeout): %s", this->get_service_name(),
+      rcl_get_error_string().str);
+    rcl_reset_error();
+    return;
+  }
+  if (ret != RCL_RET_OK) {
+    ::rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send rensponse");
+  }
+}
+
+}  // namespace agnocast::vendor_rclcpp


### PR DESCRIPTION
## Description

This PR vendors `GenericService` from rclcpp. Although `GenericService` exists in the latest rclcpp, it is not available in the versions of ROS 2 Humble or Jazzy. We need it to implement generic service bridging in the near future, so we have decided to vendor it. It is located within the `agnocast::vendor_rclcpp` namespace. Much of the implementation is taken directly from `rclcpp`, with a few minor refactorings to align it with Agnocast's conventions.

### Key differences from upstrem

1. **Simplified callback model.** The number of callback variants is reduced from 5 to 2 (`BasicCallback` + `DeferredCallback`), similar to Agnocast's `Service`.
2. **Factory function.** In order to pack everything inside the `GenericService` class, the factory function (`create_generic_service()`) is defined as a static member function of `GenericService`.
3. **Introspection loading.** The way of loading introspection is changed to make it work with both Humble and Jazzy.
4. **Tracing removed.** No `tracetools` dependency.

## Related links

The implementation of `GenericService` in rclcpp:

- https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/generic_service.hpp
- https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/generic_service.cpp

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

I used a client and a generic server to verify that they work as expected. The source code is available at the `bdm-k/vendored-generic-service-test` branch.

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
