### PR TITLE
docs(agnocast): correct message queue mentions left stale by earlier refactors

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -627,8 +627,8 @@ int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret)
   return 0;
 }
 
-// A performance bridge manager is per-(ipc_ns, domain): its MQ name carries the
-// domain suffix, so each domain needs its own manager. Gate on the domain too,
+// A performance bridge manager is per-(ipc_ns, domain): its UDS address carries
+// the domain suffix, so each domain needs its own manager. Gate on the domain too,
 // otherwise a manager in one domain would suppress spawning in another.
 static bool has_alive_performance_bridge_manager(
   const struct ipc_namespace * ipc_ns, const uint32_t domain_id)

--- a/docs/shared_memory.md
+++ b/docs/shared_memory.md
@@ -21,7 +21,6 @@ When a process first calls malloc or other memory related functions, Agnocast st
 
 1. get an allocatable area through `AGNOCAST_ADD_PROCESS_CMD` ioctl.
 2. open a writable shared memory on the allocatable area, with `shm_open`, `ftruncate` and `mmap` system calls.
-3. create a thread and open a message queue so that the process can recognize a emergence of a new publisher later.
 
 #### Creation of a publisher
 
@@ -29,8 +28,8 @@ When a process calls `create_publisher` for a topic `T`, the shared memory of th
 Thus the following procedures are executed:
 
 1. The publisher process gets the information about subscribers already registered for the topic `T` through `AGNOCAST_ADD_PUBLISHER_CMD` ioctl.
-2. The publisher process opens a message queue and send the shared memory information in order to notify the subscribers already created for the topic `T` that a new publisher is registered.
-3. The subscriber process receives the message and maps the publisher's shared memory area with a read-only privilege.
+2. The kernel module returns the new publisher's shared memory information to each subscriber on its next `AGNOCAST_RECEIVE_MSG_CMD` or `AGNOCAST_TAKE_MSG_CMD` ioctl.
+3. The subscriber process maps the publisher's shared memory area with a read-only privilege.
 
 #### Creation of a subscriber
 
@@ -44,10 +43,6 @@ When a process calls `create_subscription` for topic `T`, then the process maps 
 In Agnocast, there is exactly one writable process and there are some read-only processes for a shared memory.
 Suppose the writable process's id is `pid`, then the shared memory is named as "/agnocast@pid".
 The name should start with '/' and should not include '/' any more.
-
-Message queue is also created for each process.
-Suppose the process's id is `pid`, then the message queue is named as "/new_publisher@pid".
-The restriction for the name is the same as the shared memory.
 
 ## Memory allocation for shared memory
 


### PR DESCRIPTION
## Description

Two message queue mentions no longer match the code:

- `docs/shared_memory.md` describes a per-process `/new_publisher@pid` message queue that notifies subscribers of a new publisher. That queue is gone; the kernel module now returns the new publisher's shm info on the subscriber's next `AGNOCAST_RECEIVE_MSG_CMD` / `AGNOCAST_TAKE_MSG_CMD`.
- `agnocast_ioctl.c` says the performance bridge manager is keyed by its MQ name. It has used a UDS address since #1433.

Documentation and comment only, no behavior change.

## Related links

- #1433 (bridge MQ replaced with UDS)

## How was this PR tested?

Not applicable: no executable code changed. `agnocast_kmod` still builds.

## Notes for reviewers

Both mentions were already stale before #1503; they are split out here to keep that PR scoped to what it makes obsolete itself.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
