### PR TITLE
refactor(ros2agnocast_discovery_agent): rename the executable to agnocast_discovery_agent

### DIFF
--- a/scripts/test/e2e_test_cross_ns_cli.bash
+++ b/scripts/test/e2e_test_cross_ns_cli.bash
@@ -64,7 +64,7 @@ cleanup() {
 trap cleanup EXIT
 
 yellow "Starting agnocast_discovery_agent and talker..."
-ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
 sleep "$DAEMON_WARMUP_SEC"
 ros2 launch agnocast_sample_application talker.launch.xml > "$LOG_DIR/talker.log" 2>&1 &
 sleep "$TALKER_WARMUP_SEC"

--- a/scripts/test/e2e_test_discovery_agent.bash
+++ b/scripts/test/e2e_test_discovery_agent.bash
@@ -53,14 +53,14 @@ cleanup() {
     # talker / agent as grandchildren, so also match by binary path.
     pkill -P $$ 2>/dev/null || true
     pkill -KILL -f '/agnocast_sample_application/lib/.*/talker' 2>/dev/null || true
-    pkill -KILL -f '/ros2agnocast_discovery_agent/lib/ros2agnocast_discovery_agent/discovery_agent' 2>/dev/null || true
+    pkill -KILL -f '/ros2agnocast_discovery_agent/lib/ros2agnocast_discovery_agent/agnocast_discovery_agent' 2>/dev/null || true
     sleep 1
     rm -rf "$LOG_DIR"
 }
 trap cleanup EXIT
 
 yellow "Starting agnocast_discovery_agent..."
-ros2 run ros2agnocast_discovery_agent discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
+ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent > "$LOG_DIR/agent.log" 2>&1 &
 sleep "$DAEMON_WARMUP_SEC"
 
 if ! grep -q "discovery_agent up" "$LOG_DIR/agent.log"; then

--- a/src/agnocastlib/package.xml
+++ b/src/agnocastlib/package.xml
@@ -48,9 +48,9 @@
   <!-- Uncomment when agnocast_heaphook is released from PPA -->
   <!-- <exec_depend>agnocast_heaphook</exec_depend> -->
 
-  <!-- initialize_agnocast() forks+execs `ros2 run ros2agnocast_discovery_agent discovery_agent`
-       (the auto-forked discovery agent), so the package must be present at runtime. Runtime-only,
-       so it does not affect build order. -->
+  <!-- initialize_agnocast() forks+execs the auto-forked discovery agent
+       (`ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent`), so the package must be
+       present at runtime. Runtime-only, so it does not affect build order. -->
   <exec_depend>ros2agnocast_discovery_agent</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>

--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -245,8 +245,8 @@ void poll_for_bridge_manager()
 void exec_discovery_agent()
 {
   execlp(
-    "ros2", "ros2", "run", "ros2agnocast_discovery_agent", "discovery_agent", "--exit-when-idle",
-    static_cast<char *>(nullptr));
+    "ros2", "ros2", "run", "ros2agnocast_discovery_agent", "agnocast_discovery_agent",
+    "--exit-when-idle", static_cast<char *>(nullptr));
   // execlp only returns on failure. This still runs in the pre-allocator forked child, so the
   // failure path must be async-signal-safe and allocation-free: RCLCPP_ERROR / strerror / exit()
   // may allocate or run atexit handlers before the TLSF allocator is ready. Use write() + _exit().

--- a/src/ros2agnocast/ros2agnocast/discovery.py
+++ b/src/ros2agnocast/ros2agnocast/discovery.py
@@ -160,7 +160,7 @@ def warn_if_using_fallback(
         print(
             'NOTE: no /_agnocast_discovery agent visible; showing local '
             'NS only via ioctl. Start one with '
-            '`ros2 run ros2agnocast_discovery_agent discovery_agent` to '
+            '`ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent` to '
             'see other NSes / ECUs.',
             file=sys.stderr)
     else:

--- a/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
+++ b/src/ros2agnocast_discovery_agent/launch/discovery_agent.launch.xml
@@ -9,6 +9,6 @@
        (`agnocast_discovery_agent_<host8hex>_<ipc_ns_inode>`). Setting
        `name=` here would remap and break the per-NS uniqueness. -->
   <node pkg="ros2agnocast_discovery_agent"
-        exec="discovery_agent"
+        exec="agnocast_discovery_agent"
         output="screen"/>
 </launch>

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -496,5 +496,17 @@ def main(argv=None) -> int:
     return 0
 
 
+def main_deprecated_alias(argv=None) -> int:
+    """Entry point for the old ``discovery_agent`` name: warn once, then run ``main()``.
+
+    Kept so launch files and units that still spawn ``discovery_agent`` keep working; it is
+    scheduled for removal, which is a user-facing break and needs its own release.
+    """
+    sys.stderr.write(
+        'agnocast_discovery_agent: the `discovery_agent` executable is deprecated; '
+        'use `agnocast_discovery_agent` instead.\n')
+    return main(argv)
+
+
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/src/ros2agnocast_discovery_agent/scripts/agnocast_discovery_agent
+++ b/src/ros2agnocast_discovery_agent/scripts/agnocast_discovery_agent
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Console-script wrapper so `ros2 run ros2agnocast_discovery_agent discovery_agent` works.
+"""Wrapper so `ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent` works.
 
 ament_python's `entry_points` would normally produce a binary in `bin/`, but
 `ros2 run` looks in `lib/<pkg>/`. The setup.py installs this file to
-`lib/<pkg>/discovery_agent` so the standard ros2 run discovery rule finds it.
+`lib/<pkg>/agnocast_discovery_agent` so the standard ros2 run rule finds it.
 """
 import sys
 

--- a/src/ros2agnocast_discovery_agent/scripts/discovery_agent
+++ b/src/ros2agnocast_discovery_agent/scripts/discovery_agent
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Deprecated alias of `agnocast_discovery_agent`, kept so existing callers keep working.
+
+Installed to `lib/<pkg>/discovery_agent` for `ros2 run` (and as a `bin/` console script),
+alongside the new name. Warns on stderr and then runs the agent.
+"""
+import sys
+
+from ros2agnocast_discovery_agent.agent import main_deprecated_alias
+
+if __name__ == '__main__':
+    sys.exit(main_deprecated_alias(sys.argv))

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -14,7 +14,7 @@ setup(
         ('share/' + package_name + '/systemd',
             ['systemd/agnocast-domain-bridge.service.example', 'systemd/README.md']),
         ('lib/' + package_name,
-            ['scripts/discovery_agent', 'scripts/register_domain_bridge']),
+            ['scripts/agnocast_discovery_agent', 'scripts/register_domain_bridge']),
     ],
     install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
@@ -29,7 +29,7 @@ setup(
     license='Apache License 2.0',
     entry_points={
         'console_scripts': [
-            'discovery_agent = ros2agnocast_discovery_agent.agent:main',
+            'agnocast_discovery_agent = ros2agnocast_discovery_agent.agent:main',
             'register_domain_bridge = '
             'ros2agnocast_discovery_agent.register_domain_bridge:main',
         ],

--- a/src/ros2agnocast_discovery_agent/setup.py
+++ b/src/ros2agnocast_discovery_agent/setup.py
@@ -14,7 +14,8 @@ setup(
         ('share/' + package_name + '/systemd',
             ['systemd/agnocast-domain-bridge.service.example', 'systemd/README.md']),
         ('lib/' + package_name,
-            ['scripts/agnocast_discovery_agent', 'scripts/register_domain_bridge']),
+            ['scripts/agnocast_discovery_agent', 'scripts/discovery_agent',
+             'scripts/register_domain_bridge']),
     ],
     install_requires=['setuptools', 'pyyaml'],
     zip_safe=True,
@@ -30,6 +31,8 @@ setup(
     entry_points={
         'console_scripts': [
             'agnocast_discovery_agent = ros2agnocast_discovery_agent.agent:main',
+            # Deprecated alias of the above; remove in a release that may break users.
+            'discovery_agent = ros2agnocast_discovery_agent.agent:main_deprecated_alias',
             'register_domain_bridge = '
             'ros2agnocast_discovery_agent.register_domain_bridge:main',
         ],

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -322,6 +322,15 @@ def test_main_returns_error_when_claim_ioctl_fails(monkeypatch):
     assert agent.main(argv=[]) == 1
 
 
+def test_main_deprecated_alias_warns_and_delegates(monkeypatch, capsys):
+    """The old `discovery_agent` name still runs the agent, but says it is deprecated."""
+    from ros2agnocast_discovery_agent import agent
+    fake = _FakeSingletonLib(register_ret=-1)
+    monkeypatch.setattr(agent, '_load_ioctl_wrapper', lambda: fake)
+    assert agent.main_deprecated_alias(argv=[]) == 1
+    assert 'deprecated' in capsys.readouterr().err
+
+
 def test_main_returns_error_when_wrapper_unavailable(monkeypatch):
     """A missing library or symbol (version skew) exits 1 cleanly, not with a traceback."""
     from ros2agnocast_discovery_agent import agent


### PR DESCRIPTION
## Description

Rename the discovery agent executable from `discovery_agent` to `agnocast_discovery_agent`. The old
name is generic enough to collide with an unrelated executable of the same name, which matters now
that the executable is also resolved by name rather than only through `ros2 run`.

The recommended way to start an agent manually becomes:

```
ros2 run ros2agnocast_discovery_agent agnocast_discovery_agent
```

The old name stays installed as a deprecated alias (both as a `bin/` console script and under
`lib/<pkg>/`), so launch files, systemd units and scripts that spawn `discovery_agent` keep working;
it prints a one-line deprecation notice on stderr and then runs the agent. Removing the alias is a
user-facing break and is left to a release that may make one.

`register_domain_bridge` is left as is.

## Related links
https://github.com/autowarefoundation/agnocast/issues/1497

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`ros2 pkg executables ros2agnocast_discovery_agent` lists both names,
`ros2 launch ros2agnocast_discovery_agent discovery_agent.launch.xml` brings the agent up under the
new name, and `ros2 run ros2agnocast_discovery_agent discovery_agent` still starts it after printing
the deprecation notice.

## Notes for reviewers

`autoware_core`'s `autoware_agnocast_wrapper` spawns the agent with `executable="discovery_agent"`
(`launch/discovery_agent.launch.py`). A `launch_ros` `Node` whose executable cannot be found aborts
the whole launch tree, not just that node, which is why the alias is kept rather than renaming
outright.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

Will be updated in the following PR.
https://github.com/autowarefoundation/agnocast_doc/pull/50

## Version Update Label (Required)

`need-patch-update`
