### PR TITLE
feat(agnocastlib): add GenericClient

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -262,6 +262,16 @@ public:
   }
 };
 
+/**
+ * @brief Generic service client for zero-copy Agnocast service communication.
+ *
+ * The service type is supplied as a runtime string rather than a compile-time template argument.
+ * If the given service type is invalid, the constructor will throw an exception.
+ *
+ * The basic usage is the same as agnocast::Client, except that if you decide not to send a loaned
+ * request, you must call cancel_request() to free the loaned request memory. Otherwise, the process
+ * will terminate.
+ */
 class GenericClient
 {
 public:
@@ -386,6 +396,9 @@ public:
     const rclcpp::CallbackGroup::SharedPtr & group = nullptr,
     ClientRole role = ClientRole::Default);
 
+  /// @brief Allocate a type-erased request message in shared memory.
+  /// @return Owned pointer to the request message in shared memory, which must be either sent via
+  /// async_send_request() or freed via cancel_request() later.
   ipc_shared_ptr<void> borrow_loaned_request();
 
   const char * get_service_name() const { return service_name_.c_str(); }
@@ -401,11 +414,22 @@ public:
       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));
   }
 
+  /// @brief Send a request asynchronously and invoke a callback when the response arrives.
+  /// @param request Request from borrow_loaned_request(). Must be moved in.
+  /// @param callback Invoked with a SharedFuture when the response arrives. Call .get() to obtain
+  /// the response.
+  /// @return A SharedFutureAndRequestId containing the shared future and the sequence number of
+  /// the request.
   SharedFutureAndRequestId async_send_request(
     ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> && callback);
 
+  /// @brief Send a request asynchronously and return a future for the response.
+  /// @param request Request from borrow_loaned_request(). Must be moved in.
+  /// @return A FutureAndRequestId containing the future and the sequence number of the request.
   FutureAndRequestId async_send_request(ipc_shared_ptr<void> && request);
 
+  /// @brief Cancel a request that was not sent via async_send_request().
+  /// @param request Request from borrow_loaned_request(). Must be moved in.
   void cancel_request(ipc_shared_ptr<void> && request);
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -99,7 +99,7 @@ private:
   using ServiceRequestPublisher = Publisher<RequestT>;
   using ServiceResponseSubscriber = Subscription<ResponseT>;
 
-  std::atomic<int64_t> next_sequence_number_;
+  std::atomic<int64_t> next_sequence_number_{0};
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   std::string node_name_;
@@ -295,7 +295,7 @@ private:
     }
   };
 
-  std::atomic<int64_t> next_sequence_number_;
+  std::atomic<int64_t> next_sequence_number_{0};
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   std::string node_name_;

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -305,8 +305,8 @@ private:
   typename Subscription<void>::SharedPtr subscriber_;
 
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
-  const rosidl_typesupport_introspection_cpp::MessageMembers * request_members_;
-  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * request_members_{nullptr};
+  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_{nullptr};
 
   void load_typesupport_impl(const std::string & service_type);
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -402,7 +402,7 @@ public:
   }
 
   SharedFutureAndRequestId async_send_request(
-    ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> callback);
+    ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> && callback);
 
   FutureAndRequestId async_send_request(ipc_shared_ptr<void> && request);
 

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -7,6 +7,7 @@
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
+#include "agnocast/internal/service_wire_type.hpp"
 #include "agnocast/node/agnocast_context.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -78,16 +79,8 @@ public:
   };
 
 private:
-  // To avoid name conflicts, members of RequestT and ResponseT are given an underscore prefix.
-  struct RequestT : public ServiceT::Request
-  {
-    std::string _node_name;
-    int64_t _sequence_number;
-  };
-  struct ResponseT : public ServiceT::Response
-  {
-    int64_t _sequence_number;
-  };
+  using RequestT = ServiceRequestWrapper<ServiceT>;
+  using ResponseT = ServiceResponseWrapper<ServiceT>;
 
   struct ResponseCallInfo
   {
@@ -143,7 +136,7 @@ private:
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
       /* --- critical section begin --- */
       // Get the corresponding ResponseCallInfo and remove it from the map
-      auto it = seqno2_response_call_info_.find(response->_sequence_number);
+      auto it = seqno2_response_call_info_.find(response->seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
         RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
@@ -194,8 +187,8 @@ public:
   ipc_shared_ptr<typename ServiceT::Request> borrow_loaned_request()
   {
     auto request = publisher_->borrow_loaned_message();
-    request->_node_name = node_name_;
-    request->_sequence_number = next_sequence_number_.fetch_add(1);
+    request->node_name = node_name_;
+    request->seqno = next_sequence_number_.fetch_add(1);
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
 
@@ -235,7 +228,7 @@ public:
   {
     SharedFuture shared_future;
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->_sequence_number;
+    int64_t seqno = internal_request->seqno;
 
     {
       std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
@@ -256,7 +249,7 @@ public:
   {
     Future future;
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->_sequence_number;
+    int64_t seqno = internal_request->seqno;
 
     {
       std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
@@ -267,6 +260,153 @@ public:
     publisher_->publish(std::move(internal_request));
     return FutureAndRequestId(std::move(future), seqno);
   }
+};
+
+class GenericClient
+{
+public:
+  using SharedPtr = std::shared_ptr<GenericClient>;
+
+  using Future = std::future<ipc_shared_ptr<void>>;
+  using SharedFuture = std::shared_future<ipc_shared_ptr<void>>;
+
+  struct FutureAndRequestId : rclcpp::detail::FutureAndRequestId<Future>
+  {
+    using rclcpp::detail::FutureAndRequestId<Future>::FutureAndRequestId;
+    SharedFuture share() noexcept { return this->future.share(); }
+  };
+  struct SharedFutureAndRequestId : rclcpp::detail::FutureAndRequestId<SharedFuture>
+  {
+    using rclcpp::detail::FutureAndRequestId<SharedFuture>::FutureAndRequestId;
+  };
+
+private:
+  struct ResponseCallInfo
+  {
+    std::promise<ipc_shared_ptr<void>> promise;
+    std::optional<SharedFuture> shared_future;
+    std::optional<std::function<void(SharedFuture)>> callback;
+
+    ResponseCallInfo() = default;
+
+    explicit ResponseCallInfo(std::function<void(SharedFuture)> && cb) : callback(std::move(cb))
+    {
+      shared_future = promise.get_future().share();
+    }
+  };
+
+  std::atomic<int64_t> next_sequence_number_;
+  std::mutex seqno2_response_call_info_mtx_;
+  std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
+  std::string node_name_;
+  std::string service_name_;
+  std::function<bool()> check_context_ok_;
+  typename TypeErasedPublisher::SharedPtr publisher_;
+  typename Subscription<void>::SharedPtr subscriber_;
+
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * request_members_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_;
+
+  void load_typesupport_impl(const std::string & service_type);
+
+  template <typename NodeT>
+  void constructor_impl(
+    NodeT * node, const std::string & service_name, const std::string & service_type,
+    const rclcpp::QoS & qos_arg, const rclcpp::CallbackGroup::SharedPtr & group, ClientRole role)
+  {
+    node_name_ = node->get_fully_qualified_name();
+    service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
+
+    check_context_ok_ = [context = node->get_node_base_interface()->get_context()]() {
+      if constexpr (std::is_same_v<agnocast::Node, NodeT>) {
+        return agnocast::ok();
+      } else {
+        return rclcpp::ok(context);
+      }
+    };
+
+    load_typesupport_impl(service_type);
+
+    // TransientLocal durability is not allowed for services.
+    const rclcpp::QoS qos = rclcpp::QoS(qos_arg).durability_volatile();
+
+    agnocast::PublisherOptions pub_options;
+    std::string req_topic_name = create_service_request_topic_name(service_name_);
+    publisher_ = std::make_shared<TypeErasedPublisher>(
+      node, req_topic_name, "", qos, pub_options, PublisherRole::AgnocastOnly);
+
+    auto subscriber_callback = [this, node](ipc_shared_ptr<void> && response) {
+      auto generic_response_wrapper =
+        GenericResponseWrapper(response_members_, std::move(response));
+      int64_t response_seqno = generic_response_wrapper.seqno();
+
+      std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
+      /* --- critical section begin --- */
+      // Get the corresponding ResponseCallInfo and remove it from the map
+      auto it = seqno2_response_call_info_.find(response_seqno);
+      if (it == seqno2_response_call_info_.end()) {
+        lock.unlock();
+        RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
+        return;
+      }
+      ResponseCallInfo info = std::move(it->second);
+      seqno2_response_call_info_.erase(it);
+      /* --- critical section end --- */
+      lock.unlock();
+
+      info.promise.set_value(std::move(generic_response_wrapper).take_response());
+      if (info.callback.has_value()) {
+        (info.callback.value())(info.shared_future.value());
+      }
+    };
+
+    SubscriptionOptions sub_options{group};
+    std::string res_topic_name = create_service_response_topic_name(service_name_, node_name_);
+    subscriber_ = std::make_shared<Subscription<void>>(
+      node, res_topic_name, "", qos, std::move(subscriber_callback), sub_options,
+      SubscriptionRole::AgnocastOnly);
+
+    if (role == ClientRole::Default) {
+      register_service_bridge(
+        service_type, service_name_, BridgeDirection::AGNOCAST_TO_ROS2, std::nullopt);
+    }
+  }
+
+public:
+  GenericClient(
+    rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+    const rclcpp::CallbackGroup::SharedPtr & group = nullptr,
+    ClientRole role = ClientRole::Default);
+
+  GenericClient(
+    agnocast::Node * node, const std::string & service_name, const std::string & service_type,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+    const rclcpp::CallbackGroup::SharedPtr & group = nullptr,
+    ClientRole role = ClientRole::Default);
+
+  ipc_shared_ptr<void> borrow_loaned_request();
+
+  const char * get_service_name() const { return service_name_.c_str(); }
+
+  bool service_is_ready() const { return service_is_ready_core(service_name_); }
+
+  template <typename RepT = int64_t, typename RatioT = std::milli>
+  bool wait_for_service(
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1)) const
+  {
+    return wait_for_service_nanoseconds(
+      check_context_ok_, service_name_,
+      std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));
+  }
+
+  SharedFutureAndRequestId async_send_request(
+    ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> callback);
+
+  FutureAndRequestId async_send_request(ipc_shared_ptr<void> && request);
+
+  void cancel_request(ipc_shared_ptr<void> && request);
 };
 
 /**

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -6,6 +6,7 @@
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_node.hpp"
+#include "agnocast/internal/service_wire_type.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include <memory>
@@ -44,16 +45,8 @@ private:
   {
   };
 
-  // To avoid name conflicts, members of RequestT and ResponseT are given an underscore prefix.
-  struct RequestT : public ServiceT::Request
-  {
-    std::string _node_name;
-    int64_t _sequence_number;
-  };
-  struct ResponseT : public ServiceT::Response
-  {
-    int64_t _sequence_number;
-  };
+  using RequestT = ServiceRequestWrapper<ServiceT>;
+  using ResponseT = ServiceResponseWrapper<ServiceT>;
 
   using ServiceResponsePublisher = Publisher<ResponseT>;
   using ServiceRequestSubscriber = Subscription<RequestT>;
@@ -93,10 +86,10 @@ private:
   auto wrap_basic_service_callback_for_subscriber(Func && callback)
   {
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<RequestT> && request) {
-      auto publisher = this->get_or_create_publisher_for(request->_node_name);
+      auto publisher = this->get_or_create_publisher_for(request->node_name);
 
       ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
-      response->_sequence_number = request->_sequence_number;
+      response->seqno = request->seqno;
 
       ipc_shared_ptr<typename ServiceT::Response> response_double(response);
 
@@ -202,7 +195,7 @@ public:
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
     auto internal_response = static_ipc_shared_ptr_cast<ResponseT>(std::move(response));
-    auto publisher = get_or_create_publisher_for(internal_request->_node_name);
+    auto publisher = get_or_create_publisher_for(internal_request->node_name);
     publisher->publish(std::move(internal_response));
   }
 
@@ -221,9 +214,9 @@ public:
     const ipc_shared_ptr<typename ServiceT::Request> & request)
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(request);
-    auto publisher = get_or_create_publisher_for(internal_request->_node_name);
+    auto publisher = get_or_create_publisher_for(internal_request->node_name);
     ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
-    response->_sequence_number = internal_request->_sequence_number;
+    response->seqno = internal_request->seqno;
     return ipc_shared_ptr<typename ServiceT::Response>(std::move(response));
   }
 };

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "agnocast/agnocast_ioctl.hpp"  // NODE_NAME_BUFFER_SIZE
 #include "agnocast/agnocast_smart_pointer.hpp"
 
 namespace
@@ -83,8 +82,17 @@ public:
 
   ipc_shared_ptr<void> && take_request() && { return std::move(request_); }
 
+  /// @brief Allocate a wire-format request buffer in shared memory.
+  ///
+  /// The payload buffer is initialized via the introspection init function with
+  /// MessageInitialization::SKIP. The seqno number is uninitialized (garbage), and the node_name
+  /// string is default-constructed via placement new.
+  ///
+  /// @param request_members The introspection message members for the request type.
+  /// @param borrow_loaned_message A callable that allocates a buffer of the given size in shared
+  /// memory. In practice, this should be TypeErasedPublisher::borrow_loaned_message().
   template <typename Func>
-  static GenericRequestWrapper create(
+  static GenericRequestWrapper allocate(
     const rosidl_typesupport_introspection_cpp::MessageMembers * request_members,
     Func && borrow_loaned_message)
   {
@@ -101,6 +109,9 @@ public:
     return wrapper;
   }
 
+  /// @brief Free a wire-format request buffer in shared memory.
+  /// @param ptr Pointer to the request buffer.
+  /// @param request_members The introspection message members for the request type.
   static void free(
     void * ptr, const rosidl_typesupport_introspection_cpp::MessageMembers * request_members)
   {

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -18,6 +18,15 @@
 
 #include "agnocast/agnocast_smart_pointer.hpp"
 
+#include <rosidl_runtime_cpp/message_initialization.hpp>
+#include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <string>
+
 namespace
 {
 

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -1,0 +1,149 @@
+// On-the-wire layout of Agnocast service request/response messages.
+//
+// ┌───────────┬────────────────────────┐
+// │           │  correlation metadata  │
+// │  payload  ├─────────┬──────────────┤
+// │           │  seqno  │  node_name   │
+// └───────────┼─────────┴──────────────┘
+//             └ 16-byte aligned
+//
+// payload: request/response payload (ServiceT::Request or ServiceT::Response).
+//
+// seqno: A sequence number to identify each service call (int64_t). To avoid nastiness that may be
+// caused by compiler-inserted padding, this field is conservatively aligned to 16 bytes.
+//
+// node_name: The node name of the caller (std::string). This field only exists in the request.
+
+#pragma once
+
+#include "agnocast/agnocast_ioctl.hpp"  // NODE_NAME_BUFFER_SIZE
+#include "agnocast/agnocast_smart_pointer.hpp"
+
+namespace
+{
+
+constexpr size_t offsetof_meta(size_t base_size)
+{
+  return (base_size + 15) & (~15);
+}
+
+}  // namespace
+
+namespace agnocast
+{
+
+template <typename ServiceT>
+struct ServiceRequestWrapper : public ServiceT::Request
+{
+  alignas(16) int64_t seqno;
+  std::string node_name;
+};
+
+template <typename ServiceT>
+struct ServiceResponseWrapper : public ServiceT::Response
+{
+  alignas(16) int64_t seqno;
+};
+
+class GenericRequestWrapper
+{
+  struct Meta
+  {
+    alignas(16) int64_t seqno;
+    std::string node_name;
+  };
+
+  static constexpr size_t get_wire_size(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * request_members)
+  {
+    return offsetof_meta(request_members->size_of_) + sizeof(Meta);
+  }
+
+  static Meta * get_meta_ptr(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * request_members,
+    void * request_ptr)
+  {
+    return reinterpret_cast<Meta *>(
+      static_cast<char *>(request_ptr) + offsetof_meta(request_members->size_of_));
+  }
+
+  ipc_shared_ptr<void> request_;
+  Meta * const meta_ptr_;
+
+public:
+  explicit GenericRequestWrapper(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * request_members,
+    ipc_shared_ptr<void> && request)
+  : request_(std::move(request)), meta_ptr_(get_meta_ptr(request_members, request_.get()))
+  {
+  }
+
+  int64_t & seqno() { return meta_ptr_->seqno; }
+  std::string & node_name() { return meta_ptr_->node_name; }
+
+  ipc_shared_ptr<void> && take_request() && { return std::move(request_); }
+
+  template <typename Func>
+  static GenericRequestWrapper create(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * request_members,
+    Func && borrow_loaned_message)
+  {
+    ipc_shared_ptr<void> request = borrow_loaned_message(get_wire_size(request_members));
+    auto wrapper = GenericRequestWrapper(request_members, std::move(request));
+
+    request_members->init_function(
+      wrapper.request_.get(), rosidl_runtime_cpp::MessageInitialization::SKIP);
+
+    // Use placement new to construct node_name.
+    auto * node_name_ptr = &wrapper.node_name();
+    new (node_name_ptr) std::string{};
+
+    return wrapper;
+  }
+
+  static void free(
+    void * ptr, const rosidl_typesupport_introspection_cpp::MessageMembers * request_members)
+  {
+    request_members->fini_function(ptr);
+
+    // Destroy node_name by calling std::destroy_at().
+    Meta * meta_ptr = get_meta_ptr(request_members, ptr);
+    auto * node_name_ptr = &meta_ptr->node_name;
+    std::destroy_at(node_name_ptr);
+
+    ::operator delete(ptr);
+  }
+};
+
+class GenericResponseWrapper
+{
+  struct Meta
+  {
+    alignas(16) int64_t seqno;
+  };
+
+  static Meta * get_meta_ptr(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
+    void * response_ptr)
+  {
+    return reinterpret_cast<Meta *>(
+      static_cast<char *>(response_ptr) + offsetof_meta(response_members->size_of_));
+  }
+
+  ipc_shared_ptr<void> response_;
+  Meta * const meta_ptr_;
+
+public:
+  explicit GenericResponseWrapper(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
+    ipc_shared_ptr<void> && response)
+  : response_(std::move(response)), meta_ptr_(get_meta_ptr(response_members, response_.get()))
+  {
+  }
+
+  int64_t & seqno() { return meta_ptr_->seqno; }
+
+  ipc_shared_ptr<void> && take_response() && { return std::move(response_); }
+};
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -122,7 +122,7 @@ GenericClient::GenericClient(
 
 ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
 {
-  auto generic_request_wrapper = GenericRequestWrapper::create(
+  auto generic_request_wrapper = GenericRequestWrapper::allocate(
     request_members_, [this](size_t size) { return publisher_->borrow_loaned_message(size); });
 
   generic_request_wrapper.node_name() = node_name_;

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -147,7 +147,7 @@ GenericClient::SharedFutureAndRequestId GenericClient::async_send_request(
   publisher_->publish(std::move(generic_request_wrapper).take_request(), [this](void * p) {
     GenericRequestWrapper::free(p, this->request_members_);
   });
-  return SharedFutureAndRequestId(std::move(shared_future), seqno);
+  return {std::move(shared_future), seqno};
 }
 
 GenericClient::FutureAndRequestId GenericClient::async_send_request(ipc_shared_ptr<void> && request)
@@ -165,7 +165,7 @@ GenericClient::FutureAndRequestId GenericClient::async_send_request(ipc_shared_p
   publisher_->publish(std::move(generic_request_wrapper).take_request(), [this](void * p) {
     GenericRequestWrapper::free(p, this->request_members_);
   });
-  return FutureAndRequestId(std::move(future), seqno);
+  return {std::move(future), seqno};
 }
 
 void GenericClient::cancel_request(ipc_shared_ptr<void> && request)

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -132,7 +132,7 @@ ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
 }
 
 GenericClient::SharedFutureAndRequestId GenericClient::async_send_request(
-  ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> callback)
+  ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> && callback)
 {
   SharedFuture shared_future;
   auto generic_request_wrapper = GenericRequestWrapper(request_members_, std::move(request));

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast/agnocast_ioctl.hpp"
 #include "agnocast/node/agnocast_context.hpp"
+#include "agnocast/node/agnocast_node.hpp"
 
 #include <array>
 #include <chrono>
@@ -76,6 +77,102 @@ bool wait_for_service_nanoseconds(
     // If timeout is negative, time_to_wait will never reach zero.
   } while (time_to_wait > nanoseconds(0));
   return false;
+}
+
+void GenericClient::load_typesupport_impl(const std::string & service_type)
+{
+  static const std::string ts_introspection_identifier = "rosidl_typesupport_introspection_cpp";
+  const std::string request_type = service_type + "_Request";
+  const std::string response_type = service_type + "_Response";
+
+  ts_lib_introspection_ =
+    rclcpp::get_typesupport_library(service_type, ts_introspection_identifier);
+
+#if RCLCPP_VERSION_MAJOR >= 28
+  const rosidl_message_type_support_t * request_ts = rclcpp::get_message_typesupport_handle(
+    request_type, ts_introspection_identifier, *ts_lib_introspection_);
+  const rosidl_message_type_support_t * response_ts = rclcpp::get_message_typesupport_handle(
+    response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#else
+  const rosidl_message_type_support_t * request_ts = rclcpp::get_typesupport_handle(
+    request_type, ts_introspection_identifier, *ts_lib_introspection_);
+  const rosidl_message_type_support_t * response_ts = rclcpp::get_typesupport_handle(
+    response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#endif
+
+  request_members_ =
+    static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(request_ts->data);
+  response_members_ =
+    static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(response_ts->data);
+}
+
+GenericClient::GenericClient(
+  rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+  const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group, ClientRole role)
+{
+  constructor_impl(node, service_name, service_type, qos, group, role);
+}
+
+GenericClient::GenericClient(
+  agnocast::Node * node, const std::string & service_name, const std::string & service_type,
+  const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group, ClientRole role)
+{
+  constructor_impl(node, service_name, service_type, qos, group, role);
+}
+
+ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
+{
+  auto generic_request_wrapper = GenericRequestWrapper::create(
+    request_members_, [this](size_t size) { return publisher_->borrow_loaned_message(size); });
+
+  generic_request_wrapper.node_name() = node_name_;
+  generic_request_wrapper.seqno() = next_sequence_number_.fetch_add(1);
+
+  return std::move(generic_request_wrapper).take_request();
+}
+
+GenericClient::SharedFutureAndRequestId GenericClient::async_send_request(
+  ipc_shared_ptr<void> && request, std::function<void(SharedFuture)> callback)
+{
+  SharedFuture shared_future;
+  auto generic_request_wrapper = GenericRequestWrapper(request_members_, std::move(request));
+  int64_t seqno = generic_request_wrapper.seqno();
+
+  {
+    std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
+    auto it = seqno2_response_call_info_.try_emplace(seqno, std::move(callback)).first;
+    shared_future = it->second.shared_future.value();
+  }
+
+  publisher_->publish(std::move(generic_request_wrapper).take_request(), [this](void * p) {
+    GenericRequestWrapper::free(p, this->request_members_);
+  });
+  return SharedFutureAndRequestId(std::move(shared_future), seqno);
+}
+
+GenericClient::FutureAndRequestId GenericClient::async_send_request(ipc_shared_ptr<void> && request)
+{
+  Future future;
+  auto generic_request_wrapper = GenericRequestWrapper(request_members_, std::move(request));
+  int64_t seqno = generic_request_wrapper.seqno();
+
+  {
+    std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
+    auto it = seqno2_response_call_info_.try_emplace(seqno).first;
+    future = it->second.promise.get_future();
+  }
+
+  publisher_->publish(std::move(generic_request_wrapper).take_request(), [this](void * p) {
+    GenericRequestWrapper::free(p, this->request_members_);
+  });
+  return FutureAndRequestId(std::move(future), seqno);
+}
+
+void GenericClient::cancel_request(ipc_shared_ptr<void> && request)
+{
+  publisher_->cancel_message(std::move(request), [this](void * p) {
+    GenericRequestWrapper::free(p, this->request_members_);
+  });
 }
 
 }  // namespace agnocast


### PR DESCRIPTION
## Description

This PR introduces a type-erased `GenericClient` class for Agnocast services, and extracts the on-the-wire service message layout into a shared `internal/service_wire_type.hpp` header.

### On-the-wire service message layout

`internal/service_wire_type.hpp` defines the canonical on-the-wire layout for service messages and provides four types that encapsulates the layout.

- `ServiceRequestWrapper` and `ServiceResponseWrapper` are typed wire-format messages whose metadata fields are exposed as data members.
- `GenericRequestWrapper` and `GenericResponseWrapper` are type-erased counterparts whose metadata fields are exposed as accessor methods.

Existing `BasicClient` and `BasicService` are refactored to use `ServiceRequestWrapper` and `ServiceResponseWrapper`.

### `GenericClient` class

`GenericClient` is a type-erased service client that mirrors `BasicClient` but operates without compile-time service type knowledge. It uses `TypeErasedPublisher` and `Subscription<void>` instead of typed publishers/subscribers, and exposes the same interface as `BasicClient`. One method specific to `GenericClient` is `cancel_request()`, which delegates to `TypeErasedPublisher`'s `cancel_message()`.

## Related links

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

I wrote a sample client application using `GenericClient` and verified that it communicates with the sample server application without any problems. The code is available in branch `bdm-k/cherry-tern`

## Notes for reviewers

- `BasicClient` and `GenericClient` share much code. I will refactor them to deduplicate code in the next PR.
-  Once #1424 is merged, I will also add tests for `GenericClient`.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)