### PR TITLE
refactor(agnocast_kmod): funnel publisher/subscriber_info release through helpers

### DIFF
--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -70,8 +70,7 @@ static void pre_handler_subscriber_exit(
     }
 
     hash_del(&sub_info->node);
-    kfree(sub_info->node_name);
-    kfree(sub_info);
+    free_subscriber_info(sub_info);
 
     if (subscriber_id < 0 || subscriber_id >= MAX_TOPIC_LOCAL_ID) {
       dev_warn(
@@ -111,8 +110,7 @@ static void pre_handler_subscriber_exit(
       pub_info->entries_num--;
       if (pub_info->entries_num == 0) {
         hash_del(&pub_info->node);
-        kfree(pub_info->node_name);
-        kfree(pub_info);
+        free_publisher_info(pub_info);
       }
     }
   }
@@ -147,8 +145,7 @@ static void pre_handler_publisher_exit(struct topic_wrapper * wrapper, const pid
 
     if (pub_info->entries_num == 0) {
       hash_del(&pub_info->node);
-      kfree(pub_info->node_name);
-      kfree(pub_info);
+      free_publisher_info(pub_info);
     }
   }
 }
@@ -216,8 +213,7 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
     hash_for_each_safe(wrapper->topic->pub_info_htable, bkt_pub, tmp_pub, pub_info, node)
     {
       hash_del(&pub_info->node);
-      kfree(pub_info->node_name);
-      kfree(pub_info);
+      free_publisher_info(pub_info);
     }
 
     struct subscriber_info * sub_info;
@@ -226,8 +222,7 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper)
     hash_for_each_safe(wrapper->topic->sub_info_htable, bkt_sub, tmp_sub, sub_info, node)
     {
       hash_del(&sub_info->node);
-      kfree(sub_info->node_name);
-      kfree(sub_info);
+      free_subscriber_info(sub_info);
     }
 
     kfree(wrapper->topic);

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -94,6 +94,12 @@ struct publisher_info
   struct hlist_node node;
 };
 
+static inline void free_publisher_info(struct publisher_info * pub_info)
+{
+  kfree(pub_info->node_name);
+  kfree(pub_info);
+}
+
 struct subscriber_info
 {
   topic_local_id_t id;
@@ -111,6 +117,12 @@ struct subscriber_info
   bool is_bridge;
   struct hlist_node node;
 };
+
+static inline void free_subscriber_info(struct subscriber_info * sub_info)
+{
+  kfree(sub_info->node_name);
+  kfree(sub_info);
+}
 
 // Helper to copy a name_info string from userspace to a kernel stack buffer.
 // Returns 0 on success, -EINVAL if too long, -EFAULT on copy failure.

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1953,8 +1953,7 @@ int agnocast_ioctl_remove_subscriber(
   }
 
   hash_del(&sub_info->node);
-  kfree(sub_info->node_name);
-  kfree(sub_info);
+  free_subscriber_info(sub_info);
 
   if (!is_parameter_service_topic(topic_name)) {
     dev_info(
@@ -2001,8 +2000,7 @@ int agnocast_ioctl_remove_subscriber(
     pub_info->entries_num--;
     if (pub_info->entries_num == 0) {
       hash_del(&pub_info->node);
-      kfree(pub_info->node_name);
-      kfree(pub_info);
+      free_publisher_info(pub_info);
     }
   }
 
@@ -2056,8 +2054,7 @@ int agnocast_ioctl_remove_publisher(
 
   if (pub_info->entries_num == 0) {
     hash_del(&pub_info->node);
-    kfree(pub_info->node_name);
-    kfree(pub_info);
+    free_publisher_info(pub_info);
 
     if (!is_parameter_service_topic(topic_name)) {
       dev_info(


### PR DESCRIPTION
## Description

`publisher_info` and `subscriber_info` were released by open-coding `kfree(x->node_name); kfree(x);` at each of the eight sites that drop an endpoint. Nothing tied those sites together, so a field added to either struct had to be released by hand at every one of them, and missing a site produces a leak that is invisible at the call site.

Introduce `free_publisher_info()` / `free_subscriber_info()` and route all eight sites through them, so that release stays in one place per struct.

Pure refactor, no behavior change.

## Related links

Split out of #1432, which adds an owned `eventfd_ctx *` to `subscriber_info` and so has to release it on every one of these paths.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Not yet run — draft. So far only confirmed that both `make` and `make test` build clean with `-Wall -Werror`. The required suites will be run before this leaves draft.

## Notes for reviewers

The eight sites are unchanged in behavior; each helper is exactly the two `kfree()` calls it replaces, in the same order.

`agnocast_release_topic_wrapper()` and `pre_handler_subscriber_exit()` keep their own `hash_del()` before the call, since not every release path unlinks from the same table.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` — internal cleanup only, no kmod/agnocastlib interface change.
