### PR TITLE
fix(bridge):fix for `create_callback_group` contention

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_timer_info.hpp
@@ -74,6 +74,11 @@ void register_timer_info(
 
 void unregister_timer_info(uint32_t timer_id);
 
+// Whether the given callback group owns any agnocast timer. Used alongside
+// get_agnocast_topics_by_group() so a timer-only group is still classified as needing an
+// agnocast-capable executor.
+bool group_has_agnocast_timer(const rclcpp::CallbackGroup::SharedPtr & group);
+
 class TimerEventHandler : public EpollEventHandler
 {
   pid_t my_pid_;

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -76,7 +76,12 @@ void CallbackIsolatedAgnocastExecutor::spin()
       auto agnocast_topics = agnocast::get_agnocast_topics_by_group(group);
       auto callback_group_id = agnocast::create_callback_group_id(group, node, agnocast_topics);
 
-      if (agnocast_topics.empty()) {
+      // A group needs an agnocast-capable executor if it owns any agnocast entity: subscription
+      // or timer.
+      const bool needs_agnocast_executor =
+        !agnocast_topics.empty() || agnocast::group_has_agnocast_timer(group);
+
+      if (!needs_agnocast_executor) {
         executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
         std::static_pointer_cast<rclcpp::executors::SingleThreadedExecutor>(executor)
           ->add_callback_group(group, node);
@@ -127,6 +132,21 @@ void CallbackIsolatedAgnocastExecutor::spin()
 
     {
       std::lock_guard<std::mutex> guard{mutex_};
+
+      // Manually added groups have automatically_add_to_executor_with_node()==false, so the node
+      // scan below skips them; pick them up here or they never spawn.
+      for (const auto & weak_group_to_node : weak_groups_to_nodes_) {
+        auto group = weak_group_to_node.first.lock();
+        if (!group || group->get_associated_with_executor_atomic().load()) {
+          continue;
+        }
+        auto node = weak_group_to_node.second.lock();
+        if (!node) {
+          continue;
+        }
+        new_groups.emplace_back(group, node);
+      }
+
       for (const auto & weak_node : weak_nodes_) {
         auto node = weak_node.lock();
         if (!node) {
@@ -195,22 +215,26 @@ void CallbackIsolatedAgnocastExecutor::add_callback_group(
 
   std::lock_guard<std::mutex> guard{mutex_};
 
-  // Confirm that group_ptr does not refer to any of the callback groups held by nodes in
-  // weak_nodes_.
-  for (const auto & weak_node : weak_nodes_) {
-    auto n = weak_node.lock();
+  // A group with automatically_add_to_executor_with_node()==false is never picked up by add_node()
+  // (the node scans filter on that flag), so manually adding it is the only way to attach it, even
+  // when its owning node is already in weak_nodes_. Only reject a manually added group that its
+  // node would also add automatically, which would be a genuine double-add.
+  if (group_ptr->automatically_add_to_executor_with_node()) {
+    for (const auto & weak_node : weak_nodes_) {
+      auto n = weak_node.lock();
 
-    if (!n) {
-      continue;
-    }
-
-    if (n->callback_group_in_node(group_ptr)) {
-      RCLCPP_ERROR(
-        logger, "Callback group already exists in node: %s", n->get_fully_qualified_name());
-      if (agnocast_fd != -1) {
-        close(agnocast_fd);
+      if (!n) {
+        continue;
       }
-      exit(EXIT_FAILURE);
+
+      if (n->callback_group_in_node(group_ptr)) {
+        RCLCPP_ERROR(
+          logger, "Callback group already exists in node: %s", n->get_fully_qualified_name());
+        if (agnocast_fd != -1) {
+          close(agnocast_fd);
+        }
+        exit(EXIT_FAILURE);
+      }
     }
   }
 
@@ -320,12 +344,12 @@ void CallbackIsolatedAgnocastExecutor::add_node(
 
   std::lock_guard<std::mutex> guard{mutex_};
 
-  // Confirm that any callback group in weak_groups_to_nodes_ does not refer to any of the callback
-  // groups held by node_ptr.
+  // Only auto_add==true groups are a real double-add here; auto_add==false groups are never picked
+  // up by the node scan, so their owning node being added later is fine. Mirrors add_callback_group().
   for (const auto & weak_group_to_node : weak_groups_to_nodes_) {
     auto group = weak_group_to_node.first.lock();
 
-    if (!group) {
+    if (!group || !group->automatically_add_to_executor_with_node()) {
       continue;
     }
 

--- a/src/agnocastlib/src/agnocast_component_container_cie.cpp
+++ b/src/agnocastlib/src/agnocast_component_container_cie.cpp
@@ -1,4 +1,5 @@
 #include "agnocast/agnocast_single_threaded_executor.hpp"
+#include "agnocast/agnocast_timer_info.hpp"
 #include "agnocast/cie_client_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/component_manager.hpp"
@@ -156,9 +157,14 @@ void ComponentManagerCallbackIsolated::start_executor_for_callback_group(
   auto agnocast_topics = agnocast::get_agnocast_topics_by_group(callback_group);
   std::string group_id = agnocast::create_callback_group_id(callback_group, node, agnocast_topics);
 
+  // A group needs an agnocast-capable executor if it owns any agnocast entity: subscription or
+  // timer.
+  const bool needs_agnocast_executor =
+    !agnocast_topics.empty() || agnocast::group_has_agnocast_timer(callback_group);
+
   std::shared_ptr<rclcpp::Executor> executor;
 
-  if (agnocast_topics.empty()) {
+  if (!needs_agnocast_executor) {
     auto rclcpp_executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     rclcpp_executor->add_callback_group(callback_group, node);
     executor = std::move(rclcpp_executor);

--- a/src/agnocastlib/src/agnocast_timer_info.cpp
+++ b/src/agnocastlib/src/agnocast_timer_info.cpp
@@ -335,6 +335,17 @@ void unregister_timer_info(uint32_t timer_id)
   id2_timer_info.erase(timer_id);
 }
 
+bool group_has_agnocast_timer(const rclcpp::CallbackGroup::SharedPtr & group)
+{
+  std::lock_guard<std::mutex> lock(id2_timer_info_mtx);
+  for (const auto & [id, timer_info] : id2_timer_info) {
+    if (timer_info && timer_info->callback_group == group) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void TimerInfo::set_period(std::chrono::nanoseconds new_period)
 {
   // rcl_timer_exchange_period semantics.

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -190,6 +190,9 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
 
     if (result.count <= 0 || !is_demanded_by_ros2) {
       if (r2a_it->second.callback_group) {
+        // Mirror the add at creation. Remove before stop so the monitoring loop cannot re-spawn
+        // the group mid-teardown.
+        executor_->remove_callback_group(r2a_it->second.callback_group);
         executor_->stop_callback_group(r2a_it->second.callback_group);
       }
       r2a_it = active_pubsub_r2a_bridges_.erase(r2a_it);
@@ -220,6 +223,9 @@ void PerformanceBridgeManager::check_and_remove_pubsub_bridges()
 
     if (result.count <= 0 || !is_demanded_by_ros2) {
       if (a2r_it->second.callback_group) {
+        // Mirror the add at creation. Remove before stop so the monitoring loop cannot re-spawn
+        // the group mid-teardown.
+        executor_->remove_callback_group(a2r_it->second.callback_group);
         executor_->stop_callback_group(a2r_it->second.callback_group);
       }
       a2r_it = active_pubsub_a2r_bridges_.erase(a2r_it);
@@ -351,11 +357,19 @@ void PerformanceBridgeManager::create_pubsub_bridge_if_needed(
           RCLCPP_ERROR(
             logger_, "Failed to update ROS 2 publisher count for topic '%s'.", topic_name.c_str());
         }
+        if (result.callback_group) {
+          executor_->add_callback_group(
+            result.callback_group, container_node_->get_node_base_interface());
+        }
         active_pubsub_r2a_bridges_[topic_name] = result;
       } else {
         if (!update_ros2_subscriber_num(container_node_.get(), topic_name)) {
           RCLCPP_ERROR(
             logger_, "Failed to update ROS 2 subscriber count for topic '%s'.", topic_name.c_str());
+        }
+        if (result.callback_group) {
+          executor_->add_callback_group(
+            result.callback_group, container_node_->get_node_base_interface());
         }
         active_pubsub_a2r_bridges_[topic_name] = result;
       }

--- a/src/agnocastlib/test/integration/test_agnocast_epoll_update.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_epoll_update.cpp
@@ -118,21 +118,34 @@ protected:
       node, std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME), period,
       [&flag_to_set]() { flag_to_set = true; }, cbg);
   }
+
+  static constexpr bool is_callback_isolated_executor()
+  {
+    return std::is_same_v<ExecutorType, agnocast::CallbackIsolatedAgnocastExecutor> ||
+           std::is_same_v<ExecutorType, agnocast::AgnocastOnlyCallbackIsolatedExecutor>;
+  }
+
+  // The callback-isolated executors pick a child executor per callback group from a snapshot of
+  // the group's agnocast entities taken when the group is first spawned, and never revisit it.
+  // Tests that create the timer after the group has been spawned therefore cannot pass on these
+  // executors yet. See issue #1263.
+  void skip_if_callback_isolated_and_entity_added_after_spawn()
+  {
+    if (is_callback_isolated_executor()) {
+      GTEST_SKIP() << "callback-isolated executor classifies a group before the later-created "
+                      "timer exists; see issue #1263";
+    }
+  }
 };
 
 using ExecutorTypes = ::testing::Types<
   agnocast::SingleThreadedAgnocastExecutor, agnocast::MultiThreadedAgnocastExecutor,
-  // CallbackIsolatedAgnocastExecutor is commented out because this test fails
-  // when the Agnocast callback is created after associating CallbackGroup
-  // with the executor.
-  // See issue #1263 for details:
-  // https://github.com/autowarefoundation/agnocast/issues/1263
-  // TODO(ruth561): Fix the issue and re-enable this executor in the test suite.
-  // agnocast::CallbackIsolatedAgnocastExecutor,
-  agnocast::AgnocastOnlySingleThreadedExecutor, agnocast::AgnocastOnlyMultiThreadedExecutor
-  // AgnocastOnlyCallbackIsolatedExecutor is commented out because it
-  // unexpectedly terminates when adding CallbackGroup via add_callback_group.
-  // TODO(ruth561): Fix the issue and re-enable this executor in the test suite.
+  agnocast::CallbackIsolatedAgnocastExecutor, agnocast::AgnocastOnlySingleThreadedExecutor,
+  agnocast::AgnocastOnlyMultiThreadedExecutor
+  // AgnocastOnlyCallbackIsolatedExecutor is left out: unlike CallbackIsolatedAgnocastExecutor it
+  // still terminates when a callback group is added via add_callback_group, which is a separate
+  // issue from the bridge race fixed here.
+  // TODO(ruth561): Fix that and re-enable this executor.
   // agnocast::AgnocastOnlyCallbackIsolatedExecutor
   >;
 
@@ -188,6 +201,7 @@ TYPED_TEST(EpollUpdateTest, CbgTimerSpinAdd)
 
 TYPED_TEST(EpollUpdateTest, CbgSpinAddTimer)
 {
+  this->skip_if_callback_isolated_and_entity_added_after_spawn();
   std::atomic_bool callback_started{false};
   auto node = this->create_test_node();
 
@@ -206,6 +220,7 @@ TYPED_TEST(EpollUpdateTest, CbgSpinAddTimer)
 
 TYPED_TEST(EpollUpdateTest, SpinAddCbgTimer)
 {
+  this->skip_if_callback_isolated_and_entity_added_after_spawn();
   std::atomic_bool callback_started{false};
   auto node = this->create_test_node();
 
@@ -226,6 +241,7 @@ TYPED_TEST(EpollUpdateTest, SpinAddCbgTimer)
 // Spin -> Timer.
 TYPED_TEST(EpollUpdateTest, CbgAddSpinTimer)
 {
+  this->skip_if_callback_isolated_and_entity_added_after_spawn();
   std::atomic_bool callback_started{false};
   auto node = this->create_test_node();
 
@@ -279,6 +295,7 @@ TYPED_TEST(EpollUpdateTest, AddSpinCbgTimer)
 
 TYPED_TEST(EpollUpdateTest, SpinCbgAddTimer)
 {
+  this->skip_if_callback_isolated_and_entity_added_after_spawn();
   std::atomic_bool callback_started{false};
   auto node = this->create_test_node();
 
@@ -354,6 +371,7 @@ TYPED_TEST(EpollUpdateTest, SpinCbgTimerAddcbg)
 
 TYPED_TEST(EpollUpdateTest, SpinCbgAddcbgTimer)
 {
+  this->skip_if_callback_isolated_and_entity_added_after_spawn();
   std::atomic_bool callback_started{false};
   auto node = this->create_test_node();
 

--- a/src/ros2agnocast/ros2agnocast/static_sources/generic_functions.cpp
+++ b/src/ros2agnocast/ros2agnocast/static_sources/generic_functions.cpp
@@ -5,7 +5,10 @@ PerformancePubsubBridgeResult create_r2a_generic_bridge(
   const std::string & type_name,
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
 {
-  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // auto_add=false: the bridge manager adds this group to the executor explicitly, after the
+  // subscription is created, so it is never classified before its subscription exists. Do not drop
+  // the false here; with the default (true) the manager's explicit add_callback_group would abort.
+  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   rclcpp::SubscriptionOptions opts;
   opts.ignore_local_publications = true;
   opts.callback_group = cb_group;

--- a/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/pubsub_bridge_plugin.cpp.em
@@ -58,7 +58,10 @@ extern "C" PerformancePubsubBridgeResult create_a2r_pubsub_bridge_@(snake_type_n
     topic_name, "@(msg_type)",
     rclcpp::QoS(agnocast::DEFAULT_QOS_DEPTH).reliable().transient_local());
 
-  auto cb_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  // auto_add=false: the bridge manager adds this group to the executor explicitly, after the
+  // subscription is created, so it is never classified before its subscription exists.
+  auto cb_group =
+    node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
 
   auto agno_callback = [ros_pub](const agnocast::ipc_shared_ptr<MsgT> msg) {
     static const rclcpp::Serialization<MsgT> serialization;


### PR DESCRIPTION
## Description
This is a fix for `2.3.5-fixed-for-x2.v4.4.1` branch equivalent to the PR for main in https://github.com/autowarefoundation/agnocast/pull/1455.
This PR will be merged before merging https://github.com/autowarefoundation/agnocast/pull/1455 since this fix is already verified in TIER IV internal evaluation environment.

## Related links
https://github.com/autowarefoundation/agnocast/pull/1455
[TIER IV Internal Slack
](https://star4.slack.com/archives/C02G6HT8TNX/p1782086394646059)

## How was this PR tested?
- [x] [TIER IV Internal Evaluation environment](https://evaluation.ci.tier4.jp/evaluation/reports/7ed32a98-d87e-5572-ad0b-3fb6f6d881bf?project_id=x2_dev)
- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
