### PR TITLE
feat(agnocastlib): show daemon output on the terminal instead of discarding it

### DIFF
--- a/src/agnocastlib/src/agnocast.cpp
+++ b/src/agnocastlib/src/agnocast.cpp
@@ -429,14 +429,23 @@ pid_t spawn_daemon_process(Func && func)
         fail("Failed to open /dev/null: %s");
       }
 
+      // Send the output to the terminal rather than discarding it. Must be opened before setsid(),
+      // which drops the controlling terminal /dev/tty resolves against. stdin stays on /dev/null
+      // because this is write-only, so reads see EOF rather than EBADF.
+      const int tty = open("/dev/tty", O_WRONLY);
+      const int out_fd = (tty >= 0) ? tty : devnull;
+
       if (dup2(devnull, STDIN_FILENO) < 0) {
         fail("dup2 for stdin failed: %s");
       }
-      if (dup2(devnull, STDOUT_FILENO) < 0) {
+      if (dup2(out_fd, STDOUT_FILENO) < 0) {
         fail("dup2 for stdout failed: %s");
       }
-      if (dup2(devnull, STDERR_FILENO) < 0) {
+      if (dup2(out_fd, STDERR_FILENO) < 0) {
         fail("dup2 for stderr failed: %s");
+      }
+      if (out_fd != devnull) {
+        close(out_fd);
       }
       close(devnull);
     }


### PR DESCRIPTION
## Description

The forked daemons (shm_unlink, performance bridge manager, discovery agent) send stdout/stderr to `/dev/null` whenever they inherit a pipe or socket, which is the case under `ros2 launch` and CTest, so everything they log is discarded — including the errors explaining why one of them died. Send it to the controlling terminal instead.

Only the target changes; what the redirect is there for is that `dup2` closes the inherited descriptor, so the daemon stops holding a pipe whose reader waits for EOF from a process that outlives it. `/dev/tty` is opened before `setsid()` drops the controlling terminal it resolves against, and stdin stays on `/dev/null` since it is opened write-only. With no controlling terminal (systemd, containers, CI) the open fails and `/dev/null` is used as before, so no case gets worse. Nothing is configurable.

Launch's `[node-N]` prefix is missing, but rcutils prints the logger name and colours by severity. Two rough edges are accepted: the daemons are singletons, so output lands on the terminal that started whichever process won the race to spawn them, and a daemon outlives its launch, so a line can arrive after the prompt returns and writes fail with `EIO` once that terminal closes.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

None.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
