### PR TITLE
bench: eventfd-vs-MQ latency probe (measurement harness for #1432, DO NOT MERGE)

### DIFF
--- a/src/agnocast_bench/CMakeLists.txt
+++ b/src/agnocast_bench/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.14)
+project(agnocast_bench)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(agnocastlib REQUIRED)
+find_package(agnocast_sample_interfaces REQUIRED)
+
+add_executable(bench_pub src/bench_pub.cpp)
+ament_target_dependencies(bench_pub rclcpp agnocastlib agnocast_sample_interfaces)
+target_include_directories(bench_pub PRIVATE ${agnocastlib_INCLUDE_DIRS})
+
+add_executable(bench_sub src/bench_sub.cpp)
+ament_target_dependencies(bench_sub rclcpp agnocastlib agnocast_sample_interfaces)
+target_include_directories(bench_sub PRIVATE ${agnocastlib_INCLUDE_DIRS})
+
+install(TARGETS bench_pub bench_sub
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/src/agnocast_bench/README.md
+++ b/src/agnocast_bench/README.md
@@ -1,0 +1,65 @@
+# agnocast_bench — publish-notification latency probe (eventfd vs MQ)
+
+Local benchmarking tool used to measure the latency improvement of the
+**eventfd publish-notification** change ([#1432]) versus the POSIX-MQ baseline.
+Not for merge — it is a measurement harness.
+
+## What it measures
+
+A single publisher and *N* subscribers on one topic (`StaticSizeArray`,
+`id` + `timestamp` + 1 KB payload). Two fair metrics:
+
+- **publish latency** — publisher wall-clock around `publish()`. This is exactly
+  where the mechanisms differ: MQ does one userspace `mq_send` **per subscriber**
+  (N syscalls); eventfd signals all subscribers with **one** in-ioctl call.
+- **e2e latency** — publisher `timestamp` (stamped just before `publish()`) to
+  subscriber callback entry. Both sides stamp `CLOCK_MONOTONIC` on the same host,
+  so `e2e = recv - timestamp` needs no clock sync. Warmup messages are skipped by
+  `id`, so no barrier is needed.
+
+The subscriber count is swept (fan-out): the eventfd win grows with N (N→1
+syscalls) and converges around N ≈ number of logical CPUs, where the scheduler's
+O(N) wakeup cost dominates.
+
+## Why not the original `isorc26_tmp` repo
+
+The previous measurements ([#1272]) used the `isorc26_tmp` benchmark nodes, but
+those **no longer run on current Agnocast**:
+
+- They use the **old client API** (`agnocast::init` / `agnocast::Node` /
+  `AgnocastOnlySingleThreadedExecutor`). Against current `agnocastlib` this
+  registers the process **twice**, so the kmod's `add_process` rejects the second
+  call with `-EINVAL` ("process already exists"); when timing lets it through, the
+  publish path **segfaults**. Each crash also leaks kmod per-process state, so
+  runs poison each other until the module is reloaded.
+- The harness also assumes a flat workspace layout (`~/install`), which no longer
+  matches where `agnocastlib` builds.
+
+Rather than resurrect the stale harness, this probe is rebuilt on the **current**
+API (`rclcpp::Node` + `SingleThreadedAgnocastExecutor`), mirroring the maintained
+sample apps in `agnocast_sample_application` — which do run cleanly on current
+Agnocast. It is self-contained (one small package) so it can't inherit the old
+harness's layout/state issues.
+
+## Fairness
+
+The A/B compares two branches that share base **#1426** and differ **only** by the
+notification mechanism:
+
+- `bench/base` — MQ baseline (main-snapshot + timing instrumentation).
+- `feat/eventfd-publish-notification-v2` — eventfd (#1432) + the **byte-identical**
+  instrumentation.
+
+`run_ab.sh` rebuilds this probe against each branch's `agnocastlib`, loads the
+matching kmod, and sweeps N. Same rate/QoS/warmup/measurement, same host,
+back-to-back, no RT scheduling (identical on both sides).
+
+## How to run
+
+```bash
+bash src/agnocast_bench/run_ab.sh            # builds each branch, loads kmod, sweeps N
+python3 src/agnocast_bench/analyze.py ~/eventfd_bench_<timestamp>   # p50/p99 table + Δ
+```
+
+[#1272]: https://github.com/autowarefoundation/agnocast/pull/1272
+[#1432]: https://github.com/autowarefoundation/agnocast/pull/1432

--- a/src/agnocast_bench/analyze.py
+++ b/src/agnocast_bench/analyze.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Aggregate agnocast_bench results into a MQ-vs-eventfd comparison table.
+
+Usage: python3 analyze.py <results_dir>
+
+<results_dir> layout (produced by run_eventfd_bench.sh):
+  <results_dir>/{mq_base,eventfd}/N<k>/pub.csv        # publish_latency_ns
+  <results_dir>/{mq_base,eventfd}/N<k>/sub_*.csv       # e2e_latency_ns (merged)
+"""
+import glob
+import os
+import sys
+
+
+def _pct(values, p):
+    if not values:
+        return None
+    s = sorted(values)
+    idx = min(len(s) - 1, int(round(p / 100.0 * len(s))))
+    return s[idx]
+
+
+def _read(path):
+    out = []
+    try:
+        with open(path) as f:
+            next(f, None)  # header
+            for line in f:
+                line = line.strip()
+                if line:
+                    out.append(int(line))
+    except FileNotFoundError:
+        pass
+    return out
+
+
+def _collect(tag_dir):
+    """Return {N: {'publish': [...], 'e2e': [...]}} for one branch dir."""
+    res = {}
+    for nd in sorted(glob.glob(os.path.join(tag_dir, "N*"))):
+        n = int(os.path.basename(nd)[1:])
+        publish = _read(os.path.join(nd, "pub.csv"))
+        e2e = []
+        for sub in glob.glob(os.path.join(nd, "sub_*.csv")):
+            e2e += _read(sub)
+        res[n] = {"publish": publish, "e2e": e2e}
+    return res
+
+
+def _us(ns):
+    return "-" if ns is None else f"{ns / 1000.0:.1f}"
+
+
+def _delta(base, ev):
+    if not base or not ev or base[0] is None or ev[0] is None:
+        return "-"
+    return f"{(ev[1] - base[1]) / base[1] * 100.0:+.0f}%"  # base/ev are (label, p50)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <results_dir>")
+    root = sys.argv[1]
+    mq = _collect(os.path.join(root, "mq_base"))
+    ev = _collect(os.path.join(root, "eventfd"))
+    ns = sorted(set(mq) & set(ev))
+
+    for metric in ("publish", "e2e"):
+        title = "publish latency (publisher wall-clock)" if metric == "publish" \
+            else "e2e latency (publish -> callback)"
+        print(f"\n=== {title} — us ===")
+        print(f"{'N':>4} | {'MQ p50':>8} {'MQ p99':>8} | {'evfd p50':>8} {'evfd p99':>8} | "
+              f"{'p50 Δ':>6} {'p99 Δ':>6}")
+        print("-" * 66)
+        for n in ns:
+            mv, ev_v = mq[n][metric], ev[n][metric]
+            m50, m99 = _pct(mv, 50), _pct(mv, 99)
+            e50, e99 = _pct(ev_v, 50), _pct(ev_v, 99)
+            d50 = _delta(("mq", m50), ("ev", e50)) if (m50 and e50) else "-"
+            d99 = _delta(("mq", m99), ("ev", e99)) if (m99 and e99) else "-"
+            print(f"{n:>4} | {_us(m50):>8} {_us(m99):>8} | {_us(e50):>8} {_us(e99):>8} | "
+                  f"{d50:>6} {d99:>6}   (n_mq={len(mv)}, n_ev={len(ev_v)})")
+    print("\nΔ = eventfd vs MQ; negative = eventfd faster.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agnocast_bench/package.xml
+++ b/src/agnocast_bench/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>agnocast_bench</name>
+  <version>0.0.0</version>
+  <description>Minimal 1-pub/N-sub latency probe for comparing publish-notification mechanisms (local benchmarking only; do not merge).</description>
+  <maintainer email="keita.morisaki@tier4.jp">Keita Morisaki</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>agnocastlib</depend>
+  <depend>agnocast_sample_interfaces</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/agnocast_bench/run_ab.sh
+++ b/src/agnocast_bench/run_ab.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Fair A/B latency benchmark: MQ baseline (bench/base) vs eventfd (#1432 v2),
+# using the self-contained agnocast_bench probe (src/agnocast_bench, current API).
+#
+# Both branches share base #1426; the ONLY functional difference is the
+# publish-notification mechanism (MQ mq_send x N  vs  one in-ioctl eventfd signal).
+# For each branch: clean-build agnocast (which also builds the probe), load the
+# matching kmod, then sweep the subscriber count and record publish/e2e latency.
+#
+# Run:  bash /tmp/run_eventfd_bench.sh
+set -uo pipefail
+
+AGNO=~/agnocast
+RATE=100          # publish rate (Hz)
+WARMUP=2          # warmup seconds (samples skipped by id)
+MEASURE=10        # measurement seconds
+QOS=10
+SUBS=(1 2 4 8 16 32)          # fan-out sweep (32 = nproc here)
+STAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS=~/eventfd_bench_${STAMP}
+BASE_BRANCH="bench/base"
+EVENTFD_BRANCH="feat/eventfd-publish-notification-v2"
+
+sudo -v || { echo "sudo required"; exit 1; }
+( while true; do sudo -n true; sleep 60; done ) & KA=$!
+trap 'kill $KA 2>/dev/null' EXIT
+# MQ baseline creates one notification MQ per subscriber; give it headroom.
+sudo sysctl -w fs.mqueue.queues_max=4096 >/dev/null
+
+run_branch() {
+  local branch="$1" tag="$2"
+  echo "==================== $branch ($tag) ===================="
+  cd "$AGNO" || exit 1
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "ERROR: $AGNO has tracked changes; commit/stash first."; exit 1
+  fi
+  git switch "$branch" || exit 1
+
+  rm -rf build install
+  bash scripts/dev/build_all.bash > "/tmp/ba_${tag}.log" 2>&1
+  if grep -qE "^Failed +<<<|package(s)? (failed|aborted)" "/tmp/ba_${tag}.log"; then
+    echo "ERROR: agnocast build failed on $branch (see /tmp/ba_${tag}.log)"; exit 1
+  fi
+
+  sudo rmmod agnocast 2>/dev/null || true
+  sudo insmod agnocast_kmod/agnocast.ko || { echo "insmod failed"; exit 1; }
+
+  source /opt/ros/humble/setup.bash >/dev/null 2>&1
+  source "$AGNO/install/setup.bash" >/dev/null 2>&1
+  local HH="$AGNO/install/agnocastlib/lib/libagnocast_heaphook.so"
+  local PUB="$AGNO/install/agnocast_bench/lib/agnocast_bench/bench_pub"
+  local SUB="$AGNO/install/agnocast_bench/lib/agnocast_bench/bench_sub"
+
+  for N in "${SUBS[@]}"; do
+    local od="${RESULTS}/${tag}/N${N}"; mkdir -p "$od"
+    echo "--- $tag  N=$N ---"
+    for s in $(seq 0 $((N - 1))); do
+      LD_PRELOAD="$HH" "$SUB" --ros-args \
+        -p rate_hz:=$RATE -p warmup_sec:=$WARMUP -p qos_depth:=$QOS \
+        -p output:="$od/sub_$s.csv" > "$od/sub_$s.log" 2>&1 &
+    done
+    sleep 3   # let subscribers connect
+    LD_PRELOAD="$HH" timeout 180 "$PUB" --ros-args \
+      -p rate_hz:=$RATE -p warmup_sec:=$WARMUP -p measure_sec:=$MEASURE \
+      -p num_subs:=$N -p qos_depth:=$QOS -p output:="$od/pub.csv" \
+      > "$od/pub.log" 2>&1
+    sleep 3   # let subscribers receive the sentinels and flush
+    pkill -9 -x bench_sub 2>/dev/null || true
+    pkill -9 -x bench_pub 2>/dev/null || true
+    sleep 1
+    rm -f /dev/shm/agnocast@* /dev/mqueue/agnocast* 2>/dev/null || true
+    sleep 1
+  done
+}
+
+mkdir -p "$RESULTS"
+run_branch "$BASE_BRANCH"    "mq_base"
+run_branch "$EVENTFD_BRANCH" "eventfd"
+
+echo ""
+echo "==================== DONE ===================="
+echo "Results: $RESULTS"
+python3 "$AGNO/src/agnocast_bench/analyze.py" "$RESULTS" || \
+  echo "(run: python3 ~/agnocast/src/agnocast_bench/analyze.py $RESULTS)"
+echo "NOTE: both branches carry the TEMP instrumentation commit; drop it before pushing #1432."

--- a/src/agnocast_bench/src/bench_pub.cpp
+++ b/src/agnocast_bench/src/bench_pub.cpp
@@ -1,0 +1,122 @@
+// Minimal 1-publisher / N-subscriber latency probe (publisher side).
+//
+// Measures the wall-clock cost of publish() — which is exactly where the
+// notification mechanism differs (MQ: N userspace mq_send syscalls; eventfd:
+// one in-ioctl signal). Uses the current agnocast API (rclcpp::Node +
+// SingleThreadedAgnocastExecutor), mirroring the sample apps.
+//
+// Phases: wait until num_subs subscribers are connected, then publish
+// warmup+measure messages (recording publish latency during the measure
+// window, keyed by id), then publish sentinels (id < 0) so subscribers flush
+// and exit, then write the CSV and shut down.
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/msg/static_size_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <fstream>
+#include <vector>
+
+using Msg = agnocast_sample_interfaces::msg::StaticSizeArray;
+
+static int64_t now_ns()
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+class BenchPub : public rclcpp::Node
+{
+public:
+  BenchPub() : Node("bench_pub")
+  {
+    const int rate_hz = declare_parameter<int>("rate_hz", 100);
+    const int warmup_sec = declare_parameter<int>("warmup_sec", 2);
+    const int measure_sec = declare_parameter<int>("measure_sec", 10);
+    const int qos_depth = declare_parameter<int>("qos_depth", 10);
+    num_subs_ = declare_parameter<int>("num_subs", 1);
+    output_ = declare_parameter<std::string>("output", "/tmp/bench_pub.csv");
+
+    warmup_count_ = static_cast<int64_t>(rate_hz) * warmup_sec;
+    measure_count_ = static_cast<int64_t>(rate_hz) * measure_sec;
+    drain_count_ = static_cast<int64_t>(rate_hz) * 2;  // 2s of sentinels
+    pub_lat_ns_.reserve(measure_count_);
+
+    pub_ = agnocast::create_publisher<Msg>(this, "/bench", qos_depth);
+    const auto period = std::chrono::nanoseconds(1000000000LL / rate_hz);
+    timer_ = create_wall_timer(period, std::bind(&BenchPub::tick, this));
+  }
+
+private:
+  void tick()
+  {
+    if (!started_) {
+      if (static_cast<int>(pub_->get_subscription_count()) < num_subs_) return;
+      started_ = true;
+      RCLCPP_INFO(get_logger(), "%d subscribers connected; starting", num_subs_);
+    }
+
+    const int64_t total = warmup_count_ + measure_count_;
+
+    if (count_ < total) {
+      auto msg = pub_->borrow_loaned_message();
+      msg->id = count_;
+      msg->timestamp = now_ns();
+      const int64_t t0 = now_ns();
+      pub_->publish(std::move(msg));
+      const int64_t t1 = now_ns();
+      if (count_ >= warmup_count_) pub_lat_ns_.push_back(t1 - t0);
+      count_++;
+      return;
+    }
+
+    if (count_ < total + drain_count_) {
+      auto msg = pub_->borrow_loaned_message();
+      msg->id = -1;  // sentinel: tells subscribers to flush + exit
+      msg->timestamp = now_ns();
+      pub_->publish(std::move(msg));
+      count_++;
+      return;
+    }
+
+    timer_->cancel();
+    write();
+    rclcpp::shutdown();
+  }
+
+  void write()
+  {
+    std::sort(pub_lat_ns_.begin(), pub_lat_ns_.end());
+    std::ofstream f(output_);
+    f << "publish_latency_ns\n";
+    for (const auto v : pub_lat_ns_) f << v << "\n";
+    RCLCPP_INFO(
+      get_logger(), "wrote %zu publish-latency samples to %s", pub_lat_ns_.size(),
+      output_.c_str());
+  }
+
+  agnocast::Publisher<Msg>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  int64_t count_ = 0;
+  int num_subs_ = 1;
+  int64_t warmup_count_ = 0;
+  int64_t measure_count_ = 0;
+  int64_t drain_count_ = 0;
+  std::string output_;
+  std::vector<int64_t> pub_lat_ns_;
+  bool started_ = false;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  agnocast::SingleThreadedAgnocastExecutor executor;
+  auto node = std::make_shared<BenchPub>();
+  executor.add_node(node);
+  executor.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/agnocast_bench/src/bench_sub.cpp
+++ b/src/agnocast_bench/src/bench_sub.cpp
@@ -1,0 +1,84 @@
+// Minimal 1-publisher / N-subscriber latency probe (subscriber side).
+//
+// Records end-to-end latency (publish timestamp -> callback entry) per message,
+// keyed by id so warmup messages are skipped without any clock sync. Both sides
+// stamp CLOCK_MONOTONIC on the same host, so e2e = recv - msg.timestamp is exact.
+// Exits on the publisher's sentinel (id < 0), flushing its samples.
+#include "agnocast/agnocast.hpp"
+#include "agnocast_sample_interfaces/msg/static_size_array.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <algorithm>
+#include <ctime>
+#include <fstream>
+#include <vector>
+
+using Msg = agnocast_sample_interfaces::msg::StaticSizeArray;
+
+static int64_t now_ns()
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+class BenchSub : public rclcpp::Node
+{
+public:
+  BenchSub() : Node("bench_sub")
+  {
+    const int rate_hz = declare_parameter<int>("rate_hz", 100);
+    const int warmup_sec = declare_parameter<int>("warmup_sec", 2);
+    const int qos_depth = declare_parameter<int>("qos_depth", 10);
+    output_ = declare_parameter<std::string>("output", "/tmp/bench_sub.csv");
+    warmup_count_ = static_cast<int64_t>(rate_hz) * warmup_sec;
+    e2e_ns_.reserve(static_cast<size_t>(rate_hz) * 60);
+
+    auto group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    agnocast::SubscriptionOptions opts;
+    opts.callback_group = group;
+    sub_ = agnocast::create_subscription<Msg>(
+      this, "/bench", qos_depth, std::bind(&BenchSub::callback, this, std::placeholders::_1), opts);
+  }
+
+private:
+  void callback(const agnocast::ipc_shared_ptr<Msg> & msg)
+  {
+    if (msg->id < 0) {  // sentinel
+      if (!done_) {
+        done_ = true;
+        write();
+        rclcpp::shutdown();
+      }
+      return;
+    }
+    const int64_t e2e = now_ns() - msg->timestamp;
+    if (msg->id >= warmup_count_) e2e_ns_.push_back(e2e);
+  }
+
+  void write()
+  {
+    std::sort(e2e_ns_.begin(), e2e_ns_.end());
+    std::ofstream f(output_);
+    f << "e2e_latency_ns\n";
+    for (const auto v : e2e_ns_) f << v << "\n";
+    RCLCPP_INFO(get_logger(), "wrote %zu e2e samples to %s", e2e_ns_.size(), output_.c_str());
+  }
+
+  agnocast::Subscription<Msg>::SharedPtr sub_;
+  int64_t warmup_count_ = 0;
+  std::string output_;
+  std::vector<int64_t> e2e_ns_;
+  bool done_ = false;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  agnocast::SingleThreadedAgnocastExecutor executor;
+  auto node = std::make_shared<BenchSub>();
+  executor.add_node(node);
+  executor.spin();
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
**Not for merge** — this is the benchmark harness used to measure the eventfd publish-notification change (#1432) vs the POSIX-MQ baseline, attached so reviewers can see how the numbers were produced.

## What it is
A self-contained package (`src/agnocast_bench`) with a 1-publisher/N-subscriber latency probe:
- **`bench_pub` / `bench_sub`** — publish a `StaticSizeArray` (`id` + `timestamp` + 1 KB) at a fixed rate; record **publish latency** (publisher wall-clock around `publish()` — where MQ's *N* `mq_send` syscalls vs eventfd's single in-ioctl signal differ) and **e2e latency** (publish→callback). Warmup skipped by `id`; no barrier needed.
- **`run_ab.sh`** — for each branch, clean-build, load the matching kmod, and sweep the subscriber count.
- **`analyze.py`** — p50/p90/p99 table with % deltas.

## Why not the original `isorc26_tmp` repo
The prior measurements (#1272) used the `isorc26_tmp` nodes, which **no longer run on current Agnocast**: they use the legacy `agnocast::init` / `agnocast::Node` / `AgnocastOnlySingleThreadedExecutor` API, which against current `agnocastlib` **double-registers the process** — the kmod's `add_process` returns `-EINVAL` ("process already exists") — and **segfaults on the publish path** when timing lets it through (each crash also leaks kmod per-process state). So this probe is rebuilt on the **current** API (mirroring `agnocast_sample_application`, which runs cleanly), self-contained so it can't inherit the old harness's layout/state issues.

## Fairness
A/B compares two branches sharing base #1426, differing **only** by the notification mechanism: `bench/base` (MQ) vs `feat/eventfd-publish-notification-v2` (eventfd), with byte-identical timing instrumentation. Same probe rebuilt per branch, same params, same host, back-to-back, no RT. Full rationale in `src/agnocast_bench/README.md`.
