### PR TITLE
feat(ros2agnocast): hide internal CIE and discovery agent nodes/topics unless -d is passed

### DIFF
--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -223,6 +223,25 @@ def topics_of_node(
     return pubs, subs
 
 
+# Prefixes/namespaces for Agnocast-internal nodes. These are implementation
+# details (not application nodes), so list verbs hide them by default behind
+# ``-d/--debug``, same as the domain bridge nodes.
+BRIDGE_NODE_PREFIX = 'agnocast_bridge_node_'
+DISCOVERY_AGENT_NODE_PREFIX = 'agnocast_discovery_agent_'
+CIE_THREAD_CONFIGURATOR_NAMESPACE = '/agnocast_cie_thread_configurator/'
+
+
+def is_internal_node_name(node_name: str) -> bool:
+    """True for Agnocast-internal nodes (domain bridge, CIE thread configurator,
+    discovery agent) that should be hidden unless ``-d/--debug`` is given."""
+    name = node_name if node_name.startswith('/') else '/' + node_name
+    return (
+        name.startswith('/' + BRIDGE_NODE_PREFIX)
+        or name.startswith('/' + DISCOVERY_AGENT_NODE_PREFIX)
+        or name.startswith(CIE_THREAD_CONFIGURATOR_NAMESPACE)
+    )
+
+
 # Bridge-label states for the CLI verbs. Wording is shared so list/info stay
 # consistent.
 BRIDGE_ENABLED = 'enabled'

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -226,20 +226,29 @@ def topics_of_node(
 # Prefixes/namespaces for Agnocast-internal nodes. These are implementation
 # details (not application nodes), so list verbs hide them by default behind
 # ``-d/--debug``, same as the domain bridge nodes.
-BRIDGE_NODE_PREFIX = 'agnocast_bridge_node_'
-DISCOVERY_AGENT_NODE_PREFIX = 'agnocast_discovery_agent_'
-CIE_THREAD_CONFIGURATOR_NAMESPACE = '/agnocast_cie_thread_configurator/'
+BRIDGE_NODE_PREFIX = '/agnocast_bridge_node_'
+DISCOVERY_AGENT_NODE_PREFIX = '/agnocast_discovery_agent_'
+# No trailing slash: also matches the per-domain helper nodes
+# (``/agnocast_cie_thread_configurator_domain_<id>``) created by
+# ``create_node_for_domain`` in util.cpp, not just the per-process client
+# nodes under the namespace.
+CIE_THREAD_CONFIGURATOR_NODE_PREFIX = '/agnocast_cie_thread_configurator'
+# Trailing slash kept for the topic filter, which only needs to match
+# topics published under the namespace.
+CIE_THREAD_CONFIGURATOR_NAMESPACE = CIE_THREAD_CONFIGURATOR_NODE_PREFIX + '/'
+
+_INTERNAL_NODE_PREFIXES = (
+    BRIDGE_NODE_PREFIX,
+    DISCOVERY_AGENT_NODE_PREFIX,
+    CIE_THREAD_CONFIGURATOR_NODE_PREFIX,
+)
 
 
 def is_internal_node_name(node_name: str) -> bool:
     """True for Agnocast-internal nodes (domain bridge, CIE thread configurator,
     discovery agent) that should be hidden unless ``-d/--debug`` is given."""
     name = node_name if node_name.startswith('/') else '/' + node_name
-    return (
-        name.startswith('/' + BRIDGE_NODE_PREFIX)
-        or name.startswith('/' + DISCOVERY_AGENT_NODE_PREFIX)
-        or name.startswith(CIE_THREAD_CONFIGURATOR_NAMESPACE)
-    )
+    return name.startswith(_INTERNAL_NODE_PREFIXES)
 
 
 # Bridge-label states for the CLI verbs. Wording is shared so list/info stay

--- a/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_list_agnocast.py
@@ -7,6 +7,7 @@ from ros2agnocast.discovery import (
     add_gossip_timeout_arg,
     all_nodes,
     collect_announcements_with_fallback,
+    is_internal_node_name,
     warn_if_gossip_timeout_overridden,
     warn_if_using_fallback,
 )
@@ -28,7 +29,8 @@ class ListAgnocastVerb(VerbExtension):
             help='Only display the number of nodes discovered')
         parser.add_argument(
             '-d', '--debug', action='store_true',
-            help='Include internal bridge nodes (agnocast_bridge_node_*) in the output')
+            help='Include internal nodes (domain bridge, CIE thread configurator, '
+                 'discovery agent) in the output')
         add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
@@ -73,7 +75,7 @@ class ListAgnocastVerb(VerbExtension):
             ########################################################################
             merged_node_name = agnocast_node_name | ros2_node_name
             if not args.all and not args.debug:
-                merged_node_name = {node for node in merged_node_name if not node.startswith("/agnocast_bridge_node_")}
+                merged_node_name = {node for node in merged_node_name if not is_internal_node_name(node)}
             if args.count_nodes:
                 total_nodes = len(merged_node_name)
                 print(total_nodes)

--- a/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/topic_list_agnocast.py
@@ -7,6 +7,7 @@ from ros2agnocast.discovery import (
     all_topic_names,
     bridge_label_from_roles,
     BRIDGE_LABEL_TEXT,
+    CIE_THREAD_CONFIGURATOR_NAMESPACE,
     collect_announcements_with_fallback,
     collect_bridge_roles,
     warn_if_gossip_timeout_overridden,
@@ -17,6 +18,9 @@ class ListAgnocastVerb(VerbExtension):
     "Output a list of available topics including Agnocast"
 
     def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-d', '--debug', action='store_true',
+            help='Include internal topics (CIE thread configurator) in the output')
         add_gossip_timeout_arg(parser)
 
     def main(self, *, args):
@@ -68,7 +72,14 @@ class ListAgnocastVerb(VerbExtension):
             ros2_sub_set = set(ros2_sub_topics)
             ros2_topics_set = ros2_only_topics | ros2_pub_set | ros2_sub_set
 
-            for topic in sorted(agnocast_topics_set | ros2_topics_set):
+            merged_topics = agnocast_topics_set | ros2_topics_set
+            if not args.debug:
+                merged_topics = {
+                    topic for topic in merged_topics
+                    if not topic.startswith(CIE_THREAD_CONFIGURATOR_NAMESPACE)
+                }
+
+            for topic in sorted(merged_topics):
                 if topic in agnocast_topics_set:
                     status = bridge_label_from_roles(
                         bridge_roles.get(topic, []), topic in ros2_pub_set, topic in ros2_sub_set)

--- a/src/ros2agnocast/test/test_discovery.py
+++ b/src/ros2agnocast/test/test_discovery.py
@@ -16,6 +16,7 @@ from ros2agnocast.discovery import (
     BRIDGE_WARN,
     collect_announcements_with_fallback,
     collect_bridge_roles,
+    is_internal_node_name,
     topic_endpoints,
     topics_of_node,
     warn_if_using_fallback,
@@ -154,6 +155,30 @@ def test_collect_bridge_roles_extracts_real_and_bridge_roles_per_ns():
     roles = collect_bridge_roles([snap_a, snap_b, snap_c])
     assert roles['/foo'] == [(True, False, False, True), (False, True, False, False)]
     assert '/bridge_only' not in roles
+
+
+def test_is_internal_node_name_true_for_bridge_discovery_agent_and_cie_client():
+    assert is_internal_node_name('/agnocast_bridge_node_0')
+    assert is_internal_node_name('/agnocast_discovery_agent_0')
+    assert is_internal_node_name('/agnocast_cie_thread_configurator/client_0')
+
+
+def test_is_internal_node_name_true_for_cie_domain_helper_node():
+    # Per-domain helper node created by create_node_for_domain in util.cpp; it has no
+    # trailing slash after the namespace prefix, unlike the per-process client nodes.
+    assert is_internal_node_name('/agnocast_cie_thread_configurator_domain_1')
+
+
+def test_is_internal_node_name_false_for_ordinary_application_nodes():
+    assert not is_internal_node_name('/cie_listener_node')
+    assert not is_internal_node_name('/talker')
+
+
+def test_is_internal_node_name_matches_regardless_of_leading_slash():
+    assert is_internal_node_name('agnocast_bridge_node_0')
+    assert is_internal_node_name('agnocast_discovery_agent_0')
+    assert is_internal_node_name('agnocast_cie_thread_configurator/client_0')
+    assert not is_internal_node_name('cie_listener_node')
 
 
 def test_resolve_spin_node_returns_node_as_is_when_not_nodestrategy():


### PR DESCRIPTION
## Description
- `ros2 node list_agnocast` and `ros2 topic list_agnocast` currently expose Agnocast-internal
  implementation nodes/topics (CIE thread configurator client nodes, the CIE
  `callback_group_info` topic, and the discovery agent node) unconditionally, even though the
  existing `-d/--debug` flag already hides domain bridge nodes the same way.
- Added `is_internal_node_name()` and shared prefix/namespace constants
  (`BRIDGE_NODE_PREFIX`, `DISCOVERY_AGENT_NODE_PREFIX`, `CIE_THREAD_CONFIGURATOR_NAMESPACE`) in
  `discovery.py`, and reused them in `node_list_agnocast` to also hide CIE thread configurator
  and discovery agent nodes behind `-d`.
- Added a new `-d/--debug` flag to `topic_list_agnocast` (it previously had none) and used it to
  hide the `/agnocast_cie_thread_configurator/*` topic namespace by default.
- Ordinary application nodes such as `/cie_listener_node` / `/cie_listener_container` are
  untouched — only the internal per-process configurator/discovery nodes and topics are hidden.

## Related links

## How was this PR tested?

To test locally, run the following command:

`bash scripts/sample_application/run_cie_listener.bash`

```
yutarokobayashi@npc2500109:~/agnocast$ ros2 node list_agnocast 
/cie_listener_container
/cie_listener_node
/launch_ros_52915

yutarokobayashi@npc2500109:~/agnocast$ ros2 node list_agnocast -d
/agnocast_bridge_node_performance
/agnocast_cie_thread_configurator/client_node_52928
/agnocast_cie_thread_configurator/client_node_52931
/agnocast_discovery_agent_25c9a78b_4026531839_d0
/cie_listener_container
/cie_listener_node
/launch_ros_52915

yutarokobayashi@npc2500109:~/agnocast$ ros2 topic list_agnocast 
/my_topic (Agnocast enabled)
/parameter_events
/ros_other_topic
/ros_topic
/rosout

yutarokobayashi@npc2500109:~/agnocast$ ros2 topic list_agnocast -d
/agnocast_cie_thread_configurator/callback_group_info
/my_topic (Agnocast enabled)
/parameter_events
/ros_other_topic
/ros_topic
/rosout
```


- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

https://github.com/autowarefoundation/agnocast_doc/pull/43

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
