### PR TITLE
refactor(cie_thread_configurator): remove remove_trailing_waitable

### DIFF
--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -5,7 +5,6 @@
 
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <unordered_set>
 #include <utility>
 
@@ -16,24 +15,6 @@ const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
 };
-
-namespace
-{
-// Backward compatibility: strip trailing "@Waitable" suffixes from a callback-group id.
-std::string remove_trailing_waitable(std::string s)
-{
-  static constexpr std::string_view suffix = "@Waitable";
-  const std::size_t suffix_size = suffix.size();
-  std::size_t s_size = s.size();
-  while (s_size >= suffix_size &&
-         std::char_traits<char>::compare(
-           s.data() + (s_size - suffix_size), suffix.data(), suffix_size) == 0) {
-    s_size -= suffix_size;
-  }
-  s.resize(s_size);
-  return s;
-}
-}  // namespace
 
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,
@@ -51,7 +32,7 @@ void parse_yaml(
     const auto & cg = callback_groups[i];
     auto & cfg = callback_groups_out[i];
 
-    cfg.thread_str = remove_trailing_waitable(cg["id"].as<std::string>());
+    cfg.thread_str = cg["id"].as<std::string>();
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
     for (auto & cpu : cg["affinity"]) cfg.affinity.push_back(cpu.as<int>());
     cfg.policy = cg["policy"].as<std::string>();

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -157,23 +157,6 @@ non_ros_threads:
   EXPECT_EQ(nrt[0].priority, 30);
 }
 
-TEST(ParseYaml, StripsTrailingWaitableSuffix)
-{
-  auto y = yaml_from_str(R"YAML(
-callback_groups:
-  - id: my_cbg@Waitable@Waitable
-    domain_id: 0
-    policy: SCHED_OTHER
-    priority: 0
-    affinity: []
-non_ros_threads: []
-)YAML");
-  std::vector<acie::ThreadConfig> cb, nrt;
-  acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
-  ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].thread_str, "my_cbg");
-}
-
 TEST(ParseYaml, ClearsOutputVectorsOnReparse)
 {
   auto y1 = yaml_from_str(R"YAML(


### PR DESCRIPTION
## Description

Removes the `remove_trailing_waitable` helper from `thread_config.cpp` in `agnocast_cie_thread_configurator`, along with its dedicated unit test (`ParseYaml.StripsTrailingWaitableSuffix`) and the now-unused `<string_view>` include.

The helper stripped trailing `@Waitable` suffixes from callback-group ids for backward compatibility with an old id format. No YAML config or code in the repository produces or references the `@Waitable` suffix anymore, so `parse_yaml` now uses the `id` field as written. Any config file still using the old suffixed ids would need to be updated, but none exist in the repository.

Verified by building with `-DBUILD_TESTING=ON` and running `test_thread_config` (all 12 tests pass).

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.