### PR TITLE
feat(agnocast_kmod, agnocastlib)[needs minor version update]: notify renamed cross-domain subscribers on the canonical MQ

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -66,6 +66,10 @@ union ioctl_add_subscriber_args {
   struct
   {
     topic_local_id_t ret_id;
+    // Topic name to use for the publish-notification MQ. Equal to the requested topic for a plain
+    // topic, but for a domain-bridged (incl. renamed) topic it is the pair's canonical name, so a
+    // publisher and a renamed subscriber that share one topic_struct derive the same MQ name.
+    char ret_mq_topic_name[TOPIC_NAME_BUFFER_SIZE];
   };
 };
 
@@ -81,6 +85,8 @@ union ioctl_add_publisher_args {
   struct
   {
     topic_local_id_t ret_id;
+    // See ioctl_add_subscriber_args::ret_mq_topic_name.
+    char ret_mq_topic_name[TOPIC_NAME_BUFFER_SIZE];
   };
 };
 

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -24,6 +24,14 @@ int has_new_pid;
 
 struct tracepoint * tp_sched_process_exit;
 
+// The topic name a topic's endpoints notify on. Endpoints of a bridged (incl. renamed) topic share
+// one topic_struct but keep their own per-domain names, so return the rule's canonical name -- a
+// publisher and a renamed subscriber then derive the same publish-notification MQ name.
+const char * agnocast_notify_mq_topic_name(const struct topic_wrapper * wrapper)
+{
+  return wrapper->topic->rule ? wrapper->topic->rule->topic_name_a : wrapper->key;
+}
+
 static void pre_handler_subscriber_exit(
   struct topic_wrapper * wrapper, const pid_t pid, struct process_info * proc_info)
 {
@@ -47,7 +55,8 @@ static void pre_handler_subscriber_exit(
       struct exit_subscription_entry * exit_entry =
         kmalloc(sizeof(struct exit_subscription_entry), GFP_KERNEL);
       if (exit_entry) {
-        strscpy(exit_entry->topic_name, wrapper->key, TOPIC_NAME_BUFFER_SIZE);
+        strscpy(
+          exit_entry->topic_name, agnocast_notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
         exit_entry->subscriber_id = subscriber_id;
         list_add_tail(&exit_entry->list, &proc_info->exit_subscription_list);
         proc_info->exit_subscription_count++;

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -233,6 +233,10 @@ bool agnocast_wrapper_has_domain_endpoints(const struct topic_wrapper * wrapper)
 
 bool agnocast_is_referenced(struct entry_node * en);
 
+// The canonical topic name whose publish-notification MQ this wrapper's endpoints use. Shared
+// between registration (returned to userspace) and exit cleanup so both derive the same MQ name.
+const char * agnocast_notify_mq_topic_name(const struct topic_wrapper * wrapper);
+
 struct process_info * agnocast_find_process_info(const pid_t pid);
 
 void agnocast_free_exit_subscription_list(struct process_info * proc_info);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -706,6 +706,14 @@ unlock:
   return ret;
 }
 
+// The topic name a topic's endpoints notify on. Endpoints of a bridged (incl. renamed) topic share
+// one topic_struct but keep their own per-domain names, so return the rule's canonical name -- a
+// publisher and a renamed subscriber then derive the same publish-notification MQ name.
+static const char * notify_mq_topic_name(const struct topic_wrapper * wrapper)
+{
+  return wrapper->topic->rule ? wrapper->topic->rule->topic_name_a : wrapper->key;
+}
+
 int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
@@ -731,6 +739,7 @@ int agnocast_ioctl_add_subscriber(
   }
 
   ioctl_ret->ret_id = sub_info->id;
+  strscpy(ioctl_ret->ret_mq_topic_name, notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -760,6 +769,7 @@ int agnocast_ioctl_add_publisher(
   }
 
   ioctl_ret->ret_id = pub_info->id;
+  strscpy(ioctl_ret->ret_mq_topic_name, notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
 
   // set true to subscriber_info.need_mmap_update to notify
   struct subscriber_info * sub_info;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -706,14 +706,6 @@ unlock:
   return ret;
 }
 
-// The topic name a topic's endpoints notify on. Endpoints of a bridged (incl. renamed) topic share
-// one topic_struct but keep their own per-domain names, so return the rule's canonical name -- a
-// publisher and a renamed subscriber then derive the same publish-notification MQ name.
-static const char * notify_mq_topic_name(const struct topic_wrapper * wrapper)
-{
-  return wrapper->topic->rule ? wrapper->topic->rule->topic_name_a : wrapper->key;
-}
-
 int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
   const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
@@ -739,7 +731,8 @@ int agnocast_ioctl_add_subscriber(
   }
 
   ioctl_ret->ret_id = sub_info->id;
-  strscpy(ioctl_ret->ret_mq_topic_name, notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
+  strscpy(
+    ioctl_ret->ret_mq_topic_name, agnocast_notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
 
 unlock:
   up_write(&global_htables_rwsem);
@@ -769,7 +762,8 @@ int agnocast_ioctl_add_publisher(
   }
 
   ioctl_ret->ret_id = pub_info->id;
-  strscpy(ioctl_ret->ret_mq_topic_name, notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
+  strscpy(
+    ioctl_ret->ret_mq_topic_name, agnocast_notify_mq_topic_name(wrapper), TOPIC_NAME_BUFFER_SIZE);
 
   // set true to subscriber_info.need_mmap_update to notify
   struct subscriber_info * sub_info;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 #include <linux/delay.h>
+#include <linux/mm.h>
+#include <linux/string.h>
 
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
@@ -450,4 +452,51 @@ void test_case_domain_bridge_rename_notify_uses_canonical_name(struct kunit * te
   // and the renamed subscriber on RN_DST@2 both report RN_SRC as their notification MQ topic.
   KUNIT_EXPECT_STREQ(test, pub_args.ret_mq_topic_name, RN_SRC);
   KUNIT_EXPECT_STREQ(test, sub_args.ret_mq_topic_name, RN_SRC);
+}
+
+// A renamed subscriber opens its notification MQ under the canonical (domain_a) name, so the
+// exit-cleanup record the daemon later unlinks must carry that same canonical name -- not the
+// subscriber's own per-domain name -- otherwise a crashed renamed subscriber's MQ leaks.
+void test_case_domain_bridge_rename_exit_cleanup_uses_canonical_name(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  add_publisher_named(test, current->tgid, RN_SRC);
+
+  const pid_t subscriber_pid = 1001;
+  setup_process_in_domain(test, subscriber_pid, 2);
+  const topic_local_id_t sub_id = add_subscriber_named(test, subscriber_pid, RN_DST);
+
+  agnocast_enqueue_exit_pid(subscriber_pid);
+  msleep(20);  // let exit_worker_thread record the subscription MQ
+
+  struct ioctl_get_exit_process_args get_exit_args;
+  const uint32_t buf_size = 4;
+  struct exit_subscription_mq_info * mq_info_buf =
+    kvcalloc(buf_size, sizeof(*mq_info_buf), GFP_KERNEL);
+  KUNIT_ASSERT_NOT_NULL(test, mq_info_buf);
+
+  memset(&get_exit_args, 0, sizeof(get_exit_args));
+  pid_t global_pid = -1;
+  KUNIT_EXPECT_EQ(
+    test,
+    agnocast_ioctl_get_exit_process(
+      current->nsproxy->ipc_ns, &get_exit_args, mq_info_buf, buf_size, &global_pid),
+    0);
+
+  KUNIT_EXPECT_EQ(test, get_exit_args.ret_pid, subscriber_pid);
+  KUNIT_EXPECT_EQ(test, (int)get_exit_args.ret_subscription_mq_info_num, 1);
+  // domain_a is the lower domain (1), so the daemon must unlink the MQ under the canonical name
+  // RN_SRC -- the name the renamed subscriber opened it under -- not its own name RN_DST.
+  KUNIT_EXPECT_STREQ(test, mq_info_buf[0].topic_name, RN_SRC);
+  KUNIT_EXPECT_EQ(test, mq_info_buf[0].subscriber_id, sub_id);
+
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(
+    current->nsproxy->ipc_ns, global_pid, get_exit_args.ret_subscription_mq_info_num,
+    &daemon_should_exit);
+
+  kvfree(mq_info_buf);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -419,3 +419,35 @@ void test_case_domain_bridge_rename_multi_publisher(struct kunit * test)
   KUNIT_EXPECT_EQ(test, publish_args.ret_subscriber_num, (uint32_t)1);
   KUNIT_EXPECT_EQ(test, subscriber_ids_buf[0], sub_d2);
 }
+
+void test_case_domain_bridge_rename_notify_uses_canonical_name(struct kunit * test)
+{
+  // Both endpoints of a renamed pair must derive the same publish-notification MQ name -- the
+  // pair's canonical (domain_a) name -- even though they publish/subscribe under different
+  // per-domain names. Otherwise the userspace publisher and the renamed subscriber open different
+  // MQs and the subscriber is never notified.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  setup_process_in_domain(test, current->tgid, 1);
+  union ioctl_add_publisher_args pub_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      RN_SRC, current->nsproxy->ipc_ns, "/kunit_node", current->tgid, 1, false, false, &pub_args),
+    0);
+
+  setup_process_in_domain(test, 1001, 2);
+  union ioctl_add_subscriber_args sub_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      RN_DST, current->nsproxy->ipc_ns, "/kunit_node", 1001, 1, false, true, false, false, false,
+      &sub_args),
+    0);
+
+  // domain_a is the lower domain (1), so the canonical name is RN_SRC: the publisher on RN_SRC@1
+  // and the renamed subscriber on RN_DST@2 both report RN_SRC as their notification MQ topic.
+  KUNIT_EXPECT_STREQ(test, pub_args.ret_mq_topic_name, RN_SRC);
+  KUNIT_EXPECT_STREQ(test, sub_args.ret_mq_topic_name, RN_SRC);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -21,7 +21,8 @@
     KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),         \
     KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),               \
     KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher),               \
-    KUNIT_CASE(test_case_domain_bridge_rename_notify_uses_canonical_name)
+    KUNIT_CASE(test_case_domain_bridge_rename_notify_uses_canonical_name),    \
+    KUNIT_CASE(test_case_domain_bridge_rename_exit_cleanup_uses_canonical_name)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -42,3 +43,4 @@ void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
 void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
 void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);
 void test_case_domain_bridge_rename_notify_uses_canonical_name(struct kunit * test);
+void test_case_domain_bridge_rename_exit_cleanup_uses_canonical_name(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -20,7 +20,8 @@
     KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),               \
     KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),         \
     KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),               \
-    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
+    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher),               \
+    KUNIT_CASE(test_case_domain_bridge_rename_notify_uses_canonical_name)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -40,3 +41,4 @@ void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
 void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
 void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);
+void test_case_domain_bridge_rename_notify_uses_canonical_name(struct kunit * test);

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -85,6 +85,10 @@ union ioctl_add_subscriber_args {
   struct
   {
     topic_local_id_t ret_id;
+    // Topic name to use for the publish-notification MQ: the requested topic for a plain topic, or
+    // the domain-bridge pair's canonical name for a bridged (incl. renamed) topic, so a publisher
+    // and a renamed subscriber sharing one topic_struct derive the same MQ name.
+    char ret_mq_topic_name[TOPIC_NAME_BUFFER_SIZE];
   };
 };
 #pragma GCC diagnostic pop
@@ -103,6 +107,8 @@ union ioctl_add_publisher_args {
   struct
   {
     topic_local_id_t ret_id;
+    // See ioctl_add_subscriber_args::ret_mq_topic_name.
+    char ret_mq_topic_name[TOPIC_NAME_BUFFER_SIZE];
   };
 };
 #pragma GCC diagnostic pop

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -26,10 +26,11 @@ const void * get_node_base_address(Node * node);
 // These are cut out of the class for information hiding.
 topic_local_id_t initialize_publisher(
   const std::string & topic_name, const std::string & node_name, const rclcpp::QoS & qos,
-  const bool is_bridge, const std::string & type_name);
+  const bool is_bridge, const std::string & type_name, std::string & out_mq_topic_name);
 union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle, /* for CARET */ const std::string & topic_name,
-  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
+  const std::string & mq_topic_name, const topic_local_id_t publisher_id,
+  const uint64_t msg_virtual_address,
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> & opened_mqs);
 uint32_t get_subscription_count_core(const std::string & topic_name);
 uint32_t get_intra_subscription_count_core(const std::string & topic_name);
@@ -85,6 +86,10 @@ class PublisherBase
 protected:
   topic_local_id_t id_ = -1;
   std::string topic_name_;
+  // Topic name for the publish-notification MQ (returned by the kmod). Differs from topic_name_
+  // only for a domain-bridged/renamed topic, where it is the pair's canonical name so a publisher
+  // and a renamed subscriber derive the same MQ name.
+  std::string mq_topic_name_;
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> opened_mqs_;
   std::mutex opened_mqs_mtx_;
   rmw_gid_t gid_;
@@ -228,7 +233,8 @@ public:
     union ioctl_publish_msg_args publish_msg_args;
     {
       std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
-      publish_msg_args = publish_core(this, topic_name_, id_, msg_virtual_address, opened_mqs_);
+      publish_msg_args =
+        publish_core(this, topic_name_, mq_topic_name_, id_, msg_virtual_address, opened_mqs_);
     }
 
     for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {
@@ -307,7 +313,8 @@ public:
     union ioctl_publish_msg_args publish_msg_args;
     {
       std::lock_guard<std::mutex> lock(opened_mqs_mtx_);
-      publish_msg_args = publish_core(this, topic_name_, id_, msg_virtual_address, opened_mqs_);
+      publish_msg_args =
+        publish_core(this, topic_name_, mq_topic_name_, id_, msg_virtual_address, opened_mqs_);
     }
 
     for (uint32_t i = 0; i < publish_msg_args.ret_released_num; i++) {

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -104,6 +104,10 @@ class SubscriptionBase
 protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
+  // Topic name for the publish-notification MQ (returned by the kmod). Differs from topic_name_
+  // only for a domain-bridged/renamed topic, where it is the pair's canonical name so a publisher
+  // and a renamed subscriber derive the same MQ name.
+  std::string mq_topic_name_;
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     SubscriptionRole role, const std::string & node_name, const std::string & type_name);
@@ -170,7 +174,7 @@ class Subscription : public SubscriptionBase
 
     const rclcpp::QoS actual_qos = init_base(node, qos, type_name, false, options, role);
 
-    mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
+    mqd_t mq = open_mq_for_subscription(mq_topic_name_, id_, mq_subscription_);
 
     const bool is_transient_local =
       actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -53,7 +53,7 @@ void decrement_borrowed_publisher_num()
 
 topic_local_id_t initialize_publisher(
   const std::string & topic_name, const std::string & node_name, const rclcpp::QoS & qos,
-  const bool is_bridge, const std::string & type_name)
+  const bool is_bridge, const std::string & type_name, std::string & out_mq_topic_name)
 {
   validate_ld_preload();
 
@@ -76,12 +76,15 @@ topic_local_id_t initialize_publisher(
     exit(EXIT_FAILURE);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+  out_mq_topic_name = pub_args.ret_mq_topic_name;
   return pub_args.ret_id;
 }
 
 union ioctl_publish_msg_args publish_core(
   [[maybe_unused]] const void * publisher_handle /* for CARET */, const std::string & topic_name,
-  const topic_local_id_t publisher_id, const uint64_t msg_virtual_address,
+  const std::string & mq_topic_name, const topic_local_id_t publisher_id,
+  const uint64_t msg_virtual_address,
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> & opened_mqs)
 {
   std::array<topic_local_id_t, MAX_SUBSCRIBER_NUM> subscriber_ids_buffer{};
@@ -115,7 +118,7 @@ union ioctl_publish_msg_args publish_core(
       // later.
       std::get<1>(t) = true;
     } else {
-      const std::string mq_name = create_mq_name_for_agnocast_publish(topic_name, subscriber_id);
+      const std::string mq_name = create_mq_name_for_agnocast_publish(mq_topic_name, subscriber_id);
       mq = mq_open(mq_name.c_str(), O_WRONLY | O_NONBLOCK);
       if (mq == -1) {
         // Right after a subscriber is added, its message queue has not been created yet. Therefore,
@@ -227,7 +230,8 @@ rclcpp::QoS PublisherBase::init_base(
 
   const bool is_bridge = (role == PublisherRole::BridgeInternal);
   const std::string node_name = node->get_fully_qualified_name();
-  id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
+  id_ =
+    initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name, mq_topic_name_);
   generate_gid();
 
   if (role == PublisherRole::Default) {

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -51,6 +51,8 @@ void SubscriptionBase::initialize(
   }
 
   id_ = add_subscriber_args.ret_id;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+  mq_topic_name_ = add_subscriber_args.ret_mq_topic_name;
 
   if (role == SubscriptionRole::Default) {
     if (!type_name.empty()) {
@@ -192,7 +194,7 @@ rclcpp::QoS GenericSubscription::constructor_impl(
 {
   const rclcpp::QoS actual_qos = init_base(node, qos, topic_type, false, options, role);
 
-  mqd_t mq = open_mq_for_subscription(topic_name_, id_, mq_subscription_);
+  mqd_t mq = open_mq_for_subscription(mq_topic_name_, id_, mq_subscription_);
 
   const bool is_transient_local =
     actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -40,12 +40,14 @@ void increment_borrowed_publisher_num()
 }
 
 topic_local_id_t initialize_publisher(
-  const std::string &, const std::string &, const rclcpp::QoS &, const bool, const std::string &)
+  const std::string & topic_name, const std::string &, const rclcpp::QoS &, const bool,
+  const std::string &, std::string & out_mq_topic_name)
 {
-  return 0;  // Dummy value
+  out_mq_topic_name = topic_name;  // non-bridged: the notification MQ uses the topic's own name
+  return 0;                        // Dummy value
 }
 union ioctl_publish_msg_args publish_core(
-  const void *, const std::string &, const topic_local_id_t, const uint64_t,
+  const void *, const std::string &, const std::string &, const topic_local_id_t, const uint64_t,
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> &)
 {
   publish_core_mock_called_count++;

--- a/src/agnocastlib/test/unit/tf2/test_broadcasters.cpp
+++ b/src/agnocastlib/test/unit/tf2/test_broadcasters.cpp
@@ -70,16 +70,17 @@ void decrement_borrowed_publisher_num()
 
 topic_local_id_t initialize_publisher(
   const std::string & topic_name, const std::string &, const rclcpp::QoS & qos, const bool,
-  const std::string &)
+  const std::string &, std::string & out_mq_topic_name)
 {
   initialize_publisher_call_count++;
   last_initialized_topic_name = topic_name;
   last_initialized_qos = qos;
+  out_mq_topic_name = topic_name;  // non-bridged: the notification MQ uses the topic's own name
   return 0;
 }
 
 union ioctl_publish_msg_args publish_core(
-  const void *, const std::string & topic_name, const topic_local_id_t,
+  const void *, const std::string & topic_name, const std::string &, const topic_local_id_t,
   const uint64_t msg_virtual_address,
   std::unordered_map<topic_local_id_t, std::tuple<mqd_t, bool>> &)
 {


### PR DESCRIPTION
## Description

Fixes cross-domain **topic rename** publish notifications. Rename's *data* path already works (#1436 groups the renamed cells into one `topic_struct`), but the subscriber was never woken. Publish notifications go over a POSIX MQ whose name is derived from the topic name, and a publisher and subscriber on a bridged topic each built that name from their **own per-domain name**. That matches for same-name bridging but diverges under rename — the publisher signalled `/agnocast@my_topic@<id>` while the subscriber waited on `/agnocast@renamed@<id>` — so `/renamed@2` received nothing.

- **kmod:** `add_publisher` / `add_subscriber` now return `ret_mq_topic_name` — the requested name for a plain topic, or the bridge pair's **canonical name** (`rule->topic_name_a`) for a bridged/renamed topic.
- **agnocastlib:** the publisher and subscriber use this returned name for the **notification MQ only**; topic identity and every other ioctl still use the endpoint's own name. Both ends of a renamed pair therefore derive the same MQ name.
- Non-bridged and same-name topics are **unaffected** (`ret_mq_topic_name` == the requested name).

This is why the kmod KUnit alone missed it: it exercises in-kernel entry delivery, not the userspace MQ. The end-to-end guard lives in #1437 (the `E2E_REMAP` case of `e2e_test_domain_bridge.bash`), which is what surfaced this bug.

## Related links

Domain-bridge **rename** stack (merge order):

1. `#1436` — kmod rename grouping/routing
2. **this PR** — canonical notification MQ
3. `#1437` — userspace `remap` registration + rename e2e

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- New KUnit `test_case_domain_bridge_rename_notify_uses_canonical_name`: both endpoints of a renamed pair report the canonical name.
- agnocastlib unit tests pass; kmod + agnocastlib build clean; clang-format + CI-style checkpatch clean.
- End-to-end: `E2E_REMAP=/renamed bash scripts/test/e2e_test_domain_bridge.bash` (in #1437) — `/my_topic@1` reaches `/renamed@2` with `AGNOCAST_BRIDGE_MODE=off` (so delivery is necessarily the kmod zero-copy path). Checkboxes left for the run-build-test pass.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if needed)

## Version Update Label

`need-minor-update` — kmod ABI change (`add_publisher` / `add_subscriber` return a canonical MQ topic name); reflected in the PR title.
