### PR TITLE
feat(agnocastlib): add GenericService

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(agnocast SHARED
   src/agnocast_smart_pointer.cpp src/agnocast_callback_info.cpp src/agnocast_epoll.cpp src/agnocast_epoll_update_dispatcher.cpp src/agnocast_timer_info.cpp src/agnocast_timer.cpp src/agnocast_executor.cpp
   src/agnocast_single_threaded_executor.cpp src/agnocast_multi_threaded_executor.cpp
   src/agnocast_callback_isolated_executor.cpp
-  src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp
+  src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp src/agnocast_service.cpp
   src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_signal_handler.cpp
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -324,6 +324,19 @@ typename Service<ServiceT>::SharedPtr create_service(
     node, service_name, std::forward<Func>(callback), qos, group);
 }
 
+template <typename NodeT, typename Func>
+typename GenericService::SharedPtr create_generic_service(
+  NodeT * node, const std::string & service_name, const std::string & service_type,
+  Func && callback, const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+  const rclcpp::CallbackGroup::SharedPtr & group = nullptr)
+{
+  static_assert(
+    std::is_base_of_v<rclcpp::Node, NodeT> || std::is_base_of_v<agnocast::Node, NodeT>,
+    "NodeT must be rclcpp::Node or agnocast::Node (or derived from them)");
+  return std::make_shared<GenericService>(
+    node, service_name, service_type, std::forward<Func>(callback), qos, group);
+}
+
 /**
  * @brief Create a timer with a given clock.
  *

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -276,7 +276,20 @@ class GenericService : public std::enable_shared_from_this<GenericService>
       ipc_shared_ptr<void> response = std::move(res_wrapper).take_response();
       ipc_shared_ptr<void> response_double(response);
 
-      callback(std::move(req_wrapper).take_request(), std::move(response_double));
+      // If the callback throws, we destroy the `response` (ipc_shared_ptr<void>) via
+      // cancel_message() to prevent ipc_shared_ptr::reset() from calling std::terminate(), and then
+      // rethrow. We only need to destroy `response`, not `response_double`:
+      // (1) If `response_double` was moved from, it is empty and does not need to be destroyed.
+      // (2) If `response_double` was not moved from, it will be invalidated when `response` is
+      //     destroyed.
+      try {
+        callback(std::move(req_wrapper).take_request(), std::move(response_double));
+      } catch (...) {
+        publisher->cancel_message(std::move(response), [this](void * p) {
+          GenericResponseWrapper::free(p, this->response_members_);
+        });
+        throw;
+      }
 
       publisher->publish(std::move(response), [this](void * p) {
         GenericResponseWrapper::free(p, this->response_members_);

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -221,6 +221,17 @@ public:
   }
 };
 
+/**
+ * @brief Generic service server for zero-copy Agnocast service communication.
+ *
+ * The service type is supplied as a runtime string, rather than a compile-time template argument.
+ * If the given service type is invalid, the constructor will throw an exception.
+ *
+ * The usage is mostly the same as agnocast::Service. One difference is cancel_response(), which
+ * only exists in GenericService. This is relevant for deferred callbacks. The user must either call
+ * send_response() or cancel_response() for every response borrowed via borrow_loaned_response().
+ * Otherwise, the process will terminate.
+ */
 class GenericService : public std::enable_shared_from_this<GenericService>
 {
   template <typename Func>

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -221,6 +221,145 @@ public:
   }
 };
 
+class GenericService : public std::enable_shared_from_this<GenericService>
+{
+  template <typename Func>
+  struct is_basic_cb
+  : std::bool_constant<
+      std::is_invocable_v<std::decay_t<Func>, ipc_shared_ptr<void> &&, ipc_shared_ptr<void> &&>>
+  {
+  };
+  template <typename Func>
+  struct is_deferred_cb
+  : std::bool_constant<std::is_invocable_v<
+      std::decay_t<Func>, std::shared_ptr<GenericService>, ipc_shared_ptr<void> &&>>
+  {
+  };
+
+  const std::variant<rclcpp::Node *, agnocast::Node *> node_;
+  std::string service_name_;
+  const rclcpp::QoS qos_;
+  std::mutex publishers_mtx_;
+  std::unordered_map<std::string, typename TypeErasedPublisher::SharedPtr> publishers_;
+  typename Subscription<void>::SharedPtr subscriber_;
+
+  std::shared_ptr<rcpputils::SharedLibrary> ts_lib_introspection_;
+  const rosidl_typesupport_introspection_cpp::MessageMembers * request_members_{nullptr};
+  const rosidl_typesupport_introspection_cpp::MessageMembers * response_members_{nullptr};
+
+  typename TypeErasedPublisher::SharedPtr get_or_create_publisher_for(
+    const std::string & node_name);
+
+  template <typename Func>
+  auto wrap_basic_service_callback_for_subscriber(Func && callback)
+  {
+    return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<void> && request) {
+      auto req_wrapper = GenericRequestWrapper(request_members_, std::move(request));
+      auto publisher = this->get_or_create_publisher_for(req_wrapper.node_name());
+
+      auto res_wrapper = GenericResponseWrapper::allocate(
+        response_members_,
+        [&publisher](size_t size) { return publisher->borrow_loaned_message(size); });
+      res_wrapper.seqno() = req_wrapper.seqno();
+
+      ipc_shared_ptr<void> response = std::move(res_wrapper).take_response();
+      ipc_shared_ptr<void> response_double(response);
+
+      callback(std::move(req_wrapper).take_request(), std::move(response_double));
+
+      publisher->publish(std::move(response), [this](void * p) {
+        GenericResponseWrapper::free(p, this->response_members_);
+      });
+
+      // Safety regarding response_double
+      //   When `response` is published, all references that share its control block are
+      //   invalidated. Since `response_double` shares its control block with `response`,
+      //   dereferencing `response_double` after publication is disallowed, preventing accidental
+      //   (and erroneous) writes to the response via `response_double`.
+    };
+  }
+
+  template <typename Func>
+  auto wrap_deferred_service_callback_for_subscriber(Func && callback)
+  {
+    return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<void> && request) {
+      callback(this->shared_from_this(), std::move(request));
+    };
+  }
+
+  void load_typesupport_impl(const std::string & service_type);
+
+  template <typename Func, typename NodeT>
+  void constructor_impl(
+    NodeT * node, const std::string & service_name, const std::string & service_type,
+    Func && callback, const rclcpp::CallbackGroup::SharedPtr & group, ServiceRole role)
+  {
+    static_assert(
+      is_basic_cb<Func>::value || is_deferred_cb<Func>::value,
+      "Callback must be callable with one of the following argument pairs:\n"
+      "1. basic: (ipc_shared_ptr<void>, ipc_shared_ptr<void>)\n"
+      "2. deferred: (std::shared_ptr<GenericService>, ipc_shared_ptr<void>)\n"
+      "ipc_shared_ptr arguments can be received by const&, &&, or by value");
+
+    load_typesupport_impl(service_type);
+
+    service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
+
+    SubscriptionOptions sub_options{group};
+    std::string req_topic_name = create_service_request_topic_name(service_name_);
+    if constexpr (is_basic_cb<Func>::value) {
+      subscriber_ = std::make_shared<Subscription<void>>(
+        node, req_topic_name, "", qos_,
+        wrap_basic_service_callback_for_subscriber(std::forward<Func>(callback)), sub_options,
+        SubscriptionRole::AgnocastOnly);
+    } else if constexpr (is_deferred_cb<Func>::value) {
+      subscriber_ = std::make_shared<Subscription<void>>(
+        node, req_topic_name, "", qos_,
+        wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), sub_options,
+        SubscriptionRole::AgnocastOnly);
+    }
+
+    if (role == ServiceRole::Default) {
+      std::optional<std::pair<std::string, std::string>> shadow_node_identity{std::nullopt};
+      if constexpr (std::is_same_v<std::remove_cv_t<NodeT>, agnocast::Node>) {
+        shadow_node_identity =
+          std::make_pair(std::string(node->get_namespace()), std::string(node->get_name()));
+      }
+      register_service_bridge(
+        service_type, service_name_, BridgeDirection::ROS2_TO_AGNOCAST, shadow_node_identity);
+    }
+  }
+
+public:
+  using SharedPtr = std::shared_ptr<GenericService>;
+
+  template <typename Func>
+  GenericService(
+    rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
+    Func && callback, const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group,
+    ServiceRole role = ServiceRole::Default)
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  {
+    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group, role);
+  }
+
+  template <typename Func>
+  GenericService(
+    agnocast::Node * node, const std::string & service_name, const std::string & service_type,
+    Func && callback, const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group,
+    ServiceRole role = ServiceRole::Default)
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  {
+    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group, role);
+  }
+
+  void send_response(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response);
+
+  void cancel_response(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response);
+
+  ipc_shared_ptr<void> borrow_loaned_response(const ipc_shared_ptr<void> & request);
+};
+
 /**
  * @brief The user-facing Agnocast service server.
  * Alias for `BasicService<ServiceT>`. Use this type (not BasicService directly) when declaring

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -142,6 +142,12 @@ class GenericResponseWrapper
     alignas(16) int64_t seqno;
   };
 
+  static constexpr size_t get_wire_size(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * response_members)
+  {
+    return offsetof_meta(response_members->size_of_) + sizeof(Meta);
+  }
+
   static Meta * get_meta_ptr(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
     void * response_ptr)
@@ -164,6 +170,38 @@ public:
   int64_t & seqno() { return meta_ptr_->seqno; }
 
   ipc_shared_ptr<void> && take_response() && { return std::move(response_); }
+
+  /// @brief Allocate a wire-format response buffer in shared memory.
+  ///
+  /// The payload buffer is initialized via the introspection init function with
+  /// MessageInitialization::SKIP. The seqno number is uninitialized (garbage).
+  ///
+  /// @param response_members The introspection message members for the response type.
+  /// @param borrow_loaned_message A callable that allocates a buffer of the given size in shared
+  /// memory. In practice, this should be TypeErasedPublisher::borrow_loaned_message().
+  template <typename Func>
+  static GenericResponseWrapper allocate(
+    const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
+    Func && borrow_loaned_message)
+  {
+    ipc_shared_ptr<void> response = borrow_loaned_message(get_wire_size(response_members));
+    auto wrapper = GenericResponseWrapper(response_members, std::move(response));
+
+    response_members->init_function(
+      wrapper.response_.get(), rosidl_runtime_cpp::MessageInitialization::SKIP);
+
+    return wrapper;
+  }
+
+  /// @brief Free a wire-format response buffer in shared memory.
+  /// @param ptr Pointer to the response buffer.
+  /// @param response_members The introspection message members for the response type.
+  static void free(
+    void * ptr, const rosidl_typesupport_introspection_cpp::MessageMembers * response_members)
+  {
+    response_members->fini_function(ptr);
+    ::operator delete(ptr);
+  }
 };
 
 }  // namespace agnocast

--- a/src/agnocastlib/src/agnocast_service.cpp
+++ b/src/agnocastlib/src/agnocast_service.cpp
@@ -1,0 +1,93 @@
+#include "agnocast/agnocast_service.hpp"
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/internal/service_wire_type.hpp"
+
+namespace agnocast
+{
+
+typename TypeErasedPublisher::SharedPtr GenericService::get_or_create_publisher_for(
+  const std::string & node_name)
+{
+  typename TypeErasedPublisher::SharedPtr pub;
+  {
+    std::lock_guard<std::mutex> lock(publishers_mtx_);
+    auto it = publishers_.find(node_name);
+    if (it == publishers_.end()) {
+      std::visit(
+        [this, &pub, &node_name](auto * node) {
+          std::string topic_name = create_service_response_topic_name(service_name_, node_name);
+          agnocast::PublisherOptions pub_options;
+          pub = std::make_shared<TypeErasedPublisher>(
+            node, topic_name, "", qos_, pub_options, PublisherRole::AgnocastOnly);
+          publishers_[node_name] = pub;
+        },
+        node_);
+    } else {
+      pub = it->second;
+    }
+  }
+  return pub;
+}
+
+void GenericService::load_typesupport_impl(const std::string & service_type)
+{
+  static const std::string ts_introspection_identifier = "rosidl_typesupport_introspection_cpp";
+  const std::string request_type = service_type + "_Request";
+  const std::string response_type = service_type + "_Response";
+
+  ts_lib_introspection_ =
+    rclcpp::get_typesupport_library(service_type, ts_introspection_identifier);
+
+#if RCLCPP_VERSION_MAJOR >= 28
+  const rosidl_message_type_support_t * request_ts = rclcpp::get_message_typesupport_handle(
+    request_type, ts_introspection_identifier, *ts_lib_introspection_);
+  const rosidl_message_type_support_t * response_ts = rclcpp::get_message_typesupport_handle(
+    response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#else
+  const rosidl_message_type_support_t * request_ts = rclcpp::get_typesupport_handle(
+    request_type, ts_introspection_identifier, *ts_lib_introspection_);
+  const rosidl_message_type_support_t * response_ts = rclcpp::get_typesupport_handle(
+    response_type, ts_introspection_identifier, *ts_lib_introspection_);
+#endif
+
+  request_members_ =
+    static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(request_ts->data);
+  response_members_ =
+    static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(response_ts->data);
+}
+
+void GenericService::send_response(
+  ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response)
+{
+  auto req_wrapper = GenericRequestWrapper(this->request_members_, std::move(request));
+  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+  publisher->publish(std::move(response), [this](void * p) {
+    GenericResponseWrapper::free(p, this->response_members_);
+  });
+}
+
+void GenericService::cancel_response(
+  ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response)
+{
+  auto req_wrapper = GenericRequestWrapper(this->request_members_, std::move(request));
+  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+  publisher->cancel_message(std::move(response), [this](void * p) {
+    GenericResponseWrapper::free(p, this->response_members_);
+  });
+}
+
+ipc_shared_ptr<void> GenericService::borrow_loaned_response(const ipc_shared_ptr<void> & request)
+{
+  auto req_wrapper = GenericRequestWrapper(this->request_members_, ipc_shared_ptr<void>(request));
+  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+
+  auto res_wrapper = GenericResponseWrapper::allocate(
+    this->response_members_,
+    [&publisher](size_t size) { return publisher->borrow_loaned_message(size); });
+  res_wrapper.seqno() = req_wrapper.seqno();
+
+  return std::move(res_wrapper).take_response();
+}
+
+}  // namespace agnocast


### PR DESCRIPTION
## Description

This PR introduces `GenericService`, a type-erased Agnocast service server. `GenericService` mirrors `BasicService` but operates on type-erased `ipc_shared_ptr<void>` payloads. Under the hood, it uses `TypeErasedPublisher` and `Subscription<void>` to implement the functionality.

### Interface summary

| Function | Type |
| -------- | ---- |
| Basic callback | `void(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response)` |
| Deferred callback | `void(std::shared_ptr<GenericService> service_handle, ipc_shared_ptr<void> && request)` |
| `send_response()` | `void(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response)` |
| `cancel_response()` | `void(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response)` |
| `borrow_loaned_response()` | `ipc_shared_ptr<void>(const ipc_shared_ptr<void> & request)` |

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

I wrote a sample server application using `GenericService` and verified that it communicates with the sample client application without any problems. The code is available in branch `bdm-k/generic-service-test`. Though the sample server uses the basic callback mode, I will verify the deferred callback mode thoroughly when I implement the generic fallback for A2R service bridges.

## Notes for reviewers

- `BasicService` and `GenericService` share much code. I will refactor them to deduplicate code in the next PR.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

