### PR TITLE
fix(agnocastlib): derive bridge UDS domain suffix from the parsed ROS_DOMAIN_ID

### DIFF
--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -79,18 +79,6 @@ std::string create_mq_name_for_agnocast_publish(
   return create_mq_name("/agnocast", topic_name, id);
 }
 
-// UDS-address suffix that scopes the per-IPC-namespace bridge listener by domain.
-// An unset OR empty ROS_DOMAIN_ID means "no domain" (no suffix), keeping this in
-// sync with the Python discovery agent (bridge_decider._bridge_uds_addr).
-static std::string bridge_domain_suffix()
-{
-  const char * domain_id = getenv("ROS_DOMAIN_ID");
-  if (domain_id == nullptr || *domain_id == '\0') {
-    return "";
-  }
-  return "_d" + std::string(domain_id);
-}
-
 uint32_t get_ros_domain_id()
 {
   const char * domain_id_env = getenv("ROS_DOMAIN_ID");
@@ -106,6 +94,19 @@ uint32_t get_ros_domain_id()
     return 0;
   }
   return static_cast<uint32_t>(value);
+}
+
+// UDS-address suffix that scopes the per-IPC-namespace bridge listener by domain.
+// The kmod keys the bridge manager on the *parsed* domain, so this must use
+// get_ros_domain_id() and not the raw env string. Domain 0 takes no suffix,
+// matching the Python discovery agent (bridge_decider._bridge_uds_addr).
+static std::string bridge_domain_suffix()
+{
+  const uint32_t domain_id = get_ros_domain_id();
+  if (domain_id == 0) {
+    return "";
+  }
+  return "_d" + std::to_string(domain_id);
 }
 
 std::string create_uds_addr_for_bridge()

--- a/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_daemon_bridge_uds.cpp
@@ -113,6 +113,29 @@ TEST(DaemonBridgeUdsTest, BridgeUdsAddrUnsetDomainIdHasNoSuffix)
   EXPECT_EQ(addr.substr(1), expected);
 }
 
+// The kmod keys the bridge manager on get_ros_domain_id(), so every spelling that
+// parses to the same domain must produce the same address. Otherwise processes
+// sharing a domain bind/send to different sockets and never reach each other.
+TEST(DaemonBridgeUdsTest, BridgeUdsAddrIsCanonicalPerDomain)
+{
+  const ScopedRosDomainId guard;
+  const auto addr_for = [](const char * value) {
+    setenv("ROS_DOMAIN_ID", value, 1);
+    return agnocast::create_uds_addr_for_bridge();
+  };
+
+  unsetenv("ROS_DOMAIN_ID");
+  const auto domain_0 = agnocast::create_uds_addr_for_bridge();
+
+  // Spellings that get_ros_domain_id() normalizes to 0.
+  EXPECT_EQ(addr_for("0"), domain_0);
+  EXPECT_EQ(addr_for("abc"), domain_0);
+  EXPECT_EQ(addr_for("-5"), domain_0);
+  EXPECT_EQ(addr_for("4294967296"), domain_0);
+
+  EXPECT_EQ(addr_for("007"), addr_for("7"));
+}
+
 // Performance-mode daemon bridges have no local endpoint to query, so the QoS
 // must be rebuilt faithfully from the request's explicit fields.
 TEST(DaemonBridgeUdsTest, DaemonRequestQosReliableTransientLocal)


### PR DESCRIPTION
## Description

`bridge_domain_suffix()` built the bridge UDS suffix from the **raw** `ROS_DOMAIN_ID` string, while the kmod keys the per-domain bridge manager on the **parsed** value from `get_ros_domain_id()`. The two disagree for every spelling the parser normalizes:

| `ROS_DOMAIN_ID` | kmod domain | UDS suffix (before) | UDS suffix (after) |
|---|---|---|---|
| unset | 0 | *(none)* | *(none)* |
| `0` | 0 | `_d0` | *(none)* |
| `007` | 7 | `_d007` | `_d7` |
| `abc` / `-5` / out-of-range | 0 | `_dabc` / `_d-5` / … | *(none)* |

Consequence: a process with `ROS_DOMAIN_ID=0` and a process with it unset are both domain 0 to the kmod, but bind/send to different addresses. Whichever starts second is told by the kmod that a manager already exists (`has_alive_performance_bridge_manager`), does not spawn one, and then gets `ECONNREFUSED` on every bridge request for the rest of its life.

Deriving the suffix from `get_ros_domain_id()` makes the address canonical per domain. The comment claiming parity with the Python discovery agent was also stale — `bridge_decider._bridge_uds_addr` already used the parsed integer and already omitted the suffix for domain 0.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`test_unit_agnocastlib`: 317 passed. The added `DaemonBridgeUdsTest.BridgeUdsAddrIsCanonicalPerDomain` fails on `main` and passes with this change.

## Notes for reviewers

`create_uds_addr_for_bridge()` output changes for processes that explicitly set `ROS_DOMAIN_ID=0` (or a non-canonical spelling). Every agnocast process in a namespace must run the same version, which is already true of the existing manager-liveness protocol.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
