### PR TITLE
fix(agnocastlib): callback type resolution failure in vendored GenericService

### DIFF
--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
@@ -67,10 +67,17 @@ public:
       }
     }
 
-    if constexpr (::rclcpp::function_traits::same_arguments<Func, BasicCallback>::value) {
+    if constexpr (std::is_invocable_v<
+                    std::decay_t<Func>, std::shared_ptr<void> &&, const std::shared_ptr<void> &>) {
       callback_.template emplace<BasicCallback>(std::forward<Func>(callback));
-    } else if constexpr (::rclcpp::function_traits::same_arguments<Func, DeferredCallback>::value) {
+    } else if constexpr (std::is_invocable_v<
+                           std::decay_t<Func>, const std::shared_ptr<GenericService> &,
+                           const std::shared_ptr<rmw_request_id_t> &, std::shared_ptr<void> &&>) {
       callback_.template emplace<DeferredCallback>(std::forward<Func>(callback));
+    } else {
+      // Here, we use `sizeof(Func) == 0` to make it dependent on the template parameter, so that
+      // this assertion will only be evaluated at instantiation time.
+      static_assert(sizeof(Func) == 0, "Invalid callback type for GenericServiceCallback");
     }
   }
 

--- a/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
+++ b/src/agnocastlib/include/agnocast/vendor/rclcpp/generic_service.hpp
@@ -67,12 +67,9 @@ public:
       }
     }
 
-    if constexpr (std::is_invocable_v<
-                    std::decay_t<Func>, std::shared_ptr<void> &&, const std::shared_ptr<void> &>) {
+    if constexpr (std::is_constructible_v<BasicCallback, Func &&>) {
       callback_.template emplace<BasicCallback>(std::forward<Func>(callback));
-    } else if constexpr (std::is_invocable_v<
-                           std::decay_t<Func>, const std::shared_ptr<GenericService> &,
-                           const std::shared_ptr<rmw_request_id_t> &, std::shared_ptr<void> &&>) {
+    } else if constexpr (std::is_constructible_v<DeferredCallback, Func &&>) {
       callback_.template emplace<DeferredCallback>(std::forward<Func>(callback));
     } else {
       // Here, we use `sizeof(Func) == 0` to make it dependent on the template parameter, so that


### PR DESCRIPTION
## Description

This PR updates the `GenericServiceCallback` constructor:

1. **Stop using `rclcpp::function_traits::same_arguments`.** It performs too strict a type comparison, so it does not fit our use case. Instead, this PR uses `std::is_invocable_v` just like the Agnocast service implementation.
2. **Add a fallback else block.**  The block catches invalid callback types and asserts a failure at compile time.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

