### PR TITLE
fix: avoid duplicate agnocast performance bridge node names

### DIFF
--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstdlib>
 
 namespace agnocast
 {
@@ -75,7 +76,11 @@ void PerformanceBridgeManager::run()
 
 void PerformanceBridgeManager::start_ros_execution()
 {
-  std::string node_name = "agnocast_bridge_node_performance";
+  std::string node_name =
+    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_);
+  if (const char * ros_domain_id = std::getenv("ROS_DOMAIN_ID")) {
+    node_name += "_d" + std::string(ros_domain_id);
+  }
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -76,8 +76,8 @@ void PerformanceBridgeManager::run()
 void PerformanceBridgeManager::start_ros_execution()
 {
   std::string node_name =
-    "agnocast_bridge_node_performance_" + std::to_string(getpid());
-  container_node_ = std::make_shared<rclcpp::Node>(node_name);
+    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_) + "_" +
+    std::to_string(getpid());
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges
   // require two callback groups to execute concurrently. If a single-threaded executor is used, it

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -12,7 +12,6 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <cstdlib>
 
 namespace agnocast
 {
@@ -77,10 +76,7 @@ void PerformanceBridgeManager::run()
 void PerformanceBridgeManager::start_ros_execution()
 {
   std::string node_name =
-    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_);
-  if (const char * ros_domain_id = std::getenv("ROS_DOMAIN_ID")) {
-    node_name += "_d" + std::string(ros_domain_id);
-  }
+    "agnocast_bridge_node_performance_" + std::to_string(getpid());
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges


### PR DESCRIPTION
## Description
With the launch of Autoware’s multi-container architecture, `agnocast_bridge_node_performance` is running in each Docker container; however, since all node names are fixed, this triggers a duplicate detection.
To resolve this issue, we will add the PID to the node name so that it is no longer flagged as a duplicate.

## Related links
[internal link](https://tier4.atlassian.net/browse/T4DEV-55875)

## How was this PR tested?
Update https://evaluation.ci.tier4.jp/evaluation/reports/154d03f5-0d53-57a9-9f4e-671d1c988079?project_id=x2_dev
via OTA, and
```
ros2 topic echo /diagnostics | grep -A 12 -B 6 “Error: Duplicated nodes detected”
```

and verify that it does not appear in the “duplicated” list.

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
