### PR TITLE
fix(bridge): release the manager's UDS address before teardown

### DIFF
--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_ipc_event_loop_base.hpp
@@ -50,6 +50,10 @@ public:
   // Wake up the event loop from another thread.
   void wakeup();
 
+  // Release the abstract UDS address without waiting for destruction. Must be called from the
+  // thread that runs spin_once(), and only once it has stopped spinning.
+  void close_listener();
+
   void set_message_handler(MessageCallback cb);
   void set_signal_handler(SignalCallback cb);
   void set_socket_handler(SocketCallback cb);
@@ -168,6 +172,17 @@ inline void IpcEventLoopBase::wakeup()
   if (w == -1) {
     RCLCPP_WARN(logger_, "write() on wakeup eventfd failed: %s", strerror(errno));
   }
+}
+
+inline void IpcEventLoopBase::close_listener()
+{
+  if (listener_fd_ == -1) {
+    return;
+  }
+  if (close(listener_fd_) == -1) {
+    RCLCPP_WARN(logger_, "Failed to close bridge UDS listener_fd: %s", strerror(errno));
+  }
+  listener_fd_ = -1;
 }
 
 inline void IpcEventLoopBase::handle_signal()
@@ -427,12 +442,7 @@ inline void IpcEventLoopBase::cleanup_resources()
     wakeup_efd_ = -1;
   }
 
-  if (listener_fd_ != -1) {
-    if (close(listener_fd_) == -1) {
-      RCLCPP_WARN(logger_, "Failed to close bridge UDS listener_fd: %s", strerror(errno));
-    }
-    listener_fd_ = -1;
-  }
+  close_listener();
 }
 
 }  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_bridge_uds.hpp
@@ -21,6 +21,9 @@ namespace agnocast
 inline constexpr int BRIDGE_UDS_SEND_MAX_RETRIES = 100;
 inline constexpr useconds_t BRIDGE_UDS_SEND_RETRY_INTERVAL_US = 100000;
 
+inline constexpr int BRIDGE_UDS_BIND_MAX_RETRIES = 50;
+inline constexpr useconds_t BRIDGE_UDS_BIND_RETRY_INTERVAL_US = 100000;
+
 namespace detail
 {
 
@@ -42,7 +45,12 @@ inline socklen_t fill_abstract_sockaddr(const std::string & addr, sockaddr_un & 
 
 }  // namespace detail
 
-inline int create_bridge_uds_listener(const std::string & addr)
+// Retries on EADDRINUSE up to `max_retries` * `retry_interval_us`: a manager that has decided to
+// shut down keeps this address bound until it exits, while the kmod already reports that no manager
+// exists, so the replacement manager forked in that window must wait rather than give up.
+inline int create_bridge_uds_listener(
+  const std::string & addr, int max_retries = BRIDGE_UDS_BIND_MAX_RETRIES,
+  useconds_t retry_interval_us = BRIDGE_UDS_BIND_RETRY_INTERVAL_US)
 {
   int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
   if (fd == -1) {
@@ -52,8 +60,14 @@ inline int create_bridge_uds_listener(const std::string & addr)
   try {
     sockaddr_un sa{};
     const socklen_t alen = detail::fill_abstract_sockaddr(addr, sa);
-    if (bind(fd, reinterpret_cast<sockaddr *>(&sa), alen) == -1) {
-      throw std::system_error(errno, std::generic_category(), "bridge UDS bind() failed");
+    for (int retry = 0;; ++retry) {
+      if (bind(fd, reinterpret_cast<sockaddr *>(&sa), alen) == 0) {
+        break;
+      }
+      if (errno != EADDRINUSE || retry >= max_retries) {
+        throw std::system_error(errno, std::generic_category(), "bridge UDS bind() failed");
+      }
+      usleep(retry_interval_us);
     }
   } catch (...) {
     close(fd);

--- a/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
@@ -41,6 +41,12 @@ BridgeManager::~BridgeManager()
 {
   request_shutdown();
 
+  // Release the UDS address first. The kmod clears this process's bridge-manager flag as soon as
+  // shutdown is decided, so a process starting from here on forks a replacement manager, whose
+  // bind() fails while the address is still held. Leaving it to event_loop_'s destructor would
+  // release it only after the joins and the DDS teardown below, which can take seconds.
+  event_loop_.close_listener();
+
   // Join before any member is destroyed: the worker uses container_node_,
   // executor_ and the pending_msgs_ mutex/CV, which live only until this returns.
   if (worker_thread_.joinable()) {

--- a/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_bridge_uds.cpp
@@ -11,12 +11,14 @@
 
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <string>
 #include <system_error>
+#include <thread>
 
 namespace
 {
@@ -123,16 +125,33 @@ TEST(BridgeUdsListenerTest, RejectsInvalidAddress)
 TEST(BridgeUdsListenerTest, DuplicateBindFailsWithAddrInUse)
 {
   const std::string addr = make_unique_abstract_addr("dup");
-  ScopedFd first(agnocast::create_bridge_uds_listener(addr));
+  ScopedFd first(agnocast::create_bridge_uds_listener(addr, 0));
   ASSERT_NE(first.get(), -1);
 
   try {
-    ScopedFd second(agnocast::create_bridge_uds_listener(addr));
+    ScopedFd second(agnocast::create_bridge_uds_listener(addr, 0));
     FAIL() << "second listener on the same abstract address must fail";
   } catch (const std::system_error & e) {
     EXPECT_EQ(e.code().value(), EADDRINUSE)
       << "expected EADDRINUSE, got " << e.code().value() << " (" << e.what() << ")";
   }
+}
+
+TEST(BridgeUdsListenerTest, BindRetriesUntilAddressIsReleased)
+{
+  const std::string addr = make_unique_abstract_addr("retry");
+  const int holder = agnocast::create_bridge_uds_listener(addr, 0);
+  ASSERT_NE(holder, -1);
+
+  std::thread releaser([holder]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    close(holder);
+  });
+
+  // 100 * 20ms = 2s budget, comfortably longer than the 200ms hold above.
+  ScopedFd second(agnocast::create_bridge_uds_listener(addr, 100, 20000));
+  EXPECT_NE(second.get(), -1);
+  releaser.join();
 }
 
 // ---- send_bridge_uds_message ----------------------------------------------


### PR DESCRIPTION
## Description

The bridge manager releases its abstract UDS address only when `event_loop_` is destroyed, which happens after the thread joins and the DDS teardown in `~BridgeManager` — that is, at the very end of shutdown. The kmod, meanwhile, clears `is_bridge_manager` as soon as shutdown is decided, so a process starting in that span is told no manager exists and forks a replacement. That replacement's `bind()` fails with `EADDRINUSE` and it exits without retrying, leaving the run with no manager at all; a registration sent in the same span is instead received by the dying manager and discarded.

This closes the window from both ends. `~BridgeManager` now releases the address before the slow teardown, and `create_bridge_uds_listener()` retries on `EADDRINUSE` so a replacement forked while the address is still held waits for it rather than giving up.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`test_unit_agnocastlib --gtest_filter='BridgeUds*'` passes (10 tests), including a new case covering the retry. `bash scripts/test/e2e_test_1to1.bash -s` passes with the bridge on. The full sweeps are still to be run.

## Notes for reviewers

`close_listener()` must be called from the thread that spins the event loop, and only once it has stopped spinning. `~BridgeManager` satisfies both: `run()` and the destructor execute on the daemon's main thread, and `request_shutdown()` wakes the loop first (#1507).

One consequence worth a look: a replacement manager can now bind while the old one is still tearing down, so the two coexist briefly. The old one is already not the manager as far as the kmod is concerned and only reclaims its own bridges, but this is the part I would most like a second opinion on.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
