### PR TITLE
test(agnocastlib): drop duplicated, env-dependent bridge UDS addr test

### DIFF
--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -69,16 +69,6 @@ TEST(AgnocastUtilsTest, create_mq_name_invalid_topic)
     ::testing::ExitedWithCode(EXIT_FAILURE), "");
 }
 
-TEST(AgnocastUtilsTest, create_uds_addr_bridge_manager)
-{
-  const auto addr = agnocast::create_uds_addr_for_bridge();
-  ASSERT_FALSE(addr.empty());
-  EXPECT_EQ(addr[0], '\0');
-  const auto expected =
-    "agnocast_bridge_manager_" + std::to_string(agnocast::get_self_ipc_ns_inode());
-  EXPECT_EQ(addr.substr(1), expected);
-}
-
 TEST(AgnocastUtilsTest, validate_ld_preload_normal)
 {
   setenv("LD_PRELOAD", "libagnocast_heaphook.so:", 1);


### PR DESCRIPTION
## Description

`AgnocastUtilsTest.create_uds_addr_bridge_manager` built its expected string without the `_d<domain>` suffix that `create_uds_addr_for_bridge()` appends, so it failed whenever the developer's shell exported a non-zero `ROS_DOMAIN_ID`:

```
  addr.substr(1)  Which is: "agnocast_bridge_manager_4026531839_d138"
  expected        Which is: "agnocast_bridge_manager_4026531839"
```

Removed rather than repaired: `DaemonBridgeUdsTest.BridgeUdsAddrUnsetDomainIdHasNoSuffix` already asserts exactly the same thing in the same test binary, with `ROS_DOMAIN_ID` pinned by a guard. The empty and non-zero cases are covered there too.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`test_unit_agnocastlib`: 317 passed, unchanged from `main`. Previously failed under `ROS_DOMAIN_ID=138`, now passes in any domain.

## Notes for reviewers

Test-only. One of several `ROS_DOMAIN_ID` defects found together; the others are in separate PRs.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
