### PR TITLE
feat(agnocast_kmod, agnocastlib)[needs minor version update]: carry the message type in the kmod (1/2)

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -12,10 +12,11 @@
  * balance the number of calling ioctl and the overhead of copying data between user and kernel
  * space. */
 #define MAX_RECEIVE_NUM 10
-#define MAX_RELEASE_NUM 3           // Maximum number of entries that can be released at one ioctl
-#define NODE_NAME_BUFFER_SIZE 256   // Maximum length of node name: 256 characters
-#define TOPIC_NAME_BUFFER_SIZE 256  // Maximum length of topic name: 256 characters
-#define VERSION_BUFFER_LEN 32       // Maximum size of version number represented as a string
+#define MAX_RELEASE_NUM 3             // Maximum number of entries that can be released at one ioctl
+#define NODE_NAME_BUFFER_SIZE 256     // Maximum length of node name: 256 characters
+#define TOPIC_NAME_BUFFER_SIZE 256    // Maximum length of topic name: 256 characters
+#define MESSAGE_TYPE_BUFFER_SIZE 512  // Maximum length of message type name: 512 characters
+#define VERSION_BUFFER_LEN 32         // Maximum size of version number represented as a string
 
 typedef int32_t topic_local_id_t;
 struct publisher_shm_info
@@ -56,6 +57,7 @@ union ioctl_add_subscriber_args {
   {
     struct name_info topic_name;
     struct name_info node_name;
+    struct name_info message_type;
     uint32_t qos_depth;
     bool qos_is_transient_local;
     bool qos_is_reliable;
@@ -74,6 +76,7 @@ union ioctl_add_publisher_args {
   {
     struct name_info topic_name;
     struct name_info node_name;
+    struct name_info message_type;
     uint32_t qos_depth;
     bool qos_is_transient_local;
     bool is_bridge;
@@ -376,6 +379,8 @@ union ioctl_node_info_args {
 struct topic_info_ret
 {
   char node_name[NODE_NAME_BUFFER_SIZE];
+  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
+  pid_t pid;
   uint32_t qos_depth;
   bool qos_is_transient_local;
   bool qos_is_reliable;
@@ -420,14 +425,16 @@ void agnocast_exit_device(void);
 
 int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
-  const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
-  const bool qos_is_reliable, const bool is_take_sub, const bool ignore_local_publications,
-  const bool is_bridge, union ioctl_add_subscriber_args * ioctl_ret);
+  const char * message_type, const pid_t subscriber_pid, const uint32_t qos_depth,
+  const bool qos_is_transient_local, const bool qos_is_reliable, const bool is_take_sub,
+  const bool ignore_local_publications, const bool is_bridge,
+  union ioctl_add_subscriber_args * ioctl_ret);
 
 int agnocast_ioctl_add_publisher(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
-  const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
-  const bool is_bridge, union ioctl_add_publisher_args * ioctl_ret);
+  const char * message_type, const pid_t publisher_pid, const uint32_t qos_depth,
+  const bool qos_is_transient_local, const bool is_bridge,
+  union ioctl_add_publisher_args * ioctl_ret);
 
 int agnocast_ioctl_release_message_entry_reference(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t pubsub_id,
@@ -567,6 +574,12 @@ bool agnocast_is_in_subscriber_htable(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t subscriber_id);
 bool agnocast_is_in_publisher_htable(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t publisher_id);
+const char * agnocast_get_subscriber_message_type(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id);
+const char * agnocast_get_publisher_message_type(
   const char * topic_name, const struct ipc_namespace * ipc_ns,
   const topic_local_id_t publisher_id);
 int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns);

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -62,6 +62,7 @@ static void pre_handler_subscriber_exit(
 
     hash_del(&sub_info->node);
     kfree(sub_info->node_name);
+    kfree(sub_info->message_type);
     kfree(sub_info);
 
     if (subscriber_id < 0 || subscriber_id >= MAX_TOPIC_LOCAL_ID) {
@@ -103,6 +104,7 @@ static void pre_handler_subscriber_exit(
       if (pub_info->entries_num == 0) {
         hash_del(&pub_info->node);
         kfree(pub_info->node_name);
+        kfree(pub_info->message_type);
         kfree(pub_info);
       }
     }
@@ -139,6 +141,7 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper, const pid
     if (pub_info->entries_num == 0) {
       hash_del(&pub_info->node);
       kfree(pub_info->node_name);
+      kfree(pub_info->message_type);
       kfree(pub_info);
     }
   }
@@ -208,6 +211,7 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
     {
       hash_del(&pub_info->node);
       kfree(pub_info->node_name);
+      kfree(pub_info->message_type);
       kfree(pub_info);
     }
 
@@ -218,6 +222,7 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
     {
       hash_del(&sub_info->node);
       kfree(sub_info->node_name);
+      kfree(sub_info->message_type);
       kfree(sub_info);
     }
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -87,6 +87,7 @@ struct publisher_info
   uint32_t domain_id;
   pid_t pid;
   char * node_name;
+  char * message_type;
   uint32_t qos_depth;
   bool qos_is_transient_local;
   uint32_t entries_num;
@@ -105,6 +106,7 @@ struct subscriber_info
   bool qos_is_reliable;
   int64_t latest_received_entry_id;
   char * node_name;
+  char * message_type;
   bool is_take_sub;
   bool ignore_local_publications;
   bool need_mmap_update;

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -200,10 +200,10 @@ static struct subscriber_info * find_subscriber_info(
 }
 
 static int insert_subscriber_info(
-  struct topic_wrapper * wrapper, const char * node_name, const pid_t subscriber_pid,
-  const uint32_t qos_depth, const bool qos_is_transient_local, const bool qos_is_reliable,
-  const bool is_take_sub, bool ignore_local_publications, const bool is_bridge,
-  struct subscriber_info ** new_info)
+  struct topic_wrapper * wrapper, const char * node_name, const char * message_type,
+  const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
+  const bool qos_is_reliable, const bool is_take_sub, bool ignore_local_publications,
+  const bool is_bridge, struct subscriber_info ** new_info)
 {
   int count = agnocast_get_size_sub_info_htable(wrapper);
   if (count == MAX_SUBSCRIBER_NUM) {
@@ -237,12 +237,20 @@ static int insert_subscriber_info(
     return -ENOMEM;
   }
 
+  char * message_type_copy = kstrdup(message_type, GFP_KERNEL);
+  if (!message_type_copy) {
+    kfree(node_name_copy);
+    kfree(*new_info);
+    return -ENOMEM;
+  }
+
   const topic_local_id_t new_id = wrapper->topic->current_pubsub_id;
   wrapper->topic->current_pubsub_id++;
 
   (*new_info)->id = new_id;
   (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = subscriber_pid;
+  (*new_info)->message_type = message_type_copy;
   (*new_info)->qos_depth = qos_depth;
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
   (*new_info)->qos_is_reliable = qos_is_reliable;
@@ -304,9 +312,9 @@ static struct publisher_info * find_publisher_info(
 }
 
 static int insert_publisher_info(
-  struct topic_wrapper * wrapper, const char * node_name, const pid_t publisher_pid,
-  const uint32_t qos_depth, const bool qos_is_transient_local, const bool is_bridge,
-  struct publisher_info ** new_info)
+  struct topic_wrapper * wrapper, const char * node_name, const char * message_type,
+  const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
+  const bool is_bridge, struct publisher_info ** new_info)
 {
   int count = agnocast_get_size_pub_info_htable(wrapper);
   if (count == MAX_PUBLISHER_NUM) {
@@ -340,6 +348,13 @@ static int insert_publisher_info(
     return -ENOMEM;
   }
 
+  char * message_type_copy = kstrdup(message_type, GFP_KERNEL);
+  if (!message_type_copy) {
+    kfree(node_name_copy);
+    kfree(*new_info);
+    return -ENOMEM;
+  }
+
   const topic_local_id_t new_id = wrapper->topic->current_pubsub_id;
   wrapper->topic->current_pubsub_id++;
 
@@ -347,6 +362,7 @@ static int insert_publisher_info(
   (*new_info)->domain_id = wrapper->domain_id;
   (*new_info)->pid = publisher_pid;
   (*new_info)->node_name = node_name_copy;
+  (*new_info)->message_type = message_type_copy;
   (*new_info)->qos_depth = qos_depth;
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
   (*new_info)->entries_num = 0;
@@ -703,9 +719,10 @@ unlock:
 
 int agnocast_ioctl_add_subscriber(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
-  const pid_t subscriber_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
-  const bool qos_is_reliable, const bool is_take_sub, const bool ignore_local_publications,
-  const bool is_bridge, union ioctl_add_subscriber_args * ioctl_ret)
+  const char * message_type, const pid_t subscriber_pid, const uint32_t qos_depth,
+  const bool qos_is_transient_local, const bool qos_is_reliable, const bool is_take_sub,
+  const bool ignore_local_publications, const bool is_bridge,
+  union ioctl_add_subscriber_args * ioctl_ret)
 {
   int ret;
 
@@ -719,8 +736,8 @@ int agnocast_ioctl_add_subscriber(
 
   struct subscriber_info * sub_info;
   ret = insert_subscriber_info(
-    wrapper, node_name, subscriber_pid, qos_depth, qos_is_transient_local, qos_is_reliable,
-    is_take_sub, ignore_local_publications, is_bridge, &sub_info);
+    wrapper, node_name, message_type, subscriber_pid, qos_depth, qos_is_transient_local,
+    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, &sub_info);
   if (ret < 0) {
     goto unlock;
   }
@@ -734,8 +751,9 @@ unlock:
 
 int agnocast_ioctl_add_publisher(
   const char * topic_name, const struct ipc_namespace * ipc_ns, const char * node_name,
-  const pid_t publisher_pid, const uint32_t qos_depth, const bool qos_is_transient_local,
-  const bool is_bridge, union ioctl_add_publisher_args * ioctl_ret)
+  const char * message_type, const pid_t publisher_pid, const uint32_t qos_depth,
+  const bool qos_is_transient_local, const bool is_bridge,
+  union ioctl_add_publisher_args * ioctl_ret)
 {
   int ret;
 
@@ -749,7 +767,8 @@ int agnocast_ioctl_add_publisher(
 
   struct publisher_info * pub_info;
   ret = insert_publisher_info(
-    wrapper, node_name, publisher_pid, qos_depth, qos_is_transient_local, is_bridge, &pub_info);
+    wrapper, node_name, message_type, publisher_pid, qos_depth, qos_is_transient_local, is_bridge,
+    &pub_info);
   if (ret < 0) {
     goto unlock;
   }
@@ -1732,6 +1751,8 @@ int agnocast_ioctl_get_topic_subscriber_info(
     struct topic_info_ret * temp_info = &topic_info_mem[idx];
 
     strscpy(temp_info->node_name, sub_info->node_name, NODE_NAME_BUFFER_SIZE);
+    strscpy(temp_info->message_type, sub_info->message_type, MESSAGE_TYPE_BUFFER_SIZE);
+    temp_info->pid = sub_info->pid;
     temp_info->qos_depth = sub_info->qos_depth;
     temp_info->qos_is_transient_local = sub_info->qos_is_transient_local;
     temp_info->qos_is_reliable = sub_info->qos_is_reliable;
@@ -1822,6 +1843,8 @@ int agnocast_ioctl_get_topic_publisher_info(
     struct topic_info_ret * temp_info = &topic_info_mem[idx];
 
     strscpy(temp_info->node_name, pub_info->node_name, NODE_NAME_BUFFER_SIZE);
+    strscpy(temp_info->message_type, pub_info->message_type, MESSAGE_TYPE_BUFFER_SIZE);
+    temp_info->pid = pub_info->pid;
     temp_info->qos_depth = pub_info->qos_depth;
     temp_info->qos_is_transient_local = pub_info->qos_is_transient_local;
     temp_info->qos_is_reliable = false;  // Publishers do not have reliability QoS
@@ -1945,6 +1968,7 @@ int agnocast_ioctl_remove_subscriber(
 
   hash_del(&sub_info->node);
   kfree(sub_info->node_name);
+  kfree(sub_info->message_type);
   kfree(sub_info);
 
   if (!is_parameter_service_topic(topic_name)) {
@@ -1993,6 +2017,7 @@ int agnocast_ioctl_remove_subscriber(
     if (pub_info->entries_num == 0) {
       hash_del(&pub_info->node);
       kfree(pub_info->node_name);
+      kfree(pub_info->message_type);
       kfree(pub_info);
     }
   }
@@ -2048,6 +2073,7 @@ int agnocast_ioctl_remove_publisher(
   if (pub_info->entries_num == 0) {
     hash_del(&pub_info->node);
     kfree(pub_info->node_name);
+    kfree(pub_info->message_type);
     kfree(pub_info);
 
     if (!is_parameter_service_topic(topic_name)) {
@@ -2510,16 +2536,20 @@ static long add_subscriber_cmd(union ioctl_add_subscriber_args __user * arg)
 
   char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
   char node_name_buf[NODE_NAME_BUFFER_SIZE];
+  char message_type_buf[MESSAGE_TYPE_BUFFER_SIZE];
   ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &sub_args.topic_name);
   if (ret) return ret;
 
   ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &sub_args.node_name);
   if (ret) return ret;
 
+  ret = copy_name_from_user(message_type_buf, sizeof(message_type_buf), &sub_args.message_type);
+  if (ret) return ret;
+
   ret = agnocast_ioctl_add_subscriber(
-    topic_name_buf, ipc_ns, node_name_buf, pid, sub_args.qos_depth, sub_args.qos_is_transient_local,
-    sub_args.qos_is_reliable, sub_args.is_take_sub, sub_args.ignore_local_publications,
-    sub_args.is_bridge, &sub_args);
+    topic_name_buf, ipc_ns, node_name_buf, message_type_buf, pid, sub_args.qos_depth,
+    sub_args.qos_is_transient_local, sub_args.qos_is_reliable, sub_args.is_take_sub,
+    sub_args.ignore_local_publications, sub_args.is_bridge, &sub_args);
   if (ret == 0) {
     if (copy_to_user(arg, &sub_args, sizeof(sub_args))) return -EFAULT;
   }
@@ -2537,15 +2567,19 @@ static long add_publisher_cmd(union ioctl_add_publisher_args __user * arg)
 
   char topic_name_buf[TOPIC_NAME_BUFFER_SIZE];
   char node_name_buf[NODE_NAME_BUFFER_SIZE];
+  char message_type_buf[MESSAGE_TYPE_BUFFER_SIZE];
   ret = copy_name_from_user(topic_name_buf, sizeof(topic_name_buf), &pub_args.topic_name);
   if (ret) return ret;
 
   ret = copy_name_from_user(node_name_buf, sizeof(node_name_buf), &pub_args.node_name);
   if (ret) return ret;
 
+  ret = copy_name_from_user(message_type_buf, sizeof(message_type_buf), &pub_args.message_type);
+  if (ret) return ret;
+
   ret = agnocast_ioctl_add_publisher(
-    topic_name_buf, ipc_ns, node_name_buf, pid, pub_args.qos_depth, pub_args.qos_is_transient_local,
-    pub_args.is_bridge, &pub_args);
+    topic_name_buf, ipc_ns, node_name_buf, message_type_buf, pid, pub_args.qos_depth,
+    pub_args.qos_is_transient_local, pub_args.is_bridge, &pub_args);
   if (ret == 0) {
     if (copy_to_user(arg, &pub_args, sizeof(pub_args))) return -EFAULT;
   }
@@ -3400,6 +3434,35 @@ bool agnocast_is_in_publisher_htable(
     return false;
   }
   return true;
+}
+
+const char * agnocast_get_subscriber_message_type(
+  const char * topic_name, const struct ipc_namespace * ipc_ns,
+  const topic_local_id_t subscriber_id)
+{
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  if (!wrapper) {
+    return NULL;
+  }
+  const struct subscriber_info * sub_info = find_subscriber_info(wrapper, subscriber_id);
+  if (!sub_info) {
+    return NULL;
+  }
+  return sub_info->message_type;
+}
+
+const char * agnocast_get_publisher_message_type(
+  const char * topic_name, const struct ipc_namespace * ipc_ns, const topic_local_id_t publisher_id)
+{
+  const struct topic_wrapper * wrapper = find_topic_for_current(topic_name, ipc_ns);
+  if (!wrapper) {
+    return NULL;
+  }
+  const struct publisher_info * pub_info = find_publisher_info(wrapper, publisher_id);
+  if (!pub_info) {
+    return NULL;
+  }
+  return pub_info->message_type;
 }
 
 int agnocast_get_topic_num(const struct ipc_namespace * ipc_ns)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_publisher.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * topic_name = "/kunit_test_topic";
 static const char * node_name = "/kunit_test_node";
 static const pid_t publisher_pid = 1000;
@@ -23,7 +25,7 @@ void test_case_add_publisher_normal(struct kunit * test)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret1 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, is_bridge, &add_publisher_args);
 
   KUNIT_EXPECT_EQ(test, ret1, 0);
@@ -35,6 +37,11 @@ void test_case_add_publisher_normal(struct kunit * test)
   KUNIT_EXPECT_TRUE(
     test, agnocast_is_in_publisher_htable(
             topic_name, current->nsproxy->ipc_ns, add_publisher_args.ret_id));
+  KUNIT_EXPECT_STREQ(
+    test,
+    agnocast_get_publisher_message_type(
+      topic_name, current->nsproxy->ipc_ns, add_publisher_args.ret_id),
+    MESSAGE_TYPE);
   KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, agnocast_is_in_topic_htable(topic_name, current->nsproxy->ipc_ns));
 }
@@ -53,7 +60,7 @@ void test_case_add_publisher_many(struct kunit * test)
   union ioctl_add_publisher_args add_publisher_args;
   for (int i = 0; i < publisher_num; i++) {
     ret1 = agnocast_ioctl_add_publisher(
-      topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+      topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
       qos_is_transient_local, is_bridge, &add_publisher_args);
   }
 
@@ -81,7 +88,7 @@ void test_case_add_publisher_too_many(struct kunit * test)
   for (int i = 0; i < publisher_num; i++) {
     union ioctl_add_publisher_args add_publisher_args;
     ret1 = agnocast_ioctl_add_publisher(
-      topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+      topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
       qos_is_transient_local, is_bridge, &add_publisher_args);
   }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_subscriber.c
@@ -6,6 +6,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const bool QOS_IS_TRANSIENT_LOCAL = false;
@@ -34,14 +36,15 @@ static int add_pubsub_pair(
 {
   union ioctl_add_publisher_args add_publisher_args;
   int ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
-    IS_BRIDGE, &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pub_pid, qos_depth,
+    QOS_IS_TRANSIENT_LOCAL, IS_BRIDGE, &add_publisher_args);
   if (ret < 0) return ret;
 
   union ioctl_add_subscriber_args add_subscriber_args;
   return agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, sub_pid, qos_depth, QOS_IS_TRANSIENT_LOCAL,
-    QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, sub_pid, qos_depth,
+    QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    &add_subscriber_args);
 }
 
 // A publisher and subscriber with the same topic name but different ROS_DOMAIN_ID
@@ -85,7 +88,7 @@ void test_case_add_subscriber_normal(struct kunit * test)
 
   // Act
   int ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, qos_depth,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
 
@@ -99,6 +102,11 @@ void test_case_add_subscriber_normal(struct kunit * test)
   KUNIT_EXPECT_TRUE(
     test, agnocast_is_in_subscriber_htable(
             TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id));
+  KUNIT_EXPECT_STREQ(
+    test,
+    agnocast_get_subscriber_message_type(
+      TOPIC_NAME, current->nsproxy->ipc_ns, add_subscriber_args.ret_id),
+    MESSAGE_TYPE);
   KUNIT_EXPECT_EQ(test, agnocast_get_topic_num(current->nsproxy->ipc_ns), 1);
   KUNIT_EXPECT_TRUE(test, agnocast_is_in_topic_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
 }
@@ -113,14 +121,14 @@ void test_case_add_subscriber_too_many_subscribers(struct kunit * test)
   for (uint32_t i = 0; i < MAX_SUBSCRIBER_NUM; i++) {
     union ioctl_add_subscriber_args add_subscriber_args;
     agnocast_ioctl_add_subscriber(
-      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, qos_depth,
       QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
       &add_subscriber_args);
   }
 
   // Act
   int ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, qos_depth,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -9,6 +9,8 @@
 #include <linux/mm.h>
 #include <linux/string.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const pid_t PID_BASE = 1000;
 
 static topic_local_id_t subscriber_ids_buf[MAX_SUBSCRIBER_NUM];
@@ -49,7 +51,7 @@ static topic_local_id_t setup_one_publisher(struct kunit * test, const pid_t pub
 {
   union ioctl_add_publisher_args add_publisher_args;
   int ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, IS_BRIDGE, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -66,7 +68,7 @@ static topic_local_id_t setup_one_subscriber_on_topic(
 {
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    topic_name, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -6,6 +6,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 
 #define KUNIT_PUB_SHM_BUF_SIZE 4
@@ -28,7 +30,8 @@ static topic_local_id_t add_publisher_for(struct kunit * test, const pid_t pid)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_publisher(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", MESSAGE_TYPE, pid, 1, false, false,
+      &args),
     0);
   return args.ret_id;
 }
@@ -39,8 +42,8 @@ static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_subscriber(
-      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, true, false, false, false,
-      &args),
+      TOPIC_NAME, current->nsproxy->ipc_ns, "/kunit_node", MESSAGE_TYPE, pid, 1, false, true, false,
+      false, false, &args),
     0);
   return args.ret_id;
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_publisher_topics.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const char * NODE_NAME_WITH_SUFFIX = "/kunit_test_node_extra";
@@ -28,7 +30,7 @@ void test_case_get_node_pub_topics_exact_match(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, IS_BRIDGE,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, IS_BRIDGE,
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
@@ -49,8 +51,8 @@ void test_case_get_node_pub_topics_prefix_no_match(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME_WITH_SUFFIX, PID, QOS_DEPTH, false, IS_BRIDGE,
-    &add_pub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME_WITH_SUFFIX, MESSAGE_TYPE, PID, QOS_DEPTH,
+    false, IS_BRIDGE, &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
@@ -71,7 +73,7 @@ void test_case_get_node_pub_topics_buffer_size_exceeded(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, IS_BRIDGE,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, IS_BRIDGE,
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const char * NODE_NAME_WITH_SUFFIX = "/kunit_test_node_extra";
@@ -28,8 +30,8 @@ void test_case_get_node_sub_topics_exact_match(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, false,
+    false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // copy_to_user inside ioctl_get_node_subscriber_topics returns -EFAULT in KUnit (kernel thread)
@@ -49,8 +51,8 @@ void test_case_get_node_sub_topics_prefix_no_match(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME_WITH_SUFFIX, PID, QOS_DEPTH, false, false,
-    false, false, IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME_WITH_SUFFIX, MESSAGE_TYPE, PID, QOS_DEPTH,
+    false, false, false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   node_info_args.topic_name_buffer_size = MAX_TOPIC_NUM;
@@ -71,8 +73,8 @@ void test_case_get_node_sub_topics_buffer_size_exceeded(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, false,
+    false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // Set topic_name_buffer_size to 0 so the buffer cannot hold any entry.

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_num.c
@@ -3,6 +3,8 @@
 
 #include "../agnocast.h"
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static char * node_name = "/kunit_test_node";
 static uint32_t qos_depth = 10;
 static bool qos_is_transient_local = false;
@@ -23,7 +25,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
     &add_subscriber_args);
 
@@ -41,7 +43,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, is_bridge, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -58,7 +60,7 @@ static void setup_one_publisher_with_bridge(struct kunit * test, char * topic_na
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, true, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -189,7 +191,7 @@ void test_case_get_publisher_num_a2r_bridge_exist(struct kunit * test)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_publisher_qos.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const pid_t PUBLISHER_PID = 1000;
@@ -27,8 +29,8 @@ static void verify_publisher_qos(struct kunit * test, bool is_transient)
   setup_process(test, PUBLISHER_PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH, is_transient,
-    IS_BRIDGE, &add_pub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PUBLISHER_PID, QOS_DEPTH,
+    is_transient, IS_BRIDGE, &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   ret = agnocast_ioctl_get_publisher_qos(
@@ -76,8 +78,8 @@ void test_case_error_publisher_not_found(struct kunit * test)
   setup_process(test, PUBLISHER_PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH, false, IS_BRIDGE,
-    &add_pub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PUBLISHER_PID, QOS_DEPTH, false,
+    IS_BRIDGE, &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   topic_local_id_t invalid_id = add_pub_args.ret_id + 999;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -3,6 +3,8 @@
 
 #include "../agnocast.h"
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 char * node_name = "/kunit_test_node";
 uint32_t qos_depth = 10;
 bool qos_is_transient_local = false;
@@ -23,7 +25,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
     &add_subscriber_args);
 
@@ -41,7 +43,7 @@ static void setup_one_subscriber_with_bridge(struct kunit * test, char * topic_n
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true,
     &add_subscriber_args);
 
@@ -59,7 +61,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, is_bridge, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -76,8 +78,9 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, intra_pid, qos_depth, qos_is_transient_local,
-    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, &add_subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, intra_pid, qos_depth,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    &add_subscriber_args);
 
   KUNIT_ASSERT_TRUE(test, ret1 == 0 || ret1 == -EEXIST);
   KUNIT_ASSERT_EQ(test, ret2, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_qos.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const pid_t SUBSCRIBER_PID = 1000;
@@ -27,8 +29,8 @@ static void verify_subscriber_qos(struct kunit * test, bool is_transient, bool i
   setup_process(test, SUBSCRIBER_PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, QOS_DEPTH, is_transient,
-    is_reliable, false, false, IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, SUBSCRIBER_PID, QOS_DEPTH,
+    is_transient, is_reliable, false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   ret = agnocast_ioctl_get_subscriber_qos(
@@ -86,8 +88,8 @@ void test_case_error_subscriber_not_found(struct kunit * test)
   int ret;
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, SUBSCRIBER_PID, QOS_DEPTH, false, false, false,
-    false, IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, SUBSCRIBER_PID, QOS_DEPTH, false,
+    false, false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   topic_local_id_t invalid_id = add_sub_args.ret_id + 999;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_publisher_info.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const pid_t PID = 1000;
@@ -36,7 +38,7 @@ void test_case_get_topic_pub_info_one_publisher(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, IS_BRIDGE,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, IS_BRIDGE,
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
@@ -59,8 +61,8 @@ void test_case_get_topic_pub_info_no_publishers(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, false,
+    false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   topic_info_args.topic_info_ret_buffer_size = MAX_PUBLISHER_NUM;
@@ -92,8 +94,8 @@ void test_case_get_topic_pub_info_selects_by_domain(struct kunit * test)
 
   setup_process_domain(test, pid_d1, 1);
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid_d1, QOS_DEPTH, false, IS_BRIDGE,
-    &add_pub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid_d1, QOS_DEPTH, false,
+    IS_BRIDGE, &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // domain 1: the topic exists -> the publisher is counted (copy_to_user

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const pid_t PID = 1000;
@@ -36,8 +38,8 @@ void test_case_get_topic_sub_info_one_subscriber(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, false,
+    false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // copy_to_user inside agnocast_ioctl_get_topic_subscriber_info returns -EFAULT in KUnit
@@ -59,7 +61,7 @@ void test_case_get_topic_sub_info_no_subscribers(struct kunit * test)
   setup_process(test, PID);
 
   ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, IS_BRIDGE,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PID, QOS_DEPTH, false, IS_BRIDGE,
     &add_pub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
@@ -92,8 +94,8 @@ void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test)
 
   setup_process_domain(test, pid_d1, 1);
   ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid_d1, QOS_DEPTH, false, false, false, false,
-    IS_BRIDGE, &add_sub_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid_d1, QOS_DEPTH, false, false,
+    false, false, IS_BRIDGE, &add_sub_args);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
   // domain 1: the topic exists -> the subscriber is counted (copy_to_user

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static char * topic_name = "/kunit_test_topic";
 static char * node_name = "/kunit_test_node";
 static uint32_t qos_depth = 1;
@@ -29,7 +31,7 @@ static void setup_one_subscriber(
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
     &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
@@ -50,7 +52,7 @@ static void setup_one_publisher(
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, is_bridge, &add_publisher_args);
   *publisher_id = add_publisher_args.ret_id;
 
@@ -74,8 +76,8 @@ static void setup_pub_sub_same_process(
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret_pub = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, common_pid, qos_depth, qos_is_transient_local,
-    is_bridge, &add_publisher_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, common_pid, qos_depth,
+    qos_is_transient_local, is_bridge, &add_publisher_args);
 
   if (publisher_id) {
     *publisher_id = add_publisher_args.ret_id;
@@ -83,8 +85,9 @@ static void setup_pub_sub_same_process(
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret_sub = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, common_pid, qos_depth, qos_is_transient_local,
-    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, &add_subscriber_args);
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, common_pid, qos_depth,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
+    &add_subscriber_args);
 
   if (subscriber_id) {
     *subscriber_id = add_subscriber_args.ret_id;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -7,6 +7,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static char * TOPIC_NAME = "/kunit_test_topic";
 static char * NODE_NAME = "/kunit_test_node";
 static bool IS_TAKE_SUB = false;
@@ -29,8 +31,9 @@ static void setup_one_subscriber(
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -48,8 +51,8 @@ static void setup_one_publisher(
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   *publisher_id = add_publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -680,13 +683,14 @@ void test_case_receive_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, subscriber_qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, subscriber_qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    &add_subscriber_args);
   union ioctl_add_publisher_args add_publisher_args;
   const uint32_t publisher_qos_depth = 10;
   int ret3 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, publisher_qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, publisher_qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -723,12 +727,12 @@ void test_case_receive_msg_2pub_in_same_process(struct kunit * test)
   union ioctl_add_publisher_args add_publisher_args1;
   const uint32_t publisher_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth,
-    is_transient_local, IS_BRIDGE, &add_publisher_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid,
+    publisher_qos_depth, is_transient_local, IS_BRIDGE, &add_publisher_args1);
   union ioctl_add_publisher_args add_publisher_args2;
   int ret3 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth,
-    is_transient_local, IS_BRIDGE, &add_publisher_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid,
+    publisher_qos_depth, is_transient_local, IS_BRIDGE, &add_publisher_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -761,15 +765,15 @@ void test_case_receive_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth1,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
-    &add_subscriber_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid,
+    subscriber_qos_depth1, is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS,
+    IS_BRIDGE, &add_subscriber_args1);
   union ioctl_add_subscriber_args add_subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth2,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
-    &add_subscriber_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid,
+    subscriber_qos_depth2, is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS,
+    IS_BRIDGE, &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -989,15 +993,16 @@ void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local, IS_BRIDGE,
-    &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool ignore_local_publications = true;
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE,
+    &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
@@ -1032,15 +1037,16 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local, IS_BRIDGE,
-    &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool ignore_local_publications = false;
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE,
+    &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_release_sub_ref.c
@@ -5,6 +5,8 @@
 
 #include <kunit/test.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const bool QOS_IS_TRANSIENT_LOCAL = true;
@@ -28,7 +30,7 @@ static void setup_one_publisher(
     PUBLISHER_PID, current->nsproxy->ipc_ns, false, 0, &add_process_args);
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PUBLISHER_PID, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, PUBLISHER_PID, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, IS_BRIDGE, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -112,7 +114,7 @@ void test_case_release_sub_ref_last_reference(struct kunit * test)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -161,7 +163,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
 
   union ioctl_add_subscriber_args add_subscriber_args1;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid1, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid1, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args1);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -180,7 +182,7 @@ void test_case_release_sub_ref_multi_reference(struct kunit * test)
 
   union ioctl_add_subscriber_args add_subscriber_args2;
   int ret6 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid2, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid2, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret6, 0);
@@ -238,7 +240,7 @@ void test_case_increment_rc_already_referenced(struct kunit * test)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, false, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_publisher.c
@@ -7,6 +7,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const pid_t PID_BASE = 1000;
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
@@ -32,7 +34,7 @@ static topic_local_id_t setup_one_publisher(struct kunit * test, const pid_t pub
 {
   union ioctl_add_publisher_args add_publisher_args;
   int ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, IS_BRIDGE, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -45,7 +47,7 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
 {
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_remove_subscriber.c
@@ -7,6 +7,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const pid_t PID_BASE = 1000;
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
@@ -32,7 +34,7 @@ static topic_local_id_t setup_one_publisher(struct kunit * test, const pid_t pub
 {
   union ioctl_add_publisher_args add_publisher_args;
   int ret = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, IS_BRIDGE, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
@@ -45,7 +47,7 @@ static topic_local_id_t setup_one_subscriber(struct kunit * test, const pid_t su
 {
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, QOS_DEPTH,
     QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
     &add_subscriber_args);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_publisher_num.c
@@ -3,6 +3,8 @@
 
 #include "../agnocast.h"
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static char * node_name = "/kunit_test_node";
 static uint32_t qos_depth = 10;
 static bool qos_is_transient_local = false;
@@ -19,7 +21,7 @@ static void setup_one_publisher(struct kunit * test, char * topic_name)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, publisher_pid, qos_depth,
     qos_is_transient_local, is_bridge, &add_publisher_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_set_ros2_subscriber_num.c
@@ -3,6 +3,8 @@
 
 #include "../agnocast.h"
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static char * node_name = "/kunit_test_node";
 static uint32_t qos_depth = 10;
 static bool qos_is_transient_local = false;
@@ -22,7 +24,7 @@ static void setup_one_subscriber(struct kunit * test, char * topic_name)
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    topic_name, current->nsproxy->ipc_ns, node_name, MESSAGE_TYPE, subscriber_pid, qos_depth,
     qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge,
     &add_subscriber_args);
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -7,6 +7,8 @@
 #include <kunit/test.h>
 #include <linux/delay.h>
 
+static const char * MESSAGE_TYPE = "test_msgs/msg/Test";
+
 static const char * TOPIC_NAME = "/kunit_test_topic";
 static const char * NODE_NAME = "/kunit_test_node";
 static const bool IS_TAKE_SUB = true;
@@ -29,8 +31,9 @@ static void setup_one_subscriber(
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    &add_subscriber_args);
   *subscriber_id = add_subscriber_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -48,8 +51,8 @@ static void setup_one_publisher(
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   *publisher_id = add_publisher_args.ret_id;
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
@@ -778,14 +781,15 @@ void test_case_take_msg_pubsub_in_same_process(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args;
   const uint32_t subscriber_qos_depth = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, subscriber_qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, subscriber_qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+    &add_subscriber_args);
 
   union ioctl_add_publisher_args add_publisher_args;
   const uint32_t publisher_qos_depth = 10;
   int ret3 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, publisher_qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, publisher_qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -824,15 +828,15 @@ void test_case_take_msg_2pub_in_same_process(struct kunit * test)
   const uint32_t publisher_qos_depth1 = 10;
   const bool publisher_transient_local1 = true;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth1,
-    publisher_transient_local1, IS_BRIDGE, &add_publisher_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid,
+    publisher_qos_depth1, publisher_transient_local1, IS_BRIDGE, &add_publisher_args1);
 
   union ioctl_add_publisher_args add_publisher_args2;
   const uint32_t publisher_qos_depth2 = 1;
   const bool publisher_transient_local2 = true;
   int ret3 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, publisher_qos_depth2,
-    publisher_transient_local2, IS_BRIDGE, &add_publisher_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, publisher_pid,
+    publisher_qos_depth2, publisher_transient_local2, IS_BRIDGE, &add_publisher_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -866,16 +870,16 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test)
   union ioctl_add_subscriber_args add_subscriber_args1;
   const uint32_t subscriber_qos_depth1 = 10;
   int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth1,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
-    &add_subscriber_args1);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid,
+    subscriber_qos_depth1, is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS,
+    IS_BRIDGE, &add_subscriber_args1);
 
   union ioctl_add_subscriber_args add_subscriber_args2;
   const uint32_t subscriber_qos_depth2 = 1;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, subscriber_qos_depth2,
-    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
-    &add_subscriber_args2);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, subscriber_pid,
+    subscriber_qos_depth2, is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS,
+    IS_BRIDGE, &add_subscriber_args2);
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
   KUNIT_ASSERT_EQ(test, ret3, 0);
@@ -1026,15 +1030,16 @@ void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local, IS_BRIDGE,
-    &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool ignore_local_publications = true;
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE,
+    &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message
@@ -1071,15 +1076,16 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
 
   union ioctl_add_publisher_args add_publisher_args;
   int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local, IS_BRIDGE,
-    &add_publisher_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_BRIDGE, &add_publisher_args);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 
   const bool ignore_local_publications = false;
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret3 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE, &add_subscriber_args);
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, MESSAGE_TYPE, pid, qos_depth,
+    is_transient_local, IS_RELIABLE, IS_TAKE_SUB, ignore_local_publications, IS_BRIDGE,
+    &add_subscriber_args);
   KUNIT_ASSERT_EQ(test, ret3, 0);
 
   // Publish a message

--- a/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
+++ b/src/agnocast_ioctl_wrapper/src/agnocast_ioctl.hpp
@@ -13,6 +13,7 @@
 
 #define TOPIC_NAME_BUFFER_SIZE 256
 #define NODE_NAME_BUFFER_SIZE 256
+#define MESSAGE_TYPE_BUFFER_SIZE 512
 
 constexpr const char * AGNOCAST_DEVICE_NOT_FOUND_MSG =
   "Failed to open /dev/agnocast: Device not found. "
@@ -52,6 +53,8 @@ union ioctl_node_info_args {
 struct topic_info_ret
 {
   char node_name[NODE_NAME_BUFFER_SIZE];
+  char message_type[MESSAGE_TYPE_BUFFER_SIZE];
+  pid_t pid;
   uint32_t qos_depth;
   bool qos_is_transient_local;
   bool qos_is_reliable;

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -75,6 +75,7 @@ union ioctl_add_subscriber_args {
   {
     struct name_info topic_name;
     struct name_info node_name;
+    struct name_info message_type;
     uint32_t qos_depth;
     bool qos_is_transient_local;
     bool qos_is_reliable;
@@ -96,6 +97,7 @@ union ioctl_add_publisher_args {
   {
     struct name_info topic_name;
     struct name_info node_name;
+    struct name_info message_type;
     uint32_t qos_depth;
     bool qos_is_transient_local;
     bool is_bridge;

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -67,6 +67,7 @@ topic_local_id_t initialize_publisher(
   union ioctl_add_publisher_args pub_args = {};
   pub_args.topic_name = {topic_name.c_str(), topic_name.size()};
   pub_args.node_name = {node_name.c_str(), node_name.size()};
+  pub_args.message_type = {type_name.c_str(), type_name.size()};
   pub_args.qos_depth = qos.depth();
   pub_args.qos_is_transient_local = qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
   pub_args.is_bridge = is_bridge;

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -37,6 +37,7 @@ void SubscriptionBase::initialize(
   union ioctl_add_subscriber_args add_subscriber_args = {};
   add_subscriber_args.topic_name = {topic_name_.c_str(), topic_name_.size()};
   add_subscriber_args.node_name = {node_name.c_str(), node_name.size()};
+  add_subscriber_args.message_type = {type_name.c_str(), type_name.size()};
   add_subscriber_args.qos_depth = static_cast<uint32_t>(qos.depth());
   add_subscriber_args.qos_is_transient_local =
     qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -57,6 +57,7 @@ SELF_IPC_NS_PATH = '/proc/self/ns/ipc'
 # constants — they happen to share the value 256 today.
 NODE_NAME_BUFFER_SIZE = 256
 TOPIC_NAME_BUFFER_SIZE = 256
+MESSAGE_TYPE_BUFFER_SIZE = 512
 # How long a remote daemon's last snapshot may sit in _remote_states without
 # being refreshed before we drop it. Matches the gossip Liveliness lease so
 # DDS-side liveliness loss and local prune happen on the same timescale.
@@ -102,6 +103,8 @@ class TopicInfoRet(ctypes.Structure):
 
     _fields_ = [
         ('node_name', ctypes.c_char * NODE_NAME_BUFFER_SIZE),
+        ('message_type', ctypes.c_char * MESSAGE_TYPE_BUFFER_SIZE),
+        ('pid', ctypes.c_int32),
         ('qos_depth', ctypes.c_uint32),
         ('qos_is_transient_local', ctypes.c_bool),
         ('qos_is_reliable', ctypes.c_bool),


### PR DESCRIPTION
Part 1 of 2 for #1448 (move message type into the kmod; remove the tmpfs type registry).

Makes the message type kmod-resident. agnocastlib passes the rosidl type name into the `add_publisher` / `add_subscriber` ioctls; the kmod stores it per endpoint (kstrdup'd like `node_name`, freed on removal and on process exit); and `get_topic_{subscriber,publisher}_info` return `message_type` + `pid` on `topic_info_ret`. The struct/ioctl layout change is mirrored in the ioctl wrapper, agnocastlib, and the discovery agent's ctypes view so all stay byte-identical.

The discovery agent still reads the tmpfs registry in this PR — #1448 part 2 (stacked on top) switches it to these ioctl fields and deletes the registry.

`[needs minor version update]` — ioctl ABI change.

## Verified
- kmod KUnit (QEMU, x86_64): 190/190, incl. new `message_type` assertions in add-sub/add-pub.
- `colcon build` (agnocastlib + wrapper): clean.
- pre-commit (clang-format + KUnit hook): pass.
- checkpatch (CI config): clean.
- clang-tidy-14 on changed agnocastlib cpp: clean.

## NOT done yet
- **Functional / e2e tests have not been run** (no time to run the e2e suite / on-hardware). Draft until those pass.
