### PR TITLE
feat(agnocastlib)[needs minor version update]: support NodeGraph::get_node_names()

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -14,6 +14,7 @@
 #define MAX_RECEIVE_NUM 10
 #define MAX_RELEASE_NUM 3           // Maximum number of entries that can be released at one ioctl
 #define NODE_NAME_BUFFER_SIZE 256   // Maximum length of node name: 256 characters
+#define MAX_NODE_NUM 1024           // Maximum number of node names returned by GET_NODE_NAMES
 #define TOPIC_NAME_BUFFER_SIZE 256  // Maximum length of topic name: 256 characters
 #define VERSION_BUFFER_LEN 32       // Maximum size of version number represented as a string
 
@@ -33,6 +34,17 @@ struct name_info
 struct ioctl_get_version_args
 {
   char ret_version[VERSION_BUFFER_LEN];
+};
+
+union ioctl_get_node_names_args {
+  struct
+  {
+    // Receives the node names packed as consecutive NUL-terminated strings.
+    uint64_t node_name_buffer_addr;
+    // Capacity of the buffer above, in bytes.
+    uint32_t node_name_buffer_size;
+  };
+  uint32_t ret_node_num;
 };
 
 union ioctl_add_process_args {
@@ -352,6 +364,7 @@ struct ioctl_add_domain_bridge_args
 #define AGNOCAST_ADD_DISCOVERY_AGENT_CMD _IOWR(0xA6, 30, struct ioctl_add_discovery_agent_args)
 #define AGNOCAST_DISCOVERY_AGENT_EXISTS_CMD \
   _IOWR(0xA6, 31, struct ioctl_discovery_agent_exists_args)
+#define AGNOCAST_GET_NODE_NAMES_CMD _IOWR(0xA6, 32, union ioctl_get_node_names_args)
 
 // ================================================
 // ros2cli ioctls
@@ -471,6 +484,14 @@ int agnocast_ioctl_get_publisher_num(
 
 int agnocast_ioctl_get_topic_list(
   const struct ipc_namespace * ipc_ns, union ioctl_topic_list_args * topic_list_args);
+
+// Collects the names of all nodes that own at least one non-bridge endpoint in
+// (ipc_ns, domain_id). Names are packed into `buf` as consecutive NUL-terminated strings;
+// `ret_used` receives the number of bytes written and `ret_node_num` the number of names.
+// Returns -ENOBUFS if the names do not fit in `buf` or exceed MAX_NODE_NUM.
+int agnocast_ioctl_get_node_names(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, char * buf, const size_t buf_size,
+  size_t * ret_used, uint32_t * ret_node_num);
 
 int agnocast_ioctl_get_subscriber_qos(
   const char * topic_name, const struct ipc_namespace * ipc_ns,

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1552,6 +1552,119 @@ unlock:
   return ret;
 }
 
+// Open-addressing set used to deduplicate node names while the read lock is held.
+// Slots hold `offset + 1` into the packed name buffer, so 0 means empty. Sized well above
+// MAX_NODE_NUM so that probing always terminates on a free slot.
+#define NODE_NAME_SLOT_BITS 11
+#define NODE_NAME_SLOT_NUM (1u << NODE_NAME_SLOT_BITS)
+
+// Appends `name` to the packed buffer unless it is already there. Performs no allocation and
+// nothing that can sleep, because it runs under global_htables_rwsem.
+static int add_unique_name(
+  const char * name, uint32_t * slots, char * buf, const size_t buf_size, size_t * used,
+  uint32_t * num)
+{
+  const size_t len = strlen(name) + 1;
+  uint32_t idx = full_name_hash(NULL, name, len - 1) & (NODE_NAME_SLOT_NUM - 1);
+
+  while (slots[idx] != 0) {
+    if (strcmp(&buf[slots[idx] - 1], name) == 0) return 0;  // already collected
+    idx = (idx + 1) & (NODE_NAME_SLOT_NUM - 1);
+  }
+
+  if (*num >= MAX_NODE_NUM) {
+    dev_warn(agnocast_device, "Node count exceeds limit: MAX_NODE_NUM=%d\n", MAX_NODE_NUM);
+    return -ENOBUFS;
+  }
+
+  if (*used + len > buf_size) {
+    dev_warn(
+      agnocast_device, "Node names exceed the given buffer: node_name_buffer_size=%zu\n", buf_size);
+    return -ENOBUFS;
+  }
+
+  memcpy(buf + *used, name, len);
+  slots[idx] = (uint32_t)(*used + 1);
+  *used += len;
+  (*num)++;
+  return 0;
+}
+
+// The read section deliberately does no allocation and no copy_to_user: both can sleep, and
+// global_htables_rwsem is writer-preferring, so a sleeping reader stalls every publish behind a
+// waiting add/remove endpoint. Names are packed into a kernel buffer here and handed to
+// user-space by the caller after the lock is dropped.
+
+// Collects the node names owned by one topic. Caller holds global_htables_rwsem.
+static int collect_node_names_of_topic(
+  struct topic_wrapper * wrapper, const uint32_t domain_id, uint32_t * slots, char * buf,
+  const size_t buf_size, size_t * used, uint32_t * num)
+{
+  int ret = 0;
+
+  down_read(&wrapper->topic->rwsem);
+
+  struct publisher_info * pub_info;
+  int bkt_pub_info;
+  hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
+  {
+    if (pub_info->domain_id != domain_id || pub_info->is_bridge) continue;
+
+    ret = add_unique_name(pub_info->node_name, slots, buf, buf_size, used, num);
+    if (ret) goto unlock;
+  }
+
+  struct subscriber_info * sub_info;
+  int bkt_sub_info;
+  hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
+  {
+    if (sub_info->domain_id != domain_id || sub_info->is_bridge) continue;
+
+    ret = add_unique_name(sub_info->node_name, slots, buf, buf_size, used, num);
+    if (ret) goto unlock;
+  }
+
+unlock:
+  up_read(&wrapper->topic->rwsem);
+  return ret;
+}
+
+int agnocast_ioctl_get_node_names(
+  const struct ipc_namespace * ipc_ns, const uint32_t domain_id, char * buf, const size_t buf_size,
+  size_t * ret_used, uint32_t * ret_node_num)
+{
+  int ret = 0;
+  size_t used = 0;
+  uint32_t num = 0;
+
+  uint32_t * slots = kvcalloc(NODE_NAME_SLOT_NUM, sizeof(*slots), GFP_KERNEL);
+  if (!slots) return -ENOMEM;
+
+  down_read(&global_htables_rwsem);
+
+  struct topic_wrapper * wrapper;
+  int bkt_topic;
+  hash_for_each(topic_hashtable, bkt_topic, wrapper, node)
+  {
+    // Endpoints of both domains of a domain-bridged pair live in one shared topic_struct, so
+    // filter on the wrapper to visit that table once and on the endpoint to pick this domain.
+    if (!ipc_eq(ipc_ns, wrapper->ipc_ns) || wrapper->domain_id != domain_id) {
+      continue;
+    }
+
+    ret = collect_node_names_of_topic(wrapper, domain_id, slots, buf, buf_size, &used, &num);
+    if (ret) goto unlock;
+  }
+
+  *ret_used = used;
+  *ret_node_num = num;
+
+unlock:
+  up_read(&global_htables_rwsem);
+  kvfree(slots);
+  return ret;
+}
+
 int agnocast_ioctl_get_node_subscriber_topics(
   const struct ipc_namespace * ipc_ns, const char * node_name,
   union ioctl_node_info_args * node_info_args)
@@ -2837,6 +2950,41 @@ static long get_topic_list_cmd(union ioctl_topic_list_args __user * arg)
   return ret;
 }
 
+static long get_node_names_cmd(union ioctl_get_node_names_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  union ioctl_get_node_names_args get_node_names_args;
+  if (copy_from_user(&get_node_names_args, arg, sizeof(get_node_names_args))) return -EFAULT;
+
+  const size_t buf_size = min_t(
+    size_t, get_node_names_args.node_name_buffer_size,
+    (size_t)MAX_NODE_NUM * NODE_NAME_BUFFER_SIZE);
+  char __user * user_buf =
+    (char __user *)u64_to_user_ptr(get_node_names_args.node_name_buffer_addr);
+
+  // Staged in kernel memory so that the node names can be collected without doing copy_to_user
+  // while holding global_htables_rwsem.
+  char * buf = kvmalloc(buf_size, GFP_KERNEL);
+  if (!buf) return -ENOMEM;
+
+  size_t used = 0;
+  uint32_t node_num = 0;
+  long ret =
+    agnocast_ioctl_get_node_names(ipc_ns, get_current_domain_id(), buf, buf_size, &used, &node_num);
+  if (ret == 0) {
+    if (copy_to_user(user_buf, buf, used)) {
+      ret = -EFAULT;
+    } else {
+      get_node_names_args.ret_node_num = node_num;
+      if (copy_to_user(arg, &get_node_names_args, sizeof(get_node_names_args))) ret = -EFAULT;
+    }
+  }
+
+  kvfree(buf);
+  return ret;
+}
+
 static long get_node_subscriber_topics_cmd(union ioctl_node_info_args __user * arg)
 {
   int ret = 0;
@@ -3179,6 +3327,8 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
       return get_exit_process_cmd((struct ioctl_get_exit_process_args __user *)arg);
     case AGNOCAST_GET_TOPIC_LIST_CMD:
       return get_topic_list_cmd((union ioctl_topic_list_args __user *)arg);
+    case AGNOCAST_GET_NODE_NAMES_CMD:
+      return get_node_names_cmd((union ioctl_get_node_names_args __user *)arg);
     case AGNOCAST_GET_NODE_SUBSCRIBER_TOPICS_CMD:
       return get_node_subscriber_topics_cmd((union ioctl_node_info_args __user *)arg);
     case AGNOCAST_GET_NODE_PUBLISHER_TOPICS_CMD:

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -19,6 +19,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_set_ros2_publisher_num.o \
   agnocast_kunit_do_exit.o \
   agnocast_kunit_get_node_subscriber_topics.o \
+  agnocast_kunit_get_node_names.o \
   agnocast_kunit_get_node_publisher_topics.o \
   agnocast_kunit_get_version.o \
   agnocast_kunit_bridge_shutdown.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.c
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_get_node_names.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+static const char * TOPIC_NAME = "/kunit_test_topic";
+static const char * TOPIC_NAME2 = "/kunit_test_topic2";
+static const char * NODE_NAME = "/kunit_test_node";
+static const char * NODE_NAME2 = "/kunit_test_node2";
+static const pid_t PID = 1000;
+static const uint32_t QOS_DEPTH = 1;
+static const uint32_t DOMAIN_ID = 0;
+
+static void setup_process(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret =
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, DOMAIN_ID, &add_process_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static void add_publisher(
+  struct kunit * test, const char * topic_name, const char * node_name, const bool is_bridge)
+{
+  union ioctl_add_publisher_args add_pub_args;
+  int ret = agnocast_ioctl_add_publisher(
+    topic_name, current->nsproxy->ipc_ns, node_name, PID, QOS_DEPTH, false, is_bridge,
+    &add_pub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+static void add_subscriber(
+  struct kunit * test, const char * topic_name, const char * node_name, const bool is_bridge)
+{
+  union ioctl_add_subscriber_args add_sub_args;
+  int ret = agnocast_ioctl_add_subscriber(
+    topic_name, current->nsproxy->ipc_ns, node_name, PID, QOS_DEPTH, false, true, false, false,
+    is_bridge, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+// Returns true if `name` is among the `num` NUL-terminated strings packed into `buf`.
+static bool contains_name(const char * buf, const uint32_t num, const char * name)
+{
+  const char * p = buf;
+  uint32_t i;
+
+  for (i = 0; i < num; i++) {
+    if (strcmp(p, name) == 0) return true;
+    p += strlen(p) + 1;
+  }
+
+  return false;
+}
+
+void test_case_get_node_names_no_node(struct kunit * test)
+{
+  char buf[NODE_NAME_BUFFER_SIZE];
+  size_t used = SIZE_MAX;
+  uint32_t node_num = UINT_MAX;
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, node_num, 0);
+  KUNIT_EXPECT_EQ(test, used, 0);
+}
+
+void test_case_get_node_names_multiple_nodes(struct kunit * test)
+{
+  char buf[2 * NODE_NAME_BUFFER_SIZE];
+  size_t used = 0;
+  uint32_t node_num = 0;
+
+  setup_process(test, PID);
+  add_publisher(test, TOPIC_NAME, NODE_NAME, false);
+  add_subscriber(test, TOPIC_NAME2, NODE_NAME2, false);
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, node_num, 2);
+  KUNIT_EXPECT_EQ(test, used, strlen(NODE_NAME) + 1 + strlen(NODE_NAME2) + 1);
+  KUNIT_EXPECT_TRUE(test, contains_name(buf, node_num, NODE_NAME));
+  KUNIT_EXPECT_TRUE(test, contains_name(buf, node_num, NODE_NAME2));
+}
+
+// A node owning several endpoints is reported exactly once.
+void test_case_get_node_names_deduplicates(struct kunit * test)
+{
+  char buf[2 * NODE_NAME_BUFFER_SIZE];
+  size_t used = 0;
+  uint32_t node_num = 0;
+
+  setup_process(test, PID);
+  add_publisher(test, TOPIC_NAME, NODE_NAME, false);
+  add_publisher(test, TOPIC_NAME2, NODE_NAME, false);
+  add_subscriber(test, TOPIC_NAME, NODE_NAME, false);
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, node_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf, NODE_NAME);
+}
+
+// Endpoints created by a bridge do not introduce a node of their own.
+void test_case_get_node_names_excludes_bridge(struct kunit * test)
+{
+  char buf[2 * NODE_NAME_BUFFER_SIZE];
+  size_t used = 0;
+  uint32_t node_num = 0;
+
+  setup_process(test, PID);
+  add_publisher(test, TOPIC_NAME, NODE_NAME, false);
+  add_subscriber(test, TOPIC_NAME, NODE_NAME2, true);
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, node_num, 1);
+  KUNIT_EXPECT_STREQ(test, buf, NODE_NAME);
+}
+
+// Nodes belonging to another ROS_DOMAIN_ID are not visible.
+void test_case_get_node_names_other_domain(struct kunit * test)
+{
+  char buf[2 * NODE_NAME_BUFFER_SIZE];
+  size_t used = 0;
+  uint32_t node_num = 0;
+
+  setup_process(test, PID);
+  add_publisher(test, TOPIC_NAME, NODE_NAME, false);
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID + 1, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, node_num, 0);
+}
+
+void test_case_get_node_names_buffer_too_small(struct kunit * test)
+{
+  char buf[4];
+  size_t used = 0;
+  uint32_t node_num = 0;
+
+  setup_process(test, PID);
+  add_publisher(test, TOPIC_NAME, NODE_NAME, false);
+
+  int ret = agnocast_ioctl_get_node_names(
+    current->nsproxy->ipc_ns, DOMAIN_ID, buf, sizeof(buf), &used, &node_num);
+
+  KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_node_names.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_GET_NODE_NAMES                         \
+  KUNIT_CASE(test_case_get_node_names_no_node),           \
+    KUNIT_CASE(test_case_get_node_names_multiple_nodes),  \
+    KUNIT_CASE(test_case_get_node_names_deduplicates),    \
+    KUNIT_CASE(test_case_get_node_names_excludes_bridge), \
+    KUNIT_CASE(test_case_get_node_names_other_domain),    \
+    KUNIT_CASE(test_case_get_node_names_buffer_too_small)
+
+void test_case_get_node_names_no_node(struct kunit * test);
+void test_case_get_node_names_multiple_nodes(struct kunit * test);
+void test_case_get_node_names_deduplicates(struct kunit * test);
+void test_case_get_node_names_excludes_bridge(struct kunit * test);
+void test_case_get_node_names_other_domain(struct kunit * test);
+void test_case_get_node_names_buffer_too_small(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -8,6 +8,7 @@
 #include "agnocast_kunit/agnocast_kunit_check_and_request_bridge_shutdown.h"
 #include "agnocast_kunit/agnocast_kunit_do_exit.h"
 #include "agnocast_kunit/agnocast_kunit_domain_bridge.h"
+#include "agnocast_kunit/agnocast_kunit_get_node_names.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_publisher_num.h"
@@ -56,6 +57,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_SET_ROS2_PUBLISHER_NUM,
   TEST_CASES_DO_EXIT,
   TEST_CASES_GET_NODE_SUBSCRIBER_TOPICS,
+  TEST_CASES_GET_NODE_NAMES,
   TEST_CASES_GET_NODE_PUBLISHER_TOPICS,
   TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO,
   TEST_CASES_GET_TOPIC_PUBLISHER_INFO,

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -168,13 +168,42 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 
 ---
 
-### 2.8 Other Interfaces
+### 2.8 NodeGraphInterface
+
+**Purpose**: Graph
+
+**Important**: `agnocast::node_interfaces::NodeGraph` **inherits from** `rclcpp::node_interfaces::NodeGraphInterface`.
+
+| Feature | agnocast::Node | Support Level | Planned | Notes |
+|---------|----------------|---------------|---------|-------|
+| `get_topic_names_and_types()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_service_names_and_types()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_service_names_and_types_by_node()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_client_names_and_types_by_node()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_publisher_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_subscriber_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_node_names()` | ✗ | **Throws Exception** | Yes | To support this, the kmod must report the nodes owning an agnocast endpoint; it currently does not |
+| `get_node_names_with_enclaves()` | ✗ | **Throws Exception** | No | |
+| `get_node_names_and_namespaces()` | ✗ | **Throws Exception** | No | To support this, namespace must be managed within the kmod; however, they are currently not managed |
+| `count_publishers()` | ✓ | **Full Support** | - | Counts agnocast and ROS 2 publishers, excluding those created by bridges. `agnocast::Node::count_publishers()` delegates here |
+| `count_subscribers()` | ✓ | **Partial Support** | - | Counts agnocast and ROS 2 subscribers, excluding those created by bridges. Agnocast subscribers in the caller's own process are not counted. `agnocast::Node::count_subscribers()` delegates here |
+| `get_graph_guard_condition()` | ✗ | **Throws Exception** | No | |
+| `notify_graph_change()` | - | **No-op** | No | agnocast has no graph events, so there is nothing to notify. Made a no-op because rclcpp utilities call it unconditionally |
+| `notify_shutdown()` | - | **No-op** | No | Same as `notify_graph_change()` |
+| `get_graph_event()` | ✗ | **Throws Exception** | No | |
+| `wait_for_graph_change()` | ✗ | **Throws Exception** | No | |
+| `count_graph_users()` | ✗ | **Throws Exception** | No | |
+| `get_publishers_info_by_topic()` | ✗ | **Throws Exception** | No | To support this, namespace and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_subscriptions_info_by_topic()` | ✗ | **Throws Exception** | No | To support this, namespace and topic_type must be managed within the kmod; however, they are currently not managed |
+
+---
+
+### 2.9 Other Interfaces
 
 The following interfaces are all **unsupported**. agnocast::Node does not implement these interfaces.
 
 | Interface | Support Status | Planned | Notes |
 |-----------|---------------|---------|-------|
-| NodeGraphInterface | Unsupported | No | DDS is not used |
 | NodeTimersInterface | Unsupported | Yes | |
 | NodeWaitablesInterface | Unsupported | TBD | |
 

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -182,7 +182,7 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 | `get_client_names_and_types_by_node()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
 | `get_publisher_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
 | `get_subscriber_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
-| `get_node_names()` | ✗ | **Throws Exception** | Yes | To support this, the kmod must report the nodes owning an agnocast endpoint; it currently does not |
+| `get_node_names()` | ✓ | **Partial Support** | - | Returns the agnocast nodes of the caller's IPC namespace and `ROS_DOMAIN_ID` that own at least one non-bridge publisher/subscriber. Nodes that only use ROS 2 entities are not visible, and at most `MAX_NODE_NUM` (1024) names are returned |
 | `get_node_names_with_enclaves()` | ✗ | **Throws Exception** | No | |
 | `get_node_names_and_namespaces()` | ✗ | **Throws Exception** | No | To support this, namespace must be managed within the kmod; however, they are currently not managed |
 | `count_publishers()` | ✓ | **Full Support** | - | Counts agnocast and ROS 2 publishers, excluding those created by bridges. `agnocast::Node::count_publishers()` delegates here |

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(agnocast SHARED
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
   src/cie_client_utils.cpp
   src/internal/type_registry_writer.cpp
-  src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp
+  src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp src/node/node_interfaces/node_graph.cpp
   src/bridge/agnocast_bridge_utils.cpp src/bridge/agnocast_service_bridge.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
@@ -262,6 +262,18 @@ if(BUILD_TESTING)
     test/integration/test_agnocast_node.cpp)
   target_link_libraries(test_integration_agnocast_node_${PROJECT_NAME} agnocast)
   set_tests_properties(test_integration_agnocast_node_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
+  # NodeGraphInterface integration test (requires kernel module, no mock).
+  # count_publishers()/count_subscribers() go through the real endpoint-counting ioctls.
+  ament_add_gmock(test_integration_node_graph_${PROJECT_NAME}
+    test/integration/test_node_graph.cpp)
+  target_link_libraries(test_integration_node_graph_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_node_graph_${PROJECT_NAME} std_msgs)
+  set_tests_properties(test_integration_node_graph_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
     TIMEOUT 60
     LABELS "requires_kernel_module;requires_heaphook"

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -23,6 +23,7 @@ namespace agnocast
 #define MAX_TOPIC_INFO_RET_NUM std::max(MAX_PUBLISHER_NUM, MAX_SUBSCRIBER_NUM)
 
 #define NODE_NAME_BUFFER_SIZE 256
+#define MAX_NODE_NUM 1024  // Maximum number of node names returned by GET_NODE_NAMES
 #define TOPIC_NAME_BUFFER_SIZE 256
 #define MAX_SUBSCRIPTION_NUM_PER_PROCESS 256
 
@@ -48,6 +49,20 @@ struct ioctl_get_version_args
 {
   char ret_version[VERSION_BUFFER_LEN];
 };
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+union ioctl_get_node_names_args {
+  struct
+  {
+    // Receives the node names packed as consecutive NUL-terminated strings.
+    uint64_t node_name_buffer_addr;
+    // Capacity of the buffer above, in bytes.
+    uint32_t node_name_buffer_size;
+  };
+  uint32_t ret_node_num;
+};
+#pragma GCC diagnostic pop
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
@@ -377,5 +392,6 @@ struct ioctl_set_ros2_publisher_num_args
   _IOW(0xA6, 25, struct ioctl_set_ros2_subscriber_num_args)
 #define AGNOCAST_SET_ROS2_PUBLISHER_NUM_CMD _IOW(0xA6, 26, struct ioctl_set_ros2_publisher_num_args)
 #define AGNOCAST_NOTIFY_BRIDGE_SHUTDOWN_CMD _IO(0xA6, 27)
+#define AGNOCAST_GET_NODE_NAMES_CMD _IOWR(0xA6, 32, union ioctl_get_node_names_args)
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -10,6 +10,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/node_interfaces/node_base.hpp"
 #include "agnocast/node/node_interfaces/node_clock.hpp"
+#include "agnocast/node/node_interfaces/node_graph.hpp"
 #include "agnocast/node/node_interfaces/node_logging.hpp"
 #include "agnocast/node/node_interfaces/node_parameters.hpp"
 #include "agnocast/node/node_interfaces/node_services.hpp"
@@ -127,6 +128,13 @@ public:
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr get_node_clock_interface()
   {
     return node_clock_;
+  }
+
+  // Non-const to align with rclcpp::Node API
+  // cppcheck-suppress functionConst
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr get_node_graph_interface()
+  {
+    return node_graph_;
   }
 
   // Non-const to align with rclcpp::Node API
@@ -402,7 +410,7 @@ public:
   AGNOCAST_PUBLIC
   size_t count_publishers(const std::string & topic_name) const
   {
-    return get_publisher_count_core(node_topics_->resolve_topic_name(topic_name));
+    return node_graph_->count_publishers(topic_name);
   }
 
   /// Return the number of subscribers on a topic.
@@ -410,7 +418,7 @@ public:
   AGNOCAST_PUBLIC
   size_t count_subscribers(const std::string & topic_name) const
   {
-    return get_subscription_count_core(node_topics_->resolve_topic_name(topic_name));
+    return node_graph_->count_subscribers(topic_name);
   }
 
   /// Create a publisher (QoS overload).
@@ -654,6 +662,7 @@ private:
 
   node_interfaces::NodeBase::SharedPtr node_base_;
   rclcpp::Logger logger_;
+  node_interfaces::NodeGraph::SharedPtr node_graph_;
   node_interfaces::NodeTopics::SharedPtr node_topics_;
   node_interfaces::NodeServices::SharedPtr node_services_;
   node_interfaces::NodeParameters::SharedPtr node_parameters_;

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -23,6 +23,7 @@ public:
 
   virtual ~NodeGraph() = default;
 
+  std::vector<std::string> get_node_names() const override;
   size_t count_publishers(const std::string & topic_name) const override;
   size_t count_subscribers(const std::string & topic_name) const override;
 
@@ -31,8 +32,6 @@ public:
   void notify_shutdown() override;
 
   // ===== Not supported methods (throw runtime_error) =====
-  // Reporting the agnocast nodes requires the kmod to expose them, which it does not do yet.
-  std::vector<std::string> get_node_names() const override;
   std::map<std::string, std::vector<std::string>> get_topic_names_and_types(
     bool no_demangle = false) const override;
   std::map<std::string, std::vector<std::string>> get_service_names_and_types() const override;

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "agnocast/node/node_interfaces/node_base.hpp"
+#include "rclcpp/event.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_graph_interface.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace agnocast::node_interfaces
+{
+
+class NodeGraph : public rclcpp::node_interfaces::NodeGraphInterface
+{
+public:
+  using SharedPtr = std::shared_ptr<NodeGraph>;
+  using WeakPtr = std::weak_ptr<NodeGraph>;
+
+  explicit NodeGraph(NodeBase::SharedPtr node_base);
+
+  virtual ~NodeGraph() = default;
+
+  size_t count_publishers(const std::string & topic_name) const override;
+  size_t count_subscribers(const std::string & topic_name) const override;
+
+  // ===== No-op methods =====
+  void notify_graph_change() override;
+  void notify_shutdown() override;
+
+  // ===== Not supported methods (throw runtime_error) =====
+  // Reporting the agnocast nodes requires the kmod to expose them, which it does not do yet.
+  std::vector<std::string> get_node_names() const override;
+  std::map<std::string, std::vector<std::string>> get_topic_names_and_types(
+    bool no_demangle = false) const override;
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types() const override;
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_) const override;
+  std::map<std::string, std::vector<std::string>> get_client_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_) const override;
+  std::map<std::string, std::vector<std::string>> get_publisher_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_,
+    bool no_demangle = false) const override;
+  std::map<std::string, std::vector<std::string>> get_subscriber_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_,
+    bool no_demangle = false) const override;
+  std::vector<std::tuple<std::string, std::string, std::string>> get_node_names_with_enclaves()
+    const override;
+  std::vector<std::pair<std::string, std::string>> get_node_names_and_namespaces() const override;
+  const rcl_guard_condition_t * get_graph_guard_condition() const override;
+  rclcpp::Event::SharedPtr get_graph_event() override;
+  void wait_for_graph_change(
+    rclcpp::Event::SharedPtr event, std::chrono::nanoseconds timeout) override;
+  size_t count_graph_users() const override;
+  std::vector<rclcpp::TopicEndpointInfo> get_publishers_info_by_topic(
+    const std::string & topic_name, bool no_mangle = false) const override;
+  std::vector<rclcpp::TopicEndpointInfo> get_subscriptions_info_by_topic(
+    const std::string & topic_name, bool no_mangle = false) const override;
+
+private:
+  NodeBase::SharedPtr node_base_;
+};
+
+}  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -22,6 +22,7 @@ Node::Node(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
     options.use_intra_process_comms(), options.enable_topic_statistics())),
   logger_(rclcpp::get_logger(node_base_->get_name())),
+  node_graph_(std::make_shared<node_interfaces::NodeGraph>(node_base_)),
   node_topics_(std::make_shared<node_interfaces::NodeTopics>(node_base_)),
   node_services_(std::make_shared<node_interfaces::NodeServices>(node_base_)),
   node_parameters_(std::make_shared<node_interfaces::NodeParameters>(

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -1,7 +1,12 @@
 #include "agnocast/node/node_interfaces/node_graph.hpp"
 
+#include "agnocast/agnocast_ioctl.hpp"
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
+#include "agnocast/agnocast_utils.hpp"
+
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 namespace agnocast::node_interfaces
 {
@@ -60,11 +65,30 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_
     "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast. ");
 };
 
-// Supporting this requires the kmod to report the nodes owning an agnocast endpoint, which it
-// does not do yet.
 std::vector<std::string> NodeGraph::get_node_names() const
 {
-  throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast. ");
+  // Sized to the kernel-side limit so that the kernel never has to report -ENOBUFS.
+  std::vector<char> buffer(static_cast<size_t>(MAX_NODE_NUM) * NODE_NAME_BUFFER_SIZE);
+
+  union ioctl_get_node_names_args get_node_names_args = {};
+  get_node_names_args.node_name_buffer_addr = reinterpret_cast<uint64_t>(buffer.data());
+  get_node_names_args.node_name_buffer_size = static_cast<uint32_t>(buffer.size());
+  if (ioctl(agnocast_fd, AGNOCAST_GET_NODE_NAMES_CMD, &get_node_names_args) < 0) {
+    RCLCPP_ERROR(logger, "AGNOCAST_GET_NODE_NAMES_CMD failed: %s", strerror(errno));
+    close(agnocast_fd);
+    exit(EXIT_FAILURE);
+  }
+
+  std::vector<std::string> node_names;
+  node_names.reserve(get_node_names_args.ret_node_num);
+  const char * current_ptr = buffer.data();
+
+  for (uint32_t i = 0; i < get_node_names_args.ret_node_num; ++i) {
+    node_names.emplace_back(current_ptr);
+    current_ptr += node_names.back().length() + 1;
+  }
+
+  return node_names;
 };
 
 std::vector<std::tuple<std::string, std::string, std::string>>

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -1,0 +1,153 @@
+#include "agnocast/node/node_interfaces/node_graph.hpp"
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+
+namespace agnocast::node_interfaces
+{
+
+NodeGraph::NodeGraph(NodeBase::SharedPtr node_base) : node_base_(std::move(node_base))
+{
+}
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_topic_names_and_types(
+  bool no_demangle) const
+{
+  (void)no_demangle;
+  throw std::runtime_error("NodeGraph::get_topic_names_and_types is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types() const
+{
+  throw std::runtime_error("NodeGraph::get_service_names_and_types is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_) const
+{
+  (void)node_name;
+  (void)namespace_;
+  throw std::runtime_error(
+    "NodeGraph::get_service_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_) const
+{
+  (void)node_name;
+  (void)namespace_;
+  throw std::runtime_error(
+    "NodeGraph::get_client_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_, bool no_demangle) const
+{
+  (void)node_name;
+  (void)namespace_;
+  (void)no_demangle;
+  throw std::runtime_error(
+    "NodeGraph::get_publisher_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_, bool no_demangle) const
+{
+  (void)node_name;
+  (void)namespace_;
+  (void)no_demangle;
+  throw std::runtime_error(
+    "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast. ");
+};
+
+// Supporting this requires the kmod to report the nodes owning an agnocast endpoint, which it
+// does not do yet.
+std::vector<std::string> NodeGraph::get_node_names() const
+{
+  throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast. ");
+};
+
+std::vector<std::tuple<std::string, std::string, std::string>>
+NodeGraph::get_node_names_with_enclaves() const
+{
+  throw std::runtime_error(
+    "NodeGraph::get_node_names_with_enclaves is not supported in agnocast. ");
+};
+
+std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_namespaces() const
+{
+  throw std::runtime_error(
+    "NodeGraph::get_node_names_and_namespaces is not supported in agnocast. ");
+};
+
+// Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
+// agnocast::Node::count_publishers()/count_subscribers() delegate here, so the resolution and the
+// bridge bookkeeping live in one place.
+//
+// Note that count_subscribers() does not see agnocast subscribers in the caller's own process:
+// get_subscription_count_core() reports ret_other_process_subscriber_num, because its original
+// caller (agnocast::Publisher::get_subscription_count()) asks how many peers receive a published
+// message. count_publishers() has no such split.
+size_t NodeGraph::count_publishers(const std::string & topic_name) const
+{
+  return get_publisher_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
+};
+
+size_t NodeGraph::count_subscribers(const std::string & topic_name) const
+{
+  return get_subscription_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
+};
+
+const rcl_guard_condition_t * NodeGraph::get_graph_guard_condition() const
+{
+  throw std::runtime_error("NodeGraph::get_graph_guard_condition is not supported in agnocast. ");
+};
+
+// No-op rather than throwing: agnocast has no graph events, so there is nothing to notify.
+// rclcpp utilities call these unconditionally when entities are created or the context shuts
+// down, and throwing there would break otherwise working code.
+void NodeGraph::notify_graph_change()
+{
+}
+
+void NodeGraph::notify_shutdown()
+{
+}
+
+rclcpp::Event::SharedPtr NodeGraph::get_graph_event()
+{
+  throw std::runtime_error("NodeGraph::get_graph_event is not supported in agnocast. ");
+};
+
+void NodeGraph::wait_for_graph_change(
+  rclcpp::Event::SharedPtr event, std::chrono::nanoseconds timeout)
+{
+  (void)event;
+  (void)timeout;
+  throw std::runtime_error("NodeGraph::wait_for_graph_change is not supported in agnocast. ");
+};
+
+size_t NodeGraph::count_graph_users() const
+{
+  throw std::runtime_error("NodeGraph::count_graph_users is not supported in agnocast. ");
+};
+
+std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
+  const std::string & topic_name, bool no_mangle) const
+{
+  (void)topic_name;
+  (void)no_mangle;
+  throw std::runtime_error(
+    "NodeGraph::get_publishers_info_by_topic is not supported in agnocast. ");
+};
+
+std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topic(
+  const std::string & topic_name, bool no_mangle) const
+{
+  (void)topic_name;
+  (void)no_mangle;
+  throw std::runtime_error(
+    "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast. ");
+};
+
+}  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -4,8 +4,10 @@
 
 #include "std_msgs/msg/string.hpp"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <stdexcept>
@@ -110,6 +112,45 @@ TEST_F(NodeGraphIntegrationTest, node_delegates_counting_to_the_node_graph_inter
   EXPECT_EQ(node_->count_publishers(topic), 1u);
 }
 
+// get_node_names() reports every node of this IPC namespace and ROS_DOMAIN_ID that owns an
+// agnocast endpoint, so the assertions below check for membership rather than for an exact list:
+// the kmod still holds the nodes registered by the tests that ran before this one.
+TEST_F(NodeGraphIntegrationTest, get_node_names_includes_a_node_owning_a_publisher)
+{
+  auto pub = node_->create_publisher<StringMsg>("/test_node_graph_names_pub", 1);
+
+  EXPECT_THAT(graph_->get_node_names(), ::testing::Contains("test_node_graph"));
+}
+
+TEST_F(NodeGraphIntegrationTest, get_node_names_includes_a_node_owning_only_a_subscription)
+{
+  auto sub = node_->create_subscription<StringMsg>(
+    "/test_node_graph_names_sub", 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+
+  EXPECT_THAT(graph_->get_node_names(), ::testing::Contains("test_node_graph"));
+}
+
+// A node is reported once even when it owns endpoints on several topics.
+TEST_F(NodeGraphIntegrationTest, get_node_names_reports_a_node_once)
+{
+  auto pub1 = node_->create_publisher<StringMsg>("/test_node_graph_dedup_a", 1);
+  auto pub2 = node_->create_publisher<StringMsg>("/test_node_graph_dedup_b", 1);
+  auto sub = node_->create_subscription<StringMsg>(
+    "/test_node_graph_dedup_c", 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+
+  const auto names = graph_->get_node_names();
+  EXPECT_EQ(std::count(names.begin(), names.end(), "test_node_graph"), 1);
+}
+
+// Only nodes owning an endpoint are visible; constructing a node registers nothing by itself.
+TEST_F(NodeGraphIntegrationTest, get_node_names_excludes_a_node_without_endpoints)
+{
+  auto bare_node = std::make_shared<agnocast::Node>("test_node_graph_bare");
+
+  EXPECT_THAT(
+    graph_->get_node_names(), ::testing::Not(::testing::Contains("test_node_graph_bare")));
+}
+
 // agnocast has no graph events, but rclcpp calls these unconditionally, so they must not throw.
 TEST_F(NodeGraphIntegrationTest, notify_graph_change_and_notify_shutdown_are_no_ops)
 {
@@ -119,7 +160,6 @@ TEST_F(NodeGraphIntegrationTest, notify_graph_change_and_notify_shutdown_are_no_
 
 TEST_F(NodeGraphIntegrationTest, unsupported_methods_throw_runtime_error)
 {
-  EXPECT_THROW(graph_->get_node_names(), std::runtime_error);
   EXPECT_THROW(graph_->get_topic_names_and_types(), std::runtime_error);
   EXPECT_THROW(graph_->get_service_names_and_types(), std::runtime_error);
   EXPECT_THROW(graph_->get_service_names_and_types_by_node("n", "/"), std::runtime_error);

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -1,0 +1,138 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/node_interfaces/node_graph.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using StringMsg = std_msgs::msg::String;
+
+// The kmod keeps a topic entry alive for the lifetime of the process, so every test uses its own
+// topic name to stay independent of the ones before it.
+class NodeGraphIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    node_ = std::make_shared<agnocast::Node>("test_node_graph");
+    graph_ = node_->get_node_graph_interface();
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    graph_.reset();
+    if (agnocast::ok()) {
+      agnocast::shutdown();
+    }
+  }
+
+  std::shared_ptr<agnocast::Node> node_;
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr graph_;
+};
+
+TEST_F(NodeGraphIntegrationTest, get_node_graph_interface_returns_node_graph)
+{
+  ASSERT_NE(graph_, nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<agnocast::node_interfaces::NodeGraph>(graph_), nullptr);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_is_zero_for_unknown_topic)
+{
+  EXPECT_EQ(graph_->count_publishers("/test_node_graph_no_such_topic"), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_subscribers_is_zero_for_unknown_topic)
+{
+  EXPECT_EQ(graph_->count_subscribers("/test_node_graph_no_such_topic"), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_counts_a_created_publisher)
+{
+  const std::string topic = "/test_node_graph_count_pub";
+  EXPECT_EQ(graph_->count_publishers(topic), 0u);
+
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  EXPECT_EQ(graph_->count_publishers(topic), 1u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_counts_every_publisher_on_the_topic)
+{
+  const std::string topic = "/test_node_graph_count_two_pubs";
+
+  auto pub1 = node_->create_publisher<StringMsg>(topic, 1);
+  auto pub2 = node_->create_publisher<StringMsg>(topic, 1);
+  EXPECT_EQ(graph_->count_publishers(topic), 2u);
+}
+
+// count_subscribers() reports ret_other_process_subscriber_num, so a subscriber living in the
+// caller's own process is not counted. This is the documented limitation, not an accident: the
+// underlying helper exists to tell a publisher how many peers receive a published message.
+TEST_F(NodeGraphIntegrationTest, count_subscribers_does_not_see_same_process_subscriber)
+{
+  const std::string topic = "/test_node_graph_count_sub";
+
+  auto sub = node_->create_subscription<StringMsg>(
+    topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+  EXPECT_EQ(graph_->count_subscribers(topic), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_resolves_a_relative_topic_name)
+{
+  agnocast::shutdown();
+  agnocast::init(0, nullptr);
+  auto node = std::make_shared<agnocast::Node>("test_node_graph_rel", "/test_ns");
+  auto graph = node->get_node_graph_interface();
+
+  auto pub = node->create_publisher<StringMsg>("relative_topic", 1);
+
+  EXPECT_EQ(graph->count_publishers("relative_topic"), 1u);
+  EXPECT_EQ(graph->count_publishers("/test_ns/relative_topic"), 1u);
+  EXPECT_EQ(graph->count_publishers("/relative_topic"), 0u);
+}
+
+// agnocast::Node::count_publishers()/count_subscribers() are thin wrappers over the interface.
+TEST_F(NodeGraphIntegrationTest, node_delegates_counting_to_the_node_graph_interface)
+{
+  const std::string topic = "/test_node_graph_delegation";
+
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+
+  EXPECT_EQ(node_->count_publishers(topic), graph_->count_publishers(topic));
+  EXPECT_EQ(node_->count_subscribers(topic), graph_->count_subscribers(topic));
+  EXPECT_EQ(node_->count_publishers(topic), 1u);
+}
+
+// agnocast has no graph events, but rclcpp calls these unconditionally, so they must not throw.
+TEST_F(NodeGraphIntegrationTest, notify_graph_change_and_notify_shutdown_are_no_ops)
+{
+  EXPECT_NO_THROW(graph_->notify_graph_change());
+  EXPECT_NO_THROW(graph_->notify_shutdown());
+}
+
+TEST_F(NodeGraphIntegrationTest, unsupported_methods_throw_runtime_error)
+{
+  EXPECT_THROW(graph_->get_node_names(), std::runtime_error);
+  EXPECT_THROW(graph_->get_topic_names_and_types(), std::runtime_error);
+  EXPECT_THROW(graph_->get_service_names_and_types(), std::runtime_error);
+  EXPECT_THROW(graph_->get_service_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_client_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_publisher_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_subscriber_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_node_names_with_enclaves(), std::runtime_error);
+  EXPECT_THROW(graph_->get_node_names_and_namespaces(), std::runtime_error);
+  EXPECT_THROW(graph_->get_graph_guard_condition(), std::runtime_error);
+  EXPECT_THROW(graph_->get_graph_event(), std::runtime_error);
+  EXPECT_THROW(
+    graph_->wait_for_graph_change(nullptr, std::chrono::nanoseconds(0)), std::runtime_error);
+  EXPECT_THROW(graph_->count_graph_users(), std::runtime_error);
+  EXPECT_THROW(graph_->get_publishers_info_by_topic("/t"), std::runtime_error);
+  EXPECT_THROW(graph_->get_subscriptions_info_by_topic("/t"), std::runtime_error);
+}


### PR DESCRIPTION
## Description

Implements `NodeGraph::get_node_names()` on top of the skeleton added in #1494.

Adds `AGNOCAST_GET_NODE_NAMES_CMD`, which returns the nodes owning at least one non-bridge endpoint in the caller's IPC namespace and `ROS_DOMAIN_ID`. The kmod packs the names into a kernel buffer and copies them out after dropping `global_htables_rwsem`, so the read section neither allocates nor calls `copy_to_user`: both can sleep, and the rwsem is writer-preferring, so a sleeping reader would stall every publish queued behind a waiting add/remove endpoint. Duplicates are removed with an open-addressing set sized above `MAX_NODE_NUM`, so probing terminates without allocating under the lock.

Stacked on #1494. Review that one first; this PR's base moves to `main` once it merges.

## Related links

- Skeleton this builds on: #1494
- Supersedes #1241

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

`get_node_names()` is documented as partial support: it only sees nodes that own an agnocast endpoint, and it is capped at `MAX_NODE_NUM` (1024) names.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
