### PR TITLE
feat(bridge): support stable performance bridge node name via AGNOCAST_BRIDGE_NODE_NAME_SUFFIX (cherry-pick #1442/#1457/#1477)

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -160,7 +160,8 @@ if(BUILD_TESTING)
     test/unit/test_agnocast_generic_publisher.cpp
     test/unit/test_daemon_bridge_uds.cpp
     test/unit/test_agnocast_bridge_uds.cpp
-    test/unit/test_discovery_agent_auto_fork.cpp)
+    test/unit/test_discovery_agent_auto_fork.cpp
+    test/unit/test_bridge_node_name.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
   ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_utils.hpp
@@ -53,6 +53,7 @@ struct PublisherCountResult
 };
 
 BridgeMode get_bridge_mode();
+std::string get_performance_bridge_node_name(uint64_t self_ipc_ns_inode);
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id);
 rclcpp::QoS get_publisher_qos(const std::string & topic_name, topic_local_id_t publisher_id);
 // Rebuild a QoS profile from the fields a daemon cross-NS request carries. The

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -5,6 +5,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <rmw/validate_node_name.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -45,6 +48,40 @@ BridgeMode get_bridge_mode()
 
   RCLCPP_WARN_ONCE(logger, "Unknown AGNOCAST_BRIDGE_MODE: %s. Fallback to ON.", env_val);
   return BridgeMode::On;
+}
+
+std::string get_performance_bridge_node_name(const uint64_t self_ipc_ns_inode)
+{
+  std::string default_name = "agnocast_bridge_node_performance_" +
+                             std::to_string(self_ipc_ns_inode) + "_" + std::to_string(getpid());
+
+  const char * env_val = std::getenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX");
+  if (env_val == nullptr || *env_val == '\0') {
+    return default_name;
+  }
+
+  // Container names may contain '-' and '.', which are not allowed in ROS 2 node names.
+  std::string suffix = env_val;
+  std::replace(suffix.begin(), suffix.end(), '-', '_');
+  std::replace(suffix.begin(), suffix.end(), '.', '_');
+
+  std::string node_name = "agnocast_bridge_node_performance_" + suffix;
+
+  // rmw rejects node names longer than RMW_NODE_NAME_MAX_NAME_LENGTH.
+  const bool valid = node_name.size() <= RMW_NODE_NAME_MAX_NAME_LENGTH &&
+                     std::all_of(suffix.begin(), suffix.end(), [](const unsigned char c) {
+                       return std::isalnum(c) != 0 || c == '_';
+                     });
+  if (!valid) {
+    RCLCPP_WARN(
+      logger,
+      "AGNOCAST_BRIDGE_NODE_NAME_SUFFIX='%s' does not form a valid ROS 2 node name. "
+      "Falling back to the default node name '%s'.",
+      env_val, default_name.c_str());
+    return default_name;
+  }
+
+  return node_name;
 }
 
 rclcpp::QoS get_subscriber_qos(const std::string & topic_name, topic_local_id_t subscriber_id)

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -81,6 +81,7 @@ void PerformanceBridgeManager::start_ros_execution()
   std::string node_name =
     "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_) + "_" +
     std::to_string(getpid());
+  container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges
   // require two callback groups to execute concurrently. If a single-threaded executor is used, it

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -78,8 +78,9 @@ void PerformanceBridgeManager::run()
 
 void PerformanceBridgeManager::start_ros_execution()
 {
-  std::string node_name = "agnocast_bridge_node_performance";
-  container_node_ = std::make_shared<rclcpp::Node>(node_name);
+  std::string node_name =
+    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_) + "_" +
+    std::to_string(getpid());
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges
   // require two callback groups to execute concurrently. If a single-threaded executor is used, it

--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -78,9 +78,7 @@ void PerformanceBridgeManager::run()
 
 void PerformanceBridgeManager::start_ros_execution()
 {
-  std::string node_name =
-    "agnocast_bridge_node_performance_" + std::to_string(self_ipc_ns_inode_) + "_" +
-    std::to_string(getpid());
+  const std::string node_name = get_performance_bridge_node_name(self_ipc_ns_inode_);
   container_node_ = std::make_shared<rclcpp::Node>(node_name);
 
   // We must not use single-threaded executors because of how service bridges work. Service bridges

--- a/src/agnocastlib/test/unit/test_bridge_node_name.cpp
+++ b/src/agnocastlib/test/unit/test_bridge_node_name.cpp
@@ -1,0 +1,66 @@
+#include "agnocast/bridge/agnocast_bridge_utils.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace
+{
+
+std::string default_name_for(const uint64_t ipc_ns_inode)
+{
+  return "agnocast_bridge_node_performance_" + std::to_string(ipc_ns_inode) + "_" +
+         std::to_string(getpid());
+}
+
+class GetPerformanceBridgeNodeNameTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { unsetenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX"); }
+  void TearDown() override { unsetenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX"); }
+};
+
+TEST_F(GetPerformanceBridgeNodeNameTest, default_name_when_env_unset)
+{
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, default_name_when_env_empty)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "", 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, suffix_appended_when_env_set)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "planning_main_ecu", 1);
+  EXPECT_EQ(
+    agnocast::get_performance_bridge_node_name(123),
+    "agnocast_bridge_node_performance_planning_main_ecu");
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, hyphen_and_dot_replaced_with_underscore)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "planning-container.1", 1);
+  EXPECT_EQ(
+    agnocast::get_performance_bridge_node_name(123),
+    "agnocast_bridge_node_performance_planning_container_1");
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, invalid_characters_fall_back_to_default)
+{
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", "plan/ning", 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+TEST_F(GetPerformanceBridgeNodeNameTest, too_long_suffix_falls_back_to_default)
+{
+  // Long enough that the resulting node name exceeds RMW_NODE_NAME_MAX_NAME_LENGTH (255).
+  const std::string long_suffix(256, 'a');
+  setenv("AGNOCAST_BRIDGE_NODE_NAME_SUFFIX", long_suffix.c_str(), 1);
+  EXPECT_EQ(agnocast::get_performance_bridge_node_name(123), default_name_for(123));
+}
+
+}  // namespace


### PR DESCRIPTION
## Description

Brings the unique and stable performance bridge node naming (#1442, #1457, #1477) to `main`, so that `main` never ships the per-launch-only naming. Supersedes #1465. See #1477 for the feature description and design decisions.

- #1442 and #1457 are cherry-picked unchanged, preserving the original authorship.
- The commits of #1477 (including the follow-up clang-tidy fix) are squashed into one. Adjustments: the formatting-only change to `agnocast_callback_isolated_executor.cpp` was dropped, and the include block of `agnocast_bridge_utils.cpp` and the unit test list in `CMakeLists.txt` were adapted to `main`. The feature code and the unit test are identical to the current head of #1477.

All 6 tests in `test_bridge_node_name.cpp` pass locally (`test_unit_agnocastlib`, Release, `BUILD_TESTING=On`).

## Related links

- #1477 (source PR, merged into `2.3.5-fixed-for-x2-4.4.1`)
- #1465 (superseded by this PR)
- #1442
- #1457
- Documentation PR: https://github.com/autowarefoundation/agnocast_doc/pull/49

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers


## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
