### PR TITLE
feat(agnocastlib): add agnocast::AsyncParametersClient

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(agnocast SHARED
   src/agnocast_tracepoint_wrapper.c src/agnocast_client.cpp src/agnocast_service.cpp
   src/node/agnocast_node.cpp src/node/agnocast_arguments.cpp src/node/agnocast_context.cpp src/node/agnocast_signal_handler.cpp
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
-  src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
+  src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp src/node/agnocast_parameter_client.cpp
   src/cie_client_utils.cpp
   src/internal/type_registry_writer.cpp
   src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp src/node/node_interfaces/node_graph.cpp
@@ -275,6 +275,18 @@ if(BUILD_TESTING)
   set_tests_properties(test_integration_node_graph_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
     TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
+  # AsyncParametersClient integration test (requires kernel module, no mock).
+  # Black-box test of agnocast::AsyncParametersClient against a real
+  # agnocast::ParameterService on a second node in the same process.
+  ament_add_gmock(test_integration_agnocast_parameter_client_${PROJECT_NAME}
+    test/integration/test_agnocast_parameter_client.cpp)
+  target_link_libraries(test_integration_agnocast_parameter_client_${PROJECT_NAME} agnocast)
+  set_tests_properties(test_integration_agnocast_parameter_client_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 120
     LABELS "requires_kernel_module;requires_heaphook"
   )
 

--- a/src/agnocastlib/include/agnocast/node/agnocast_parameter_client.hpp
+++ b/src/agnocastlib/include/agnocast/node/agnocast_parameter_client.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "agnocast/agnocast_client.hpp"
+#include "agnocast/agnocast_public_api.hpp"
+#include "rcl_interfaces/srv/describe_parameters.hpp"
+#include "rcl_interfaces/srv/get_parameter_types.hpp"
+#include "rcl_interfaces/srv/get_parameters.hpp"
+#include "rcl_interfaces/srv/list_parameters.hpp"
+#include "rcl_interfaces/srv/set_parameters.hpp"
+#include "rcl_interfaces/srv/set_parameters_atomically.hpp"
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/qos.hpp"
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace agnocast
+{
+
+/// @brief Read and write another node's parameters over Agnocast.
+///
+/// The counterpart of agnocast::ParameterService: it holds one agnocast::Client per parameter
+/// service endpoint of the remote node (`<remote_node>/get_parameters` and friends) and exposes
+/// them as a single object, mirroring rclcpp::AsyncParametersClient.
+///
+/// This class exists because rclcpp::AsyncParametersClient cannot be used from an agnocast::Node:
+/// its node-taking constructors require get_node_graph_interface(), which agnocast::Node does not
+/// provide, and in an AgnocastOnly process rclcpp::init() is never called so its clients could not
+/// discover anything anyway.
+///
+/// Responses are delivered on the executor thread serving @p group, exactly like the underlying
+/// agnocast::Client, so the returned futures only resolve while the node is being spun. Requests
+/// to a remote node that still speaks ROS 2 are carried by the A2R service bridge.
+///
+/// Differences from rclcpp::AsyncParametersClient:
+///   - on_parameter_event() is not provided; agnocast::Node does not publish /parameter_events.
+///   - delete_parameters() / load_parameters() are not provided; call set_parameters() directly.
+///   - There is no synchronous counterpart (rclcpp::SyncParametersClient), because it is built on
+///     spin_until_future_complete(), which the agnocast executors do not offer.
+///   - service_is_ready() checks all six endpoints (rclcpp skips set_parameters_atomically).
+class AsyncParametersClient
+{
+public:
+  AGNOCAST_PUBLIC
+  using SharedPtr = std::shared_ptr<AsyncParametersClient>;
+
+  /// @brief Construct a parameter client targeting @p remote_node_name.
+  /// @tparam NodeT agnocast::Node or rclcpp::Node.
+  /// @param node The node that owns the underlying clients.
+  /// @param remote_node_name Name of the node whose parameters are accessed. Resolved like a
+  ///        service name, so a relative name is expanded against @p node's namespace. Defaults to
+  ///        the empty string, meaning @p node itself.
+  /// @param qos Quality of service profile for the underlying clients.
+  /// @param group Callback group the responses are delivered on. Defaults to `nullptr` (the
+  ///        node's default callback group).
+  template <typename NodeT>
+  explicit AsyncParametersClient(
+    NodeT * node, const std::string & remote_node_name = "",
+    const rclcpp::QoS & qos = rclcpp::ParametersQoS(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    remote_node_name_ =
+      remote_node_name.empty() ? node->get_fully_qualified_name() : remote_node_name;
+
+    get_parameters_client_ = std::make_shared<Client<rcl_interfaces::srv::GetParameters>>(
+      node, remote_node_name_ + "/get_parameters", qos, group);
+    get_parameter_types_client_ = std::make_shared<Client<rcl_interfaces::srv::GetParameterTypes>>(
+      node, remote_node_name_ + "/get_parameter_types", qos, group);
+    set_parameters_client_ = std::make_shared<Client<rcl_interfaces::srv::SetParameters>>(
+      node, remote_node_name_ + "/set_parameters", qos, group);
+    set_parameters_atomically_client_ =
+      std::make_shared<Client<rcl_interfaces::srv::SetParametersAtomically>>(
+        node, remote_node_name_ + "/set_parameters_atomically", qos, group);
+    describe_parameters_client_ = std::make_shared<Client<rcl_interfaces::srv::DescribeParameters>>(
+      node, remote_node_name_ + "/describe_parameters", qos, group);
+    list_parameters_client_ = std::make_shared<Client<rcl_interfaces::srv::ListParameters>>(
+      node, remote_node_name_ + "/list_parameters", qos, group);
+  }
+
+  virtual ~AsyncParametersClient() = default;
+
+  AsyncParametersClient(const AsyncParametersClient &) = delete;
+  AsyncParametersClient & operator=(const AsyncParametersClient &) = delete;
+  AsyncParametersClient(AsyncParametersClient &&) = delete;
+  AsyncParametersClient & operator=(AsyncParametersClient &&) = delete;
+
+  /// @brief Read parameters from the remote node.
+  /// @param names Parameter names to read.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to the values, in the order of @p names. Note that a single
+  ///         undeclared name makes the server return nothing at all rather than skipping just that
+  ///         name, so a short result does not identify which names exist.
+  AGNOCAST_PUBLIC
+  std::shared_future<std::vector<rclcpp::Parameter>> get_parameters(
+    const std::vector<std::string> & names,
+    std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback = nullptr);
+
+  /// @brief Read the types of parameters on the remote node.
+  /// @param names Parameter names to query.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to the parameter types.
+  AGNOCAST_PUBLIC
+  std::shared_future<std::vector<rclcpp::ParameterType>> get_parameter_types(
+    const std::vector<std::string> & names,
+    std::function<void(std::shared_future<std::vector<rclcpp::ParameterType>>)> callback = nullptr);
+
+  /// @brief Set parameters on the remote node, one by one.
+  /// @param parameters Parameters to set.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to one result per parameter.
+  AGNOCAST_PUBLIC
+  std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>> set_parameters(
+    const std::vector<rclcpp::Parameter> & parameters,
+    std::function<void(std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>)>
+      callback = nullptr);
+
+  /// @brief Set parameters on the remote node as a single all-or-nothing operation.
+  /// @param parameters Parameters to set.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to the combined result.
+  AGNOCAST_PUBLIC
+  std::shared_future<rcl_interfaces::msg::SetParametersResult> set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters,
+    std::function<void(std::shared_future<rcl_interfaces::msg::SetParametersResult>)> callback =
+      nullptr);
+
+  /// @brief Read the descriptors of parameters on the remote node.
+  /// @param names Parameter names to describe.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to the descriptors.
+  AGNOCAST_PUBLIC
+  std::shared_future<std::vector<rcl_interfaces::msg::ParameterDescriptor>> describe_parameters(
+    const std::vector<std::string> & names,
+    std::function<void(std::shared_future<std::vector<rcl_interfaces::msg::ParameterDescriptor>>)>
+      callback = nullptr);
+
+  /// @brief List the parameters of the remote node.
+  /// @param prefixes Only list parameters under these prefixes. Empty lists everything.
+  /// @param depth Maximum number of name separators to descend. 0 means unlimited.
+  /// @param callback Optional; invoked with the resolved future when the response arrives.
+  /// @return Future resolving to the listing.
+  AGNOCAST_PUBLIC
+  std::shared_future<rcl_interfaces::msg::ListParametersResult> list_parameters(
+    const std::vector<std::string> & prefixes, uint64_t depth,
+    std::function<void(std::shared_future<rcl_interfaces::msg::ListParametersResult>)> callback =
+      nullptr);
+
+  /// @brief Check whether every parameter service endpoint of the remote node is available.
+  /// @return True if all six endpoints are available.
+  AGNOCAST_PUBLIC
+  bool service_is_ready() const;
+
+  /// @brief Block until every parameter service endpoint is available or the timeout expires.
+  /// @param timeout Maximum total duration to wait across all endpoints (-1 = wait forever).
+  /// @return True if all endpoints became available, false on timeout.
+  AGNOCAST_PUBLIC
+  template <typename RepT = int64_t, typename RatioT = std::milli>
+  bool wait_for_service(
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(-1))
+  {
+    return wait_for_service_nanoseconds(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));
+  }
+
+protected:
+  AGNOCAST_PUBLIC
+  bool wait_for_service_nanoseconds(std::chrono::nanoseconds timeout);
+
+private:
+  Client<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_client_;
+  Client<rcl_interfaces::srv::GetParameterTypes>::SharedPtr get_parameter_types_client_;
+  Client<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_client_;
+  Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr set_parameters_atomically_client_;
+  Client<rcl_interfaces::srv::DescribeParameters>::SharedPtr describe_parameters_client_;
+  Client<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_client_;
+  std::string remote_node_name_;
+};
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/node/agnocast_parameter_client.cpp
+++ b/src/agnocastlib/src/node/agnocast_parameter_client.cpp
@@ -1,0 +1,225 @@
+#include "agnocast/node/agnocast_parameter_client.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace agnocast
+{
+
+std::shared_future<std::vector<rclcpp::Parameter>> AsyncParametersClient::get_parameters(
+  const std::vector<std::string> & names,
+  std::function<void(std::shared_future<std::vector<rclcpp::Parameter>>)> callback)
+{
+  auto promise = std::make_shared<std::promise<std::vector<rclcpp::Parameter>>>();
+  auto future = promise->get_future().share();
+
+  auto request = get_parameters_client_->borrow_loaned_request();
+  request->names = names;
+
+  get_parameters_client_->async_send_request(
+    std::move(request),
+    [names, promise, future,
+     callback](Client<rcl_interfaces::srv::GetParameters>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+
+      // The server omits parameters it has not declared, so the response may be shorter than the
+      // request. It must never be longer -- clamp anyway so a malformed response cannot make the
+      // name lookup below read past the end of `names`.
+      const size_t count = std::min(names.size(), response->values.size());
+      std::vector<rclcpp::Parameter> parameters;
+      parameters.reserve(count);
+      for (size_t i = 0; i < count; ++i) {
+        rcl_interfaces::msg::Parameter parameter;
+        parameter.name = names[i];
+        parameter.value = response->values[i];
+        parameters.push_back(rclcpp::Parameter::from_parameter_msg(parameter));
+      }
+
+      promise->set_value(std::move(parameters));
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+std::shared_future<std::vector<rclcpp::ParameterType>> AsyncParametersClient::get_parameter_types(
+  const std::vector<std::string> & names,
+  std::function<void(std::shared_future<std::vector<rclcpp::ParameterType>>)> callback)
+{
+  auto promise = std::make_shared<std::promise<std::vector<rclcpp::ParameterType>>>();
+  auto future = promise->get_future().share();
+
+  auto request = get_parameter_types_client_->borrow_loaned_request();
+  request->names = names;
+
+  get_parameter_types_client_->async_send_request(
+    std::move(request),
+    [promise, future,
+     callback](Client<rcl_interfaces::srv::GetParameterTypes>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+
+      std::vector<rclcpp::ParameterType> types;
+      types.reserve(response->types.size());
+      for (const uint8_t type : response->types) {
+        types.push_back(static_cast<rclcpp::ParameterType>(type));
+      }
+
+      promise->set_value(std::move(types));
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>
+AsyncParametersClient::set_parameters(
+  const std::vector<rclcpp::Parameter> & parameters,
+  std::function<void(std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>)>
+    callback)
+{
+  auto promise =
+    std::make_shared<std::promise<std::vector<rcl_interfaces::msg::SetParametersResult>>>();
+  auto future = promise->get_future().share();
+
+  auto request = set_parameters_client_->borrow_loaned_request();
+  request->parameters.reserve(parameters.size());
+  for (const auto & parameter : parameters) {
+    request->parameters.push_back(parameter.to_parameter_msg());
+  }
+
+  set_parameters_client_->async_send_request(
+    std::move(request),
+    [promise, future,
+     callback](Client<rcl_interfaces::srv::SetParameters>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+      promise->set_value(response->results);
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+std::shared_future<rcl_interfaces::msg::SetParametersResult>
+AsyncParametersClient::set_parameters_atomically(
+  const std::vector<rclcpp::Parameter> & parameters,
+  std::function<void(std::shared_future<rcl_interfaces::msg::SetParametersResult>)> callback)
+{
+  auto promise = std::make_shared<std::promise<rcl_interfaces::msg::SetParametersResult>>();
+  auto future = promise->get_future().share();
+
+  auto request = set_parameters_atomically_client_->borrow_loaned_request();
+  request->parameters.reserve(parameters.size());
+  for (const auto & parameter : parameters) {
+    request->parameters.push_back(parameter.to_parameter_msg());
+  }
+
+  set_parameters_atomically_client_->async_send_request(
+    std::move(request),
+    [promise, future,
+     callback](Client<rcl_interfaces::srv::SetParametersAtomically>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+      promise->set_value(response->result);
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+std::shared_future<std::vector<rcl_interfaces::msg::ParameterDescriptor>>
+AsyncParametersClient::describe_parameters(
+  const std::vector<std::string> & names,
+  std::function<void(std::shared_future<std::vector<rcl_interfaces::msg::ParameterDescriptor>>)>
+    callback)
+{
+  auto promise =
+    std::make_shared<std::promise<std::vector<rcl_interfaces::msg::ParameterDescriptor>>>();
+  auto future = promise->get_future().share();
+
+  auto request = describe_parameters_client_->borrow_loaned_request();
+  request->names = names;
+
+  describe_parameters_client_->async_send_request(
+    std::move(request),
+    [promise, future,
+     callback](Client<rcl_interfaces::srv::DescribeParameters>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+      promise->set_value(response->descriptors);
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+std::shared_future<rcl_interfaces::msg::ListParametersResult>
+AsyncParametersClient::list_parameters(
+  const std::vector<std::string> & prefixes, uint64_t depth,
+  std::function<void(std::shared_future<rcl_interfaces::msg::ListParametersResult>)> callback)
+{
+  auto promise = std::make_shared<std::promise<rcl_interfaces::msg::ListParametersResult>>();
+  auto future = promise->get_future().share();
+
+  auto request = list_parameters_client_->borrow_loaned_request();
+  request->prefixes = prefixes;
+  request->depth = depth;
+
+  list_parameters_client_->async_send_request(
+    std::move(request),
+    [promise, future,
+     callback](Client<rcl_interfaces::srv::ListParameters>::SharedFuture response_future) {
+      const auto & response = response_future.get();
+      promise->set_value(response->result);
+      if (callback != nullptr) {
+        callback(future);
+      }
+    });
+
+  return future;
+}
+
+bool AsyncParametersClient::service_is_ready() const
+{
+  return get_parameters_client_->service_is_ready() &&
+         get_parameter_types_client_->service_is_ready() &&
+         set_parameters_client_->service_is_ready() &&
+         set_parameters_atomically_client_->service_is_ready() &&
+         describe_parameters_client_->service_is_ready() &&
+         list_parameters_client_->service_is_ready();
+}
+
+bool AsyncParametersClient::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
+{
+  // The timeout is a budget for the whole set of endpoints, so charge each wait against it.
+  // A negative timeout means "wait forever" and is passed through untouched.
+  auto wait_one = [&timeout](const auto & client) {
+    const auto start = std::chrono::steady_clock::now();
+    if (!client->wait_for_service(timeout)) {
+      return false;
+    }
+    if (timeout > std::chrono::nanoseconds::zero()) {
+      timeout -= std::chrono::steady_clock::now() - start;
+      timeout = std::max(timeout, std::chrono::nanoseconds::zero());
+    }
+    return true;
+  };
+
+  return wait_one(get_parameters_client_) && wait_one(get_parameter_types_client_) &&
+         wait_one(set_parameters_client_) && wait_one(set_parameters_atomically_client_) &&
+         wait_one(describe_parameters_client_) && wait_one(list_parameters_client_);
+}
+
+}  // namespace agnocast

--- a/src/agnocastlib/test/integration/test_agnocast_parameter_client.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_parameter_client.cpp
@@ -1,0 +1,230 @@
+// Black-box tests for agnocast::AsyncParametersClient.
+//
+// A "server" agnocast::Node declares parameters and exposes them through its
+// agnocast::ParameterService (enabled by NodeOptions::start_parameter_services).
+// A second "client" node reads and writes them through an
+// agnocast::AsyncParametersClient. Both nodes are spun by one
+// AgnocastOnlySingleThreadedExecutor, so every request/response round trip goes
+// through the real Agnocast service path.
+
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+#include "agnocast/node/agnocast_only_single_threaded_executor.hpp"
+#include "agnocast/node/agnocast_parameter_client.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+using namespace std::chrono_literals;
+
+// Generous enough for a loaded CI machine, short enough that a genuine failure
+// does not stall the suite.
+constexpr auto kServiceTimeout = 5s;
+constexpr auto kResponseTimeout = 5s;
+}  // namespace
+
+class TestAsyncParametersClient : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+
+    rclcpp::NodeOptions server_options;
+    server_options.start_parameter_services(true);
+    server_ =
+      std::make_shared<agnocast::Node>("param_server", "/test_param_client", server_options);
+    server_->declare_parameter<bool>("enable_partial_load", true);
+    server_->declare_parameter<double>("radius", 50.0);
+    server_->declare_parameter<std::string>("nested.name", "map_loader");
+
+    // The client node needs no parameter services of its own; disabling them keeps the
+    // parameter endpoints in this process unambiguous.
+    rclcpp::NodeOptions client_options;
+    client_options.start_parameter_services(false);
+    client_ =
+      std::make_shared<agnocast::Node>("param_client", "/test_param_client", client_options);
+
+    executor_ = std::make_shared<agnocast::AgnocastOnlySingleThreadedExecutor>();
+    executor_->add_node(server_);
+    executor_->add_node(client_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+
+    params_ = std::make_shared<agnocast::AsyncParametersClient>(
+      client_.get(), server_->get_fully_qualified_name());
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    params_.reset();
+    executor_.reset();
+    client_.reset();
+    server_.reset();
+    agnocast::shutdown();
+  }
+
+  // Blocks the test thread until the response arrives; the executor thread resolves it.
+  template <typename FutureT>
+  static bool resolved(FutureT & future)
+  {
+    return future.wait_for(kResponseTimeout) == std::future_status::ready;
+  }
+
+  std::shared_ptr<agnocast::Node> server_;
+  std::shared_ptr<agnocast::Node> client_;
+  std::shared_ptr<agnocast::AgnocastOnlySingleThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::shared_ptr<agnocast::AsyncParametersClient> params_;
+};
+
+TEST_F(TestAsyncParametersClient, wait_for_service_finds_the_remote_parameter_services)
+{
+  EXPECT_TRUE(params_->wait_for_service(kServiceTimeout));
+  EXPECT_TRUE(params_->service_is_ready());
+}
+
+TEST_F(TestAsyncParametersClient, get_parameters_returns_declared_values_in_request_order)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->get_parameters({"radius", "enable_partial_load"});
+  ASSERT_TRUE(resolved(future));
+
+  const auto parameters = future.get();
+  ASSERT_EQ(2u, parameters.size());
+  EXPECT_EQ("radius", parameters[0].get_name());
+  EXPECT_DOUBLE_EQ(50.0, parameters[0].as_double());
+  EXPECT_EQ("enable_partial_load", parameters[1].get_name());
+  EXPECT_TRUE(parameters[1].as_bool());
+}
+
+TEST_F(TestAsyncParametersClient, get_parameters_returns_nothing_when_any_name_is_undeclared)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->get_parameters({"enable_partial_load", "not_declared"});
+  ASSERT_TRUE(resolved(future));
+
+  // A single undeclared name makes the server abandon the whole response, not just that name:
+  // its handler calls get_parameters() for all names at once and swallows the resulting
+  // ParameterNotDeclaredException. rclcpp::ParameterService behaves identically, so callers must
+  // treat a short response as "ask again one name at a time", not "these ones exist".
+  EXPECT_TRUE(future.get().empty());
+}
+
+TEST_F(TestAsyncParametersClient, get_parameters_invokes_the_completion_callback)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  std::promise<std::vector<rclcpp::Parameter>> from_callback;
+  auto from_callback_future = from_callback.get_future();
+  auto future = params_->get_parameters(
+    {"radius"}, [&from_callback](std::shared_future<std::vector<rclcpp::Parameter>> completed) {
+      from_callback.set_value(completed.get());
+    });
+
+  ASSERT_TRUE(resolved(future));
+  ASSERT_EQ(std::future_status::ready, from_callback_future.wait_for(kResponseTimeout));
+  const auto parameters = from_callback_future.get();
+  ASSERT_EQ(1u, parameters.size());
+  EXPECT_DOUBLE_EQ(50.0, parameters[0].as_double());
+}
+
+TEST_F(TestAsyncParametersClient, get_parameter_types_reports_the_declared_types)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->get_parameter_types({"enable_partial_load", "radius", "nested.name"});
+  ASSERT_TRUE(resolved(future));
+
+  const auto types = future.get();
+  ASSERT_EQ(3u, types.size());
+  EXPECT_EQ(rclcpp::ParameterType::PARAMETER_BOOL, types[0]);
+  EXPECT_EQ(rclcpp::ParameterType::PARAMETER_DOUBLE, types[1]);
+  EXPECT_EQ(rclcpp::ParameterType::PARAMETER_STRING, types[2]);
+}
+
+TEST_F(TestAsyncParametersClient, set_parameters_updates_the_remote_node)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->set_parameters({rclcpp::Parameter("radius", 120.0)});
+  ASSERT_TRUE(resolved(future));
+
+  const auto results = future.get();
+  ASSERT_EQ(1u, results.size());
+  EXPECT_TRUE(results[0].successful);
+  EXPECT_DOUBLE_EQ(120.0, server_->get_parameter("radius").as_double());
+}
+
+TEST_F(TestAsyncParametersClient, set_parameters_atomically_updates_the_remote_node)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->set_parameters_atomically(
+    {rclcpp::Parameter("radius", 30.0), rclcpp::Parameter("enable_partial_load", false)});
+  ASSERT_TRUE(resolved(future));
+
+  EXPECT_TRUE(future.get().successful);
+  EXPECT_DOUBLE_EQ(30.0, server_->get_parameter("radius").as_double());
+  EXPECT_FALSE(server_->get_parameter("enable_partial_load").as_bool());
+}
+
+TEST_F(TestAsyncParametersClient, describe_parameters_returns_one_descriptor_per_name)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->describe_parameters({"radius"});
+  ASSERT_TRUE(resolved(future));
+
+  const auto descriptors = future.get();
+  ASSERT_EQ(1u, descriptors.size());
+  EXPECT_EQ("radius", descriptors[0].name);
+  EXPECT_EQ(rclcpp::ParameterType::PARAMETER_DOUBLE, descriptors[0].type);
+}
+
+TEST_F(TestAsyncParametersClient, list_parameters_reports_the_declared_names)
+{
+  ASSERT_TRUE(params_->wait_for_service(kServiceTimeout));
+
+  auto future = params_->list_parameters({}, 0);
+  ASSERT_TRUE(resolved(future));
+
+  const auto & names = future.get().names;
+  EXPECT_NE(names.end(), std::find(names.begin(), names.end(), "enable_partial_load"));
+  EXPECT_NE(names.end(), std::find(names.begin(), names.end(), "radius"));
+  EXPECT_NE(names.end(), std::find(names.begin(), names.end(), "nested.name"));
+}
+
+TEST_F(TestAsyncParametersClient, empty_remote_node_name_targets_the_owning_node)
+{
+  // The client node runs no parameter services, so a self-targeted client must never
+  // become ready. This pins down which node an empty remote name resolves to.
+  auto self_client = std::make_shared<agnocast::AsyncParametersClient>(client_.get());
+  EXPECT_FALSE(self_client->wait_for_service(500ms));
+
+  auto server_side = std::make_shared<agnocast::AsyncParametersClient>(server_.get());
+  EXPECT_TRUE(server_side->wait_for_service(kServiceTimeout));
+}
+
+TEST_F(TestAsyncParametersClient, wait_for_service_times_out_for_an_unknown_node)
+{
+  auto absent = std::make_shared<agnocast::AsyncParametersClient>(
+    client_.get(), "/test_param_client/no_such_node");
+  EXPECT_FALSE(absent->wait_for_service(500ms));
+  EXPECT_FALSE(absent->service_is_ready());
+}


### PR DESCRIPTION
## Description

Adds `agnocast::AsyncParametersClient`, the client-side counterpart of the existing `agnocast::ParameterService`. It holds one `agnocast::Client` per parameter service endpoint of the remote node (`<remote_node>/get_parameters` and friends) and exposes them as a single object, mirroring `rclcpp::AsyncParametersClient`.

This is needed because `rclcpp::AsyncParametersClient` cannot be used from an `agnocast::Node`: its node-taking constructors require `get_node_graph_interface()`, which `agnocast::Node` does not provide, and in an AgnocastOnly process `rclcpp::init()` is never called so its clients could not discover anything anyway. The constructor is templated on the node type, so it works with both `agnocast::Node` and `rclcpp::Node`. Requests to a remote node that still speaks ROS 2 are carried by the A2R service bridge.

Differences from `rclcpp::AsyncParametersClient`:

- `on_parameter_event()` is not provided; `agnocast::Node` does not publish `/parameter_events`.
- `delete_parameters()` / `load_parameters()` are not provided; call `set_parameters()` directly.
- There is no synchronous counterpart (`rclcpp::SyncParametersClient`), because it is built on `spin_until_future_complete()`, which the Agnocast executors do not offer.
- `service_is_ready()` checks all six endpoints (rclcpp skips `set_parameters_atomically`).

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

An integration test covering the six endpoints is added in `src/agnocastlib/test/integration/test_agnocast_parameter_client.cpp`. The required test runs above are still pending; this PR is a draft until they are done.

## Notes for reviewers

The server omits parameters it has not declared, so a `get_parameters` response may be shorter than the request. `AsyncParametersClient::get_parameters` clamps the pairing to `min(names.size(), response->values.size())` so a malformed response cannot read past the end of `names`, but callers cannot tell from a short result which names were missing.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
