### PR TITLE
fix(kmod): return the most recent entry from take() when allow_same_message is set

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1165,6 +1165,19 @@ int agnocast_ioctl_take_msg(
 
     candidate_en = en;
     searched_count++;
+
+    // For allow_same_message = false that is the intended result: the
+    // `en->entry_id == latest_received_entry_id` break above stops the walk at the
+    // read watermark, so the surviving candidate is the oldest not-yet-received
+    // entry (FIFO).
+    //
+    // For allow_same_message = true that break is disabled, so the walk would run
+    // past the watermark down to the bottom of the window. take_data() passes true
+    // and is documented to "always return the most recent message", so stop at the
+    // first (newest) qualifying entry instead.
+    if (allow_same_message) {
+      break;
+    }
   }
 
   if (candidate_en) {

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -168,7 +168,7 @@ void test_case_take_msg_take_one(struct kunit * test)
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two(struct kunit * test)
+void test_case_take_msg_take_the_latest_one_when_sub_qos_depth_is_two(struct kunit * test)
 {
   // Arrange
   topic_local_id_t publisher_id;
@@ -206,8 +206,10 @@ void test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two(struct kuni
     KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
 
   // Assert
+  // allow_same_message is true, so take is expected to return the most recent entry
+  // regardless of the subscriber's qos_depth.
   KUNIT_EXPECT_EQ(test, ret3, 0);
-  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret1.ret_entry_id);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
     test,
     agnocast_get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
@@ -719,8 +721,10 @@ void test_case_take_msg_transient_local_publish_num_smaller_than_sub_qos_smaller
     KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
 
   // Assert
+  // allow_same_message is true, so take is expected to return the most recent entry
+  // regardless of the subscriber's qos_depth.
   KUNIT_EXPECT_EQ(test, ret4, 0);
-  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret1.ret_entry_id);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
     test,
     agnocast_get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -496,12 +496,14 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
     ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
   KUNIT_ASSERT_EQ(test, ret, 0);
 
+  int64_t latest_published_entry_id = ioctl_publish_msg_ret.ret_entry_id;
   for (uint32_t i = 0; i < qos_depth - 1; i++) {
     union ioctl_publish_msg_args ioctl_publish_msg_ret;
     int ret = agnocast_ioctl_publish_msg(
       TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, subscriber_ids_buf,
       ARRAY_SIZE(subscriber_ids_buf), &ioctl_publish_msg_ret);
     KUNIT_ASSERT_EQ(test, ret, 0);
+    latest_published_entry_id = ioctl_publish_msg_ret.ret_entry_id;
   }
 
   const bool allow_same_message = true;
@@ -515,11 +517,11 @@ void test_case_take_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret3, 0);
-  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, latest_published_entry_id);
   KUNIT_EXPECT_EQ(
     test,
     agnocast_get_latest_received_entry_id(TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id),
-    ioctl_publish_msg_ret.ret_entry_id);
+    latest_published_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_num, 1);
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].pid, publisher_pid);
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -206,8 +206,6 @@ void test_case_take_msg_take_the_latest_one_when_sub_qos_depth_is_two(struct kun
     KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
 
   // Assert
-  // allow_same_message is true, so take is expected to return the most recent entry
-  // regardless of the subscriber's qos_depth.
   KUNIT_EXPECT_EQ(test, ret3, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(
@@ -721,8 +719,6 @@ void test_case_take_msg_transient_local_publish_num_smaller_than_sub_qos_smaller
     KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
 
   // Assert
-  // allow_same_message is true, so take is expected to return the most recent entry
-  // regardless of the subscriber's qos_depth.
   KUNIT_EXPECT_EQ(test, ret4, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret2.ret_entry_id);
   KUNIT_EXPECT_EQ(

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -6,7 +6,7 @@
   KUNIT_CASE(test_case_take_msg_no_topic), KUNIT_CASE(test_case_take_msg_no_subscriber),          \
     KUNIT_CASE(test_case_take_msg_no_publish_nothing_to_take),                                    \
     KUNIT_CASE(test_case_take_msg_take_one),                                                      \
-    KUNIT_CASE(test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two),                  \
+    KUNIT_CASE(test_case_take_msg_take_the_latest_one_when_sub_qos_depth_is_two),                 \
     KUNIT_CASE(test_case_take_msg_take_one_again_with_allow_same_message),                        \
     KUNIT_CASE(test_case_take_msg_take_one_again_not_allow_same_message),                         \
     KUNIT_CASE(                                                                                   \
@@ -36,7 +36,7 @@ void test_case_take_msg_no_topic(struct kunit * test);
 void test_case_take_msg_no_subscriber(struct kunit * test);
 void test_case_take_msg_no_publish_nothing_to_take(struct kunit * test);
 void test_case_take_msg_take_one(struct kunit * test);
-void test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two(struct kunit * test);
+void test_case_take_msg_take_the_latest_one_when_sub_qos_depth_is_two(struct kunit * test);
 void test_case_take_msg_take_one_again_with_allow_same_message(struct kunit * test);
 void test_case_take_msg_take_one_again_not_allow_same_message(struct kunit * test);
 void test_case_take_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_qos_depth(

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -347,9 +347,11 @@ public:
 
   /**
    * @brief Retrieve the latest message from the topic.
-   * @param allow_same_message  If true, may return the same message as the previous call
-   *                            (useful for always having the latest value). If false, returns
-   *                            only new messages since the last take.
+   * @param allow_same_message  If true, returns the most recent message regardless of the
+   *                            subscription's history depth, and may return the same message as
+   *                            the previous call (useful for always having the latest value).
+   *                            If false, returns the oldest message not yet received, i.e. FIFO,
+   *                            searching back at most the history depth.
    * @return Shared pointer to the message, or empty if unavailable.
    */
   AGNOCAST_PUBLIC


### PR DESCRIPTION
## Description
`TakeSubscription::take(allow_same_message = true)` — the mode `PollingSubscriber::take_data()` uses — returns the **oldest surviving entry within the QoS window** instead of the most recent one when the subscription's `qos_depth` is greater than 1.

The documentation, the unit tests and the implementation currently disagree with each other:

| | |
|---|---|
| `take_data()` doc comment — "Always returns the most recent message even if already retrieved" | newest |
| `take()` doc comment — "@brief Retrieve the latest message from the topic", `allow_same_message` "useful for always having the latest value" | newest (but it is the brief for both modes, so it is loose) |
| kunit `test_case_take_msg_take_the_first_one_when_sub_qos_depth_is_two` | **oldest** |
| implementation | **oldest** |

This PR resolves the contradiction in favour of the documentation, because the purpose of `take_data()` (polling for the current value, mirroring `autoware_utils_rclcpp::InterProcessPollingSubscriber`) only makes sense with "newest".

`take(allow_same_message = false)` is untouched and keeps returning the oldest not-yet-received entry (FIFO).

### Observed behaviour before this change

With a subscriber polling at the publish rate, the returned message stays exactly `qos_depth - 1` messages behind the newest one and the lag never recovers.

Reproducer: a single `rclcpp::Node` with an agnocast publisher at 5 Hz and a `PollingSubscriber` polled at 1 Hz on the same topic, each message carrying a sequence number. `lag` is `newest_published_seq - taken_seq`.

```
###### sub_qos_depth=1 ######
take: seq=4    entry_id=5    lag=0   (last_published seq=4)
take: seq=9    entry_id=10   lag=0   (last_published seq=9)

###### sub_qos_depth=3 ######
take: seq=2    entry_id=3    lag=2   (last_published seq=4)
take: seq=7    entry_id=8    lag=2   (last_published seq=9)

###### sub_qos_depth=10 ######
take: seq=0    entry_id=1    lag=4   (last_published seq=4)
take: seq=0    entry_id=1    lag=9   (last_published seq=9)   <- same entry returned again
take: seq=5    entry_id=6    lag=9   (last_published seq=14)  <- seq 1..4 skipped
take: seq=10   entry_id=11   lag=9   (last_published seq=19)
```

After this change, all three depths report `lag=0` with identical output.

### Side effect worth noting

After this change the subscription's `qos_depth` has **no effect** on `take(allow_same_message = true)`: the search stops on the first iteration. `sub_info->qos_depth` is only consulted in `receive_msg()` and in this loop, and entry retention is bounded by the *publisher's* `qos_depth`.

Since `PollingSubscriber` only exposes `take_data()`, the `rclcpp::QoS` depth passed to it becomes meaningless. Autoware's `InterProcessPollingSubscriber` rejects `depth > 1` in `check_qos()` for that reason. 

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
