### PR TITLE
feat(agnocastlib): add NodeGraphInterface skeleton

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -168,13 +168,42 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 
 ---
 
-### 2.8 Other Interfaces
+### 2.8 NodeGraphInterface
+
+**Purpose**: Graph
+
+**Important**: `agnocast::node_interfaces::NodeGraph` **inherits from** `rclcpp::node_interfaces::NodeGraphInterface`.
+
+| Feature | agnocast::Node | Support Level | Planned | Notes |
+|---------|----------------|---------------|---------|-------|
+| `get_topic_names_and_types()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_service_names_and_types()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_service_names_and_types_by_node()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_client_names_and_types_by_node()` | ✗ | **Throws Exception** | No | Agnocast does not officially support Service |
+| `get_publisher_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_subscriber_names_and_types_by_node()` | ✗ | **Throws Exception** | No | To support this, topic_name and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_node_names()` | ✗ | **Throws Exception** | Yes | To support this, the kmod must report the nodes owning an agnocast endpoint; it currently does not |
+| `get_node_names_with_enclaves()` | ✗ | **Throws Exception** | No | |
+| `get_node_names_and_namespaces()` | ✗ | **Throws Exception** | No | To support this, namespace must be managed within the kmod; however, they are currently not managed |
+| `count_publishers()` | ✓ | **Full Support** | - | Counts agnocast and ROS 2 publishers, excluding those created by bridges. `agnocast::Node::count_publishers()` delegates here |
+| `count_subscribers()` | ✓ | **Partial Support** | - | Counts agnocast and ROS 2 subscribers, excluding those created by bridges. Agnocast subscribers in the caller's own process are not counted. `agnocast::Node::count_subscribers()` delegates here |
+| `get_graph_guard_condition()` | ✗ | **Throws Exception** | No | |
+| `notify_graph_change()` | - | **No-op** | No | agnocast has no graph events, so there is nothing to notify. Made a no-op because rclcpp utilities call it unconditionally |
+| `notify_shutdown()` | - | **No-op** | No | Same as `notify_graph_change()` |
+| `get_graph_event()` | ✗ | **Throws Exception** | No | |
+| `wait_for_graph_change()` | ✗ | **Throws Exception** | No | |
+| `count_graph_users()` | ✗ | **Throws Exception** | No | |
+| `get_publishers_info_by_topic()` | ✗ | **Throws Exception** | No | To support this, namespace and topic_type must be managed within the kmod; however, they are currently not managed |
+| `get_subscriptions_info_by_topic()` | ✗ | **Throws Exception** | No | To support this, namespace and topic_type must be managed within the kmod; however, they are currently not managed |
+
+---
+
+### 2.9 Other Interfaces
 
 The following interfaces are all **unsupported**. agnocast::Node does not implement these interfaces.
 
 | Interface | Support Status | Planned | Notes |
 |-----------|---------------|---------|-------|
-| NodeGraphInterface | Unsupported | No | DDS is not used |
 | NodeTimersInterface | Unsupported | Yes | |
 | NodeWaitablesInterface | Unsupported | TBD | |
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -267,8 +267,7 @@ if(BUILD_TESTING)
     LABELS "requires_kernel_module;requires_heaphook"
   )
 
-  # NodeGraphInterface integration test (requires kernel module, no mock).
-  # count_publishers()/count_subscribers() go through the real endpoint-counting ioctls.
+  # NodeGraphInterface integration test (requires kernel module, no mock)
   ament_add_gmock(test_integration_node_graph_${PROJECT_NAME}
     test/integration/test_node_graph.cpp)
   target_link_libraries(test_integration_node_graph_${PROJECT_NAME} agnocast)

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(agnocast SHARED
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
   src/cie_client_utils.cpp
   src/internal/type_registry_writer.cpp
-  src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp
+  src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp src/node/node_interfaces/node_graph.cpp
   src/bridge/agnocast_bridge_utils.cpp src/bridge/agnocast_service_bridge.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
   src/node/tf2/buffer.cpp src/node/tf2/transform_broadcaster.cpp src/node/tf2/transform_listener.cpp src/node/tf2/static_transform_broadcaster.cpp
@@ -262,6 +262,18 @@ if(BUILD_TESTING)
     test/integration/test_agnocast_node.cpp)
   target_link_libraries(test_integration_agnocast_node_${PROJECT_NAME} agnocast)
   set_tests_properties(test_integration_agnocast_node_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
+  # NodeGraphInterface integration test (requires kernel module, no mock).
+  # count_publishers()/count_subscribers() go through the real endpoint-counting ioctls.
+  ament_add_gmock(test_integration_node_graph_${PROJECT_NAME}
+    test/integration/test_node_graph.cpp)
+  target_link_libraries(test_integration_node_graph_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_node_graph_${PROJECT_NAME} std_msgs)
+  set_tests_properties(test_integration_node_graph_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
     TIMEOUT 60
     LABELS "requires_kernel_module;requires_heaphook"

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -406,6 +406,11 @@ public:
   rclcpp::Time now() const { return node_clock_->get_clock()->now(); }
 
   /// Return the number of publishers on a topic.
+  ///
+  /// Counts the agnocast publishers in the same domain, plus the ROS 2 publishers reported by a
+  /// bridge when one is running. Endpoints that a bridge created itself are excluded, so the
+  /// result reflects the publishers the application set up.
+  /// @param topic_name Topic name. A relative name is resolved against this node's namespace.
   /// @return Publisher count.
   AGNOCAST_PUBLIC
   size_t count_publishers(const std::string & topic_name) const
@@ -414,7 +419,15 @@ public:
   }
 
   /// Return the number of subscribers on a topic.
-  /// @return Subscriber count.
+  ///
+  /// Counts the agnocast subscribers in the same domain, plus the ROS 2 subscribers reported by a
+  /// bridge when one is running. Endpoints that a bridge created itself are excluded, so the
+  /// result reflects the subscribers the application set up.
+  ///
+  /// Agnocast subscribers living in the calling process are not counted, because the underlying
+  /// query answers how many other processes receive a published message.
+  /// @param topic_name Topic name. A relative name is resolved against this node's namespace.
+  /// @return Subscriber count, excluding agnocast subscribers in the calling process.
   AGNOCAST_PUBLIC
   size_t count_subscribers(const std::string & topic_name) const
   {

--- a/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_node.hpp
@@ -10,6 +10,7 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/node_interfaces/node_base.hpp"
 #include "agnocast/node/node_interfaces/node_clock.hpp"
+#include "agnocast/node/node_interfaces/node_graph.hpp"
 #include "agnocast/node/node_interfaces/node_logging.hpp"
 #include "agnocast/node/node_interfaces/node_parameters.hpp"
 #include "agnocast/node/node_interfaces/node_services.hpp"
@@ -127,6 +128,13 @@ public:
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr get_node_clock_interface()
   {
     return node_clock_;
+  }
+
+  // Non-const to align with rclcpp::Node API
+  // cppcheck-suppress functionConst
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr get_node_graph_interface()
+  {
+    return node_graph_;
   }
 
   // Non-const to align with rclcpp::Node API
@@ -402,7 +410,7 @@ public:
   AGNOCAST_PUBLIC
   size_t count_publishers(const std::string & topic_name) const
   {
-    return get_publisher_count_core(node_topics_->resolve_topic_name(topic_name));
+    return node_graph_->count_publishers(topic_name);
   }
 
   /// Return the number of subscribers on a topic.
@@ -410,7 +418,7 @@ public:
   AGNOCAST_PUBLIC
   size_t count_subscribers(const std::string & topic_name) const
   {
-    return get_subscription_count_core(node_topics_->resolve_topic_name(topic_name));
+    return node_graph_->count_subscribers(topic_name);
   }
 
   /// Create a publisher (QoS overload).
@@ -654,6 +662,7 @@ private:
 
   node_interfaces::NodeBase::SharedPtr node_base_;
   rclcpp::Logger logger_;
+  node_interfaces::NodeGraph::SharedPtr node_graph_;
   node_interfaces::NodeTopics::SharedPtr node_topics_;
   node_interfaces::NodeServices::SharedPtr node_services_;
   node_interfaces::NodeParameters::SharedPtr node_parameters_;

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -4,10 +4,13 @@
 #include "rclcpp/event.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
-#include "rclcpp/rclcpp.hpp"
 
+#include <chrono>
 #include <map>
 #include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace agnocast::node_interfaces

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -26,6 +26,9 @@ public:
 
   virtual ~NodeGraph() = default;
 
+  NodeGraph(const NodeGraph &) = delete;
+  NodeGraph & operator=(const NodeGraph &) = delete;
+
   size_t count_publishers(const std::string & topic_name) const override;
   size_t count_subscribers(const std::string & topic_name) const override;
 

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -4,6 +4,7 @@
 #include "rclcpp/event.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
+#include "rclcpp/version.h"
 
 #include <chrono>
 #include <map>
@@ -64,6 +65,12 @@ public:
     const std::string & topic_name, bool no_mangle = false) const override;
   std::vector<rclcpp::TopicEndpointInfo> get_subscriptions_info_by_topic(
     const std::string & topic_name, bool no_mangle = false) const override;
+
+  // rclcpp 28+ (Jazzy) added these methods to NodeGraphInterface.
+#if RCLCPP_VERSION_MAJOR >= 28
+  size_t count_clients(const std::string & service_name) const override;
+  size_t count_services(const std::string & service_name) const override;
+#endif
 
 private:
   NodeBase::SharedPtr node_base_;

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_graph.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "agnocast/node/node_interfaces/node_base.hpp"
+#include "rclcpp/event.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_graph_interface.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace agnocast::node_interfaces
+{
+
+class NodeGraph : public rclcpp::node_interfaces::NodeGraphInterface
+{
+public:
+  using SharedPtr = std::shared_ptr<NodeGraph>;
+  using WeakPtr = std::weak_ptr<NodeGraph>;
+
+  explicit NodeGraph(NodeBase::SharedPtr node_base);
+
+  virtual ~NodeGraph() = default;
+
+  size_t count_publishers(const std::string & topic_name) const override;
+  size_t count_subscribers(const std::string & topic_name) const override;
+
+  // ===== No-op methods =====
+  void notify_graph_change() override;
+  void notify_shutdown() override;
+
+  // ===== Not supported methods (throw runtime_error) =====
+  // Reporting the agnocast nodes requires the kmod to expose them, which it does not do yet.
+  std::vector<std::string> get_node_names() const override;
+  std::map<std::string, std::vector<std::string>> get_topic_names_and_types(
+    bool no_demangle = false) const override;
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types() const override;
+  std::map<std::string, std::vector<std::string>> get_service_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_) const override;
+  std::map<std::string, std::vector<std::string>> get_client_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_) const override;
+  std::map<std::string, std::vector<std::string>> get_publisher_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_,
+    bool no_demangle = false) const override;
+  std::map<std::string, std::vector<std::string>> get_subscriber_names_and_types_by_node(
+    const std::string & node_name, const std::string & namespace_,
+    bool no_demangle = false) const override;
+  std::vector<std::tuple<std::string, std::string, std::string>> get_node_names_with_enclaves()
+    const override;
+  std::vector<std::pair<std::string, std::string>> get_node_names_and_namespaces() const override;
+  const rcl_guard_condition_t * get_graph_guard_condition() const override;
+  rclcpp::Event::SharedPtr get_graph_event() override;
+  void wait_for_graph_change(
+    rclcpp::Event::SharedPtr event, std::chrono::nanoseconds timeout) override;
+  size_t count_graph_users() const override;
+  std::vector<rclcpp::TopicEndpointInfo> get_publishers_info_by_topic(
+    const std::string & topic_name, bool no_mangle = false) const override;
+  std::vector<rclcpp::TopicEndpointInfo> get_subscriptions_info_by_topic(
+    const std::string & topic_name, bool no_mangle = false) const override;
+
+private:
+  NodeBase::SharedPtr node_base_;
+};
+
+}  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -22,6 +22,7 @@ Node::Node(
     node_name, namespace_, options.context(), local_args_.get(), options.use_global_arguments(),
     options.use_intra_process_comms(), options.enable_topic_statistics())),
   logger_(rclcpp::get_logger(node_base_->get_name())),
+  node_graph_(std::make_shared<node_interfaces::NodeGraph>(node_base_)),
   node_topics_(std::make_shared<node_interfaces::NodeTopics>(node_base_)),
   node_services_(std::make_shared<node_interfaces::NodeServices>(node_base_)),
   node_parameters_(std::make_shared<node_interfaces::NodeParameters>(

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -15,12 +15,12 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_topic_names_and_t
 {
   (void)no_demangle;
   throw std::runtime_error("NodeGraph::get_topic_names_and_types is not supported in agnocast.");
-};
+}
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types() const
 {
   throw std::runtime_error("NodeGraph::get_service_names_and_types is not supported in agnocast.");
-};
+}
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types_by_node(
   const std::string & node_name, const std::string & namespace_) const
@@ -29,7 +29,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and
   (void)namespace_;
   throw std::runtime_error(
     "NodeGraph::get_service_names_and_types_by_node is not supported in agnocast.");
-};
+}
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_types_by_node(
   const std::string & node_name, const std::string & namespace_) const
@@ -38,7 +38,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_
   (void)namespace_;
   throw std::runtime_error(
     "NodeGraph::get_client_names_and_types_by_node is not supported in agnocast.");
-};
+}
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_and_types_by_node(
   const std::string & node_name, const std::string & namespace_, bool no_demangle) const
@@ -48,7 +48,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_a
   (void)no_demangle;
   throw std::runtime_error(
     "NodeGraph::get_publisher_names_and_types_by_node is not supported in agnocast.");
-};
+}
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_and_types_by_node(
   const std::string & node_name, const std::string & namespace_, bool no_demangle) const
@@ -58,26 +58,26 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_
   (void)no_demangle;
   throw std::runtime_error(
     "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast.");
-};
+}
 
 // Supporting this requires the kmod to report the nodes owning an agnocast endpoint, which it
 // does not do yet.
 std::vector<std::string> NodeGraph::get_node_names() const
 {
   throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast.");
-};
+}
 
 std::vector<std::tuple<std::string, std::string, std::string>>
 NodeGraph::get_node_names_with_enclaves() const
 {
   throw std::runtime_error("NodeGraph::get_node_names_with_enclaves is not supported in agnocast.");
-};
+}
 
 std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_namespaces() const
 {
   throw std::runtime_error(
     "NodeGraph::get_node_names_and_namespaces is not supported in agnocast.");
-};
+}
 
 // Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
 // agnocast::Node::count_publishers()/count_subscribers() delegate here, so the resolution and the
@@ -90,17 +90,17 @@ std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_n
 size_t NodeGraph::count_publishers(const std::string & topic_name) const
 {
   return get_publisher_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
-};
+}
 
 size_t NodeGraph::count_subscribers(const std::string & topic_name) const
 {
   return get_subscription_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
-};
+}
 
 const rcl_guard_condition_t * NodeGraph::get_graph_guard_condition() const
 {
   throw std::runtime_error("NodeGraph::get_graph_guard_condition is not supported in agnocast.");
-};
+}
 
 // No-op rather than throwing: agnocast has no graph events, so there is nothing to notify.
 // rclcpp utilities call these unconditionally when entities are created or the context shuts
@@ -116,7 +116,7 @@ void NodeGraph::notify_shutdown()
 rclcpp::Event::SharedPtr NodeGraph::get_graph_event()
 {
   throw std::runtime_error("NodeGraph::get_graph_event is not supported in agnocast.");
-};
+}
 
 void NodeGraph::wait_for_graph_change(
   rclcpp::Event::SharedPtr event, std::chrono::nanoseconds timeout)
@@ -124,12 +124,12 @@ void NodeGraph::wait_for_graph_change(
   (void)event;
   (void)timeout;
   throw std::runtime_error("NodeGraph::wait_for_graph_change is not supported in agnocast.");
-};
+}
 
 size_t NodeGraph::count_graph_users() const
 {
   throw std::runtime_error("NodeGraph::count_graph_users is not supported in agnocast.");
-};
+}
 
 std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
   const std::string & topic_name, bool no_mangle) const
@@ -137,7 +137,7 @@ std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
   (void)topic_name;
   (void)no_mangle;
   throw std::runtime_error("NodeGraph::get_publishers_info_by_topic is not supported in agnocast.");
-};
+}
 
 std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topic(
   const std::string & topic_name, bool no_mangle) const
@@ -146,6 +146,6 @@ std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topi
   (void)no_mangle;
   throw std::runtime_error(
     "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast.");
-};
+}
 
 }  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -3,6 +3,8 @@
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 
+#include <stdexcept>
+
 namespace agnocast::node_interfaces
 {
 

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -150,4 +150,19 @@ std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topi
     "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast.");
 }
 
+// rclcpp 28+ (Jazzy) added these methods to NodeGraphInterface.
+#if RCLCPP_VERSION_MAJOR >= 28
+size_t NodeGraph::count_clients(const std::string & service_name) const
+{
+  (void)service_name;
+  throw std::runtime_error("NodeGraph::count_clients is not supported in agnocast.");
+}
+
+size_t NodeGraph::count_services(const std::string & service_name) const
+{
+  (void)service_name;
+  throw std::runtime_error("NodeGraph::count_services is not supported in agnocast.");
+}
+#endif
+
 }  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -14,12 +14,12 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_topic_names_and_t
   bool no_demangle) const
 {
   (void)no_demangle;
-  throw std::runtime_error("NodeGraph::get_topic_names_and_types is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_topic_names_and_types is not supported in agnocast.");
 };
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types() const
 {
-  throw std::runtime_error("NodeGraph::get_service_names_and_types is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_service_names_and_types is not supported in agnocast.");
 };
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types_by_node(
@@ -28,7 +28,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and
   (void)node_name;
   (void)namespace_;
   throw std::runtime_error(
-    "NodeGraph::get_service_names_and_types_by_node is not supported in agnocast. ");
+    "NodeGraph::get_service_names_and_types_by_node is not supported in agnocast.");
 };
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_types_by_node(
@@ -37,7 +37,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_
   (void)node_name;
   (void)namespace_;
   throw std::runtime_error(
-    "NodeGraph::get_client_names_and_types_by_node is not supported in agnocast. ");
+    "NodeGraph::get_client_names_and_types_by_node is not supported in agnocast.");
 };
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_and_types_by_node(
@@ -47,7 +47,7 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_a
   (void)namespace_;
   (void)no_demangle;
   throw std::runtime_error(
-    "NodeGraph::get_publisher_names_and_types_by_node is not supported in agnocast. ");
+    "NodeGraph::get_publisher_names_and_types_by_node is not supported in agnocast.");
 };
 
 std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_and_types_by_node(
@@ -57,27 +57,26 @@ std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_
   (void)namespace_;
   (void)no_demangle;
   throw std::runtime_error(
-    "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast. ");
+    "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast.");
 };
 
 // Supporting this requires the kmod to report the nodes owning an agnocast endpoint, which it
 // does not do yet.
 std::vector<std::string> NodeGraph::get_node_names() const
 {
-  throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast.");
 };
 
 std::vector<std::tuple<std::string, std::string, std::string>>
 NodeGraph::get_node_names_with_enclaves() const
 {
-  throw std::runtime_error(
-    "NodeGraph::get_node_names_with_enclaves is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_node_names_with_enclaves is not supported in agnocast.");
 };
 
 std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_namespaces() const
 {
   throw std::runtime_error(
-    "NodeGraph::get_node_names_and_namespaces is not supported in agnocast. ");
+    "NodeGraph::get_node_names_and_namespaces is not supported in agnocast.");
 };
 
 // Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
@@ -100,7 +99,7 @@ size_t NodeGraph::count_subscribers(const std::string & topic_name) const
 
 const rcl_guard_condition_t * NodeGraph::get_graph_guard_condition() const
 {
-  throw std::runtime_error("NodeGraph::get_graph_guard_condition is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_graph_guard_condition is not supported in agnocast.");
 };
 
 // No-op rather than throwing: agnocast has no graph events, so there is nothing to notify.
@@ -116,7 +115,7 @@ void NodeGraph::notify_shutdown()
 
 rclcpp::Event::SharedPtr NodeGraph::get_graph_event()
 {
-  throw std::runtime_error("NodeGraph::get_graph_event is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_graph_event is not supported in agnocast.");
 };
 
 void NodeGraph::wait_for_graph_change(
@@ -124,12 +123,12 @@ void NodeGraph::wait_for_graph_change(
 {
   (void)event;
   (void)timeout;
-  throw std::runtime_error("NodeGraph::wait_for_graph_change is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::wait_for_graph_change is not supported in agnocast.");
 };
 
 size_t NodeGraph::count_graph_users() const
 {
-  throw std::runtime_error("NodeGraph::count_graph_users is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::count_graph_users is not supported in agnocast.");
 };
 
 std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
@@ -137,8 +136,7 @@ std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
 {
   (void)topic_name;
   (void)no_mangle;
-  throw std::runtime_error(
-    "NodeGraph::get_publishers_info_by_topic is not supported in agnocast. ");
+  throw std::runtime_error("NodeGraph::get_publishers_info_by_topic is not supported in agnocast.");
 };
 
 std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topic(
@@ -147,7 +145,7 @@ std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topi
   (void)topic_name;
   (void)no_mangle;
   throw std::runtime_error(
-    "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast. ");
+    "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast.");
 };
 
 }  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -1,0 +1,153 @@
+#include "agnocast/node/node_interfaces/node_graph.hpp"
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_subscription.hpp"
+
+namespace agnocast::node_interfaces
+{
+
+NodeGraph::NodeGraph(NodeBase::SharedPtr node_base) : node_base_(std::move(node_base))
+{
+}
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_topic_names_and_types(
+  bool no_demangle) const
+{
+  (void)no_demangle;
+  throw std::runtime_error("NodeGraph::get_topic_names_and_types is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types() const
+{
+  throw std::runtime_error("NodeGraph::get_service_names_and_types is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_service_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_) const
+{
+  (void)node_name;
+  (void)namespace_;
+  throw std::runtime_error(
+    "NodeGraph::get_service_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_client_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_) const
+{
+  (void)node_name;
+  (void)namespace_;
+  throw std::runtime_error(
+    "NodeGraph::get_client_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_publisher_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_, bool no_demangle) const
+{
+  (void)node_name;
+  (void)namespace_;
+  (void)no_demangle;
+  throw std::runtime_error(
+    "NodeGraph::get_publisher_names_and_types_by_node is not supported in agnocast. ");
+};
+
+std::map<std::string, std::vector<std::string>> NodeGraph::get_subscriber_names_and_types_by_node(
+  const std::string & node_name, const std::string & namespace_, bool no_demangle) const
+{
+  (void)node_name;
+  (void)namespace_;
+  (void)no_demangle;
+  throw std::runtime_error(
+    "NodeGraph::get_subscriber_names_and_types_by_node is not supported in agnocast. ");
+};
+
+// Supporting this requires the kmod to report the nodes owning an agnocast endpoint, which it
+// does not do yet.
+std::vector<std::string> NodeGraph::get_node_names() const
+{
+  throw std::runtime_error("NodeGraph::get_node_names is not supported in agnocast. ");
+};
+
+std::vector<std::tuple<std::string, std::string, std::string>>
+NodeGraph::get_node_names_with_enclaves() const
+{
+  throw std::runtime_error(
+    "NodeGraph::get_node_names_with_enclaves is not supported in agnocast. ");
+};
+
+std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_namespaces() const
+{
+  throw std::runtime_error(
+    "NodeGraph::get_node_names_and_namespaces is not supported in agnocast. ");
+};
+
+// Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
+// agnocast::Node::count_publishers()/count_subscribers() delegate here, so the resolution and the
+// bridge bookkeeping live in one place.
+//
+// Note that count_subscribers() does not see agnocast subscribers in the caller's own process:
+// get_subscription_count_core() reports ret_other_process_subscriber_num, because its original
+// caller (agnocast::Publisher::get_subscription_count()) asks how many peers receive a published
+// message. count_publishers() has no such split.
+size_t NodeGraph::count_publishers(const std::string & topic_name) const
+{
+  return get_publisher_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
+};
+
+size_t NodeGraph::count_subscribers(const std::string & topic_name) const
+{
+  return get_subscription_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
+};
+
+const rcl_guard_condition_t * NodeGraph::get_graph_guard_condition() const
+{
+  throw std::runtime_error("NodeGraph::get_graph_guard_condition is not supported in agnocast. ");
+};
+
+// No-op rather than throwing: agnocast has no graph events, so there is nothing to notify.
+// rclcpp utilities call these unconditionally when entities are created or the context shuts
+// down, and throwing there would break otherwise working code.
+void NodeGraph::notify_graph_change()
+{
+}
+
+void NodeGraph::notify_shutdown()
+{
+}
+
+rclcpp::Event::SharedPtr NodeGraph::get_graph_event()
+{
+  throw std::runtime_error("NodeGraph::get_graph_event is not supported in agnocast. ");
+};
+
+void NodeGraph::wait_for_graph_change(
+  rclcpp::Event::SharedPtr event, std::chrono::nanoseconds timeout)
+{
+  (void)event;
+  (void)timeout;
+  throw std::runtime_error("NodeGraph::wait_for_graph_change is not supported in agnocast. ");
+};
+
+size_t NodeGraph::count_graph_users() const
+{
+  throw std::runtime_error("NodeGraph::count_graph_users is not supported in agnocast. ");
+};
+
+std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_publishers_info_by_topic(
+  const std::string & topic_name, bool no_mangle) const
+{
+  (void)topic_name;
+  (void)no_mangle;
+  throw std::runtime_error(
+    "NodeGraph::get_publishers_info_by_topic is not supported in agnocast. ");
+};
+
+std::vector<rclcpp::TopicEndpointInfo> NodeGraph::get_subscriptions_info_by_topic(
+  const std::string & topic_name, bool no_mangle) const
+{
+  (void)topic_name;
+  (void)no_mangle;
+  throw std::runtime_error(
+    "NodeGraph::get_subscriptions_info_by_topic is not supported in agnocast. ");
+};
+
+}  // namespace agnocast::node_interfaces

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -13,8 +13,6 @@
 
 using StringMsg = std_msgs::msg::String;
 
-// The kmod keeps a topic entry alive for the lifetime of the process, so every test uses its own
-// topic name to stay independent of the ones before it.
 class NodeGraphIntegrationTest : public ::testing::Test
 {
 protected:
@@ -27,8 +25,8 @@ protected:
 
   void TearDown() override
   {
-    node_.reset();
     graph_.reset();
+    node_.reset();
     if (agnocast::ok()) {
       agnocast::shutdown();
     }
@@ -72,6 +70,16 @@ TEST_F(NodeGraphIntegrationTest, count_publishers_counts_every_publisher_on_the_
   EXPECT_EQ(graph_->count_publishers(topic), 2u);
 }
 
+TEST_F(NodeGraphIntegrationTest, count_publishers_drops_when_the_publisher_is_destroyed)
+{
+  const std::string topic = "/test_node_graph_pub_destroyed";
+  {
+    auto pub = node_->create_publisher<StringMsg>(topic, 1);
+    ASSERT_EQ(graph_->count_publishers(topic), 1u);
+  }
+  EXPECT_EQ(graph_->count_publishers(topic), 0u);
+}
+
 // count_subscribers() reports ret_other_process_subscriber_num, so a subscriber living in the
 // caller's own process is not counted. This is the documented limitation, not an accident: the
 // underlying helper exists to tell a publisher how many peers receive a published message.
@@ -86,8 +94,6 @@ TEST_F(NodeGraphIntegrationTest, count_subscribers_does_not_see_same_process_sub
 
 TEST_F(NodeGraphIntegrationTest, count_publishers_resolves_a_relative_topic_name)
 {
-  agnocast::shutdown();
-  agnocast::init(0, nullptr);
   auto node = std::make_shared<agnocast::Node>("test_node_graph_rel", "/test_ns");
   auto graph = node->get_node_graph_interface();
 
@@ -98,15 +104,10 @@ TEST_F(NodeGraphIntegrationTest, count_publishers_resolves_a_relative_topic_name
   EXPECT_EQ(graph->count_publishers("/relative_topic"), 0u);
 }
 
-// agnocast::Node::count_publishers()/count_subscribers() are thin wrappers over the interface.
 TEST_F(NodeGraphIntegrationTest, node_delegates_counting_to_the_node_graph_interface)
 {
   const std::string topic = "/test_node_graph_delegation";
-
   auto pub = node_->create_publisher<StringMsg>(topic, 1);
-
-  EXPECT_EQ(node_->count_publishers(topic), graph_->count_publishers(topic));
-  EXPECT_EQ(node_->count_subscribers(topic), graph_->count_subscribers(topic));
   EXPECT_EQ(node_->count_publishers(topic), 1u);
 }
 

--- a/src/agnocastlib/test/integration/test_node_graph.cpp
+++ b/src/agnocastlib/test/integration/test_node_graph.cpp
@@ -1,0 +1,138 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/node_interfaces/node_graph.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using StringMsg = std_msgs::msg::String;
+
+// The kmod keeps a topic entry alive for the lifetime of the process, so every test uses its own
+// topic name to stay independent of the ones before it.
+class NodeGraphIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    node_ = std::make_shared<agnocast::Node>("test_node_graph");
+    graph_ = node_->get_node_graph_interface();
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    graph_.reset();
+    if (agnocast::ok()) {
+      agnocast::shutdown();
+    }
+  }
+
+  std::shared_ptr<agnocast::Node> node_;
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr graph_;
+};
+
+TEST_F(NodeGraphIntegrationTest, get_node_graph_interface_returns_node_graph)
+{
+  ASSERT_NE(graph_, nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<agnocast::node_interfaces::NodeGraph>(graph_), nullptr);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_is_zero_for_unknown_topic)
+{
+  EXPECT_EQ(graph_->count_publishers("/test_node_graph_no_such_topic"), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_subscribers_is_zero_for_unknown_topic)
+{
+  EXPECT_EQ(graph_->count_subscribers("/test_node_graph_no_such_topic"), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_counts_a_created_publisher)
+{
+  const std::string topic = "/test_node_graph_count_pub";
+  EXPECT_EQ(graph_->count_publishers(topic), 0u);
+
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  EXPECT_EQ(graph_->count_publishers(topic), 1u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_counts_every_publisher_on_the_topic)
+{
+  const std::string topic = "/test_node_graph_count_two_pubs";
+
+  auto pub1 = node_->create_publisher<StringMsg>(topic, 1);
+  auto pub2 = node_->create_publisher<StringMsg>(topic, 1);
+  EXPECT_EQ(graph_->count_publishers(topic), 2u);
+}
+
+// count_subscribers() reports ret_other_process_subscriber_num, so a subscriber living in the
+// caller's own process is not counted. This is the documented limitation, not an accident: the
+// underlying helper exists to tell a publisher how many peers receive a published message.
+TEST_F(NodeGraphIntegrationTest, count_subscribers_does_not_see_same_process_subscriber)
+{
+  const std::string topic = "/test_node_graph_count_sub";
+
+  auto sub = node_->create_subscription<StringMsg>(
+    topic, 1, [](const agnocast::ipc_shared_ptr<StringMsg> &) {});
+  EXPECT_EQ(graph_->count_subscribers(topic), 0u);
+}
+
+TEST_F(NodeGraphIntegrationTest, count_publishers_resolves_a_relative_topic_name)
+{
+  agnocast::shutdown();
+  agnocast::init(0, nullptr);
+  auto node = std::make_shared<agnocast::Node>("test_node_graph_rel", "/test_ns");
+  auto graph = node->get_node_graph_interface();
+
+  auto pub = node->create_publisher<StringMsg>("relative_topic", 1);
+
+  EXPECT_EQ(graph->count_publishers("relative_topic"), 1u);
+  EXPECT_EQ(graph->count_publishers("/test_ns/relative_topic"), 1u);
+  EXPECT_EQ(graph->count_publishers("/relative_topic"), 0u);
+}
+
+// agnocast::Node::count_publishers()/count_subscribers() are thin wrappers over the interface.
+TEST_F(NodeGraphIntegrationTest, node_delegates_counting_to_the_node_graph_interface)
+{
+  const std::string topic = "/test_node_graph_delegation";
+
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+
+  EXPECT_EQ(node_->count_publishers(topic), graph_->count_publishers(topic));
+  EXPECT_EQ(node_->count_subscribers(topic), graph_->count_subscribers(topic));
+  EXPECT_EQ(node_->count_publishers(topic), 1u);
+}
+
+// agnocast has no graph events, but rclcpp calls these unconditionally, so they must not throw.
+TEST_F(NodeGraphIntegrationTest, notify_graph_change_and_notify_shutdown_are_no_ops)
+{
+  EXPECT_NO_THROW(graph_->notify_graph_change());
+  EXPECT_NO_THROW(graph_->notify_shutdown());
+}
+
+TEST_F(NodeGraphIntegrationTest, unsupported_methods_throw_runtime_error)
+{
+  EXPECT_THROW(graph_->get_node_names(), std::runtime_error);
+  EXPECT_THROW(graph_->get_topic_names_and_types(), std::runtime_error);
+  EXPECT_THROW(graph_->get_service_names_and_types(), std::runtime_error);
+  EXPECT_THROW(graph_->get_service_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_client_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_publisher_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_subscriber_names_and_types_by_node("n", "/"), std::runtime_error);
+  EXPECT_THROW(graph_->get_node_names_with_enclaves(), std::runtime_error);
+  EXPECT_THROW(graph_->get_node_names_and_namespaces(), std::runtime_error);
+  EXPECT_THROW(graph_->get_graph_guard_condition(), std::runtime_error);
+  EXPECT_THROW(graph_->get_graph_event(), std::runtime_error);
+  EXPECT_THROW(
+    graph_->wait_for_graph_change(nullptr, std::chrono::nanoseconds(0)), std::runtime_error);
+  EXPECT_THROW(graph_->count_graph_users(), std::runtime_error);
+  EXPECT_THROW(graph_->get_publishers_info_by_topic("/t"), std::runtime_error);
+  EXPECT_THROW(graph_->get_subscriptions_info_by_topic("/t"), std::runtime_error);
+}


### PR DESCRIPTION
## Description

Adds `agnocast::node_interfaces::NodeGraph`, an implementation of `rclcpp::node_interfaces::NodeGraphInterface` reachable via `agnocast::Node::get_node_graph_interface()`.

- `count_publishers()` / `count_subscribers()` are supported. They delegate to the same helpers as `agnocast::Publisher::get_subscription_count()` / `agnocast::Subscription::get_publisher_count()`, so the bridge-endpoint bookkeeping stays in one place.
- `notify_graph_change()` / `notify_shutdown()` are no-ops. agnocast has no graph events, and rclcpp utilities call these unconditionally when entities are created or the context shuts down, so throwing would break otherwise working code.
- The remaining methods throw `std::runtime_error`. The per-method status is documented in `docs/agnocast_node_interface_comparison.md`.

No kmod change. `get_node_names()` needs the kmod to report the nodes owning an agnocast endpoint and is added in a follow-up.

## Related links

- Follow-up that implements `get_node_names()`: #1493
- Supersedes #1241

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Only `count_publishers()` / `count_subscribers()` are reachable behaviour here; everything else either throws or is a no-op.

## Post-merge checklist

- [x] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
