### PR TITLE
feat(agnocastlib): accept std::shared_ptr<const MessageT> subscription callbacks

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -273,7 +273,7 @@ The following tables compare methods that are **directly defined** in each class
 | API | rclcpp::Node | agnocast::Node | Notes |
 |-----|:------------:|:--------------:|-------|
 | `create_publisher<MessageT>()` | ✓ | ✓ | Return type differs (rclcpp::Publisher vs agnocast::Publisher) |
-| `create_subscription<MessageT>()` | ✓ | ✓ | Return type differs (rclcpp::Subscription vs agnocast::Subscription) |
+| `create_subscription<MessageT>()` | ✓ | ✓ | Return type differs (rclcpp::Subscription vs agnocast::Subscription). Callbacks taking `MessageT::ConstSharedPtr` are source-compatible with rclcpp; `MessageT::SharedPtr` and `MessageT::UniquePtr` are not accepted |
 | `create_generic_publisher()` | ✓ | ✗ | |
 | `create_generic_subscription()` | ✓ | ✗ | |
 

--- a/docs/autoware_integration.md
+++ b/docs/autoware_integration.md
@@ -49,6 +49,41 @@ std::shared_ptr<agnocast::Subscription<MessageType>> message_sub_;
 message_sub_ = agnocast::create_subscription<MessageType>("/topic_name", rclcpp::QoS{x}, callback);
 ```
 
+### Keeping a `MessageT::ConstSharedPtr` callback signature
+
+A subscription callback may take the plain ROS 2 `MessageT::ConstSharedPtr` instead of an
+`agnocast::ipc_shared_ptr`, so a callback whose signature cannot be changed — a virtual method
+overridden downstream, a pluginlib boundary, a third-party callback — needs no edit at all:
+
+```c++
+// void on_message(const MessageType::ConstSharedPtr & msg);  // signature is fixed
+message_sub_ = agnocast::create_subscription<MessageType>(
+  "/topic_name", rclcpp::QoS{x},
+  [this](const MessageType::ConstSharedPtr & msg) { on_message(msg); });
+```
+
+The payload is not copied: the pointer aliases the shared-memory message and shares ownership with
+it. Three things to know before using it:
+
+- **It costs one extra heap allocation per message** (the `std::shared_ptr` control block). Prefer
+  `agnocast::ipc_shared_ptr` on hot paths; this form is for the boundaries where you cannot.
+- **It may be retained beyond the callback, but it pins one shared-memory entry** for as long as it
+  lives. The publisher's entry count can then exceed its QoS depth, and caching messages in an
+  unbounded container can exhaust the process mempool (see [shared_memory.md](shared_memory.md)).
+- **It must not outlive the `Subscription` that delivered it.** Since members are destroyed in
+  reverse declaration order, declare the subscription first so it is destroyed last:
+
+  ```c++
+  class Foo : public rclcpp::Node {
+    std::shared_ptr<agnocast::Subscription<MessageType>> message_sub_;  // destroyed last
+    MessageType::ConstSharedPtr latest_msg_;                            // destroyed first
+  };
+  ```
+
+`MessageT::SharedPtr` (non-const) and `MessageT::UniquePtr` are rejected at compile time: the
+message lives in shared memory that other subscribers read concurrently, and it must not be freed
+with `operator delete`.
+
 ### Other tips
 
 - Until the subscription callback thread is integrated into ROS 2 executor, all callback functions should be guarded with mutex lock.

--- a/docs/message_filters_design_document.md
+++ b/docs/message_filters_design_document.md
@@ -62,6 +62,8 @@ Supported parameter types:
 
 **Difference from ROS 2**: ROS 2 additionally supports `std::shared_ptr<M>` (non-const), `const M&`, and `M` (by value). These are omitted because agnocast messages are always accessed via `ipc_shared_ptr<const M>`.
 
+Note that plain `agnocast::Subscription` callbacks *do* accept `std::shared_ptr<const M>` (see `agnocast::to_std_shared_ptr()`). That does not extend to `registerCallback()` here: `ParameterAdapter` still only handles the `ipc_shared_ptr` forms listed above.
+
 ### Signal1 (`signal1.hpp`)
 
 Thread-safe single-message signal dispatcher. Uses `ParameterAdapter` to adapt callback signatures.

--- a/src/agnocast_e2e_test/src/test_subscriber.cpp
+++ b/src/agnocast_e2e_test/src/test_subscriber.cpp
@@ -7,17 +7,18 @@ using std::placeholders::_1;
 
 class TestSubscriber : public rclcpp::Node
 {
+  // Declared before any message-holding member so that it is destroyed last.
   agnocast::Subscription<std_msgs::msg::Int64>::SharedPtr sub_;
   bool forever_;
   int64_t target_end_id_;
   int target_end_count_;
   int received_end_count_ = 0;
 
-  void callback(const agnocast::ipc_shared_ptr<std_msgs::msg::Int64> & message)
+  void handle(const int64_t data)
   {
-    RCLCPP_INFO(this->get_logger(), "Receiving %ld.", message->data);
+    RCLCPP_INFO(this->get_logger(), "Receiving %ld.", data);
 
-    if (message->data == target_end_id_) {
+    if (data == target_end_id_) {
       received_end_count_++;
 
       if (received_end_count_ >= target_end_count_) {
@@ -32,6 +33,17 @@ class TestSubscriber : public rclcpp::Node
     }
   }
 
+  void callback(const agnocast::ipc_shared_ptr<std_msgs::msg::Int64> & message)
+  {
+    handle(message->data);
+  }
+
+  // Plain ROS 2 callback shape, selected by the `const_shared_ptr` parameter.
+  void const_shared_ptr_callback(const std_msgs::msg::Int64::ConstSharedPtr & message)
+  {
+    handle(message->data);
+  }
+
 public:
   explicit TestSubscriber(const rclcpp::NodeOptions & options) : Node("test_subscription", options)
   {
@@ -41,6 +53,7 @@ public:
     this->declare_parameter<bool>("forever", false);
     this->declare_parameter<int64_t>("target_end_id", 0);
     this->declare_parameter<int>("target_end_count", 1);
+    this->declare_parameter<bool>("const_shared_ptr", false);
     std::string topic_name = this->get_parameter("topic_name").as_string();
     forever_ = this->get_parameter("forever").as_bool();
     target_end_id_ = this->get_parameter("target_end_id").as_int();
@@ -55,8 +68,14 @@ public:
     auto cbg = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     agnocast::SubscriptionOptions sub_options;
     sub_options.callback_group = cbg;
-    sub_ = agnocast::create_subscription<std_msgs::msg::Int64>(
-      this, topic_name, qos, std::bind(&TestSubscriber::callback, this, _1), sub_options);
+    if (this->get_parameter("const_shared_ptr").as_bool()) {
+      sub_ = agnocast::create_subscription<std_msgs::msg::Int64>(
+        this, topic_name, qos, std::bind(&TestSubscriber::const_shared_ptr_callback, this, _1),
+        sub_options);
+    } else {
+      sub_ = agnocast::create_subscription<std_msgs::msg::Int64>(
+        this, topic_name, qos, std::bind(&TestSubscriber::callback, this, _1), sub_options);
+    }
   }
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast.hpp
@@ -148,7 +148,11 @@ GenericPublisher::SharedPtr create_generic_publisher(
 /// @brief Create an Agnocast subscription (Stage 1 free function, QoS overload).
 /// @tparam MessageT ROS message type.
 /// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
-/// @tparam Func Callback callable with `void(agnocast::ipc_shared_ptr<const MessageT>&&)`.
+/// @tparam Func Callback callable with either `agnocast::ipc_shared_ptr<const MessageT>`
+///         (zero-copy, no extra allocation) or `std::shared_ptr<const MessageT>`, i.e.
+///         `MessageT::ConstSharedPtr` (one extra heap allocation per message). Either can be
+///         taken by value, by const&, or by &&. See agnocast::to_std_shared_ptr() for the
+///         lifetime contract of the `std::shared_ptr` form.
 /// @param node Pointer to the node.
 /// @param topic_name Topic name.
 /// @param qos Quality of service profile.
@@ -171,7 +175,11 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
 /// @brief Create an Agnocast subscription (Stage 1 free function, history-depth overload).
 /// @tparam MessageT ROS message type.
 /// @tparam NodeT Node type (rclcpp::Node or agnocast::Node).
-/// @tparam Func Callback callable with `void(agnocast::ipc_shared_ptr<const MessageT>&&)`.
+/// @tparam Func Callback callable with either `agnocast::ipc_shared_ptr<const MessageT>`
+///         (zero-copy, no extra allocation) or `std::shared_ptr<const MessageT>`, i.e.
+///         `MessageT::ConstSharedPtr` (one extra heap allocation per message). Either can be
+///         taken by value, by const&, or by &&. See agnocast::to_std_shared_ptr() for the
+///         lifetime contract of the `std::shared_ptr` form.
 /// @param node Pointer to the node.
 /// @param topic_name Topic name.
 /// @param qos_history_depth History depth for the QoS profile.

--- a/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_callback_info.hpp
@@ -72,6 +72,47 @@ extern std::atomic<uint32_t> next_callback_info_id;
 
 uint32_t allocate_callback_info_id();
 
+namespace detail
+{
+
+// Accepts ipc_shared_ptr<MessageT> or ipc_shared_ptr<const MessageT>, by value, const&, or &&.
+template <typename MessageT, typename Func>
+struct is_ipc_shared_ptr_cb
+: std::bool_constant<
+    std::is_invocable_v<std::decay_t<Func>, agnocast::ipc_shared_ptr<MessageT> &&> ||
+    std::is_invocable_v<std::decay_t<Func>, agnocast::ipc_shared_ptr<const MessageT> &&>>
+{
+};
+
+// The std::shared_ptr shapes below are never valid on the type-erased (MessageT = void) path, so
+// the primary template makes them hard-false and no std::shared_ptr<const void> is ever formed.
+template <typename MessageT, typename Func, typename Enable = void>
+struct is_const_std_shared_ptr_cb : std::false_type
+{
+};
+template <typename MessageT, typename Func>
+struct is_const_std_shared_ptr_cb<MessageT, Func, std::enable_if_t<!std::is_void_v<MessageT>>>
+: std::bool_constant<std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<const MessageT>>>
+{
+};
+
+// Diagnostic only: shapes that are deliberately rejected, so that register_callback() can explain
+// why instead of falling through to the generic "unsupported callback" message.
+template <typename MessageT, typename Func, typename Enable = void>
+struct is_unsupported_std_ptr_cb : std::false_type
+{
+};
+template <typename MessageT, typename Func>
+struct is_unsupported_std_ptr_cb<MessageT, Func, std::enable_if_t<!std::is_void_v<MessageT>>>
+: std::bool_constant<
+    std::is_invocable_v<std::decay_t<Func>, std::shared_ptr<MessageT>> ||
+    std::is_invocable_v<std::decay_t<Func>, std::unique_ptr<MessageT>> ||
+    std::is_invocable_v<std::decay_t<Func>, std::unique_ptr<const MessageT>>>
+{
+};
+
+}  // namespace detail
+
 template <typename T, typename Func>
 TypeErasedCallback get_erased_callback(Func && callback)
 {
@@ -88,20 +129,56 @@ TypeErasedCallback get_erased_callback(Func && callback)
   };
 }
 
+// Adapts any supported callback shape to the ipc_shared_ptr<MessageT>&& shape that
+// get_erased_callback() expects. The ipc_shared_ptr branch is checked FIRST so that generic
+// callables (e.g. `[](auto msg) {}`) and every existing callsite keep their current behavior.
+template <typename MessageT, typename Func>
+TypeErasedCallback make_type_erased_callback(Func && callback)
+{
+  if constexpr (detail::is_ipc_shared_ptr_cb<MessageT, Func>::value) {
+    return get_erased_callback<MessageT>(std::forward<Func>(callback));
+  } else {
+    static_assert(detail::is_const_std_shared_ptr_cb<MessageT, Func>::value);
+    return get_erased_callback<MessageT>(
+      [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
+        // The converting move constructor transfers the control block without touching the
+        // reference count, so this adds no atomic traffic and no allocation of its own.
+        callback(
+          agnocast::to_std_shared_ptr(agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+      });
+  }
+}
+
 template <typename MessageT, typename Func>
 uint32_t register_callback(
   Func && callback, const std::string & topic_name, const topic_local_id_t subscriber_id,
   const bool is_transient_local, mqd_t mqdes, rclcpp::CallbackGroup::SharedPtr callback_group)
 {
+  // Fires before the generic assertion below, so that a deliberately rejected shape gets a precise
+  // reason instead of just the list of accepted ones.
+  static_assert(
+    !detail::is_unsupported_std_ptr_cb<MessageT, Func>::value ||
+      detail::is_ipc_shared_ptr_cb<MessageT, Func>::value ||
+      detail::is_const_std_shared_ptr_cb<MessageT, Func>::value,
+    "Unsupported callback shape. std::shared_ptr<MessageT> (MessageT::SharedPtr) is rejected "
+    "because the message lives in shared memory that other subscribers read concurrently; "
+    "std::unique_ptr is rejected because the message must not be freed with operator delete. "
+    "Use std::shared_ptr<const MessageT> (MessageT::ConstSharedPtr) instead.");
+
   // NOTE: ipc_shared_ptr<MessageT> and ipc_shared_ptr<MessageT>&& make no difference in the
   // assertion expression below, but we go with ipc_shared_ptr<MessageT>&&.
   static_assert(
-    std::is_invocable_v<std::decay_t<Func>, agnocast::ipc_shared_ptr<MessageT> &&> ||
-      std::is_invocable_v<std::decay_t<Func>, agnocast::ipc_shared_ptr<const MessageT> &&>,
-    "Callback must be callable with ipc_shared_ptr<T> or ipc_shared_ptr<const T> (const&, &&, or "
-    "by-value)");
+    detail::is_ipc_shared_ptr_cb<MessageT, Func>::value ||
+      detail::is_const_std_shared_ptr_cb<MessageT, Func>::value,
+    "Callback must be callable with one of:\n"
+    "1. agnocast::ipc_shared_ptr<MessageT> or ipc_shared_ptr<const MessageT> (zero-copy, no extra "
+    "allocation)\n"
+    "2. std::shared_ptr<const MessageT>, i.e. MessageT::ConstSharedPtr (one extra heap allocation "
+    "per message)\n"
+    "Either can be taken by value, by const&, or by &&.");
 
-  TypeErasedCallback erased_callback = get_erased_callback<MessageT>(std::forward<Func>(callback));
+  TypeErasedCallback erased_callback =
+    make_type_erased_callback<MessageT>(std::forward<Func>(callback));
 
   auto message_creator = [](
                            void * ptr, const std::string & topic_name,

--- a/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_smart_pointer.hpp
@@ -97,6 +97,13 @@ struct control_block
  * - `get()` returns `nullptr`, `operator bool()` returns `false`.
  * - `operator->()` and `operator*()` call `std::terminate()`.
  *
+ * @par Conversion to std::shared_ptr
+ * A message received by a subscription can be handed to code that expects a plain
+ * `std::shared_ptr` via to_std_shared_ptr(), without copying the payload. The result keeps the
+ * kernel-side reference alive, so it may be retained beyond the callback -- but it must not
+ * outlive the `Subscription` that delivered it, and it pins one shared-memory entry for as long
+ * as it lives. See to_std_shared_ptr() for the full contract.
+ *
  * @tparam T  The message type (or `const`-qualified message type on the subscriber side).
  */
 AGNOCAST_PUBLIC
@@ -399,6 +406,66 @@ ipc_shared_ptr<T> static_ipc_shared_ptr_cast(ipc_shared_ptr<U> && r) noexcept
 {
   T * ptr = static_cast<T *>(r.get());
   return ipc_shared_ptr<T>(std::move(r), ptr);
+}
+
+/**
+ * @brief Convert an `ipc_shared_ptr` into a `std::shared_ptr` that keeps the Agnocast
+ * (kernel-side) reference alive.
+ *
+ * The returned pointer shares ownership with a hidden `ipc_shared_ptr<T>` holder, so the
+ * kernel-side reference is released only once the last `std::shared_ptr` copy is destroyed. The
+ * payload is never copied; the cost is one extra heap allocation (the `std::shared_ptr` control
+ * block) per conversion, on top of the `ipc_shared_ptr`'s own control block.
+ *
+ * @warning The returned pointer must not outlive the `Subscription` that delivered the message.
+ * Declare the `Subscription` member **before** any member that caches messages, so that it is
+ * destroyed last.
+ * @warning Holding the returned pointer pins a shared-memory entry: the publisher's entry count
+ * can exceed its QoS depth for as long as the reference is held. Caching messages in an unbounded
+ * container can exhaust the process mempool (see `docs/shared_memory.md`).
+ * @warning Unlike `ipc_shared_ptr`, the result carries no invalidation check: dereferencing an
+ * empty one segfaults instead of printing a diagnostic. Test it with `if (!msg)` first.
+ *
+ * @param p Pointer to convert. Taken by value; pass an rvalue to avoid a reference-count bump.
+ * @return `std::shared_ptr<T>` sharing ownership of the message, or an empty `std::shared_ptr`
+ *         if `p` is empty or has been invalidated by publish().
+ */
+AGNOCAST_PUBLIC
+template <typename T>
+std::shared_ptr<T> to_std_shared_ptr(ipc_shared_ptr<T> p)
+{
+  static_assert(
+    !std::is_void_v<T>,
+    "to_std_shared_ptr() does not support ipc_shared_ptr<void>: a type-erased message has no "
+    "well-defined std::shared_ptr element type.");
+
+  // Empty, or publisher-invalidated (get() returns nullptr after publish()). Return an empty
+  // std::shared_ptr rather than a non-empty one wrapping nullptr, so that `if (!msg)` works.
+  if (p.get() == nullptr) {
+    return nullptr;
+  }
+
+  // Subscriber-side pointers only. Wrapping a publisher-side (borrowed) pointer would be unsafe:
+  // std::shared_ptr has no invalidation check, so publish() would leave the result silently
+  // dangling, and a borrowed message that is never published would run the "dropped before
+  // publish" path (decrement_borrowed_publisher_num() + delete) at an arbitrary time on an
+  // arbitrary thread, corrupting the heaphook's borrow-window accounting.
+  if (p.get_entry_id() == ENTRY_ID_NOT_ASSIGNED) {
+    RCLCPP_ERROR(
+      logger,
+      "to_std_shared_ptr() was called on a publisher-side (borrowed) ipc_shared_ptr. "
+      "Only messages received by a subscription can be converted.");
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+
+  T * const raw = p.get();
+  auto holder = std::make_shared<ipc_shared_ptr<T>>(std::move(p));
+  // Aliasing constructor: shares the holder's control block but exposes the message pointer.
+  // NOTE: under C++17 std::move() still selects the copy form of the aliasing constructor (one
+  // atomic increment, undone when `holder` goes out of scope). C++20 adds the move form, which
+  // avoids even that.
+  return std::shared_ptr<T>(std::move(holder), raw);
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -156,6 +156,19 @@ public:
  * writes to the topic. Allocate instances with
  * `agnocast::create_subscription<MessageT>()` or construct directly.
  *
+ * @par Supported callback signatures
+ * - `agnocast::ipc_shared_ptr<MessageT>` / `ipc_shared_ptr<const MessageT>` -- zero-copy, no
+ *   allocation beyond the message's own control block. Prefer this on hot paths.
+ * - `std::shared_ptr<const MessageT>`, i.e. `MessageT::ConstSharedPtr` -- the plain ROS 2 shape,
+ *   for interfaces that cannot be templated on the pointer type. The payload is still not copied,
+ *   but each message costs one extra heap allocation. See agnocast::to_std_shared_ptr().
+ *
+ * Either form can be taken by value, by const&, or by &&. `MessageT::SharedPtr` and
+ * `std::unique_ptr` are rejected at compile time.
+ *
+ * @warning A message reference must not outlive the `Subscription` that delivered it. Declare the
+ * `Subscription` member **before** any member that caches messages, so that it is destroyed last.
+ *
  * @tparam MessageT  ROS message type.
  */
 AGNOCAST_PUBLIC

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -446,7 +446,8 @@ public:
 
   /// Create a subscription (QoS overload).
   /// @tparam MessageT ROS message type.
-  /// @tparam Func Callback type.
+  /// @tparam Func Callback type. See agnocast::create_subscription() for the accepted callback
+  ///         signatures.
   /// @param topic_name Topic name.
   /// @param qos Quality of service profile.
   /// @param callback Callback invoked on each received message.
@@ -464,7 +465,8 @@ public:
 
   /// Create a subscription (queue-size overload).
   /// @tparam MessageT ROS message type.
-  /// @tparam Func Callback type.
+  /// @tparam Func Callback type. See agnocast::create_subscription() for the accepted callback
+  ///         signatures.
   /// @param topic_name Topic name.
   /// @param queue_size History depth for the QoS profile.
   /// @param callback Callback invoked on each received message.

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -619,6 +619,8 @@ protected:
   {
     dummy_tn = "dummy";
     dummy_pubsub_id = 1;
+
+    release_subscriber_reference_mock_called_count = 0;
   }
 
   std::string dummy_tn;
@@ -778,4 +780,241 @@ TEST_F(AgnocastSmartPointerTest, converting_move_assignment)
   EXPECT_EQ(ptr, sut2.get());
   EXPECT_EQ(dummy_tn, sut2.get_topic_name());
   EXPECT_EQ(dummy_entry_id, sut2.get_entry_id());
+}
+
+// =========================================
+// to_std_shared_ptr tests
+// =========================================
+
+TEST_F(AgnocastSmartPointerTest, to_std_shared_ptr_keeps_reference_alive)
+{
+  // Arrange
+  int data = 42;
+  std::shared_ptr<int> sut;
+
+  // Act: the ipc_shared_ptr is consumed and goes out of scope, but the returned std::shared_ptr
+  // holds the only remaining reference.
+  {
+    agnocast::ipc_shared_ptr<int> original{&data, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+    sut = agnocast::to_std_shared_ptr(std::move(original));
+    EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+  }
+
+  // Assert
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+  EXPECT_EQ(&data, sut.get());
+  EXPECT_EQ(42, *sut);
+
+  sut.reset();
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 1);
+}
+
+TEST_F(AgnocastSmartPointerTest, to_std_shared_ptr_empty)
+{
+  // Arrange
+  agnocast::ipc_shared_ptr<int> original;
+
+  // Act
+  std::shared_ptr<int> sut = agnocast::to_std_shared_ptr(std::move(original));
+
+  // Assert: an empty std::shared_ptr, not a non-empty one wrapping nullptr, so that `if (!sut)`
+  // works and no reference is released.
+  EXPECT_EQ(nullptr, sut);
+  EXPECT_EQ(0, sut.use_count());
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+}
+
+TEST_F(AgnocastSmartPointerTest, to_std_shared_ptr_last_copy_releases)
+{
+  // Arrange
+  int data = 7;
+  agnocast::ipc_shared_ptr<int> original{&data, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+  std::shared_ptr<int> first = agnocast::to_std_shared_ptr(std::move(original));
+
+  // Act
+  std::shared_ptr<int> second = first;
+  std::shared_ptr<int> third = second;
+  first.reset();
+  second.reset();
+
+  // Assert: only the last copy reaches the kernel.
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+  EXPECT_EQ(7, *third);
+  third.reset();
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 1);
+}
+
+TEST_F(AgnocastSmartPointerTest, to_std_shared_ptr_const)
+{
+  // Arrange
+  int data = 3;
+  agnocast::ipc_shared_ptr<const int> original{&data, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+
+  // Act
+  auto sut = agnocast::to_std_shared_ptr(std::move(original));
+
+  // Assert: constness is carried through by deduction, no separate overload needed.
+  static_assert(std::is_same_v<decltype(sut), std::shared_ptr<const int>>);
+  EXPECT_EQ(&data, sut.get());
+  EXPECT_EQ(3, *sut);
+}
+
+TEST_F(AgnocastSmartPointerTest, to_std_shared_ptr_shares_with_ipc_copy)
+{
+  // Arrange: an ipc_shared_ptr copy and a converted std::shared_ptr share one control block.
+  int data = 11;
+  agnocast::ipc_shared_ptr<int> kept{&data, dummy_tn, dummy_pubsub_id, dummy_entry_id};
+  agnocast::ipc_shared_ptr<int> converted = kept;
+
+  // Act
+  std::shared_ptr<int> sut = agnocast::to_std_shared_ptr(std::move(converted));
+  sut.reset();
+
+  // Assert: the surviving ipc_shared_ptr still holds the reference.
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+  kept.reset();
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 1);
+}
+
+TEST_F(AgnocastInvalidationTest, to_std_shared_ptr_after_publish_returns_empty)
+{
+  // Arrange: borrow a message, keep a copy, then publish so the copy is invalidated.
+  agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
+  agnocast::ipc_shared_ptr<std_msgs::msg::Int32> copy = message;
+  dummy_publisher->publish(std::move(message));
+
+  // Act
+  std::shared_ptr<std_msgs::msg::Int32> sut = agnocast::to_std_shared_ptr(std::move(copy));
+
+  // Assert: get() already returns nullptr for an invalidated handle, so the result is empty rather
+  // than a dangling pointer.
+  EXPECT_EQ(nullptr, sut);
+}
+
+TEST_F(AgnocastInvalidationTest, to_std_shared_ptr_on_borrowed_message_exits)
+{
+  // Arrange: a borrowed (publisher-side) message has no entry_id assigned.
+  agnocast::ipc_shared_ptr<std_msgs::msg::Int32> message = dummy_publisher->borrow_loaned_message();
+
+  // Act & Assert
+  EXPECT_EXIT(
+    agnocast::to_std_shared_ptr(std::move(message)), ::testing::ExitedWithCode(EXIT_FAILURE),
+    "publisher-side");
+}
+
+// =========================================
+// Callback shape dispatch tests
+// =========================================
+
+TEST_F(AgnocastCallbackInfoTest, dispatch_const_std_shared_ptr_callback)
+{
+  // Arrange
+  int data = 7;
+  agnocast::TypedMessagePtr<int> int_arg{
+    agnocast::ipc_shared_ptr<int>(&data, dummy_tn, dummy_pubsub_id, /*entry_id=*/1)};
+  std::shared_ptr<const int> captured;
+  auto callback = [&](std::shared_ptr<const int> msg) { captured = std::move(msg); };
+
+  // Act
+  agnocast::TypeErasedCallback erased_callback =
+    agnocast::make_type_erased_callback<int, decltype(callback) &>(callback);
+  erased_callback(std::move(int_arg));
+
+  // Assert: the message outlives the dispatch, which is the point of this shape.
+  ASSERT_NE(nullptr, captured);
+  EXPECT_EQ(7, *captured);
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 0);
+  captured.reset();
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 1);
+}
+
+TEST_F(AgnocastCallbackInfoTest, dispatch_const_std_shared_ptr_callback_by_const_ref)
+{
+  // Arrange
+  int data = 5;
+  agnocast::TypedMessagePtr<int> int_arg{
+    agnocast::ipc_shared_ptr<int>(&data, dummy_tn, dummy_pubsub_id, /*entry_id=*/1)};
+  bool callback_called = false;
+  auto callback = [&](const std::shared_ptr<const int> & msg) {
+    callback_called = true;
+    EXPECT_EQ(5, *msg);
+  };
+
+  // Act
+  agnocast::TypeErasedCallback erased_callback =
+    agnocast::make_type_erased_callback<int, decltype(callback) &>(callback);
+  erased_callback(std::move(int_arg));
+
+  // Assert
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(release_subscriber_reference_mock_called_count, 1);
+}
+
+TEST_F(AgnocastCallbackInfoTest, dispatch_prefers_ipc_branch_for_generic_lambda)
+{
+  // Arrange: a generic callable is invocable with both shapes, so branch ordering decides which one
+  // it observes. Regression guard: it must keep resolving to ipc_shared_ptr.
+  int data = 1;
+  agnocast::TypedMessagePtr<int> int_arg{
+    agnocast::ipc_shared_ptr<int>(&data, dummy_tn, dummy_pubsub_id, /*entry_id=*/1)};
+  const std::type_info * observed = nullptr;
+  auto callback = [&](auto msg) { observed = &typeid(decltype(msg)); };
+
+  // Act
+  agnocast::TypeErasedCallback erased_callback =
+    agnocast::make_type_erased_callback<int, decltype(callback) &>(callback);
+  erased_callback(std::move(int_arg));
+
+  // Assert
+  ASSERT_NE(nullptr, observed);
+  EXPECT_EQ(typeid(agnocast::ipc_shared_ptr<int>), *observed);
+}
+
+// =========================================
+// Callback shape trait tests
+// =========================================
+
+TEST(CallbackShapeTraitsTest, ipc_shared_ptr_shapes_are_recognized)
+{
+  auto by_value = [](agnocast::ipc_shared_ptr<int>) {};
+  auto by_const_ref = [](const agnocast::ipc_shared_ptr<const int> &) {};
+  auto by_rvalue_ref = [](agnocast::ipc_shared_ptr<int> &&) {};
+
+  static_assert(agnocast::detail::is_ipc_shared_ptr_cb<int, decltype(by_value)>::value);
+  static_assert(agnocast::detail::is_ipc_shared_ptr_cb<int, decltype(by_const_ref)>::value);
+  static_assert(agnocast::detail::is_ipc_shared_ptr_cb<int, decltype(by_rvalue_ref)>::value);
+  static_assert(!agnocast::detail::is_const_std_shared_ptr_cb<int, decltype(by_value)>::value);
+}
+
+TEST(CallbackShapeTraitsTest, const_std_shared_ptr_shapes_are_recognized)
+{
+  auto by_value = [](std::shared_ptr<const int>) {};
+  auto by_const_ref = [](const std::shared_ptr<const int> &) {};
+
+  static_assert(agnocast::detail::is_const_std_shared_ptr_cb<int, decltype(by_value)>::value);
+  static_assert(agnocast::detail::is_const_std_shared_ptr_cb<int, decltype(by_const_ref)>::value);
+  static_assert(!agnocast::detail::is_ipc_shared_ptr_cb<int, decltype(by_value)>::value);
+}
+
+TEST(CallbackShapeTraitsTest, mutable_and_unique_ptr_shapes_are_rejected)
+{
+  auto mutable_shared = [](std::shared_ptr<int>) {};
+  auto unique = [](std::unique_ptr<int>) {};
+
+  static_assert(agnocast::detail::is_unsupported_std_ptr_cb<int, decltype(mutable_shared)>::value);
+  static_assert(agnocast::detail::is_unsupported_std_ptr_cb<int, decltype(unique)>::value);
+  static_assert(!agnocast::detail::is_const_std_shared_ptr_cb<int, decltype(unique)>::value);
+  static_assert(!agnocast::detail::is_ipc_shared_ptr_cb<int, decltype(unique)>::value);
+}
+
+TEST(CallbackShapeTraitsTest, std_shared_ptr_traits_are_false_for_void_message)
+{
+  // The GenericSubscription path instantiates register_callback<void>. No std::shared_ptr<const
+  // void> must ever be formed there.
+  auto void_callback = [](agnocast::ipc_shared_ptr<void> &&) {};
+
+  static_assert(agnocast::detail::is_ipc_shared_ptr_cb<void, decltype(void_callback)>::value);
+  static_assert(
+    !agnocast::detail::is_const_std_shared_ptr_cb<void, decltype(void_callback)>::value);
+  static_assert(!agnocast::detail::is_unsupported_std_ptr_cb<void, decltype(void_callback)>::value);
 }


### PR DESCRIPTION
## Description

A subscription callback may now take the plain ROS 2 `MessageT::ConstSharedPtr` in addition to `agnocast::ipc_shared_ptr`. This is for interfaces that cannot be templated on the message pointer type: a virtual method overridden downstream, a pluginlib boundary, a third-party callback.

```c++
// void on_pointcloud(const PointCloud2::ConstSharedPtr &);  // signature is fixed
agnocast::create_subscription<PointCloud2>(
  node, "input", qos, [this](const PointCloud2::ConstSharedPtr & msg) { on_pointcloud(msg); });
```

**The payload is never copied.** The new `agnocast::to_std_shared_ptr()` wraps the incoming `ipc_shared_ptr` in a `std::make_shared` holder and returns an aliasing `std::shared_ptr` over it, so the kernel-side reference stays alive until the last copy is destroyed. The pointer may therefore be retained beyond the callback — at the cost of one extra heap allocation per message (the `std::shared_ptr` control block) and of pinning one shared-memory entry for as long as it lives. `ipc_shared_ptr` remains the zero-allocation path and is still what hot paths should use.

`MessageT::SharedPtr` (non-const) is deliberately **not** accepted: the message lives in shared memory that other subscribers read concurrently, and for a same-process publisher the mapping is writable, so a mutation would silently corrupt the message for every other subscriber. `std::unique_ptr` is not accepted either, since the message must not be freed with `operator delete`. Both get a dedicated `static_assert` message rather than the generic one.

### Nothing existing changes

The whole dispatch lives in `register_callback()`, so `create_subscription()`, `Subscription`, the executors, `message_creator`, `get_erased_callback()` and the runtime dispatch path are untouched — the existing overloads simply accept one more callback shape. The `ipc_shared_ptr` branch is probed **first**, so a generic callable (`[](auto msg) {}`) and every existing callsite resolve exactly as before; there is a regression test pinning that ordering.

Wrapping inside `register_callback()` rather than in `create_subscription()` is deliberate: `Subscription::constructor_impl` captures `tracetools::get_symbol(callback)` *before* calling `register_callback()`, so CARET/LTTng keeps reporting the **user's** symbol rather than the adapter lambda's.

For `MessageT = void` (the `GenericSubscription` path) the `std::shared_ptr` traits are hard-`false` via partial specialization, so no `std::shared_ptr<const void>` is ever formed.

## Related links

Complements <https://github.com/autowarefoundation/autoware_core/pull/1314>, which adds the same shape at the `autoware_agnocast_wrapper` layer. That PR and the already-merged `AgnocastPollingSubscriber::take_data_impl()` each hand-roll the same aliasing construction; `to_std_shared_ptr()` is intended to replace both so the pattern lives in one place.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

14 new unit tests in `test/unit/test_mocked_agnocast.cpp`, all passing (`331/331` for the whole target, built with `-DCOVERAGE=OFF`):

- **Lifetime** (`AgnocastSmartPointerTest`): the reference survives the `ipc_shared_ptr` going out of scope and is released exactly once when the last `std::shared_ptr` copy dies; an empty input yields an *empty* `std::shared_ptr` (`use_count() == 0`) so `if (!msg)` works; constness is carried through by deduction; an `ipc_shared_ptr` copy and a converted `std::shared_ptr` share one control block.
- **Invalidation** (`AgnocastInvalidationTest`): converting an already-published handle yields an empty pointer; converting a publisher-side borrowed message exits with a diagnostic.
- **Dispatch** (`AgnocastCallbackInfoTest`): a `std::shared_ptr<const int>` callback receives a message that outlives the dispatch (0 releases during, 1 after); plus the by-`const&` form and the branch-ordering guard asserting a generic lambda still observes `ipc_shared_ptr<int>`.
- **Traits** (`CallbackShapeTraitsTest`): each shape classifies correctly, and all `std::shared_ptr` traits are false for `MessageT = void`.

The three rejected/accepted shapes were also verified by temporarily compiling each one and reading the resulting diagnostic (not committed): `Msg::SharedPtr` and `Msg::UniquePtr` fire the dedicated `static_assert`, `Msg::ConstSharedPtr` compiles.

`colcon build` is clean for `agnocastlib`, `agnocast_e2e_test`, `agnocast_sample_application`, `agnocast_cie_thread_configurator` and `ros2agnocast`, which is what demonstrates the "no existing callsite changes branch" claim (`message_filters/subscriber.hpp`, tf2 `transform_listener`, `node_time_source`, `agnocast_client`, `agnocast_service`, `GenericSubscription`, the `pubsub_bridge_plugin` template, and every e2e/sample subscriber).

`src/agnocast_e2e_test/src/test_subscriber.cpp` gained a `const_shared_ptr` parameter (default `false`, so existing e2e expectations are unchanged) that selects the new shape, giving the real-kmod path coverage when the harness runs.

**The `requires_kernel_module` boxes are unchecked because they could not be executed locally**, not because they were skipped: the kernel module loaded on this dev machine is a different build from this tree (`srcversion` `420C297BB435D4E4C49FE61` loaded vs `C05DDBB9EF2AA5477122DA4` built from source), which makes `AGNOCAST_ADD_SUBSCRIBER_CMD` fail with `EINVAL` for every such test, including ones untouched here. CI should be the judge.

## Notes for reviewers

`to_std_shared_ptr()` uses a `make_shared` holder plus the aliasing constructor rather than `std::shared_ptr<T>(p.get(), [holder = std::move(p)](T*){})`. Both are one allocation, but the deleter form relies on `ipc_shared_ptr` being copyable (the standard lets the implementation copy `D`, and each copy is an atomic on the agnocast control block), and it would sit one line away in shape from the genuinely **non-owning** no-op deleter already in `agnocast_performance_bridge_loader.cpp:367`. The holder form states the ownership in the type.

Please do **not** later add an implicit `operator std::shared_ptr<T>()` to `ipc_shared_ptr`: it would make both shape traits true for every callback and destroy the discrimination. The explicit free function is the right shape for that reason.

Under C++17 `std::move(holder)` still selects the copy form of the aliasing constructor (one atomic increment, undone immediately). The allocation-free move form arrives with C++20.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` — additive only: one more accepted callback signature plus a new free function. No existing signature changes meaning.
