### PR TITLE
fix(ros2agnocast_discovery_agent): log the idle exit at debug level

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -395,7 +395,7 @@ class DiscoveryAgent(Node):
             return
         if self._idle_tracker.update(ret == 1):
             if self._lib.agnocast_discovery_agent_commit_exit(self._domain_id) == 1:
-                self.get_logger().info(
+                self.get_logger().debug(
                     f'no Agnocast node in (ipc_ns={self._ipc_ns_inode}, domain={self._domain_id}) '
                     f'for {EXIT_WHEN_IDLE_GRACE_SEC:.0f}s; exiting.')
                 raise ExternalShutdownException()


### PR DESCRIPTION
## Description

The discovery agent logged its idle exit (`no Agnocast node in (ipc_ns=..., domain=...) for 30s; exiting.`) at info level. Since the agent is forked by Agnocast processes and writes to their `/dev/tty`, it outlives them and prints this line onto an idle shell prompt ~30s after the last node exits, e.g. right after an e2e test finishes. Idle exit is the designed behavior, so this is now a debug log.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`pytest src/ros2agnocast_discovery_agent/test/test_agent.py` passes (24 passed).

## Notes for reviewers

Log level only. The exit path itself (kmod-gated commit, veto handling) is unchanged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
