### PR TITLE
feat(bridge): support stable performance bridge node name via AGNOCAST_BRIDGE_NODE_NAME_SUFFIX

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -150,7 +150,8 @@ if(BUILD_TESTING)
     test/unit/test_cie_client_utils.cpp
     test/unit/test_agnocast_context.cpp
     test/unit/test_diagnostic_updater.cpp
-    test/unit/test_type_registry_writer.cpp)
+    test/unit/test_type_registry_writer.cpp
+    test/unit/test_bridge_node_name.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater)

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -58,6 +58,7 @@ struct PublisherCountResult
 };
 
 BridgeMode get_bridge_mode();
+std::string get_performance_bridge_node_name(uint64_t self_ipc_ns_inode);
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id);
 rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t publisher_id);
 PublisherCountResult get_agnocast_publisher_count(const std::string & topic_name);

--- a/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
+++ b/src/agnocastlib/src/agnocast_callback_isolated_executor.cpp
@@ -345,7 +345,8 @@ void CallbackIsolatedAgnocastExecutor::add_node(
   std::lock_guard<std::mutex> guard{mutex_};
 
   // Only auto_add==true groups are a real double-add here; auto_add==false groups are never picked
-  // up by the node scan, so their owning node being added later is fine. Mirrors add_callback_group().
+  // up by the node scan, so their owning node being added later is fine. Mirrors
+  // add_callback_group().
   for (const auto & weak_group_to_node : weak_groups_to_nodes_) {
     auto group = weak_group_to_node.first.lock();
 

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -5,12 +5,15 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <dlfcn.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cctype>
 #include <cstdarg>
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <stdexcept>
@@ -43,6 +46,37 @@ BridgeMode get_bridge_mode()
 
   RCLCPP_WARN(logger, "Unknown AGNOCAST_BRIDGE_MODE: %s. Fallback to STANDARD.", env_val);
   return BridgeMode::Standard;
+}
+
+std::string get_performance_bridge_node_name(const uint64_t self_ipc_ns_inode)
+{
+  const std::string default_name = "agnocast_bridge_node_performance_" +
+                                   std::to_string(self_ipc_ns_inode) + "_" +
+                                   std::to_string(getpid());
+
+  const char * env_val = std::getenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX");
+  if (env_val == nullptr || *env_val == '\0') {
+    return default_name;
+  }
+
+  // Container names may contain '-' and '.', which are not allowed in ROS 2 node names.
+  std::string suffix = env_val;
+  std::replace(suffix.begin(), suffix.end(), '-', '_');
+  std::replace(suffix.begin(), suffix.end(), '.', '_');
+
+  const bool valid = std::all_of(suffix.begin(), suffix.end(), [](const unsigned char c) {
+    return std::isalnum(c) != 0 || c == '_';
+  });
+  if (!valid) {
+    RCLCPP_WARN(
+      logger,
+      "AGNOCAST_BRIDGE_NODE_NAME_SUFFIX='%s' contains characters not allowed in a ROS 2 node name. "
+      "Falling back to the default node name '%s'.",
+      env_val, default_name.c_str());
+    return default_name;
+  }
+
+  return "agnocast_bridge_node_performance_" + suffix;
 }
 
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id)

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -5,6 +5,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <dlfcn.h>
+#include <rmw/validate_node_name.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -64,19 +65,23 @@ std::string get_performance_bridge_node_name(const uint64_t self_ipc_ns_inode)
   std::replace(suffix.begin(), suffix.end(), '-', '_');
   std::replace(suffix.begin(), suffix.end(), '.', '_');
 
-  const bool valid = std::all_of(suffix.begin(), suffix.end(), [](const unsigned char c) {
-    return std::isalnum(c) != 0 || c == '_';
-  });
+  const std::string node_name = "agnocast_bridge_node_performance_" + suffix;
+
+  // rmw rejects node names longer than RMW_NODE_NAME_MAX_NAME_LENGTH.
+  const bool valid = node_name.size() <= RMW_NODE_NAME_MAX_NAME_LENGTH &&
+                     std::all_of(suffix.begin(), suffix.end(), [](const unsigned char c) {
+                       return std::isalnum(c) != 0 || c == '_';
+                     });
   if (!valid) {
     RCLCPP_WARN(
       logger,
-      "AGNOCAST_BRIDGE_NODE_NAME_SUFFIX='%s' contains characters not allowed in a ROS 2 node name. "
+      "AGNOCAST_BRIDGE_NODE_NAME_SUFFIX='%s' does not form a valid ROS 2 node name. "
       "Falling back to the default node name '%s'.",
       env_val, default_name.c_str());
     return default_name;
   }
 
-  return "agnocast_bridge_node_performance_" + suffix;
+  return node_name;
 }
 
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id)

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -51,9 +51,8 @@ BridgeMode get_bridge_mode()
 
 std::string get_performance_bridge_node_name(const uint64_t self_ipc_ns_inode)
 {
-  const std::string default_name = "agnocast_bridge_node_performance_" +
-                                   std::to_string(self_ipc_ns_inode) + "_" +
-                                   std::to_string(getpid());
+  std::string default_name = "agnocast_bridge_node_performance_" +
+                             std::to_string(self_ipc_ns_inode) + "_" + std::to_string(getpid());
 
   const char * env_val = std::getenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX");
   if (env_val == nullptr || *env_val == '\0') {
@@ -65,7 +64,7 @@ std::string get_performance_bridge_node_name(const uint64_t self_ipc_ns_inode)
   std::replace(suffix.begin(), suffix.end(), '-', '_');
   std::replace(suffix.begin(), suffix.end(), '.', '_');
 
-  const std::string node_name = "agnocast_bridge_node_performance_" + suffix;
+  std::string node_name = "agnocast_bridge_node_performance_" + suffix;
 
   // rmw rejects node names longer than RMW_NODE_NAME_MAX_NAME_LENGTH.
   const bool valid = node_name.size() <= RMW_NODE_NAME_MAX_NAME_LENGTH &&

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -75,9 +75,7 @@ void PerformanceBridgeManager::run()
 
 void PerformanceBridgeManager::start_ros_execution()
 {
-  std::string node_name =
-    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_) + "_" +
-    std::to_string(getpid());
+  const std::string node_name = get_performance_bridge_node_name(self_ipc_ns_inode_);
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges

--- a/src/agnocastlib/test/unit/test_bridge_node_name.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_node_name.cpp
@@ -1,0 +1,59 @@
+#include "agnocast/bridge/agnocast_bridge_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace
+{
+
+std::string default_name_for(const uint64_t ipc_ns_inode)
+{
+  return "agnocast_bridge_node_performance_" + std::to_string(ipc_ns_inode) + "_" +
+         std::to_string(getpid());
+}
+
+class GetPerformanceBridgeNodeNameTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { unsetenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX"); }
+  void TearDown() override { unsetenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX"); }
+};
+
+TEST_F(GetPerformanceBridgeNodeNameTest, default_name_when_env_unset)
+{
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, default_name_when_env_empty)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "", 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, suffix_appended_when_env_set)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "planning_main_ecu", 1);
+  EXPECT_EQ(
+    agnocast::get_performance_bridge_node_name(123),
+    "agnocast_bridge_node_performance_planning_main_ecu");
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, hyphen_and_dot_replaced_with_underscore)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "planning-container.1", 1);
+  EXPECT_EQ(
+    agnocast::get_performance_bridge_node_name(123),
+    "agnocast_bridge_node_performance_planning_container_1");
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, invalid_characters_fall_back_to_default)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "plan/ning", 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+}  // namespace

--- a/src/agnocastlib/test/unit/test_bridge_node_name.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_node_name.cpp
@@ -55,4 +55,12 @@ TEST_F(GetPerformanceBridgeNodeNameTest, invalid_characters_fall_back_to_default
   EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
 }
 
+TEST_F(GetPerformanceBridgeNodeNameTest, too_long_suffix_falls_back_to_default)
+{
+  // Long enough that the resulting node name exceeds RMW_NODE_NAME_MAX_NAME_LENGTH (255).
+  const std::string long_suffix(256, 'a');
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", long_suffix.c_str(), 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
 }  // namespace

--- a/src/agnocastlib/test/unit/test_bridge_node_name.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_node_name.cpp
@@ -1,7 +1,6 @@
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
 
 #include <gtest/gtest.h>
-
 #include <unistd.h>
 
 #include <cstdlib>


### PR DESCRIPTION
## Description

With the multi-container architecture, `agnocast_bridge_node_performance` runs in each Docker container, and #1442 made the node name unique by appending `<ipc_ns_inode>_<pid>`. These values change on every launch, so tools that reference node names in static configuration files can no longer match the bridge node. In particular, CIE thread configuration entries are keyed by node name, which makes it impossible to give the bridge threads a static scheduling configuration.

This PR adds an explicit override: when the `AGNOCAST_BRIDGE_NODE_NAME_SUFFIX` environment variable is set, the performance bridge node is named `agnocast_bridge_node_performance_<suffix>`. The deployment configuration (e.g. `docker-compose.yaml`) is responsible for injecting a value that is unique within the ROS 2 domain, such as the container name (combined with an ECU name in multi-ECU setups):

```yaml
services:
  planning:
    environment:
      - AGNOCAST_BRIDGE_MODE=performance
      - AGNOCAST_BRIDGE_NODE_NAME_SUFFIX=main_planning # -> /agnocast_bridge_node_performance_main_planning
```

Design decisions:

- When the variable is unset or empty, the existing per-launch unique naming (`agnocast_bridge_node_performance_<ipc_ns_inode>_<pid>`) is kept, so current setups are unaffected.
- The variable carries only the suffix (not the full node name) so that the `agnocast_bridge_node_` prefix is preserved; `ros2agnocast` CLI filters and other tools rely on this prefix.
- `-` and `.` (common in container names) are mapped to `_`. Values containing other characters not allowed in ROS 2 node names, or values so long that the resulting node name would exceed `RMW_NODE_NAME_MAX_NAME_LENGTH`, are ignored with a warning and the default naming is used, so a misconfigured value never prevents the bridge from starting.
- The standard bridge is out of scope: it spawns one manager per target process, so a single shared suffix would collide across instances. It also does not run in performance mode.

## Related links

- #1442
- TIER IV internal Slack discussion: https://star4.slack.com/archives/C07FL8616EM/p1784776596353979
- Deployment-side change: https://github.com/tier4/pilot-auto.x2/pull/5237

## How was this PR tested?

Added unit tests (`test/unit/test_bridge_node_name.cpp`) covering: default naming when the variable is unset or empty, suffix naming when set, `-`/`.` sanitization, fallback to the default name on invalid characters, and fallback when the suffix would exceed the maximum node name length. All 6 pass (Release, `BUILD_TESTING=On`).

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

- After this lands, the cherry-pick to `main` (#1465) can carry this commit together with #1442/#1457 so that `main` never ships the per-launch-only naming.
- The `style: apply clang-format` commit contains a formatting-only fix to `agnocast_callback_isolated_executor.cpp` picked up by the pre-commit hook; it is unrelated to this feature.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.