### PR TITLE
feat(agnocastlib): add vendored GenericClient

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(agnocast SHARED
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
   src/node/diagnostic_updater/diagnostic_updater.cpp
-  src/vendor/rclcpp/generic_service.cpp)
+  src/vendor/rclcpp/generic_service.cpp src/vendor/rclcpp/generic_client.cpp)
 
 ament_target_dependencies(agnocast rclcpp rcpputils rmw agnocast_cie_thread_configurator rosgraph_msgs agnocast_cie_config_msgs ament_index_cpp message_filters tf2 tf2_ros tf2_msgs geometry_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_introspection_cpp)
 

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_client.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_client.hpp
@@ -17,6 +17,8 @@
 // GenericClient is not available in ROS 2 Humble, so it is vendored here to implement Agnocast's
 // service bridging feature.
 
+#pragma once
+
 #include <rclcpp/version.h>
 
 #if RCLCPP_VERSION_MAJOR < 28

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_client.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_client.hpp
@@ -1,0 +1,98 @@
+// Copyright 2023 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file has been modified from the original.
+
+// GenericClient is not available in ROS 2 Humble, so it is vendored here to implement Agnocast's
+// service bridging feature.
+
+#include <rclcpp/version.h>
+
+#if RCLCPP_VERSION_MAJOR < 28
+
+#include <rclcpp/client.hpp>
+#include <rclcpp/node.hpp>
+#include <rcpputils/shared_library.hpp>
+#include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
+
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace agnocast::vendor_rclcpp
+{
+
+class GenericClient : public rclcpp::ClientBase
+{
+public:
+  using SharedPtr = std::shared_ptr<GenericClient>;
+
+  using Promise = std::promise<std::shared_ptr<void>>;
+
+  using Future = std::future<std::shared_ptr<void>>;
+  using SharedFuture = std::shared_future<std::shared_ptr<void>>;
+
+  using CallbackType = std::function<void(SharedFuture)>;
+
+  struct FutureAndRequestId : rclcpp::detail::FutureAndRequestId<Future>
+  {
+    using rclcpp::detail::FutureAndRequestId<Future>::FutureAndRequestId;
+    SharedFuture share() noexcept { return this->future.share(); }
+  };
+  struct SharedFutureAndRequestId : rclcpp::detail::FutureAndRequestId<SharedFuture>
+  {
+    using rclcpp::detail::FutureAndRequestId<SharedFuture>::FutureAndRequestId;
+  };
+
+  GenericClient(
+    rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    const rclcpp::QoS & qos);
+
+  static SharedPtr create_generic_client(
+    rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+    const rclcpp::CallbackGroup::SharedPtr & group = nullptr);
+
+  // --- rclcpp::ClientBase overrides (driven by the executor) ---
+  std::shared_ptr<void> create_response() override;
+  std::shared_ptr<rmw_request_id_t> create_request_header() override;
+  void handle_response(
+    std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<void> response) override;
+
+  SharedFutureAndRequestId async_send_request(const void *& request, CallbackType && cb);
+
+protected:
+  using PendingRequest = std::tuple<CallbackType, SharedFuture, Promise>;
+
+  std::optional<PendingRequest> get_and_erase_pending_request(int64_t sequence_number);
+
+  RCLCPP_DISABLE_COPY(GenericClient)
+
+  std::map<int64_t, std::pair<std::chrono::time_point<std::chrono::system_clock>, PendingRequest>>
+    pending_requests_;
+  std::mutex pending_requests_mutex_;
+
+private:
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_;
+};
+
+}  // namespace agnocast::vendor_rclcpp
+
+#endif

--- a/src/agnocastlib/src/vendor/rclcpp/generic_client.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_client.cpp
@@ -59,7 +59,7 @@ GenericClient::GenericClient(
     &client_options);
   if (ret != RCL_RET_OK) {
     if (ret == RCL_RET_SERVICE_NAME_INVALID) {
-      auto rcl_node_handle = this->get_rcl_node_handle();
+      auto * rcl_node_handle = this->get_rcl_node_handle();
       // this will throw on any validation problem
       rcl_reset_error();
       rclcpp::expand_topic_or_service_name(
@@ -88,15 +88,15 @@ std::shared_ptr<void> GenericClient::create_response()
 {
   void * response = new uint8_t[response_members_->size_of_];
   response_members_->init_function(response, rosidl_runtime_cpp::MessageInitialization::ZERO);
-  return std::shared_ptr<void>(response, [this](void * p) {
-    response_members_->fini_function(p);
-    delete[] reinterpret_cast<uint8_t *>(p);
-  });
+  return {response, [this](void * p) {
+            response_members_->fini_function(p);
+            delete[] reinterpret_cast<uint8_t *>(p);  // NOLINT(cppcoreguidelines-owning-memory)
+          }};
 }
 
 std::shared_ptr<rmw_request_id_t> GenericClient::create_request_header()
 {
-  return std::shared_ptr<rmw_request_id_t>(new rmw_request_id_t);
+  return std::make_shared<rmw_request_id_t>();
 }
 
 void GenericClient::handle_response(
@@ -120,7 +120,7 @@ GenericClient::SharedFutureAndRequestId GenericClient::async_send_request(
 {
   GenericClient::Promise promise;
   auto shared_future = promise.get_future().share();
-  int64_t sequence_number;
+  int64_t sequence_number = 0;
 
   {
     std::lock_guard<std::mutex> lock(pending_requests_mutex_);

--- a/src/agnocastlib/src/vendor/rclcpp/generic_client.cpp
+++ b/src/agnocastlib/src/vendor/rclcpp/generic_client.cpp
@@ -1,0 +1,156 @@
+// Copyright 2023 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file has been modified from the original.
+
+#include <rclcpp/version.h>
+
+#if RCLCPP_VERSION_MAJOR < 28
+
+#include "agnocast/vendor/rclcpp/generic_client.hpp"
+#include "agnocast/vendor/rclcpp/generic_service.hpp"  // get_service_typesupport_handle
+
+namespace agnocast::vendor_rclcpp
+{
+
+GenericClient::GenericClient(
+  rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+  const rclcpp::QoS & qos)
+: ClientBase(node->get_node_base_interface().get(), node->get_node_graph_interface())
+{
+  static const std::string ts_identifier = "rosidl_typesupport_cpp";
+  static const std::string ts_introspection_identifier = "rosidl_typesupport_introspection_cpp";
+
+  const std::string response_type = service_type + "_Response";
+
+  const rosidl_service_type_support_t * service_ts = nullptr;
+  try {
+    ts_lib_ = rclcpp::get_typesupport_library(service_type, ts_identifier);
+    ts_lib_introspection_ =
+      rclcpp::get_typesupport_library(service_type, ts_introspection_identifier);
+
+    service_ts = get_service_typesupport_handle(service_type, ts_identifier, *ts_lib_);
+
+    const rosidl_message_type_support_t * response_ts = rclcpp::get_typesupport_handle(
+      response_type, ts_introspection_identifier, *ts_lib_introspection_);
+    response_members_ =
+      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(response_ts->data);
+  } catch (std::runtime_error & err) {
+    RCLCPP_ERROR(node_logger_.get_child("agnocast.rclcpp"), "Invalid service type: %s", err.what());
+    throw;
+  }
+
+  rcl_client_options_t client_options = rcl_client_get_default_options();
+  client_options.qos = qos.get_rmw_qos_profile();
+
+  rcl_ret_t ret = rcl_client_init(
+    this->get_client_handle().get(), this->get_rcl_node_handle(), service_ts, service_name.c_str(),
+    &client_options);
+  if (ret != RCL_RET_OK) {
+    if (ret == RCL_RET_SERVICE_NAME_INVALID) {
+      auto rcl_node_handle = this->get_rcl_node_handle();
+      // this will throw on any validation problem
+      rcl_reset_error();
+      rclcpp::expand_topic_or_service_name(
+        service_name, rcl_node_get_name(rcl_node_handle), rcl_node_get_namespace(rcl_node_handle),
+        true);
+    }
+    rclcpp::exceptions::throw_from_rcl_error(ret, "could not create generic client");
+  }
+}
+
+GenericClient::SharedPtr GenericClient::create_generic_client(
+  rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+  const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group)
+{
+  auto client = std::make_shared<GenericClient>(
+    node, rclcpp::extend_name_with_sub_namespace(service_name, node->get_sub_namespace()),
+    service_type, qos);
+
+  std::shared_ptr<rclcpp::ClientBase> base_sp = client;
+  node->get_node_services_interface()->add_client(std::move(base_sp), group);
+
+  return client;
+}
+
+std::shared_ptr<void> GenericClient::create_response()
+{
+  void * response = new uint8_t[response_members_->size_of_];
+  response_members_->init_function(response, rosidl_runtime_cpp::MessageInitialization::ZERO);
+  return std::shared_ptr<void>(response, [this](void * p) {
+    response_members_->fini_function(p);
+    delete[] reinterpret_cast<uint8_t *>(p);
+  });
+}
+
+std::shared_ptr<rmw_request_id_t> GenericClient::create_request_header()
+{
+  return std::shared_ptr<rmw_request_id_t>(new rmw_request_id_t);
+}
+
+void GenericClient::handle_response(
+  std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<void> response)
+{
+  auto optional_pending_request =
+    this->get_and_erase_pending_request(request_header->sequence_number);
+  if (!optional_pending_request) {
+    return;
+  }
+  auto & value = *optional_pending_request;
+  const auto & callback = std::get<CallbackType>(value);
+  auto & promise = std::get<Promise>(value);
+  auto & future = std::get<SharedFuture>(value);
+  promise.set_value(std::move(response));
+  callback(std::move(future));
+}
+
+GenericClient::SharedFutureAndRequestId GenericClient::async_send_request(
+  const void *& request, GenericClient::CallbackType && cb)
+{
+  GenericClient::Promise promise;
+  auto shared_future = promise.get_future().share();
+  int64_t sequence_number;
+
+  {
+    std::lock_guard<std::mutex> lock(pending_requests_mutex_);
+    rcl_ret_t ret = rcl_send_request(get_client_handle().get(), request, &sequence_number);
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send request");
+    }
+    pending_requests_.try_emplace(
+      sequence_number, std::make_pair(
+                         std::chrono::system_clock::now(),
+                         std::make_tuple(std::move(cb), shared_future, std::move(promise))));
+  }
+
+  return {std::move(shared_future), sequence_number};
+}
+
+std::optional<GenericClient::PendingRequest> GenericClient::get_and_erase_pending_request(
+  int64_t sequence_number)
+{
+  std::lock_guard<std::mutex> lock(pending_requests_mutex_);
+  auto it = pending_requests_.find(sequence_number);
+  if (it == pending_requests_.end()) {
+    RCUTILS_LOG_DEBUG_NAMED("agnocast.rclcpp", "Received invalid sequence number. Ignoring...");
+    return std::nullopt;
+  }
+  auto value = std::move(it->second.second);
+  pending_requests_.erase(sequence_number);
+  return value;
+}
+
+}  // namespace agnocast::vendor_rclcpp
+
+#endif


### PR DESCRIPTION
## Description

This PR vendors `GenericClient` to make it available in ROS 2 Humble. We will need it to implement generic A2R service bridging. Since `GenericClient` does not exist in ROS 2 Humble but is available in ROS 2 Jazzy, the vendored `GenericClient` is guarded by `RCLCPP_VERSION_MAJOR < 28` to ensure the original `GenericClient` is used in ROS 2 Jazzy.

### Key differences from upstream

1. **Stripped down `async_send_request()`.** Only the overload with a callback is implemented. As part of this change, the management of pending requests is also simplified.
1. **Factory function.** In order to pack everything inside the `GenericClient` class, the factory function (`create_generic_client()`) is defined as a static member function of `GenericClient`.
1. **Introspection loading.** The way of loading introspection is changed to make it work in ROS 2 Humble.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

I added a sample client application that uses the vendored `GenericClient` and verified it works as expected with a ROS 2 server application. The source code is available at the `bdm-k/vendored-generic-client-test` branch.

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

