### PR TITLE
feat(agnocast_cie_thread_configurator): support wildcard callback group ids (<node name>/*) in the config YAML

### DIFF
--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -10,8 +10,8 @@
 # "<domain_id>:<full callback_group_id>" key per known matched instance in
 # applied/failed, and a single "<domain_id>:<node name>/*" key in skipped
 # while no instance has been announced yet. Instances are matched to entries
-# at announcement time only; reapply does not move instances between entries,
-# so an entry that changed form (exact <-> wildcard) starts over as skipped.
+# at announcement time only, so an entry that changed form (exact <-> wildcard)
+# starts over as skipped.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -11,7 +11,10 @@
 # applied/failed, and a single "<domain_id>:<node name>/*" key in skipped
 # while no instance has been announced yet. Instances are matched to entries
 # at announcement time only, so an entry that changed form (exact <-> wildcard)
-# starts over as skipped.
+# starts over as skipped. An exact entry added for an instance already matched
+# by a wildcard likewise takes over at the next announcement; until then the
+# wildcard keeps applying to that instance, and from then on only the exact
+# entry does.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -6,6 +6,12 @@
 # no state is mutated. hardware_info / rt_throttling are NOT re-evaluated
 # on reapply; changes there require a process restart.
 ---
+# Wildcard ("<node name>/*") callback-group entries report one
+# "<domain_id>:<full callback_group_id>" key per known matched instance in
+# applied/failed, and a single "<domain_id>:<node name>/*" key in skipped
+# while no instance has been announced yet. Instances are matched to entries
+# at announcement time only; reapply does not move instances between entries,
+# so an entry that changed form (exact <-> wildcard) starts over as skipped.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -37,7 +37,7 @@ struct ThreadConfig
   bool applied = false;  // true once issue_syscalls() has succeeded
 
   // Whether this is a wildcard callback-group entry.
-  bool is_wildcard() const;
+  bool is_wildcard() const noexcept;
   // The "<node name>" part of a wildcard id: thread_str minus the trailing
   // "/*". Only meaningful when is_wildcard().
   std::string wildcard_prefix() const;

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -27,19 +27,16 @@ struct ThreadConfig
   unsigned int period = 0;
   unsigned int deadline = 0;
 
-  // Full incoming callback_group_id -> last announced tid. Wildcard
-  // ("<node name>/*") callback-group entries only; unused by non_ros_threads.
-  // For a wildcard entry, `applied` means "at least one matched instance has
-  // been configured" and thread_id stays -1. std::map for deterministic
-  // iteration order in the reapply response arrays.
+  // Full incoming callback_group_id -> last announced tid; wildcard
+  // ("<node name>/*") entries only. For such entries `applied` means "at least
+  // one matched instance has been configured" and thread_id stays -1. std::map
+  // for deterministic iteration order in the reapply response arrays.
   std::map<std::string, int64_t> matched_tids;
 
   bool applied = false;  // true once issue_syscalls() has succeeded
 
-  // Whether this is a wildcard callback-group entry.
   bool is_wildcard() const noexcept;
-  // The "<node name>" part of a wildcard id: thread_str minus the trailing
-  // "/*". Only meaningful when is_wildcard().
+  // thread_str minus the trailing "/*"; only meaningful when is_wildcard().
   std::string wildcard_prefix() const;
 };
 

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -3,6 +3,7 @@
 #include "yaml-cpp/yaml.h"
 
 #include <cstdint>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -26,8 +27,25 @@ struct ThreadConfig
   unsigned int period = 0;
   unsigned int deadline = 0;
 
+  // Full incoming callback_group_id -> last announced tid. Wildcard
+  // ("<node name>/*") callback-group entries only; unused by non_ros_threads.
+  // For a wildcard entry, `applied` means "at least one matched instance has
+  // been configured" and thread_id stays -1. std::map for deterministic
+  // iteration order in the reapply response arrays.
+  std::map<std::string, int64_t> matched_tids;
+
   bool applied = false;  // true once issue_syscalls() has succeeded
+
+  // Whether this is a wildcard callback-group entry.
+  bool is_wildcard() const;
+  // The "<node name>" part of a wildcard id: thread_str minus the trailing
+  // "/*". Only meaningful when is_wildcard().
+  std::string wildcard_prefix() const;
 };
+
+// Node-name part of an incoming callback_group_id: the substring before the
+// first '@' (the whole string when no '@' is present).
+std::string extract_node_part(const std::string & callback_group_id);
 
 // Mapping from the policy string in the YAML to the kernel SCHED_* constant.
 // Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
@@ -37,6 +55,10 @@ extern const std::unordered_map<std::string, int> policy_to_sched_const;
 // Throws std::runtime_error on per-entry validation error. Output ThreadConfigs
 // have thread_id=-1 and applied=false; callers that re-parse must carry
 // thread_id over from their existing index manually.
+// A callback-group id ending in "/*" is a wildcard entry matching every
+// callback group whose node part (before the first '@') equals the prefix,
+// within the same domain; exact entries take precedence over wildcards.
+// non_ros_threads names are always matched exactly.
 // hardware_info / rt_throttling are validated only at startup, not here.
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -9,6 +9,7 @@
 #include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -19,9 +20,10 @@ class ThreadConfiguratorNode : public rclcpp::Node
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
 
   // Concurrency:
-  // - callback_group_configs_ / id_to_callback_group_config_: written by the
-  //   subscription callbacks AND the reapply service handler, all on the same
-  //   SingleThreadedExecutor — no mutex needed.
+  // - callback_group_configs_ / id_to_callback_group_config_ /
+  //   node_to_wildcard_config_ (incl. each entry's matched_tids): written by
+  //   the subscription callbacks AND the reapply service handler, all on the
+  //   same SingleThreadedExecutor — no mutex needed.
   // - non_ros_thread_configs_ / id_to_non_ros_thread_config_: written by both
   //   the NonRosThreadInfoListener reader thread and the reapply handler;
   //   all access must hold non_ros_state_mutex_.
@@ -40,7 +42,9 @@ private:
   void validate_hardware_info(const YAML::Node & yaml);
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
-  bool issue_syscalls(const ThreadConfig & config);
+  // thread_id is passed explicitly because a wildcard entry applies to many
+  // threads (one per matched_tids element), not just config.thread_id.
+  bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
   void callback_group_callback(
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
@@ -57,8 +61,10 @@ private:
   rclcpp::Service<agnocast_cie_config_msgs::srv::ReapplyConfig>::SharedPtr reapply_service_;
 
   std::vector<ThreadConfig> callback_group_configs_;
-  // (domain_id, callback_group_id) -> ThreadConfig*
+  // (domain_id, callback_group_id) -> ThreadConfig*, exact entries only
   std::map<std::pair<size_t, std::string>, ThreadConfig *> id_to_callback_group_config_;
+  // (domain_id, wildcard_prefix) -> ThreadConfig*, wildcard ("<node>/*") entries only
+  std::map<std::pair<size_t, std::string>, ThreadConfig *> node_to_wildcard_config_;
 
   std::vector<ThreadConfig> non_ros_thread_configs_;
   // thread_name -> ThreadConfig*

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -5,6 +5,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 
@@ -15,6 +16,23 @@ const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
 };
+
+bool ThreadConfig::is_wildcard() const
+{
+  static constexpr std::string_view suffix = "/*";
+  return thread_str.size() >= suffix.size() &&
+         thread_str.compare(thread_str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string ThreadConfig::wildcard_prefix() const
+{
+  return thread_str.substr(0, thread_str.size() - 2);
+}
+
+std::string extract_node_part(const std::string & callback_group_id)
+{
+  return callback_group_id.substr(0, callback_group_id.find('@'));
+}
 
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,
@@ -33,6 +51,27 @@ void parse_yaml(
     auto & cfg = callback_groups_out[i];
 
     cfg.thread_str = cg["id"].as<std::string>();
+    if (cfg.thread_str.find('*') != std::string::npos) {
+      // A typo'd pattern silently treated as an exact id would never match,
+      // so any id containing '*' must be a well-formed "<node name>/*".
+      if (!cfg.is_wildcard()) {
+        throw std::runtime_error(
+          "Invalid id '" + cfg.thread_str +
+          "': '*' is only allowed as a trailing \"/*\" wildcard (e.g. /my_node/*)");
+      }
+      const std::string prefix = cfg.wildcard_prefix();
+      if (prefix.empty() || prefix.find('*') != std::string::npos) {
+        throw std::runtime_error(
+          "Invalid wildcard id '" + cfg.thread_str +
+          "': the part before \"/*\" must be a non-empty node name without '*'");
+      }
+      if (prefix.find('@') != std::string::npos) {
+        throw std::runtime_error(
+          "Invalid wildcard id '" + cfg.thread_str +
+          "': the part before \"/*\" must be a plain node name, not a full callback-group id "
+          "containing '@'");
+      }
+    }
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
     for (auto & cpu : cg["affinity"]) cfg.affinity.push_back(cpu.as<int>());
     cfg.policy = cg["policy"].as<std::string>();

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -17,7 +17,7 @@ const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
 };
 
-bool ThreadConfig::is_wildcard() const
+bool ThreadConfig::is_wildcard() const noexcept
 {
   static constexpr std::string_view suffix = "/*";
   return thread_str.size() >= suffix.size() &&

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -413,9 +413,8 @@ void ThreadConfiguratorNode::callback_group_callback(
     config = it->second;
     already_seen = config->applied;
   } else {
-    const std::string node_part =
-      agnocast_cie_thread_configurator::extract_node_part(msg->callback_group_id);
-    auto wit = node_to_wildcard_config_.find(std::make_pair(domain_id, node_part));
+    auto wit = node_to_wildcard_config_.find(std::make_pair(
+      domain_id, agnocast_cie_thread_configurator::extract_node_part(msg->callback_group_id)));
     if (wit == node_to_wildcard_config_.end()) {
       RCLCPP_INFO(
         this->get_logger(),

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -433,8 +433,7 @@ void ThreadConfiguratorNode::callback_group_callback(
   if (already_seen) {
     // Always re-apply: the OS may reuse the same thread IDs after an application
     // restarts, so we cannot use thread_id equality to skip reconfiguration.
-    // "tracked", not "configured": for a wildcard instance already_seen only
-    // means the tid was recorded; its first syscall may have failed.
+    // "tracked", not "configured": a recorded wildcard tid's syscall may have failed.
     RCLCPP_INFO(
       this->get_logger(),
       "Re-applying configuration for already tracked callback group "
@@ -550,13 +549,10 @@ void ThreadConfiguratorNode::on_reapply_config_request(
 
   // Carry known tids over from the existing state, same-form entries only:
   // exact entries carry thread_id, wildcard entries carry matched_tids. An
-  // entry that changed form (exact <-> wildcard) starts fresh and is picked up
-  // at the next announcement, i.e. when the target application restarts; in
-  // particular, "exact overrides wildcard" is decided at announcement time
-  // only, so an exact override added for an already-matched instance does not
-  // take effect on reapply. 'applied' is intentionally NOT carried: a syscall
-  // failure below must leave applied=false, not the stale 'true' that a
-  // verbatim carry-over would imply.
+  // entry that changed form (exact <-> wildcard) starts fresh and is only
+  // picked up at the next announcement (see ReapplyConfig.srv). 'applied' is
+  // intentionally NOT carried: a syscall failure below must leave
+  // applied=false, not the stale 'true' that a verbatim carry-over would imply.
   for (auto & cfg : new_cb) {
     if (cfg.is_wildcard()) {
       auto it = node_to_wildcard_config_.find(std::make_pair(cfg.domain_id, cfg.wildcard_prefix()));

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -412,6 +412,13 @@ void ThreadConfiguratorNode::callback_group_callback(
   if (it != id_to_callback_group_config_.end()) {
     config = it->second;
     already_seen = config->applied;
+    // Drop stale tracking left in a wildcard entry from before this exact entry
+    // existed; otherwise reapply would apply both entries to the same thread.
+    auto wit = node_to_wildcard_config_.find(std::make_pair(
+      domain_id, agnocast_cie_thread_configurator::extract_node_part(msg->callback_group_id)));
+    if (wit != node_to_wildcard_config_.end()) {
+      wit->second->matched_tids.erase(msg->callback_group_id);
+    }
   } else {
     auto wit = node_to_wildcard_config_.find(std::make_pair(
       domain_id, agnocast_cie_thread_configurator::extract_node_part(msg->callback_group_id)));

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -58,8 +58,11 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
   std::set<size_t> domain_ids;
   for (auto & cfg : callback_group_configs_) {
     domain_ids.insert(cfg.domain_id);
-    auto key = std::make_pair(cfg.domain_id, cfg.thread_str);
-    id_to_callback_group_config_[key] = &cfg;
+    if (cfg.is_wildcard()) {
+      node_to_wildcard_config_[std::make_pair(cfg.domain_id, cfg.wildcard_prefix())] = &cfg;
+    } else {
+      id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+    }
   }
   for (auto & cfg : non_ros_thread_configs_) {
     id_to_non_ros_thread_config_[cfg.thread_str] = &cfg;
@@ -301,7 +304,7 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
   return true;
 }
 
-bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
+bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t thread_id)
 {
   if (
     config.policy == "SCHED_OTHER" || config.policy == "SCHED_BATCH" ||
@@ -309,19 +312,18 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = 0;
 
-    if (
-      sched_setscheduler(config.thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
+    if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
-        config.thread_str.c_str(), config.thread_id, strerror(errno));
+        config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
 
     // Specify nice value
-    if (setpriority(PRIO_PROCESS, config.thread_id, config.priority) == -1) {
+    if (setpriority(PRIO_PROCESS, thread_id, config.priority) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure nice value (thread=%s, tid=%ld): %s",
-        config.thread_str.c_str(), config.thread_id, strerror(errno));
+        config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
 
@@ -329,11 +331,10 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     struct sched_param param;
     param.sched_priority = config.priority;
 
-    if (
-      sched_setscheduler(config.thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
+    if (sched_setscheduler(thread_id, policy_to_sched_const.at(config.policy), &param) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
-        config.thread_str.c_str(), config.thread_id, strerror(errno));
+        config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
 
@@ -354,25 +355,25 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
     attr.sched_period = config.period;
     attr.sched_deadline = config.deadline;
 
-    if (sched_setattr(config.thread_id, &attr, 0) == -1) {
+    if (sched_setattr(thread_id, &attr, 0) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure policy (thread=%s, tid=%ld): %s",
-        config.thread_str.c_str(), config.thread_id, strerror(errno));
+        config.thread_str.c_str(), thread_id, strerror(errno));
       return false;
     }
   } else {
     RCLCPP_ERROR(
       this->get_logger(), "Unknown scheduling policy '%s' (thread=%s, tid=%ld)",
-      config.policy.c_str(), config.thread_str.c_str(), config.thread_id);
+      config.policy.c_str(), config.thread_str.c_str(), thread_id);
     return false;
   }
 
   if (config.affinity.size() > 0) {
     if (config.policy == "SCHED_DEADLINE") {
-      if (!set_affinity_by_cgroup(config.thread_id, config.affinity)) {
+      if (!set_affinity_by_cgroup(thread_id, config.affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), config.thread_id,
+          config.thread_str.c_str(), thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
         return false;
@@ -383,10 +384,10 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config)
       for (int cpu : config.affinity) {
         CPU_SET(cpu, &set);
       }
-      if (sched_setaffinity(config.thread_id, sizeof(set), &set) == -1) {
+      if (sched_setaffinity(thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), config.thread_id, strerror(errno));
+          config.thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
     }
@@ -403,24 +404,41 @@ const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_
 void ThreadConfiguratorNode::callback_group_callback(
   size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg)
 {
-  auto key = std::make_pair(domain_id, msg->callback_group_id);
-  auto it = id_to_callback_group_config_.find(key);
-  if (it == id_to_callback_group_config_.end()) {
+  ThreadConfig * config = nullptr;
+  bool already_seen = false;
+
+  // Exact entries take precedence over wildcard ("<node>/*") entries.
+  auto it = id_to_callback_group_config_.find(std::make_pair(domain_id, msg->callback_group_id));
+  if (it != id_to_callback_group_config_.end()) {
+    config = it->second;
+    already_seen = config->applied;
+  } else {
+    const std::string node_part =
+      agnocast_cie_thread_configurator::extract_node_part(msg->callback_group_id);
+    auto wit = node_to_wildcard_config_.find(std::make_pair(domain_id, node_part));
+    if (wit == node_to_wildcard_config_.end()) {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Received CallbackGroupInfo: but the yaml file does not "
+        "contain configuration for domain=%zu, id=%s (tid=%ld)",
+        domain_id, msg->callback_group_id.c_str(), msg->thread_id);
+      return;
+    }
+    config = wit->second;
+    already_seen = config->matched_tids.count(msg->callback_group_id) > 0;
     RCLCPP_INFO(
-      this->get_logger(),
-      "Received CallbackGroupInfo: but the yaml file does not "
-      "contain configuration for domain=%zu, id=%s (tid=%ld)",
-      domain_id, msg->callback_group_id.c_str(), msg->thread_id);
-    return;
+      this->get_logger(), "Callback group (domain=%zu, id=%s) matched wildcard entry '%s'",
+      domain_id, msg->callback_group_id.c_str(), config->thread_str.c_str());
   }
 
-  ThreadConfig * config = it->second;
-  if (config->applied) {
+  if (already_seen) {
     // Always re-apply: the OS may reuse the same thread IDs after an application
     // restarts, so we cannot use thread_id equality to skip reconfiguration.
+    // "tracked", not "configured": for a wildcard instance already_seen only
+    // means the tid was recorded; its first syscall may have failed.
     RCLCPP_INFO(
       this->get_logger(),
-      "Re-applying configuration for already configured callback group "
+      "Re-applying configuration for already tracked callback group "
       "(domain=%zu, id=%s, tid=%ld)",
       domain_id, msg->callback_group_id.c_str(), msg->thread_id);
   }
@@ -428,9 +446,14 @@ void ThreadConfiguratorNode::callback_group_callback(
   RCLCPP_INFO(
     this->get_logger(), "Received CallbackGroupInfo: domain=%zu | tid=%ld | %s", domain_id,
     msg->thread_id, msg->callback_group_id.c_str());
-  config->thread_id = msg->thread_id;
+  // Record the tid before the syscall so a failed attempt can be retried via reapply.
+  if (config->is_wildcard()) {
+    config->matched_tids[msg->callback_group_id] = msg->thread_id;
+  } else {
+    config->thread_id = msg->thread_id;
+  }
 
-  if (!issue_syscalls(*config)) {
+  if (!issue_syscalls(*config, msg->thread_id)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for callback group (domain=%zu, id=%s, tid=%ld) due to syscall "
@@ -479,7 +502,7 @@ void ThreadConfiguratorNode::non_ros_thread_callback(
     this->get_logger(), "Received NonRosThreadInfo: tid=%ld | %s", info.tid, info.name.c_str());
   config->thread_id = info.tid;
 
-  if (!issue_syscalls(*config)) {
+  if (!issue_syscalls(*config, info.tid)) {
     RCLCPP_WARN(
       this->get_logger(),
       "Skipping configuration for non-ROS thread (name=%s, tid=%ld) due to syscall "
@@ -526,20 +549,38 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     return;
   }
 
-  // Carry thread_id over from existing state. 'applied' is intentionally NOT
-  // carried: a syscall failure below must leave applied=false, not the stale
-  // 'true' that a verbatim carry-over would imply.
+  // Carry known tids over from the existing state, same-form entries only:
+  // exact entries carry thread_id, wildcard entries carry matched_tids. An
+  // entry that changed form (exact <-> wildcard) starts fresh and is picked up
+  // at the next announcement, i.e. when the target application restarts; in
+  // particular, "exact overrides wildcard" is decided at announcement time
+  // only, so an exact override added for an already-matched instance does not
+  // take effect on reapply. 'applied' is intentionally NOT carried: a syscall
+  // failure below must leave applied=false, not the stale 'true' that a
+  // verbatim carry-over would imply.
   for (auto & cfg : new_cb) {
-    auto it = id_to_callback_group_config_.find(std::make_pair(cfg.domain_id, cfg.thread_str));
-    if (it != id_to_callback_group_config_.end()) {
-      cfg.thread_id = it->second->thread_id;
+    if (cfg.is_wildcard()) {
+      auto it = node_to_wildcard_config_.find(std::make_pair(cfg.domain_id, cfg.wildcard_prefix()));
+      if (it != node_to_wildcard_config_.end()) {
+        cfg.matched_tids = it->second->matched_tids;
+      }
+    } else {
+      auto it = id_to_callback_group_config_.find(std::make_pair(cfg.domain_id, cfg.thread_str));
+      if (it != id_to_callback_group_config_.end()) {
+        cfg.thread_id = it->second->thread_id;
+      }
     }
   }
 
   callback_group_configs_ = std::move(new_cb);
   id_to_callback_group_config_.clear();
+  node_to_wildcard_config_.clear();
   for (auto & cfg : callback_group_configs_) {
-    id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+    if (cfg.is_wildcard()) {
+      node_to_wildcard_config_[std::make_pair(cfg.domain_id, cfg.wildcard_prefix())] = &cfg;
+    } else {
+      id_to_callback_group_config_[std::make_pair(cfg.domain_id, cfg.thread_str)] = &cfg;
+    }
   }
 
   // One lock spans non-ROS carry-over + swap + unapplied_num_ recompute so the
@@ -565,12 +606,37 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   }
 
   for (auto & cfg : callback_group_configs_) {
+    if (cfg.is_wildcard()) {
+      // One applied/failed key per known instance; the pattern itself is
+      // reported as skipped only while no instance has been announced yet.
+      if (cfg.matched_tids.empty()) {
+        response->skipped_callback_groups.push_back(
+          std::to_string(cfg.domain_id) + ":" + cfg.thread_str);
+        continue;
+      }
+      bool any_applied = false;
+      for (const auto & [full_id, tid] : cfg.matched_tids) {
+        std::string key = std::to_string(cfg.domain_id) + ":" + full_id;
+        if (issue_syscalls(cfg, tid)) {
+          response->applied_callback_groups.push_back(std::move(key));
+          any_applied = true;
+        } else {
+          response->failed_callback_groups.push_back(std::move(key));
+        }
+      }
+      if (any_applied) {
+        cfg.applied = true;
+        unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
+      }
+      continue;
+    }
+
     std::string key = std::to_string(cfg.domain_id) + ":" + cfg.thread_str;
     if (cfg.thread_id == -1) {
       response->skipped_callback_groups.push_back(std::move(key));
       continue;
     }
-    if (issue_syscalls(cfg)) {
+    if (issue_syscalls(cfg, cfg.thread_id)) {
       response->applied_callback_groups.push_back(std::move(key));
       cfg.applied = true;
       unapplied_num_.fetch_sub(1, std::memory_order_acq_rel);
@@ -586,7 +652,7 @@ void ThreadConfiguratorNode::on_reapply_config_request(
         response->skipped_non_ros_threads.push_back(cfg.thread_str);
         continue;
       }
-      if (issue_syscalls(cfg)) {
+      if (issue_syscalls(cfg, cfg.thread_id)) {
         response->applied_non_ros_threads.push_back(cfg.thread_str);
         if (!cfg.applied) {
           cfg.applied = true;

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -51,6 +51,7 @@ non_ros_threads: []
   EXPECT_EQ(cb[0].affinity, (std::vector<int>{0, 1}));
   EXPECT_EQ(cb[0].thread_id, -1);
   EXPECT_FALSE(cb[0].applied);
+  EXPECT_FALSE(cb[0].is_wildcard());
 }
 
 TEST(ParseYaml, FallsBackToDefaultDomainId)
@@ -243,4 +244,172 @@ non_ros_threads:
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
   EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+// ---------- wildcard ("<node name>/*") callback-group ids ----------
+
+TEST(ParseYaml, ParsesWildcardCallbackGroupId)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /perception/lidar_node/*
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: [2]
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_TRUE(cb[0].is_wildcard());
+  EXPECT_EQ(cb[0].wildcard_prefix(), "/perception/lidar_node");
+  EXPECT_EQ(cb[0].thread_str, "/perception/lidar_node/*");  // kept as written
+  EXPECT_TRUE(cb[0].matched_tids.empty());
+}
+
+TEST(ParseYaml, RejectsWildcardWithEmptyNodePart)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsStrayAsteriskInId)
+{
+  for (const char * bad_id :
+       {"/node*", "/node/**", "/node/*x", "/a/*/b", "*", "/node/*@Waitable"}) {
+    auto y = yaml_from_str(("callback_groups:\n"
+                            "  - id: \"" +
+                            std::string(bad_id) +
+                            "\"\n"
+                            "    domain_id: 0\n"
+                            "    policy: SCHED_OTHER\n"
+                            "    priority: 0\n"
+                            "    affinity: []\n"
+                            "non_ros_threads: []\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
+      << "id=" << bad_id;
+  }
+}
+
+TEST(ParseYaml, RejectsAtSignInWildcardPrefix)
+{
+  // A full callback-group id copied from the template with "/*" appended.
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /node@Timer(100)/*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsDuplicateWildcardKey)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /node/*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - id: /node/*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, AllowsSameWildcardInDifferentDomains)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /node/*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - id: /node/*
+    domain_id: 1
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 2u);
+}
+
+TEST(ParseYaml, AllowsExactAndWildcardForSameNode)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: /node/*
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+  - id: /node@Timer(100)
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 80
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 2u);
+  EXPECT_TRUE(cb[0].is_wildcard());
+  EXPECT_FALSE(cb[1].is_wildcard());
+}
+
+TEST(ParseYaml, NonRosThreadNameEndingInSlashStarStaysExact)
+{
+  // Wildcards are a callback_groups-only feature; non_ros_threads names are
+  // opaque strings matched exactly, even when they happen to end in "/*".
+  // parse_yaml must accept such a name verbatim, unlike the equivalent
+  // callback-group id which would be treated as a wildcard pattern.
+  auto y = yaml_from_str(R"YAML(
+callback_groups: []
+non_ros_threads:
+  - name: worker/*
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(nrt.size(), 1u);
+  EXPECT_EQ(nrt[0].thread_str, "worker/*");
+}
+
+// ---------- extract_node_part ----------
+
+TEST(ExtractNodePart, SplitsAtFirstAtSign)
+{
+  EXPECT_EQ(acie::extract_node_part("/ns/node@Timer(1000000)@Subscription(/topic)"), "/ns/node");
+  EXPECT_EQ(acie::extract_node_part("/plain_node"), "/plain_node");
+  EXPECT_EQ(acie::extract_node_part("/node@"), "/node");
+  EXPECT_EQ(acie::extract_node_part("@Timer(1)"), "");
+  EXPECT_EQ(acie::extract_node_part(""), "");
 }

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -387,8 +387,6 @@ TEST(ParseYaml, NonRosThreadNameEndingInSlashStarStaysExact)
 {
   // Wildcards are a callback_groups-only feature; non_ros_threads names are
   // opaque strings matched exactly, even when they happen to end in "/*".
-  // parse_yaml must accept such a name verbatim, unlike the equivalent
-  // callback-group id which would be treated as a wildcard pattern.
   auto y = yaml_from_str(R"YAML(
 callback_groups: []
 non_ros_threads:

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -137,6 +137,7 @@ if(BUILD_TESTING)
   add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_reapply_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_wildcard_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_thread_configurator_precedence_launch.py TIMEOUT 120)
 endif()
 
 ament_package()

--- a/src/agnocast_e2e_test/CMakeLists.txt
+++ b/src/agnocast_e2e_test/CMakeLists.txt
@@ -136,6 +136,7 @@ if(BUILD_TESTING)
   add_launch_test(test/functional/test_multi_domain_cie_talker_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_restart_launch.py TIMEOUT 120)
   add_launch_test(test/functional/test_thread_configurator_reapply_launch.py TIMEOUT 120)
+  add_launch_test(test/functional/test_thread_configurator_wildcard_launch.py TIMEOUT 120)
 endif()
 
 ament_package()

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
@@ -1,0 +1,265 @@
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import yaml
+from ament_index_python.packages import get_package_prefix
+
+import rclpy
+from agnocast_cie_config_msgs.srv import ReapplyConfig
+
+CONFIG_DIR = os.path.join(
+    tempfile.gettempdir(), 'agnocast_test_thread_configurator_precedence'
+)
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
+
+REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
+
+TARGET_NODE = '/test_publisher_component'
+WILDCARD_ID = TARGET_NODE + '/*'
+
+# The publisher's exact entries from the prerun output, all kept alongside a
+# covering wildcard: with precedence intact every announced instance is taken
+# by its exact entry and the wildcard never matches anything.
+_PUBLISHER_ENTRIES = None
+_DOMAIN_ID = None
+
+
+def _run_prerun():
+    """Run prerun_node alongside test_cie_publisher to generate config YAML."""
+    if os.path.exists(CONFIG_DIR):
+        shutil.rmtree(CONFIG_DIR)
+    os.makedirs(CONFIG_DIR)
+
+    tc_prefix = get_package_prefix('agnocast_cie_thread_configurator')
+    prerun_exe = os.path.join(
+        tc_prefix, 'lib', 'agnocast_cie_thread_configurator', 'prerun_node'
+    )
+
+    e2e_prefix = get_package_prefix('agnocast_e2e_test')
+    publisher_exe = os.path.join(
+        e2e_prefix, 'lib', 'agnocast_e2e_test', 'test_cie_publisher'
+    )
+
+    prerun_log = tempfile.NamedTemporaryFile(
+        mode='w', suffix='.log', delete=False
+    )
+    prerun_proc = subprocess.Popen(
+        [prerun_exe],
+        cwd=CONFIG_DIR,
+        stdout=prerun_log,
+        stderr=subprocess.STDOUT,
+    )
+    publisher_proc = subprocess.Popen(
+        [publisher_exe],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    time.sleep(5)
+
+    try:
+        publisher_proc.send_signal(signal.SIGINT)
+        publisher_proc.wait(timeout=10)
+        prerun_proc.send_signal(signal.SIGINT)
+        prerun_proc.wait(timeout=10)
+    finally:
+        for proc in [publisher_proc, prerun_proc]:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    prerun_log.close()
+    if not os.path.exists(CONFIG_FILE):
+        with open(prerun_log.name) as f:
+            prerun_output = f.read()
+        os.unlink(prerun_log.name)
+        raise RuntimeError(
+            f'prerun_node failed to generate {CONFIG_FILE}.\n'
+            f'Output:\n{prerun_output}'
+        )
+    os.unlink(prerun_log.name)
+
+
+def _write_config(cfg):
+    with open(CONFIG_FILE, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _add_wildcard_alongside_exact_entries():
+    """Add a wildcard covering the publisher while keeping its exact entries.
+
+    Exact-over-wildcard precedence is decided at announcement time, so both
+    forms must already be in the config when the configurator starts.
+    """
+    global _PUBLISHER_ENTRIES, _DOMAIN_ID
+    # BaseLoader keeps every scalar as a string: this rewrite happens before
+    # the configurator starts, and safe_load would turn hardware_info values
+    # like 'cpu_max_mhz: 2101.0000' into floats whose re-dumped form ('2101.0')
+    # fails the configurator's startup hardware validation.
+    with open(CONFIG_FILE) as f:
+        cfg = yaml.load(f, Loader=yaml.BaseLoader)
+    _PUBLISHER_ENTRIES = [
+        e for e in cfg.get('callback_groups', [])
+        if e['id'].split('@', 1)[0] == TARGET_NODE
+    ]
+    if len(_PUBLISHER_ENTRIES) == 0:
+        raise RuntimeError(
+            f'prerun produced no callback_groups for {TARGET_NODE}'
+        )
+    _DOMAIN_ID = _PUBLISHER_ENTRIES[0].get('domain_id', 0)
+    # SCHED_OTHER + positive nice value: lowering priority needs no
+    # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
+    wildcard_entry = {
+        'id': WILDCARD_ID,
+        'domain_id': _DOMAIN_ID,
+        'policy': 'SCHED_OTHER',
+        'priority': 10,
+        'affinity': [],
+    }
+    cfg['callback_groups'] = cfg['callback_groups'] + [wildcard_entry]
+    _write_config(cfg)
+
+
+def _call_reapply(timeout_sec=10.0):
+    """Call the reapply_config service synchronously and return the response."""
+    rclpy.init()
+    try:
+        node = rclpy.create_node('test_reapply_client')
+        client = node.create_client(ReapplyConfig, REAPPLY_SERVICE)
+        if not client.wait_for_service(timeout_sec=timeout_sec):
+            node.destroy_node()
+            raise RuntimeError(f'service {REAPPLY_SERVICE} not available')
+        future = client.call_async(ReapplyConfig.Request())
+        rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+        if not future.done():
+            node.destroy_node()
+            raise RuntimeError('reapply service call timed out')
+        response = future.result()
+        node.destroy_node()
+        return response
+    finally:
+        rclpy.shutdown()
+
+
+def generate_test_description():
+    _run_prerun()
+    _add_wildcard_alongside_exact_entries()
+
+    thread_configurator = launch_ros.actions.Node(
+        package='agnocast_cie_thread_configurator',
+        executable='thread_configurator_node',
+        name='thread_configurator_node',
+        output='screen',
+        parameters=[{'config_file': CONFIG_FILE}],
+    )
+
+    test_app = launch_ros.actions.Node(
+        package='agnocast_e2e_test',
+        executable='test_cie_publisher',
+        output='screen',
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable(
+                'RCUTILS_LOGGING_BUFFERED_STREAM', '0'
+            ),
+
+            thread_configurator,
+
+            # Start the target app after DDS discovery has time to settle.
+            launch.actions.TimerAction(
+                period=2.0,
+                actions=[test_app],
+            ),
+
+            launch.actions.TimerAction(
+                period=8.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]),
+        {
+            'thread_configurator': thread_configurator,
+            'test_app': test_app,
+        },
+    )
+
+
+class TestThreadConfiguratorPrecedence(unittest.TestCase):
+
+    def test_exact_entries_take_precedence_over_wildcard(
+            self, proc_output, thread_configurator):
+        for entry in _PUBLISHER_ENTRIES:
+            proc_output.assertWaitFor(
+                entry['id'],
+                timeout=20.0,
+                process=thread_configurator,
+            )
+
+        # The reapply report exposes which entry tracks each instance: with
+        # precedence intact every instance is applied under its exact entry
+        # and the never-matched wildcard reports its pattern key as skipped.
+        # Were precedence broken, the wildcard would have captured the
+        # instances (their keys applied via matched_tids, pattern key absent
+        # from skipped) and the exact entries would be skipped (no known tid).
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        applied = list(response.applied_callback_groups)
+        for entry in _PUBLISHER_ENTRIES:
+            key = f"{_DOMAIN_ID}:{entry['id']}"
+            self.assertEqual(
+                applied.count(key), 1,
+                'each instance must be applied exactly once via its exact '
+                'entry; twice would mean the wildcard also recorded it',
+            )
+            self.assertNotIn(
+                key, list(response.skipped_callback_groups),
+                'an exact entry must have received the announcement itself, '
+                'not lost it to the wildcard',
+            )
+            self.assertNotIn(key, list(response.failed_callback_groups))
+        pattern_key = f'{_DOMAIN_ID}:{WILDCARD_ID}'
+        self.assertIn(
+            pattern_key, list(response.skipped_callback_groups),
+            'the wildcard must have matched nothing while every instance is '
+            'covered by an exact entry',
+        )
+        for arr in (
+            response.applied_callback_groups,
+            response.failed_callback_groups,
+        ):
+            self.assertNotIn(pattern_key, list(arr))
+
+        proc_output.assertWaitFor(
+            'Reapply done:',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestThreadConfiguratorPrecedenceShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, -signal.SIGINT]
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(CONFIG_DIR):
+            shutil.rmtree(CONFIG_DIR)

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
@@ -170,12 +170,11 @@ class TestThreadConfiguratorPrecedence(unittest.TestCase):
 
     def test_every_instance_matches_an_entry(
             self, proc_output, thread_configurator):
-        # Positive half of the precedence proof: the "| <id>" shape only
-        # occurs in the matched-announcement log; the no-configuration path
-        # logs "id=<id>" instead. Together with the post-shutdown check that
-        # the wildcard never matched, this pins each instance to its exact
-        # entry. The positive half is essential: without it, a run where
-        # nothing is announced at all would pass vacuously.
+        # Positive half of the precedence proof (the negative half is the
+        # post-shutdown wildcard-never-matched check): the "| <id>" shape
+        # only occurs in the matched-announcement log; the no-configuration
+        # path logs "id=<id>" instead. Without this half, a run announcing
+        # nothing at all would pass vacuously.
         for entry in _PUBLISHER_ENTRIES:
             proc_output.assertWaitFor(
                 f"| {entry['id']}",

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -23,13 +22,6 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
 
 TARGET_NODE = '/test_publisher_component'
 WILDCARD_ID = TARGET_NODE + '/*'
-
-# Distinct nice values per entry form, so the value read back from an
-# announced tid identifies which entry configured it. Positive values only:
-# lowering priority needs no CAP_SYS_NICE, which is not guaranteed in CI
-# sandboxes.
-EXACT_NICE = 15
-WILDCARD_NICE = 10
 
 # The publisher's exact entries from the prerun output, all kept alongside a
 # covering wildcard: with precedence intact every announced instance is taken
@@ -102,9 +94,7 @@ def _add_wildcard_alongside_exact_entries():
     """Add a wildcard covering the publisher while keeping its exact entries.
 
     Exact-over-wildcard precedence is decided at announcement time, so both
-    forms must already be in the config when the configurator starts. The
-    exact entries get EXACT_NICE and the wildcard WILDCARD_NICE, letting the
-    test identify the applied entry from the thread's actual nice value.
+    forms must already be in the config when the configurator starts.
     """
     global _PUBLISHER_ENTRIES
     # BaseLoader keeps every scalar as a string: this rewrite happens before
@@ -121,15 +111,11 @@ def _add_wildcard_alongside_exact_entries():
         raise RuntimeError(
             f'prerun produced no callback_groups for {TARGET_NODE}'
         )
-    for entry in _PUBLISHER_ENTRIES:
-        entry['policy'] = 'SCHED_OTHER'
-        entry['priority'] = EXACT_NICE
-        entry['affinity'] = []
     wildcard_entry = {
         'id': WILDCARD_ID,
         'domain_id': _PUBLISHER_ENTRIES[0].get('domain_id', 0),
         'policy': 'SCHED_OTHER',
-        'priority': WILDCARD_NICE,
+        'priority': 0,
         'affinity': [],
     }
     cfg['callback_groups'] = cfg['callback_groups'] + [wildcard_entry]
@@ -182,57 +168,30 @@ def generate_test_description():
 
 class TestThreadConfiguratorPrecedence(unittest.TestCase):
 
-    def _announced_tid(self, proc_output, entry_id, timeout_sec=20.0):
-        """Extract the tid the configurator announced for the given instance.
-
-        Only the announcement log has the "tid=<n> | <id>" shape, so the
-        pattern cannot match the wildcard-match or re-apply log lines.
-        """
-        pattern = re.compile(r'tid=(\d+) \| ' + re.escape(entry_id))
-        deadline = time.time() + timeout_sec
-        while time.time() < deadline:
-            for event in list(proc_output):
-                match = pattern.search(event.text.decode(errors='replace'))
-                if match:
-                    return int(match.group(1))
-            time.sleep(0.1)
-        self.fail(f'no announcement log found for {entry_id}')
-
-    def _assert_nice_becomes_exact(self, tid, entry_id, timeout_sec=10.0):
-        # The announcement log precedes the syscall, so the nice value is
-        # polled until it settles on one of the two configured values.
-        deadline = time.time() + timeout_sec
-        nice = None
-        while time.time() < deadline:
-            nice = os.getpriority(os.PRIO_PROCESS, tid)
-            if nice == EXACT_NICE:
-                return
-            self.assertNotEqual(
-                nice, WILDCARD_NICE,
-                f'{entry_id} (tid={tid}) was configured by the wildcard '
-                'entry although an exact entry exists',
-            )
-            time.sleep(0.1)
-        self.fail(
-            f'{entry_id} (tid={tid}) nice never became {EXACT_NICE} '
-            f'(last observed: {nice})'
-        )
-
-    def test_exact_entries_take_precedence_over_wildcard(
+    def test_every_instance_matches_an_entry(
             self, proc_output, thread_configurator):
+        # Positive half of the precedence proof: the "| <id>" shape only
+        # occurs in the matched-announcement log; the no-configuration path
+        # logs "id=<id>" instead. Together with the post-shutdown check that
+        # the wildcard never matched, this pins each instance to its exact
+        # entry. The positive half is essential: without it, a run where
+        # nothing is announced at all would pass vacuously.
         for entry in _PUBLISHER_ENTRIES:
-            tid = self._announced_tid(proc_output, entry['id'])
-            self._assert_nice_becomes_exact(tid, entry['id'])
+            proc_output.assertWaitFor(
+                f"| {entry['id']}",
+                timeout=20.0,
+                process=thread_configurator,
+            )
 
 
 @launch_testing.post_shutdown_test()
 class TestThreadConfiguratorPrecedenceShutdown(unittest.TestCase):
 
     def test_wildcard_never_matched(self, proc_output):
-        # Deterministic only here: the processes have exited, so the captured
-        # output is complete. Recording an instance into a wildcard entry
-        # always logs this line, so its absence proves the wildcard captured
-        # nothing, i.e. every instance went to its exact entry.
+        # Negative half of the precedence proof, deterministic only here: the
+        # processes have exited, so the captured output is complete.
+        # Recording an instance into a wildcard entry always logs this line,
+        # so its absence proves the wildcard captured nothing.
         for event in proc_output:
             self.assertNotIn(
                 'matched wildcard entry',

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -15,24 +16,25 @@ import launch_testing.asserts
 import yaml
 from ament_index_python.packages import get_package_prefix
 
-import rclpy
-from agnocast_cie_config_msgs.srv import ReapplyConfig
-
 CONFIG_DIR = os.path.join(
     tempfile.gettempdir(), 'agnocast_test_thread_configurator_precedence'
 )
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
 
-REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
-
 TARGET_NODE = '/test_publisher_component'
 WILDCARD_ID = TARGET_NODE + '/*'
+
+# Distinct nice values per entry form, so the value read back from an
+# announced tid identifies which entry configured it. Positive values only:
+# lowering priority needs no CAP_SYS_NICE, which is not guaranteed in CI
+# sandboxes.
+EXACT_NICE = 15
+WILDCARD_NICE = 10
 
 # The publisher's exact entries from the prerun output, all kept alongside a
 # covering wildcard: with precedence intact every announced instance is taken
 # by its exact entry and the wildcard never matches anything.
 _PUBLISHER_ENTRIES = None
-_DOMAIN_ID = None
 
 
 def _run_prerun():
@@ -100,9 +102,11 @@ def _add_wildcard_alongside_exact_entries():
     """Add a wildcard covering the publisher while keeping its exact entries.
 
     Exact-over-wildcard precedence is decided at announcement time, so both
-    forms must already be in the config when the configurator starts.
+    forms must already be in the config when the configurator starts. The
+    exact entries get EXACT_NICE and the wildcard WILDCARD_NICE, letting the
+    test identify the applied entry from the thread's actual nice value.
     """
-    global _PUBLISHER_ENTRIES, _DOMAIN_ID
+    global _PUBLISHER_ENTRIES
     # BaseLoader keeps every scalar as a string: this rewrite happens before
     # the configurator starts, and safe_load would turn hardware_info values
     # like 'cpu_max_mhz: 2101.0000' into floats whose re-dumped form ('2101.0')
@@ -117,39 +121,19 @@ def _add_wildcard_alongside_exact_entries():
         raise RuntimeError(
             f'prerun produced no callback_groups for {TARGET_NODE}'
         )
-    _DOMAIN_ID = _PUBLISHER_ENTRIES[0].get('domain_id', 0)
-    # SCHED_OTHER + positive nice value: lowering priority needs no
-    # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
+    for entry in _PUBLISHER_ENTRIES:
+        entry['policy'] = 'SCHED_OTHER'
+        entry['priority'] = EXACT_NICE
+        entry['affinity'] = []
     wildcard_entry = {
         'id': WILDCARD_ID,
-        'domain_id': _DOMAIN_ID,
+        'domain_id': _PUBLISHER_ENTRIES[0].get('domain_id', 0),
         'policy': 'SCHED_OTHER',
-        'priority': 10,
+        'priority': WILDCARD_NICE,
         'affinity': [],
     }
     cfg['callback_groups'] = cfg['callback_groups'] + [wildcard_entry]
     _write_config(cfg)
-
-
-def _call_reapply(timeout_sec=10.0):
-    """Call the reapply_config service synchronously and return the response."""
-    rclpy.init()
-    try:
-        node = rclpy.create_node('test_reapply_client')
-        client = node.create_client(ReapplyConfig, REAPPLY_SERVICE)
-        if not client.wait_for_service(timeout_sec=timeout_sec):
-            node.destroy_node()
-            raise RuntimeError(f'service {REAPPLY_SERVICE} not available')
-        future = client.call_async(ReapplyConfig.Request())
-        rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
-        if not future.done():
-            node.destroy_node()
-            raise RuntimeError('reapply service call timed out')
-        response = future.result()
-        node.destroy_node()
-        return response
-    finally:
-        rclpy.shutdown()
 
 
 def generate_test_description():
@@ -198,61 +182,62 @@ def generate_test_description():
 
 class TestThreadConfiguratorPrecedence(unittest.TestCase):
 
+    def _announced_tid(self, proc_output, entry_id, timeout_sec=20.0):
+        """Extract the tid the configurator announced for the given instance.
+
+        Only the announcement log has the "tid=<n> | <id>" shape, so the
+        pattern cannot match the wildcard-match or re-apply log lines.
+        """
+        pattern = re.compile(r'tid=(\d+) \| ' + re.escape(entry_id))
+        deadline = time.time() + timeout_sec
+        while time.time() < deadline:
+            for event in list(proc_output):
+                match = pattern.search(event.text.decode(errors='replace'))
+                if match:
+                    return int(match.group(1))
+            time.sleep(0.1)
+        self.fail(f'no announcement log found for {entry_id}')
+
+    def _assert_nice_becomes_exact(self, tid, entry_id, timeout_sec=10.0):
+        # The announcement log precedes the syscall, so the nice value is
+        # polled until it settles on one of the two configured values.
+        deadline = time.time() + timeout_sec
+        nice = None
+        while time.time() < deadline:
+            nice = os.getpriority(os.PRIO_PROCESS, tid)
+            if nice == EXACT_NICE:
+                return
+            self.assertNotEqual(
+                nice, WILDCARD_NICE,
+                f'{entry_id} (tid={tid}) was configured by the wildcard '
+                'entry although an exact entry exists',
+            )
+            time.sleep(0.1)
+        self.fail(
+            f'{entry_id} (tid={tid}) nice never became {EXACT_NICE} '
+            f'(last observed: {nice})'
+        )
+
     def test_exact_entries_take_precedence_over_wildcard(
             self, proc_output, thread_configurator):
         for entry in _PUBLISHER_ENTRIES:
-            proc_output.assertWaitFor(
-                entry['id'],
-                timeout=20.0,
-                process=thread_configurator,
-            )
-
-        # The reapply report exposes which entry tracks each instance: with
-        # precedence intact every instance is applied under its exact entry
-        # and the never-matched wildcard reports its pattern key as skipped.
-        # Were precedence broken, the wildcard would have captured the
-        # instances (their keys applied via matched_tids, pattern key absent
-        # from skipped) and the exact entries would be skipped (no known tid).
-        response = _call_reapply()
-        self.assertTrue(
-            response.success,
-            f'reapply failed unexpectedly: error_message={response.error_message!r}',
-        )
-        applied = list(response.applied_callback_groups)
-        for entry in _PUBLISHER_ENTRIES:
-            key = f"{_DOMAIN_ID}:{entry['id']}"
-            self.assertEqual(
-                applied.count(key), 1,
-                'each instance must be applied exactly once via its exact '
-                'entry; twice would mean the wildcard also recorded it',
-            )
-            self.assertNotIn(
-                key, list(response.skipped_callback_groups),
-                'an exact entry must have received the announcement itself, '
-                'not lost it to the wildcard',
-            )
-            self.assertNotIn(key, list(response.failed_callback_groups))
-        pattern_key = f'{_DOMAIN_ID}:{WILDCARD_ID}'
-        self.assertIn(
-            pattern_key, list(response.skipped_callback_groups),
-            'the wildcard must have matched nothing while every instance is '
-            'covered by an exact entry',
-        )
-        for arr in (
-            response.applied_callback_groups,
-            response.failed_callback_groups,
-        ):
-            self.assertNotIn(pattern_key, list(arr))
-
-        proc_output.assertWaitFor(
-            'Reapply done:',
-            timeout=10.0,
-            process=thread_configurator,
-        )
+            tid = self._announced_tid(proc_output, entry['id'])
+            self._assert_nice_becomes_exact(tid, entry['id'])
 
 
 @launch_testing.post_shutdown_test()
 class TestThreadConfiguratorPrecedenceShutdown(unittest.TestCase):
+
+    def test_wildcard_never_matched(self, proc_output):
+        # Deterministic only here: the processes have exited, so the captured
+        # output is complete. Recording an instance into a wildcard entry
+        # always logs this line, so its absence proves the wildcard captured
+        # nothing, i.e. every instance went to its exact entry.
+        for event in proc_output:
+            self.assertNotIn(
+                'matched wildcard entry',
+                event.text.decode(errors='replace'),
+            )
 
     def test_exit_codes(self, proc_info):
         launch_testing.asserts.assertExitCodes(

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -329,6 +329,38 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             'modified non_ros_thread must appear in applied_non_ros_threads',
         )
 
+    def test_reapply_wildcard_without_instances_is_skipped(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        added_entry = {
+            'id': '/fictitious_node/*',
+            'domain_id': 0,
+            'policy': 'SCHED_OTHER',
+            'priority': 0,
+            'affinity': [],
+        }
+        cfg.setdefault('callback_groups', []).append(added_entry)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        pattern_key = f"{added_entry['domain_id']}:{added_entry['id']}"
+        self.assertIn(pattern_key, list(response.skipped_callback_groups))
+        for arr in (
+            response.applied_callback_groups,
+            response.failed_callback_groups,
+        ):
+            self.assertNotIn(pattern_key, list(arr))
+
     def test_reapply_rejects_invalid_policy(self, proc_output, thread_configurator):
         proc_output.assertWaitFor(
             'Received CallbackGroupInfo',

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
@@ -16,6 +16,9 @@ import yaml
 from ament_index_python.packages import get_package_prefix
 
 import rclpy
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+
+from agnocast_cie_config_msgs.msg import CallbackGroupInfo
 from agnocast_cie_config_msgs.srv import ReapplyConfig
 
 CONFIG_DIR = os.path.join(
@@ -24,6 +27,7 @@ CONFIG_DIR = os.path.join(
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
 
 REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
+ANNOUNCE_TOPIC = '/agnocast_cie_thread_configurator/callback_group_info'
 
 TARGET_NODE = '/test_publisher_component'
 WILDCARD_ID = TARGET_NODE + '/*'
@@ -332,6 +336,89 @@ class TestThreadConfiguratorWildcard(unittest.TestCase):
             timeout=10.0,
             process=thread_configurator,
         )
+
+    def test_zz_exact_override_takes_over_after_reannouncement(
+            self, proc_output, thread_configurator):
+        # 'zz_' prefix forces alphabetical-last execution: the synthetic
+        # re-announcement below permanently reroutes the instance to the exact
+        # entry in configurator memory, which would break the wildcard
+        # assertions of any test that runs after this one.
+        self._wait_for_all_instances(proc_output, thread_configurator)
+
+        cfg = _read_config()
+        exact_entry = dict(_PUBLISHER_ENTRIES[0])
+        exact_entry['policy'] = 'SCHED_OTHER'
+        exact_entry['priority'] = 15
+        exact_entry['affinity'] = []
+        cfg['callback_groups'] = [exact_entry] + cfg['callback_groups']
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        key = f"{_WILDCARD_DOMAIN_ID}:{exact_entry['id']}"
+        self.assertIn(key, list(response.skipped_callback_groups))
+
+        # A live tid distinct from the wildcard-tracked one; it must outlive
+        # the reapply below, which issues syscalls on it.
+        live_proc = subprocess.Popen(['sleep', '600'])
+
+        def _stop_live_proc():
+            live_proc.kill()
+            live_proc.wait()
+
+        self.addCleanup(_stop_live_proc)
+
+        # Publishing CallbackGroupInfo directly re-announces the instance
+        # without the application restart that normally triggers it.
+        rclpy.init()
+        try:
+            node = rclpy.create_node('test_reannounce_publisher')
+            pub = node.create_publisher(
+                CallbackGroupInfo,
+                ANNOUNCE_TOPIC,
+                QoSProfile(
+                    depth=1,
+                    reliability=ReliabilityPolicy.RELIABLE,
+                    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+                ),
+            )
+            msg = CallbackGroupInfo()
+            msg.callback_group_id = exact_entry['id']
+            msg.thread_id = live_proc.pid
+            pub.publish(msg)
+            # Keep the writer alive until receipt is logged: destroying a
+            # transient_local writer discards a yet-undelivered sample.
+            proc_output.assertWaitFor(
+                f'tid={live_proc.pid}',
+                timeout=20.0,
+                process=thread_configurator,
+            )
+        finally:
+            rclpy.shutdown()
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        applied = list(response.applied_callback_groups)
+        self.assertEqual(
+            applied.count(key), 1,
+            'after re-announcement only the exact entry may report the '
+            'instance; a duplicate means the wildcard still tracks it',
+        )
+        self.assertNotIn(key, list(response.skipped_callback_groups))
+        self.assertNotIn(key, list(response.failed_callback_groups))
+        for entry in _PUBLISHER_ENTRIES[1:]:
+            other_key = f"{_WILDCARD_DOMAIN_ID}:{entry['id']}"
+            self.assertEqual(
+                applied.count(other_key), 1,
+                'instances not overridden by an exact entry must stay '
+                'wildcard-tracked',
+            )
 
 
 @launch_testing.post_shutdown_test()

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
@@ -1,0 +1,348 @@
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import yaml
+from ament_index_python.packages import get_package_prefix
+
+import rclpy
+from agnocast_cie_config_msgs.srv import ReapplyConfig
+
+CONFIG_DIR = os.path.join(
+    tempfile.gettempdir(), 'agnocast_test_thread_configurator_wildcard'
+)
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
+
+REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
+
+TARGET_NODE = '/test_publisher_component'
+WILDCARD_ID = TARGET_NODE + '/*'
+
+# The publisher's exact entries captured from the prerun output before they
+# are replaced by the wildcard; their ids equal the announced callback-group
+# ids, which the wildcard reports per instance.
+_PUBLISHER_ENTRIES = None
+_WILDCARD_DOMAIN_ID = None
+
+
+def _run_prerun():
+    """Run prerun_node alongside test_cie_publisher to generate config YAML."""
+    if os.path.exists(CONFIG_DIR):
+        shutil.rmtree(CONFIG_DIR)
+    os.makedirs(CONFIG_DIR)
+
+    tc_prefix = get_package_prefix('agnocast_cie_thread_configurator')
+    prerun_exe = os.path.join(
+        tc_prefix, 'lib', 'agnocast_cie_thread_configurator', 'prerun_node'
+    )
+
+    e2e_prefix = get_package_prefix('agnocast_e2e_test')
+    publisher_exe = os.path.join(
+        e2e_prefix, 'lib', 'agnocast_e2e_test', 'test_cie_publisher'
+    )
+
+    prerun_log = tempfile.NamedTemporaryFile(
+        mode='w', suffix='.log', delete=False
+    )
+    prerun_proc = subprocess.Popen(
+        [prerun_exe],
+        cwd=CONFIG_DIR,
+        stdout=prerun_log,
+        stderr=subprocess.STDOUT,
+    )
+    publisher_proc = subprocess.Popen(
+        [publisher_exe],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    time.sleep(5)
+
+    try:
+        publisher_proc.send_signal(signal.SIGINT)
+        publisher_proc.wait(timeout=10)
+        prerun_proc.send_signal(signal.SIGINT)
+        prerun_proc.wait(timeout=10)
+    finally:
+        for proc in [publisher_proc, prerun_proc]:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    prerun_log.close()
+    if not os.path.exists(CONFIG_FILE):
+        with open(prerun_log.name) as f:
+            prerun_output = f.read()
+        os.unlink(prerun_log.name)
+        raise RuntimeError(
+            f'prerun_node failed to generate {CONFIG_FILE}.\n'
+            f'Output:\n{prerun_output}'
+        )
+    os.unlink(prerun_log.name)
+
+
+def _read_config():
+    with open(CONFIG_FILE) as f:
+        return yaml.safe_load(f)
+
+
+def _write_config(cfg):
+    with open(CONFIG_FILE, 'w') as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _replace_publisher_entries_with_wildcard():
+    """Rewrite the prerun config so the publisher is covered by a wildcard.
+
+    Instances are matched to entries at announcement time only, so the
+    wildcard must already be in the config when the configurator starts.
+    """
+    global _PUBLISHER_ENTRIES, _WILDCARD_DOMAIN_ID
+    # BaseLoader keeps every scalar as a string: this rewrite happens before
+    # the configurator starts, and safe_load would turn hardware_info values
+    # like 'cpu_max_mhz: 2101.0000' into floats whose re-dumped form ('2101.0')
+    # fails the configurator's startup hardware validation.
+    with open(CONFIG_FILE) as f:
+        cfg = yaml.load(f, Loader=yaml.BaseLoader)
+    _PUBLISHER_ENTRIES = [
+        e for e in cfg.get('callback_groups', [])
+        if e['id'].split('@', 1)[0] == TARGET_NODE
+    ]
+    kept = [
+        e for e in cfg.get('callback_groups', [])
+        if e['id'].split('@', 1)[0] != TARGET_NODE
+    ]
+    if len(_PUBLISHER_ENTRIES) == 0:
+        raise RuntimeError(
+            f'prerun produced no callback_groups for {TARGET_NODE}'
+        )
+    _WILDCARD_DOMAIN_ID = _PUBLISHER_ENTRIES[0].get('domain_id', 0)
+    # SCHED_OTHER + positive nice value: lowering priority needs no
+    # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
+    wildcard_entry = {
+        'id': WILDCARD_ID,
+        'domain_id': _WILDCARD_DOMAIN_ID,
+        'policy': 'SCHED_OTHER',
+        'priority': 10,
+        'affinity': [],
+    }
+    cfg['callback_groups'] = kept + [wildcard_entry]
+    _write_config(cfg)
+
+
+def _call_reapply(timeout_sec=10.0):
+    """Call the reapply_config service synchronously and return the response."""
+    rclpy.init()
+    try:
+        node = rclpy.create_node('test_reapply_client')
+        client = node.create_client(ReapplyConfig, REAPPLY_SERVICE)
+        if not client.wait_for_service(timeout_sec=timeout_sec):
+            node.destroy_node()
+            raise RuntimeError(f'service {REAPPLY_SERVICE} not available')
+        future = client.call_async(ReapplyConfig.Request())
+        rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+        if not future.done():
+            node.destroy_node()
+            raise RuntimeError('reapply service call timed out')
+        response = future.result()
+        node.destroy_node()
+        return response
+    finally:
+        rclpy.shutdown()
+
+
+# Snapshot of the wildcard-rewritten YAML, restored by setUp before each test.
+_ORIGINAL_CONFIG_BYTES = None
+
+
+def _snapshot_original_config():
+    global _ORIGINAL_CONFIG_BYTES
+    with open(CONFIG_FILE, 'rb') as f:
+        _ORIGINAL_CONFIG_BYTES = f.read()
+
+
+def _restore_original_config():
+    if _ORIGINAL_CONFIG_BYTES is None:
+        raise RuntimeError(
+            '_restore_original_config called before _snapshot_original_config'
+        )
+    with open(CONFIG_FILE, 'wb') as f:
+        f.write(_ORIGINAL_CONFIG_BYTES)
+
+
+def generate_test_description():
+    _run_prerun()
+    _replace_publisher_entries_with_wildcard()
+    _snapshot_original_config()
+
+    thread_configurator = launch_ros.actions.Node(
+        package='agnocast_cie_thread_configurator',
+        executable='thread_configurator_node',
+        name='thread_configurator_node',
+        output='screen',
+        parameters=[{'config_file': CONFIG_FILE}],
+    )
+
+    test_app = launch_ros.actions.Node(
+        package='agnocast_e2e_test',
+        executable='test_cie_publisher',
+        output='screen',
+    )
+
+    return (
+        launch.LaunchDescription([
+            launch.actions.SetEnvironmentVariable(
+                'RCUTILS_LOGGING_BUFFERED_STREAM', '0'
+            ),
+
+            thread_configurator,
+
+            # Start the target app after DDS discovery has time to settle.
+            launch.actions.TimerAction(
+                period=2.0,
+                actions=[test_app],
+            ),
+
+            launch.actions.TimerAction(
+                period=8.0,
+                actions=[launch_testing.actions.ReadyToTest()],
+            ),
+        ]),
+        {
+            'thread_configurator': thread_configurator,
+            'test_app': test_app,
+        },
+    )
+
+
+class TestThreadConfiguratorWildcard(unittest.TestCase):
+
+    def setUp(self):
+        _restore_original_config()
+
+    def _wait_for_all_instances(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            f"matched wildcard entry '{WILDCARD_ID}'",
+            timeout=20.0,
+            process=thread_configurator,
+        )
+        # The configurator only knows tids for announced callback groups; wait
+        # for each instance id in its log so the reapply below covers all.
+        for entry in _PUBLISHER_ENTRIES:
+            proc_output.assertWaitFor(
+                entry['id'],
+                timeout=20.0,
+                process=thread_configurator,
+            )
+
+    def test_wildcard_matches_at_announcement(
+            self, proc_output, thread_configurator):
+        self._wait_for_all_instances(proc_output, thread_configurator)
+
+    def test_reapply_wildcard_attribute_change(
+            self, proc_output, thread_configurator):
+        self._wait_for_all_instances(proc_output, thread_configurator)
+
+        cfg = _read_config()
+        wildcard_entries = [
+            e for e in cfg.get('callback_groups', []) if e['id'] == WILDCARD_ID
+        ]
+        self.assertEqual(len(wildcard_entries), 1)
+        wildcard_entries[0]['priority'] = 11
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        # The wildcard reports one key per matched instance, so every announced
+        # instance must be applied under its full id, not under the pattern.
+        applied = list(response.applied_callback_groups)
+        for entry in _PUBLISHER_ENTRIES:
+            key = f"{_WILDCARD_DOMAIN_ID}:{entry['id']}"
+            self.assertEqual(
+                applied.count(key), 1,
+                'each matched instance must be applied once under its full id',
+            )
+        pattern_key = f'{_WILDCARD_DOMAIN_ID}:{WILDCARD_ID}'
+        for arr in (
+            response.applied_callback_groups,
+            response.skipped_callback_groups,
+            response.failed_callback_groups,
+        ):
+            self.assertNotIn(
+                pattern_key, list(arr),
+                'pattern key must not be reported once instances are known',
+            )
+
+        proc_output.assertWaitFor(
+            'Reapply done:',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_added_exact_override_stays_pending(
+            self, proc_output, thread_configurator):
+        # Pins the same-form-only carry-over semantics: an exact entry added
+        # for an instance already matched by the wildcard has no known tid on
+        # reapply, so it is reported as skipped and the wildcard keeps applying
+        # to the instance until the target application re-announces.
+        self._wait_for_all_instances(proc_output, thread_configurator)
+
+        cfg = _read_config()
+        exact_entry = dict(_PUBLISHER_ENTRIES[0])
+        exact_entry['policy'] = 'SCHED_OTHER'
+        exact_entry['priority'] = 15
+        exact_entry['affinity'] = []
+        cfg['callback_groups'] = cfg['callback_groups'] + [exact_entry]
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply failed unexpectedly: error_message={response.error_message!r}',
+        )
+        # The pending exact entry and the wildcard instance share the same
+        # reporting key: skipped for the former, applied for the latter.
+        key = f"{_WILDCARD_DOMAIN_ID}:{exact_entry['id']}"
+        self.assertIn(
+            key, list(response.skipped_callback_groups),
+            'exact entry added while its instance is wildcard-matched must '
+            'stay pending until the next announcement',
+        )
+        self.assertEqual(
+            list(response.applied_callback_groups).count(key), 1,
+            'the instance must still be applied via the wildcard',
+        )
+        self.assertNotIn(key, list(response.failed_callback_groups))
+
+        proc_output.assertWaitFor(
+            'Reapply done:',
+            timeout=10.0,
+            process=thread_configurator,
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestThreadConfiguratorWildcardShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[0, -signal.SIGINT]
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(CONFIG_DIR):
+            shutil.rmtree(CONFIG_DIR)


### PR DESCRIPTION
## Description

In the `agnocast_cie_thread_configurator` config YAML, a `callback_groups` `id` previously had to match the announced callback-group ID exactly. Since the ID embeds the callback group's entities (`<node>@Subscription(/topic)@Timer(...)`), every change to a node's callbacks forced a rewrite of all of its YAML entries.

This PR adds a wildcard form: `id: <fully qualified node name>/*` applies the scheduling attributes to **every** callback group whose node-name part (before the first `@`) equals the given node name, within the same domain.

- Matching is per node: `/perception/lidar_node/*` does not match other nodes or child-namespace nodes.
- An exact `id` entry takes precedence over a wildcard entry for the same callback group, so individual callback groups can still be overridden.
- Wildcards are supported only for `callback_groups`; `non_ros_threads` names remain exact-match.
- Malformed patterns (`/*`, `/node*`, `/a/*/b`, `/node@Timer(100)/*`) are rejected at parse time (fail-fast).
- A wildcard entry tracks its matched instances (full callback group ID to tid). The `reapply_config` service re-issues syscalls per instance and reports one `"<domain>:<full id>"` key per instance in `applied`/`failed`; the pattern key appears in `skipped` only while nothing has matched yet.
- Callback groups are matched to entries at announcement time only, and reapply carries state over per entry within the same form (exact entries carry `thread_id`, wildcard entries carry their matched instances). Changing an entry between exact and wildcard form, or adding an exact override for a callback group already matched by a wildcard, therefore takes effect at the next announcement (i.e. when the target application restarts); reapply is for updating the attributes (policy / priority / affinity) of existing entries.

```yaml
callback_groups:
  # Applies to all callback groups of /perception/lidar_node
  - id: /perception/lidar_node/*
    affinity: [2, 3]
    policy: SCHED_FIFO
    priority: 50

  # Exact entry overrides the wildcard for this specific callback group
  - id: /perception/lidar_node@Subscription(/points)
    affinity: [4]
    policy: SCHED_FIFO
    priority: 80
```

## Related links

N/A

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module) - N/A (no kernel module changes)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] Newly added tests

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.

