### PR TITLE
fix(agnocastlib): query the caller's own domain in the topic-info ioctls

### DIFF
--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -23,6 +23,7 @@ uint32_t get_agnocast_sub_count(const std::string & topic_name)
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(topic_info_buffer->data());
   topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
+  topic_info_args.domain_id = get_ros_domain_id();
   if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     RCLCPP_ERROR(logger, "AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD failed: %s", strerror(errno));
     close(agnocast_fd);

--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -246,6 +246,7 @@ rclcpp::QoS get_service_qos(const std::string & service_name)
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(topic_info_buffer->data());
   topic_info_args.topic_info_ret_buffer_size = 1;
+  topic_info_args.domain_id = get_ros_domain_id();
 
   if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     if (errno == ENOBUFS) {

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -109,6 +109,7 @@ int ServiceBridgeItem::get_agno_service_qos(rclcpp::QoS & qos)
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(topic_info_buffer->data());
   topic_info_args.topic_info_ret_buffer_size = 1;
+  topic_info_args.domain_id = get_ros_domain_id();
 
   if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     if (errno == ENOBUFS) {


### PR DESCRIPTION
## Description

`ioctl_topic_info_args` carries an explicit domain selector and the kmod matches it exactly (`find_topic()` requires `entry->domain_id == domain_id`). Three call sites left it at its zero-initialized default, so they always query domain 0 while the entities they look for are registered under the caller's own `ROS_DOMAIN_ID`. Every site asks on behalf of its own process, so `get_ros_domain_id()` is the right source at each.

Symptoms outside domain 0:

- `get_agnocast_sub_count()` — the count is always 0, so `service_is_ready()` never becomes true and `Client::wait_for_service()` never returns.
- `get_service_qos()`, `ServiceBridgeItem::get_agno_service_qos()` — the service bridge gives up with `No target agnocast service found`.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Still needed: `test_integration_client_agnocastlib` and the service-bridge e2e under a non-zero `ROS_DOMAIN_ID`.

## Notes for reviewers

The service-bridge half un-suppresses the R2A path in non-zero domains, so `start_r2a_bridge()` now runs where it previously bailed out early. Reviewers with a non-zero-domain setup: please check for `ECONNREFUSED` retries against the bridge manager. Review alongside #1485, an independent cause of the same symptom.

Supersedes #1487.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
