### PR TITLE
perf(bridge): avoid redundant copying in service bridge plugin

### DIFF
--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -70,8 +70,7 @@ extern "C" ServiceBridgeEntity create_a2r_service_bridge_@(snake_type_name)(
     [ros_client](
       typename AgnoService::SharedPtr service_handle,
       agnocast::ipc_shared_ptr<typename ServiceT::Request> && agno_req) {
-      auto ros_req = std::make_shared<typename ServiceT::Request>();
-      *ros_req = *agno_req;
+      std::shared_ptr<typename ServiceT::Request> ros_req(agno_req.get(), [](void *) {});
 
       ros_client->async_send_request(
         ros_req, [service_handle = std::move(service_handle), agno_req = std::move(agno_req)](

--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -37,9 +37,7 @@ extern "C" ServiceBridgeEntity create_r2a_service_bridge_@(snake_type_name)(
         std::move(agno_req),
         [service_handle, request_header](typename agnocast::Client<ServiceT>::SharedFuture future) {
           auto agno_res = future.get();
-          typename ServiceT::Response ros_res;
-          ros_res = *agno_res;
-          service_handle->send_response(*request_header, ros_res);
+          service_handle->send_response(*request_header, *agno_res);
         });
     },
 #if RCLCPP_VERSION_MAJOR >= 28


### PR DESCRIPTION
<!--
## Summary

Optimize the service bridge plugin template to eliminate unnecessary copies of service request and response objects, reducing overhead in bridge communication.

## Changes

1. **Directly send response from Agnocast buffer** — Instead of copying the `agno_res` result into a local `ros_res` variable before calling `send_response`, pass `*agno_res` directly. This avoids an extra copy of the response object.

2. **Use aliasing `shared_ptr` to avoid request copy** — Instead of allocating a new `shared_ptr` and copying the request data (`*ros_req = *agno_req`), use the aliasing constructor of `shared_ptr` that shares ownership of the original buffer while pointing to the existing data, with a no-op deleter. This avoids copying the request data entirely.

## Files Changed

- `src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em` (+2, −5)
-->

## Description

This PR optimizes the service bridge plugin to eliminate unnecessary copies of service request and response objects, reducing overhead in bridge communication.

### Insight

While regular memory cannot be used as Agnocast shared memory, Agnocast shared memory can, of course, be used as regular memory. By leveraging this asymmetry, we can eliminate a copy from shared memory to regular memory.

### Changes

1. In the R2A bridge, the Agnocast response is directly passed to the call of `send_response()` on the ROS 2 service.
2. In the A2R bridge, A non-owning `shared_ptr` pointing to the Agnocast request is passed to the call of `async_send_request()` on the ROS 2 client.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
