### PR TITLE
fix(agnocastlib): query the caller's own domain in the service bridge topic-info ioctl

### DIFF
--- a/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_utils.cpp
@@ -246,6 +246,12 @@ rclcpp::QoS get_service_qos(const std::string & service_name)
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(topic_info_buffer->data());
   topic_info_args.topic_info_ret_buffer_size = 1;
+  // A topic name can exist in several domains and this ioctl selects one explicitly.
+  // The bridge manager is forked per (IPC namespace, domain) and registers itself
+  // under its own ROS_DOMAIN_ID, so the domain it serves is always its own; leaving
+  // this at the zero-initialized default would query domain 0 and find no service
+  // whenever ROS_DOMAIN_ID is non-zero.
+  topic_info_args.domain_id = get_ros_domain_id();
 
   if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     if (errno == ENOBUFS) {

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -109,6 +109,9 @@ int ServiceBridgeItem::get_agno_service_qos(rclcpp::QoS & qos)
   topic_info_args.topic_info_ret_buffer_addr =
     reinterpret_cast<uint64_t>(topic_info_buffer->data());
   topic_info_args.topic_info_ret_buffer_size = 1;
+  // See get_service_qos(): the bridge manager only ever serves its own domain, and
+  // the zero-initialized default would query domain 0.
+  topic_info_args.domain_id = get_ros_domain_id();
 
   if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
     if (errno == ENOBUFS) {


### PR DESCRIPTION
## Description

Same defect as the client-side one, at the two remaining topic-info call sites:

- `get_service_qos()` (`bridge/agnocast_bridge_utils.cpp`)
- `ServiceBridgeItem::get_agno_service_qos()` (`bridge/agnocast_service_bridge.cpp`)

Both left the ioctl's domain selector at its zero-initialized default and so always queried domain 0. Under a non-zero `ROS_DOMAIN_ID` they never find the target service and the service bridge silently gives up with `No target agnocast service found` — i.e. service bridging has never worked outside domain 0.

`get_ros_domain_id()` is the right source here: the bridge manager is forked per (IPC namespace, domain) and registers itself under its own `ROS_DOMAIN_ID`, its listener socket is scoped by that domain, and bridge request payloads (`BridgeMsgServicePayload`) carry no domain of their own.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`test_unit_agnocastlib`: 317 passed, unchanged from `main`. No end-to-end run yet — see below.

## Notes for reviewers

**This is the risky one of the set and wants a careful look.**

This change un-suppresses the R2A service-bridge path in non-zero domains: `start_r2a_bridge()` now actually runs where it previously bailed out early. An earlier investigation on a `ROS_DOMAIN_ID=138` machine saw the agnocastlib suite slow from 2m40s to 6m18s with this applied, with several suites timing out on `ECONNREFUSED` retries against the bridge manager's UDS address — consistent with the manager dying partway through the run.

Two caveats on that observation, both of which argue it may not reproduce:

1. The crash captured at the time (`Executor Thread CRASHED: could not create publisher: type_support is null`) reproduces on unpatched `main` with no domain change at all, purely by running the test binary without sourcing the workspace. It is a missing-typesupport artifact, not a domain bug.
2. It predates #1434, which reworked the bridge manager's threading.

So the measurement should be redone on current `main` before merging. Reviewers with a non-zero-domain setup: please check whether `ECONNREFUSED` retries appear.

Worth reviewing alongside the UDS domain-suffix fix, which is an independent cause of exactly that `ECONNREFUSED` symptom.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
