### PR TITLE
fix(bridge): set auto_add=false for generic R2A service bridge callback groups

### DIFF
--- a/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/performance/agnocast_performance_bridge_loader.cpp
@@ -358,8 +358,11 @@ ServiceBridgeEntity PerformanceBridgeLoader::create_r2a_service_bridge_generic(
 {
   const std::string request_type = service_type + "_Request";
 
-  auto srv_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-  auto client_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  // auto_add=false: ServiceBridgeItem::start_r2a_bridge adds these groups to the executor
+  // explicitly, after the entities are created. Do not drop the false here; with the default (true)
+  // the node auto-registers them and that explicit add_callback_group would abort the process.
+  auto srv_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant, false);
+  auto client_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant, false);
 
   auto agno_client = std::make_shared<agnocast::GenericClient>(
     node.get(), service_name, service_type, qos, client_cb_group, ClientRole::AgnocastOnly);


### PR DESCRIPTION
## Description

`create_r2a_service_bridge_generic()` created its two callback groups with the default `auto_add=true`, so the container node auto-registered them. `ServiceBridgeItem::start_r2a_bridge()` then adds them explicitly, `CallbackIsolatedAgnocastExecutor::add_callback_group()` sees a double-add and calls `exit(EXIT_FAILURE)` — killing the bridge manager daemon.

#1455 applied `auto_add=false` to the pubsub generic fallbacks and the service bridge plugin template, but missed this generic service fallback (added in #1467). This aligns it with the rest.

## Related links

- #1455
- #1467

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`agnocastlib` `ctest`: 11/16 (379 s) before, 16/16 (108 s) after.

## Notes for reviewers

Only reachable when `agnocast_bridge_plugins` is not generated, so the daemon takes the generic service fallback. Once the daemon is gone, every later bridge registration burns the full 10 s `send_bridge_uds_message()` retry budget — hence the symptom was ctest timeouts rather than a visible crash.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
