### PR TITLE
perf(agnocast_kmod): precompute each publisher's notify list at registration

### DIFF
--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -35,8 +35,7 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper, const pi
 
     const topic_local_id_t subscriber_id = sub_info->id;
 
-    hash_del(&sub_info->node);
-    free_subscriber_info(sub_info);
+    agnocast_unlink_subscriber_info(wrapper, sub_info);
 
     if (subscriber_id < 0 || subscriber_id >= MAX_TOPIC_LOCAL_ID) {
       dev_warn(

--- a/agnocast_kmod/agnocast_internal.c
+++ b/agnocast_kmod/agnocast_internal.c
@@ -26,6 +26,9 @@ struct tracepoint * tp_sched_process_exit;
 
 static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper, const pid_t pid)
 {
+  // Unlinked as a batch so the notify lists are rebuilt once instead of once per subscriber, which
+  // would repeat the same work and land on the same result.
+  HLIST_HEAD(leaving);
   struct subscriber_info * sub_info;
   int bkt_sub_info;
   struct hlist_node * tmp_sub_info;
@@ -33,9 +36,22 @@ static void pre_handler_subscriber_exit(struct topic_wrapper * wrapper, const pi
   {
     if (sub_info->pid != pid) continue;
 
+    hash_del(&sub_info->node);
+    hlist_add_head(&sub_info->node, &leaving);
+  }
+
+  if (hlist_empty(&leaving)) return;
+
+  // Before the frees below, so that no list is left pointing at a released context.
+  agnocast_rebuild_notify_lists(wrapper);
+
+  struct hlist_node * tmp_leaving;
+  hlist_for_each_entry_safe(sub_info, tmp_leaving, &leaving, node)
+  {
     const topic_local_id_t subscriber_id = sub_info->id;
 
-    agnocast_unlink_subscriber_info(wrapper, sub_info);
+    hlist_del(&sub_info->node);
+    free_subscriber_info(sub_info);
 
     if (subscriber_id < 0 || subscriber_id >= MAX_TOPIC_LOCAL_ID) {
       dev_warn(

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -290,6 +290,10 @@ void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper);
 void agnocast_unlink_subscriber_info(
   struct topic_wrapper * wrapper, struct subscriber_info * sub_info);
 
+// Recomputes the publishers' notify lists, for the one caller that unlinks subscribers in bulk and
+// so cannot use agnocast_unlink_subscriber_info(). Caller holds global_htables_rwsem (write).
+void agnocast_rebuild_notify_lists(struct topic_wrapper * wrapper);
+
 long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 
 // Ring buffer to hold exited pids.

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -113,7 +113,9 @@ struct publisher_info
   // reads it.
   struct eventfd_ctx ** notify_ctxs;
   uint32_t notify_num;
-  uint32_t notify_capacity;  // Always the whole subscriber count, so only a join can grow it.
+  // Never below the topic's notifiable subscriber count, and never shrinks, so only a join can grow
+  // it and every other rebuild is allocation-free.
+  uint32_t notify_capacity;
   struct hlist_node node;
 };
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -48,6 +48,9 @@ extern struct rw_semaphore global_htables_rwsem;
 // At most one agent per (IPC namespace, domain), so the table is tiny.
 #define DISCOVERY_AGENT_HASH_BITS 4
 
+// Covers typical ROS 2 fan-out without reallocation, at a negligible per-publisher cost.
+#define NOTIFY_CTXS_MIN_CAPACITY 8
+
 // All eventfd access goes through these wrappers so the KUnit build can substitute fakes; see
 // agnocast_kunit/agnocast_kunit_eventfd.c for why real contexts are unobtainable there.
 #ifdef KUNIT_BUILD
@@ -105,11 +108,18 @@ struct publisher_info
   bool qos_is_transient_local;
   uint32_t entries_num;
   bool is_bridge;
+  // The eventfd contexts PUBLISH signals, in no particular order. Membership depends only on the
+  // endpoints, never on the message, so the list is built as endpoints register and publish only
+  // reads it.
+  struct eventfd_ctx ** notify_ctxs;
+  uint32_t notify_num;
+  uint32_t notify_capacity;  // Always the whole subscriber count, so only a join can grow it.
   struct hlist_node node;
 };
 
 static inline void free_publisher_info(struct publisher_info * pub_info)
 {
+  kvfree(pub_info->notify_ctxs);
   kfree(pub_info->node_name);
   kfree(pub_info);
 }
@@ -133,6 +143,8 @@ struct subscriber_info
   struct hlist_node node;
 };
 
+// Use agnocast_unlink_subscriber_info() instead unless the whole topic is being torn down: a
+// subscriber leaving a live topic must also leave the publishers' notify lists.
 static inline void free_subscriber_info(struct subscriber_info * sub_info)
 {
   if (sub_info->notify_ctx) agnocast_eventfd_put(sub_info->notify_ctx);
@@ -269,6 +281,12 @@ void agnocast_remove_entry_node(struct topic_wrapper * wrapper, struct entry_nod
 // struct itself) is freed only when the last referencing wrapper is dropped, so
 // a grouped partner keeps working until it too is released.
 void agnocast_release_topic_wrapper(struct topic_wrapper * wrapper);
+
+// The single place a subscriber is dropped from a live topic, so that releasing its eventfd
+// context and rebuilding the notify lists pointing at it cannot be forgotten at one call site.
+// Caller holds global_htables_rwsem (write).
+void agnocast_unlink_subscriber_info(
+  struct topic_wrapper * wrapper, struct subscriber_info * sub_info);
 
 long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg);
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -205,7 +205,8 @@ static struct subscriber_info * find_subscriber_info(
 }
 
 // Caller holds global_htables_rwsem (write), so the swap below cannot race a publish: those hold
-// the read side for their whole duration. The caller refills the list, so nothing is copied across.
+// the read side for their whole duration. The current list is carried across, so that a caller who
+// fails partway through reserving has invalidated no one's list and owes no undo.
 static int reserve_notify_ctxs(struct publisher_info * pub_info, const uint32_t needed)
 {
   if (needed <= pub_info->notify_capacity) return 0;
@@ -219,24 +220,32 @@ static int reserve_notify_ctxs(struct publisher_info * pub_info, const uint32_t 
   struct eventfd_ctx ** new_ctxs = kvmalloc_array(new_capacity, sizeof(*new_ctxs), GFP_KERNEL);
   if (!new_ctxs) return -ENOMEM;
 
+  if (pub_info->notify_ctxs)
+    memcpy(new_ctxs, pub_info->notify_ctxs, pub_info->notify_num * sizeof(*new_ctxs));
   kvfree(pub_info->notify_ctxs);
   pub_info->notify_ctxs = new_ctxs;
   pub_info->notify_capacity = new_capacity;
   return 0;
 }
 
-// Recomputes which subscribers this publisher notifies. None of the filters below depends on the
-// message, so evaluating them here leaves publish with nothing to do but signal.
-static int rebuild_notify_list(
-  struct topic_wrapper * wrapper, struct publisher_info * pub_info, const uint32_t sub_num)
+// The fallible half of a rebuild, split out so callers can do it before the change they are about
+// to make, while backing out is still free.
+static int reserve_all_notify_ctxs(struct topic_wrapper * wrapper, const uint32_t needed)
 {
-  // The subscriber count bounds the list, so one reservation covers the fill below. Reserving for
-  // the whole count (not just the matches) keeps capacity >= the topic's subscriber count for
-  // every publisher, which is what makes every rebuild but a subscriber's insertion allocation-
-  // free, and so infallible.
-  int ret = reserve_notify_ctxs(pub_info, sub_num);
-  if (ret < 0) return ret;
+  struct publisher_info * pub_info;
+  int bkt_pub_info;
+  hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
+  {
+    int ret = reserve_notify_ctxs(pub_info, needed);
+    if (ret < 0) return ret;
+  }
+  return 0;
+}
 
+// None of the filters below depends on the message, so evaluating them here leaves publish with
+// nothing to do but signal. Infallible: the caller reserved the capacity.
+static void rebuild_notify_list(struct topic_wrapper * wrapper, struct publisher_info * pub_info)
+{
   uint32_t notify_num = 0;
   struct subscriber_info * sub_info;
   int bkt_sub_info;
@@ -248,28 +257,22 @@ static int rebuild_notify_list(
       continue;
     if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
 
+    if (WARN_ON_ONCE(notify_num == pub_info->notify_capacity)) break;
     pub_info->notify_ctxs[notify_num++] = sub_info->notify_ctx;
   }
   pub_info->notify_num = notify_num;
-
-  return 0;
 }
 
-// Rebuilds every publisher's notify list on the topic. Caller holds global_htables_rwsem (write).
-// On failure the earlier publishers keep their new lists, so the caller must undo its own change
-// and rebuild again.
-static int rebuild_all_notify_lists(struct topic_wrapper * wrapper)
+// Caller holds global_htables_rwsem (write). Infallible, so it can run once a change is already
+// visible: only a join needs to grow a list, and it reserves upfront.
+static void rebuild_all_notify_lists(struct topic_wrapper * wrapper)
 {
-  const uint32_t sub_num = agnocast_get_size_sub_info_htable(wrapper);
-
   struct publisher_info * pub_info;
   int bkt_pub_info;
   hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
   {
-    int ret = rebuild_notify_list(wrapper, pub_info, sub_num);
-    if (ret < 0) return ret;
+    rebuild_notify_list(wrapper, pub_info);
   }
-  return 0;
 }
 
 void agnocast_unlink_subscriber_info(
@@ -277,9 +280,8 @@ void agnocast_unlink_subscriber_info(
 {
   hash_del(&sub_info->node);
 
-  // Before the release below, so that no list is ever left pointing at a freed context. Cannot
-  // fail: removal only lowers the subscriber count, so no list has to grow.
-  WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
+  // Before the release below, so that no list is ever left pointing at a freed context.
+  rebuild_all_notify_lists(wrapper);
 
   free_subscriber_info(sub_info);
 }
@@ -325,6 +327,19 @@ static int insert_subscriber_info(
     return -ENOMEM;
   }
 
+  // Last failure point: reserving while nothing is committed yet is what lets the rebuild below be
+  // infallible, and leaves the id counters untouched on failure.
+  if (notify_ctx) {
+    int reserve_ret =
+      reserve_all_notify_ctxs(wrapper, agnocast_get_size_sub_info_htable(wrapper) + 1);
+    if (reserve_ret < 0) {
+      kfree(node_name_copy);
+      kfree(*new_info);
+      // The caller releases notify_ctx on the error path, so it must not be released here.
+      return reserve_ret;
+    }
+  }
+
   const topic_local_id_t new_id = wrapper->topic->current_pubsub_id;
   wrapper->topic->current_pubsub_id++;
 
@@ -349,18 +364,7 @@ static int insert_subscriber_info(
   uint32_t hash_val = hash_min(new_id, SUB_INFO_HASH_BITS);
   hash_add(wrapper->topic->sub_info_htable, &(*new_info)->node, hash_val);
 
-  int ret = rebuild_all_notify_lists(wrapper);
-  if (ret < 0) {
-    hash_del(&(*new_info)->node);
-    // The publishers rebuilt before the failing one already hold this subscriber's notify_ctx, so
-    // they have to be rebuilt again before it is released. Cannot fail: the unlink above put the
-    // subscriber count back, so no list has to grow.
-    WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
-    kfree(node_name_copy);
-    kfree(*new_info);
-    // The caller releases notify_ctx on the error path, so it must not be released here.
-    return ret;
-  }
+  if (notify_ctx) rebuild_all_notify_lists(wrapper);
 
   if (!is_parameter_service_topic(wrapper->key)) {
     dev_info(
@@ -462,12 +466,13 @@ static int insert_publisher_info(
 
   // Later subscribers are folded in as they register. Failing here beats failing in publish,
   // which cannot report it.
-  int ret = rebuild_notify_list(wrapper, *new_info, agnocast_get_size_sub_info_htable(wrapper));
+  int ret = reserve_notify_ctxs(*new_info, agnocast_get_size_sub_info_htable(wrapper));
   if (ret < 0) {
     hash_del(&(*new_info)->node);
     free_publisher_info(*new_info);
     return ret;
   }
+  rebuild_notify_list(wrapper, *new_info);
 
   if (!is_parameter_service_topic(wrapper->key)) {
     dev_info(
@@ -2266,8 +2271,7 @@ int agnocast_ioctl_add_domain_bridge(
       // topic_struct once grouped, so either wrapper reaches every publisher.
       struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
       if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
-      // Cannot fail: more subscribers may match, but no new one joined, so no list has to grow.
-      if (wrapper) WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
+      if (wrapper) rebuild_all_notify_lists(wrapper);
     } else {
       ret = -EBUSY;
     }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -475,18 +475,18 @@ static int insert_publisher_info(
   (*new_info)->notify_num = 0;
   (*new_info)->notify_capacity = 0;
   INIT_HLIST_NODE(&(*new_info)->node);
-  uint32_t hash_val = hash_min(new_id, PUB_INFO_HASH_BITS);
-  hash_add(wrapper->topic->pub_info_htable, &(*new_info)->node, hash_val);
 
-  // Later subscribers are folded in as they register. Failing here beats failing in publish,
-  // which cannot report it.
+  // Before hash_add, so a failure needs no more undo than the free below: the fill reads only the
+  // subscriber table and the fields set above, so the publisher need not be linked yet.
   int ret = reserve_notify_ctxs(*new_info, notifiable_subscriber_num(wrapper));
   if (ret < 0) {
-    hash_del(&(*new_info)->node);
     free_publisher_info(*new_info);
     return ret;
   }
   rebuild_notify_list(wrapper, *new_info);
+
+  uint32_t hash_val = hash_min(new_id, PUB_INFO_HASH_BITS);
+  hash_add(wrapper->topic->pub_info_htable, &(*new_info)->node, hash_val);
 
   if (!is_parameter_service_topic(wrapper->key)) {
     dev_info(

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -204,6 +204,19 @@ static struct subscriber_info * find_subscriber_info(
   return NULL;
 }
 
+// Take subs are excluded, so they cannot inflate every publisher's array.
+static uint32_t notifiable_subscriber_num(const struct topic_wrapper * wrapper)
+{
+  uint32_t num = 0;
+  struct subscriber_info * sub_info;
+  int bkt_sub_info;
+  hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
+  {
+    if (sub_info->notify_ctx) num++;
+  }
+  return num;
+}
+
 // Caller holds global_htables_rwsem (write), so the swap below cannot race a publish: those hold
 // the read side for their whole duration. The current list is carried across, so that a caller who
 // fails partway through reserving has invalidated no one's list and owes no undo.
@@ -278,10 +291,12 @@ static void rebuild_all_notify_lists(struct topic_wrapper * wrapper)
 void agnocast_unlink_subscriber_info(
   struct topic_wrapper * wrapper, struct subscriber_info * sub_info)
 {
+  const bool was_notifiable = sub_info->notify_ctx;
   hash_del(&sub_info->node);
 
-  // Before the release below, so that no list is ever left pointing at a freed context.
-  rebuild_all_notify_lists(wrapper);
+  // Take subs are in no list, so rebuilding for one would land on the same result. Otherwise this
+  // must precede the release below, so that no list is left pointing at a freed context.
+  if (was_notifiable) rebuild_all_notify_lists(wrapper);
 
   free_subscriber_info(sub_info);
 }
@@ -330,8 +345,7 @@ static int insert_subscriber_info(
   // Last failure point: reserving while nothing is committed yet is what lets the rebuild below be
   // infallible, and leaves the id counters untouched on failure.
   if (notify_ctx) {
-    int reserve_ret =
-      reserve_all_notify_ctxs(wrapper, agnocast_get_size_sub_info_htable(wrapper) + 1);
+    int reserve_ret = reserve_all_notify_ctxs(wrapper, notifiable_subscriber_num(wrapper) + 1);
     if (reserve_ret < 0) {
       kfree(node_name_copy);
       kfree(*new_info);
@@ -466,7 +480,7 @@ static int insert_publisher_info(
 
   // Later subscribers are folded in as they register. Failing here beats failing in publish,
   // which cannot report it.
-  int ret = reserve_notify_ctxs(*new_info, agnocast_get_size_sub_info_htable(wrapper));
+  int ret = reserve_notify_ctxs(*new_info, notifiable_subscriber_num(wrapper));
   if (ret < 0) {
     hash_del(&(*new_info)->node);
     free_publisher_info(*new_info);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -288,6 +288,11 @@ static void rebuild_all_notify_lists(struct topic_wrapper * wrapper)
   }
 }
 
+void agnocast_rebuild_notify_lists(struct topic_wrapper * wrapper)
+{
+  rebuild_all_notify_lists(wrapper);
+}
+
 void agnocast_unlink_subscriber_info(
   struct topic_wrapper * wrapper, struct subscriber_info * sub_info)
 {

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -204,12 +204,95 @@ static struct subscriber_info * find_subscriber_info(
   return NULL;
 }
 
+// Caller holds global_htables_rwsem (write), so the swap below cannot race a publish: those hold
+// the read side for their whole duration. The caller refills the list, so nothing is copied across.
+static int reserve_notify_ctxs(struct publisher_info * pub_info, const uint32_t needed)
+{
+  if (needed <= pub_info->notify_capacity) return 0;
+
+  uint32_t new_capacity =
+    pub_info->notify_capacity ? pub_info->notify_capacity * 2 : NOTIFY_CTXS_MIN_CAPACITY;
+  if (new_capacity > MAX_SUBSCRIBER_NUM) new_capacity = MAX_SUBSCRIBER_NUM;
+  // Last, so that the cap above can never leave the list short of what the fill needs.
+  if (new_capacity < needed) new_capacity = needed;
+
+  struct eventfd_ctx ** new_ctxs = kvmalloc_array(new_capacity, sizeof(*new_ctxs), GFP_KERNEL);
+  if (!new_ctxs) return -ENOMEM;
+
+  kvfree(pub_info->notify_ctxs);
+  pub_info->notify_ctxs = new_ctxs;
+  pub_info->notify_capacity = new_capacity;
+  return 0;
+}
+
+// Recomputes which subscribers this publisher notifies. None of the filters below depends on the
+// message, so evaluating them here leaves publish with nothing to do but signal.
+static int rebuild_notify_list(
+  struct topic_wrapper * wrapper, struct publisher_info * pub_info, const uint32_t sub_num)
+{
+  // The subscriber count bounds the list, so one reservation covers the fill below. Reserving for
+  // the whole count (not just the matches) keeps capacity >= the topic's subscriber count for
+  // every publisher, which is what makes every rebuild but a subscriber's insertion allocation-
+  // free, and so infallible.
+  int ret = reserve_notify_ctxs(pub_info, sub_num);
+  if (ret < 0) return ret;
+
+  uint32_t notify_num = 0;
+  struct subscriber_info * sub_info;
+  int bkt_sub_info;
+  hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
+  {
+    // NULL exactly for take subs, which poll instead of being woken.
+    if (!sub_info->notify_ctx) continue;
+    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id))
+      continue;
+    if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
+
+    pub_info->notify_ctxs[notify_num++] = sub_info->notify_ctx;
+  }
+  pub_info->notify_num = notify_num;
+
+  return 0;
+}
+
+// Rebuilds every publisher's notify list on the topic. Caller holds global_htables_rwsem (write).
+// On failure the earlier publishers keep their new lists, so the caller must undo its own change
+// and rebuild again.
+static int rebuild_all_notify_lists(struct topic_wrapper * wrapper)
+{
+  const uint32_t sub_num = agnocast_get_size_sub_info_htable(wrapper);
+
+  struct publisher_info * pub_info;
+  int bkt_pub_info;
+  hash_for_each(wrapper->topic->pub_info_htable, bkt_pub_info, pub_info, node)
+  {
+    int ret = rebuild_notify_list(wrapper, pub_info, sub_num);
+    if (ret < 0) return ret;
+  }
+  return 0;
+}
+
+void agnocast_unlink_subscriber_info(
+  struct topic_wrapper * wrapper, struct subscriber_info * sub_info)
+{
+  hash_del(&sub_info->node);
+
+  // Before the release below, so that no list is ever left pointing at a freed context. Cannot
+  // fail: removal only lowers the subscriber count, so no list has to grow.
+  WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
+
+  free_subscriber_info(sub_info);
+}
+
 static int insert_subscriber_info(
   struct topic_wrapper * wrapper, const char * node_name, const pid_t subscriber_pid,
   const uint32_t qos_depth, const bool qos_is_transient_local, const bool qos_is_reliable,
   const bool is_take_sub, bool ignore_local_publications, const bool is_bridge,
   struct eventfd_ctx * notify_ctx, struct subscriber_info ** new_info)
 {
+  // rebuild_notify_list() skips take subs by testing notify_ctx alone, so the two must agree.
+  WARN_ON_ONCE(is_take_sub != (notify_ctx == NULL));
+
   int count = agnocast_get_size_sub_info_htable(wrapper);
   if (count == MAX_SUBSCRIBER_NUM) {
     dev_warn(
@@ -265,6 +348,19 @@ static int insert_subscriber_info(
   INIT_HLIST_NODE(&(*new_info)->node);
   uint32_t hash_val = hash_min(new_id, SUB_INFO_HASH_BITS);
   hash_add(wrapper->topic->sub_info_htable, &(*new_info)->node, hash_val);
+
+  int ret = rebuild_all_notify_lists(wrapper);
+  if (ret < 0) {
+    hash_del(&(*new_info)->node);
+    // The publishers rebuilt before the failing one already hold this subscriber's notify_ctx, so
+    // they have to be rebuilt again before it is released. Cannot fail: the unlink above put the
+    // subscriber count back, so no list has to grow.
+    WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
+    kfree(node_name_copy);
+    kfree(*new_info);
+    // The caller releases notify_ctx on the error path, so it must not be released here.
+    return ret;
+  }
 
   if (!is_parameter_service_topic(wrapper->key)) {
     dev_info(
@@ -357,9 +453,21 @@ static int insert_publisher_info(
   (*new_info)->qos_is_transient_local = qos_is_transient_local;
   (*new_info)->entries_num = 0;
   (*new_info)->is_bridge = is_bridge;
+  (*new_info)->notify_ctxs = NULL;
+  (*new_info)->notify_num = 0;
+  (*new_info)->notify_capacity = 0;
   INIT_HLIST_NODE(&(*new_info)->node);
   uint32_t hash_val = hash_min(new_id, PUB_INFO_HASH_BITS);
   hash_add(wrapper->topic->pub_info_htable, &(*new_info)->node, hash_val);
+
+  // Later subscribers are folded in as they register. Failing here beats failing in publish,
+  // which cannot report it.
+  int ret = rebuild_notify_list(wrapper, *new_info, agnocast_get_size_sub_info_htable(wrapper));
+  if (ret < 0) {
+    hash_del(&(*new_info)->node);
+    free_publisher_info(*new_info);
+    return ret;
+  }
 
   if (!is_parameter_service_topic(wrapper->key)) {
     dev_info(
@@ -912,18 +1020,6 @@ int agnocast_ioctl_publish_msg(
     goto unlock_all;
   }
 
-  // The subscriber count bounds how many contexts the loop below can collect. Allocated before
-  // anything is published so that a failure here cannot leave a published entry reported as an
-  // error.
-  const int sub_num = agnocast_get_size_sub_info_htable(wrapper);
-  if (sub_num > 0) {
-    notify_ctxs = kmalloc_array(sub_num, sizeof(*notify_ctxs), GFP_KERNEL);
-    if (!notify_ctxs) {
-      ret = -ENOMEM;
-      goto unlock_all;
-    }
-  }
-
   ret = insert_message_entry(wrapper, pub_info, msg_virtual_address, ioctl_ret);
   if (ret < 0) {
     goto unlock_all;
@@ -934,29 +1030,19 @@ int agnocast_ioctl_publish_msg(
     goto unlock_all;
   }
 
-  struct subscriber_info * sub_info;
-  int bkt_sub_info;
-  hash_for_each(wrapper->topic->sub_info_htable, bkt_sub_info, sub_info, node)
-  {
-    if (sub_info->is_take_sub) continue;
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id))
-      continue;
-    if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
-    if (!sub_info->notify_ctx) continue;
-
-    notify_ctxs[notify_num++] = sub_info->notify_ctx;
-  }
+  notify_ctxs = pub_info->notify_ctxs;
+  notify_num = pub_info->notify_num;
 
 unlock_all:
   up_write(&wrapper->topic->rwsem);
 
   // Signal outside topic_rwsem: RECEIVE_MSG and TAKE_MSG take it for write, so holding it here
-  // would block the very subscribers being woken. The contexts stay valid because every path that
-  // releases one takes global_htables_rwsem for write, and it is held here for read.
+  // would block the very subscribers being woken. The list and the contexts both stay valid
+  // because a context is released only once every list has stopped pointing at it, and both that
+  // and any rebuild happen under global_htables_rwsem (write), which is held here for read.
   for (uint32_t i = 0; i < notify_num; i++) {
     agnocast_eventfd_signal(notify_ctxs[i]);
   }
-  kfree(notify_ctxs);
 
 unlock_only_global:
   up_read(&global_htables_rwsem);
@@ -1903,8 +1989,7 @@ int agnocast_ioctl_remove_subscriber(
     goto unlock;
   }
 
-  hash_del(&sub_info->node);
-  free_subscriber_info(sub_info);
+  agnocast_unlink_subscriber_info(wrapper, sub_info);
 
   if (!is_parameter_service_topic(topic_name)) {
     dev_info(
@@ -2175,6 +2260,14 @@ int agnocast_ioctl_add_domain_bridge(
     if (r_a == r_b) {
       r_a->a_to_b |= from_is_a;
       r_a->b_to_a |= !from_is_a;
+
+      // Unlike the paths below, this one runs after endpoints may have registered, and the
+      // direction just enabled was denied when their notify lists were built. Both cells share one
+      // topic_struct once grouped, so either wrapper reaches every publisher.
+      struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
+      if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
+      // Cannot fail: more subscribers may match, but no new one joined, so no list has to grow.
+      if (wrapper) WARN_ON_ONCE(rebuild_all_notify_lists(wrapper) < 0);
     } else {
       ret = -EBUSY;
     }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -700,3 +700,39 @@ void test_case_do_exit_releases_notify_context(struct kunit * test)
   KUNIT_EXPECT_EQ(test, slot->put_count, 1);
   KUNIT_EXPECT_EQ(test, agnocast_kunit_eventfd_outstanding(), (int64_t)0);
 }
+
+// A process holding several subscribers on one topic drops them as a batch, which unlinks and
+// releases on separate passes. A context freed on the wrong pass would leave a list pointing at it.
+void test_case_do_exit_releases_notify_contexts_of_multiple_subscribers(struct kunit * test)
+{
+  // Arrange
+  agnocast_kunit_eventfd_reset();
+  const pid_t subscriber_pid = PID_BASE;
+  const int subscriber_num = 3;
+  setup_one_process(test, subscriber_pid);
+
+  for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
+    union ioctl_add_subscriber_args add_subscriber_args;
+    KUNIT_ASSERT_EQ(
+      test,
+      agnocast_ioctl_add_subscriber(
+        TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, QOS_DEPTH,
+        QOS_IS_TRANSIENT_LOCAL, QOS_IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE,
+        eventfd, &add_subscriber_args),
+      0);
+  }
+  KUNIT_ASSERT_EQ(test, agnocast_kunit_eventfd_outstanding(), (int64_t)subscriber_num);
+
+  // Act
+  agnocast_enqueue_exit_pid(subscriber_pid);
+  msleep(20);  // wait for exit_worker_thread to handle process exit
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(subscriber_pid));
+
+  // Assert
+  for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
+    const struct agnocast_kunit_eventfd_slot * slot = agnocast_kunit_eventfd_slot_of(eventfd);
+    KUNIT_ASSERT_NOT_NULL(test, slot);
+    KUNIT_EXPECT_EQ(test, slot->put_count, 1);
+  }
+  KUNIT_EXPECT_EQ(test, agnocast_kunit_eventfd_outstanding(), (int64_t)0);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
@@ -14,7 +14,8 @@
     KUNIT_CASE(test_case_do_exit_with_entry_with_subscriber_reference),                        \
     KUNIT_CASE(test_case_do_exit_with_multi_references_publisher_exit_first),                  \
     KUNIT_CASE(test_case_do_exit_with_multi_references_subscriber_exit_first),                 \
-    KUNIT_CASE(test_case_do_exit_releases_notify_context)
+    KUNIT_CASE(test_case_do_exit_releases_notify_context),                                     \
+    KUNIT_CASE(test_case_do_exit_releases_notify_contexts_of_multiple_subscribers)
 
 void test_case_is_agnocast_pid(struct kunit * test);
 void test_case_do_exit(struct kunit * test);
@@ -33,3 +34,4 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
 void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit * test);
 void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit * test);
 void test_case_do_exit_releases_notify_context(struct kunit * test);
+void test_case_do_exit_releases_notify_contexts_of_multiple_subscribers(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -61,9 +61,9 @@ static topic_local_id_t add_subscriber_for(struct kunit * test, const pid_t pid)
   return add_subscriber_named(test, pid, TOPIC_NAME);
 }
 
-// The helpers above pass -1, which the fake maps to its unobserved slot: the subscriber is still
-// collected and signaled on publish, but no assertion can see it. Cases that assert on delivery
-// need a real fd to observe instead.
+// The helpers above pass -1, which the fake maps to its unobserved slot: the subscriber still
+// enters the publishers' notify lists and is signaled on publish, but no assertion can see it.
+// Cases that assert on delivery need a real fd to observe instead.
 static topic_local_id_t add_subscriber_named_with_eventfd(
   struct kunit * test, const pid_t pid, const char * topic_name, const int eventfd)
 {
@@ -216,6 +216,36 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
 
   // The domain-1 subscriber must not be woken by a domain-2 publication (no 2 -> 1).
   KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
+}
+
+void test_case_domain_bridge_late_reverse_direction_delivers(struct kunit * test)
+{
+  // Same setup as above, but 2 -> 1 is declared after both endpoints have registered, so the
+  // publisher's notify list was built while that direction was still denied.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+
+  agnocast_kunit_eventfd_reset();
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 1);
+  const int eventfd = 0;
+  add_subscriber_named_with_eventfd(test, 1001, TOPIC_NAME, eventfd);
+
+  // Act
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
+
+  union ioctl_publish_msg_args publish_args;
+  int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // Assert: the newly allowed direction reaches the domain-1 subscriber.
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
 }
 
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -11,6 +11,7 @@
     KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                      \
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),             \
     KUNIT_CASE(test_case_domain_bridge_direction_respected),                  \
+    KUNIT_CASE(test_case_domain_bridge_late_reverse_direction_delivers),      \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),          \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),      \
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),             \
@@ -30,6 +31,7 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
+void test_case_domain_bridge_late_reverse_direction_delivers(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -59,10 +59,10 @@ static void setup_one_publisher(
   KUNIT_ASSERT_EQ(test, ret2, 0);
 }
 
-// The setup helpers above pass -1, which the fake maps to its unobserved slot: the subscriber is
-// still collected and signaled on publish, but no assertion can see it. Cases that assert on
-// delivery need a real fd instead.
-static void add_subscriber_with_eventfd(
+// The setup helpers above pass -1, which the fake maps to its unobserved slot: the subscriber
+// still enters the publishers' notify lists and is signaled on publish, but no assertion can see
+// it. Cases that assert on delivery need a real fd instead.
+static topic_local_id_t add_subscriber_with_eventfd(
   struct kunit * test, const pid_t pid, const int eventfd, const bool ignore_local_publications)
 {
   union ioctl_add_subscriber_args add_subscriber_args;
@@ -72,10 +72,11 @@ static void add_subscriber_with_eventfd(
     &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret, 0);
+  return add_subscriber_args.ret_id;
 }
 
 // Same, but in a process of its own.
-static void setup_one_subscriber_with_eventfd(
+static topic_local_id_t setup_one_subscriber_with_eventfd(
   struct kunit * test, const int eventfd, const bool ignore_local_publications)
 {
   subscriber_pid++;
@@ -86,7 +87,7 @@ static void setup_one_subscriber_with_eventfd(
     agnocast_ioctl_add_process(
       subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
     0);
-  add_subscriber_with_eventfd(test, subscriber_pid, eventfd, ignore_local_publications);
+  return add_subscriber_with_eventfd(test, subscriber_pid, eventfd, ignore_local_publications);
 }
 
 // One process holding both, which is what makes ignore_local_publications observable.
@@ -479,8 +480,7 @@ void test_case_publish_msg_does_not_signal_take_sub(struct kunit * test)
 
 void test_case_publish_msg_signals_large_fanout(struct kunit * test)
 {
-  // Arrange: a fan-out well past what the e2e tests reach, to exercise the collection PUBLISH
-  // does at scale.
+  // Arrange: a fan-out past a notify list's initial capacity, so the list has to grow.
   agnocast_kunit_eventfd_reset();
   topic_local_id_t publisher_id;
   uint64_t ret_addr;
@@ -505,6 +505,35 @@ void test_case_publish_msg_signals_large_fanout(struct kunit * test)
     topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
 
   // Assert: every subscriber woken exactly once, none missed and none woken twice.
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
+    KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+  }
+}
+
+// A publisher registering onto a topic that already has subscribers must pick them up right then,
+// since no later rebuild is coming. Missing them would leave the publisher signaling no one.
+void test_case_publish_msg_signals_subscribers_registered_before_publisher(struct kunit * test)
+{
+  // Arrange
+  agnocast_kunit_eventfd_reset();
+
+  const int subscriber_num = 3;
+  for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
+    setup_one_subscriber_with_eventfd(test, eventfd, false);
+  }
+
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+
+  union ioctl_publish_msg_args ioctl_publish_msg_ret = {0};
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
     KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
@@ -536,6 +565,68 @@ void test_case_publish_msg_signals_once_per_publish(struct kunit * test)
   const struct agnocast_kunit_eventfd_slot * slot = agnocast_kunit_eventfd_slot_of(eventfd);
   KUNIT_ASSERT_NOT_NULL(test, slot);
   KUNIT_EXPECT_EQ(test, slot->get_count, 1);
+}
+
+// A publisher's notify list is built as endpoints register, so a subscriber leaving has to be taken
+// out of it. Leaving it behind would make the next publish signal a released context.
+void test_case_publish_msg_stops_signaling_removed_subscriber(struct kunit * test)
+{
+  // Arrange
+  agnocast_kunit_eventfd_reset();
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+
+  const int removed_eventfd = 0;
+  const int kept_eventfd = 1;
+  const topic_local_id_t removed_id =
+    setup_one_subscriber_with_eventfd(test, removed_eventfd, false);
+  setup_one_subscriber_with_eventfd(test, kept_eventfd, false);
+
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_remove_subscriber(topic_name, current->nsproxy->ipc_ns, removed_id), 0);
+
+  // Act
+  union ioctl_publish_msg_args ioctl_publish_msg_ret = {0};
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(removed_eventfd), 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(kept_eventfd), 1);
+}
+
+// A subscriber also has to leave the notify lists when its process exits, which reaches the unlink
+// through the exit handler instead of REMOVE_SUBSCRIBER. Leaving it behind would make the next
+// publish signal a released context.
+void test_case_publish_msg_stops_signaling_exited_subscriber(struct kunit * test)
+{
+  // Arrange
+  agnocast_kunit_eventfd_reset();
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_one_publisher(test, &publisher_id, &ret_addr);
+
+  const int exited_eventfd = 0;
+  const int kept_eventfd = 1;
+  setup_one_subscriber_with_eventfd(test, exited_eventfd, false);
+  const pid_t exiting_pid = subscriber_pid;  // the helper advanced it to the pid it used
+  setup_one_subscriber_with_eventfd(test, kept_eventfd, false);
+
+  agnocast_enqueue_exit_pid(exiting_pid);
+  msleep(20);
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(exiting_pid));
+
+  // Act
+  union ioctl_publish_msg_args ioctl_publish_msg_ret = {0};
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(exited_eventfd), 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(kept_eventfd), 1);
 }
 
 // The publisher's message must live in that publisher process's own mempool. Both sides of the

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -15,7 +15,10 @@
     KUNIT_CASE(test_case_publish_msg_signals_all_subscribers),                                \
     KUNIT_CASE(test_case_publish_msg_does_not_signal_take_sub),                               \
     KUNIT_CASE(test_case_publish_msg_signals_large_fanout),                                   \
+    KUNIT_CASE(test_case_publish_msg_signals_subscribers_registered_before_publisher),        \
     KUNIT_CASE(test_case_publish_msg_signals_once_per_publish),                               \
+    KUNIT_CASE(test_case_publish_msg_stops_signaling_removed_subscriber),                     \
+    KUNIT_CASE(test_case_publish_msg_stops_signaling_exited_subscriber),                      \
     KUNIT_CASE(test_case_publish_msg_address_below_mempool),                                  \
     KUNIT_CASE(test_case_publish_msg_address_above_mempool),                                  \
     KUNIT_CASE(test_case_publish_msg_no_process)
@@ -33,7 +36,10 @@ void test_case_ignore_local_diff_pid_enabled(struct kunit * test);
 void test_case_publish_msg_signals_all_subscribers(struct kunit * test);
 void test_case_publish_msg_does_not_signal_take_sub(struct kunit * test);
 void test_case_publish_msg_signals_large_fanout(struct kunit * test);
+void test_case_publish_msg_signals_subscribers_registered_before_publisher(struct kunit * test);
 void test_case_publish_msg_signals_once_per_publish(struct kunit * test);
+void test_case_publish_msg_stops_signaling_removed_subscriber(struct kunit * test);
+void test_case_publish_msg_stops_signaling_exited_subscriber(struct kunit * test);
 void test_case_publish_msg_address_below_mempool(struct kunit * test);
 void test_case_publish_msg_address_above_mempool(struct kunit * test);
 void test_case_publish_msg_no_process(struct kunit * test);


### PR DESCRIPTION
## Description

#1432 `kmalloc_array`s the eventfd context array inside `publish_msg`, while holding `topic_rwsem` (write) and `global_htables_rwsem` (read). Allocating on the publish path is the problem this PR removes: it can sleep and reclaim with those locks held, so an unlucky publisher stalls every other publisher and subscriber on the topic. The extra hash walk per publish goes away as a side effect.

None of the take / domain / local-publication filters depends on the message, so the answer is the same for every publish until an endpoint registers or leaves. Each `publisher_info` now owns a `notify_ctxs` array rebuilt at registration, and `publish_msg` only reads it — no allocation, no walk.

- `rebuild_all_notify_lists()` runs from `insert_subscriber_info()` / `insert_publisher_info()` under `global_htables_rwsem` (write).
- `agnocast_unlink_subscriber_info()` becomes the single place a subscriber leaves a live topic, so releasing its eventfd context and rebuilding the lists that pointed at it cannot be honored at one call site and forgotten at another.
- The array only grows, geometrically from `NOTIFY_CTXS_MIN_CAPACITY`, and never during publish.

Split out of #1432 so the notification mechanism and this optimization can be reviewed apart.

## Related links

- Stacked on #1432

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` — internal only, no ABI change.
