### PR TITLE
fix(agnocast_kmod): build against the target kernel instead of the running one

### DIFF
--- a/agnocast_kmod/Makefile
+++ b/agnocast_kmod/Makefile
@@ -23,9 +23,9 @@ else
 	agnocast_internal.o
 endif
 
-KERNEL_VERSION ?= $(shell uname -r)
-KERNEL_MAJOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 1)
-KERNEL_MINOR := $(shell echo $(KERNEL_VERSION) | cut -d '.' -f 2)
+KVERSION ?= $(shell uname -r)
+KERNEL_MAJOR := $(shell echo $(KVERSION) | cut -d '.' -f 1)
+KERNEL_MINOR := $(shell echo $(KVERSION) | cut -d '.' -f 2)
 
 # In Linux kernel v5.17 and earlier, the top-level Linux Makefile specifies -std=gnu89,
 # so it is necessary to declare the variable used as the iterator in the for loop beforehand.
@@ -48,16 +48,16 @@ ifeq ($(shell expr $(KERNEL_MAJOR) \< 6 \| $(KERNEL_MAJOR) = 6 \& $(KERNEL_MINOR
 endif
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
 
 test:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) KUNIT_BUILD=y modules
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) KUNIT_BUILD=y modules
 
 sparse:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) C=2 modules > sparse.log 2>&1 || { cat sparse.log; exit 1; }
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) C=2 modules > sparse.log 2>&1 || { cat sparse.log; exit 1; }
 	! grep 'agnocast_kmod/.*warning' sparse.log && rm -f sparse.log
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
 
 .PHONY: all test sparse clean


### PR DESCRIPTION

## Description

A DKMS build for a kernel other than the running one silently produces an `agnocast.ko` for the *running* kernel. The build exits 0 and `dkms status` reports the target kernel as built, but the module carries the running kernel's vermagic. It is rejected after booting the target kernel, and the package's modules-load drop-in causes `systemd-modules-load.service` to report a failure:

```
agnocast: disagrees about version of symbol module_layout
systemd-modules-load[335]: Failed to insert module 'agnocast': Exec format error
```

This affects DKMS autoinstall during a kernel upgrade (`AUTOINSTALL="yes"`) and explicit `dkms build -k` invocations whenever the target kernel differs from the running one. A fresh `apt install` normally hides the bug because `debian/postinst` invokes DKMS without `-k`, making the target and running kernels the same.

For example, on a host running `6.12.0` with `6.8.0-136-generic` headers installed:

```console
$ dkms build -m agnocast -v 2.3.5 -k 6.8.0-136-generic
$ grep -m2 -E '^# command:|^make -C' /var/lib/dkms/agnocast/2.3.5/6.8.0-136-generic/x86_64/log/make.log
# command: make -j12 KERNELRELEASE=6.8.0-136-generic all KVERSION=6.8.0-136-generic
make -C /lib/modules/6.12.0/build M=... modules
$ modinfo -F vermagic .../agnocast/2.3.5/6.8.0-136-generic/x86_64/module/agnocast.ko
6.12.0 SMP preempt mod_unload modversions
```

The root cause is a variable-name mismatch plus hardcoded build-tree paths. `dkms.conf` passes the target version as `KVERSION`, while the Makefile reads `KERNEL_VERSION`; the `all`, `test`, `sparse`, and `clean` recipes also use `/lib/modules/$(shell uname -r)/build` directly. DKMS supplies the target version, but neither value reaches the kernel build-tree path.

Rename `KERNEL_VERSION` to `KVERSION` so the Makefile reads what `dkms.conf` already passes, and use `$(KVERSION)` for the build tree in `all:`, `test:`, `sparse:` and `clean:`. The `?= $(shell uname -r)` fallback is kept, so `make`, `make sparse`, `make test` and `debian/postinst` (which calls dkms without `-k`) are unaffected. `dkms.conf` is unchanged.

## Related links

- [Ubuntu DKMS packaging guide](https://wiki.ubuntu.com/Kernel/Dev/DKMSPackaging) — where the `MAKE=` line comes from; it pairs it with `-C /lib/modules/$(KVERSION)/build`

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Built through `dkms build -k` before and after the patch, on a host running `6.12.0` with `6.8.0-136-generic` headers also installed. DKMS reported `built` for the target in both cases:

| | tree entered | vermagic of resulting `agnocast.ko` |
|---|---|---|
| before | `/lib/modules/6.12.0/build` | `6.12.0 SMP preempt mod_unload modversions` |
| after | `/lib/modules/6.8.0-136-generic/build` | `6.8.0-136-generic SMP preempt mod_unload modversions` |

## Notes for reviewers

An alternative would be to pass `$kernel_source_dir` as `KDIR`, which would also support `--kernelsourcedir`. I chose `KVERSION` because it keeps `dkms.conf` unchanged and is also needed to derive `KERNEL_MAJOR` and `KERNEL_MINOR`.

*Disclosure: I used Claude Code and Codex to investigate the DKMS/kbuild interaction, prepare the patch, and draft this description. I reviewed the resulting patch and validated it using the before/after DKMS results shown above.*

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

- `need-patch-update`
