### PR TITLE
test(kmod): cover process exit under a renaming bridge rule

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.c
@@ -700,3 +700,96 @@ void test_case_do_exit_releases_notify_context(struct kunit * test)
   KUNIT_EXPECT_EQ(test, slot->put_count, 1);
   KUNIT_EXPECT_EQ(test, agnocast_kunit_eventfd_outstanding(), (int64_t)0);
 }
+
+// The daemon's poll_for_unlink() loop terminates on ret_daemon_should_exit, which Phase 2 raises
+// once get_process_num() drops to 0.
+void test_case_do_exit_reports_daemon_should_exit(struct kunit * test)
+{
+  // Arrange
+  const pid_t exiting_pid = PID_BASE;
+  setup_one_process(test, exiting_pid);
+
+  agnocast_enqueue_exit_pid(exiting_pid);
+  msleep(20);  // wait for exit_worker_thread to handle process exit
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(exiting_pid));
+
+  // Act
+  struct ioctl_get_exit_process_args get_exit_args = {};
+  const pid_t global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_args);
+  KUNIT_ASSERT_EQ(test, get_exit_args.ret_pid, exiting_pid);
+
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 0);
+
+  // Phase 2 freed proc_info, so there is nothing left to report.
+  struct ioctl_get_exit_process_args second_get_args = {};
+  KUNIT_EXPECT_EQ(
+    test, agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &second_get_args), (pid_t)-1);
+  KUNIT_EXPECT_EQ(test, second_get_args.ret_pid, -1);
+}
+
+// The counterpart of the case above: one process of two exits, so the daemon has to stay up. It
+// then commits the -1 that an empty Phase 1 reported, which must leave the remaining process alone.
+void test_case_do_exit_keeps_daemon_alive_for_remaining_process(struct kunit * test)
+{
+  // Arrange
+  const pid_t exiting_pid = PID_BASE;
+  const pid_t remaining_pid = PID_BASE + 1;
+  setup_one_process(test, exiting_pid);
+  setup_one_process(test, remaining_pid);
+
+  agnocast_enqueue_exit_pid(exiting_pid);
+  msleep(20);  // wait for exit_worker_thread to handle process exit
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(exiting_pid));
+
+  // Act
+  struct ioctl_get_exit_process_args get_exit_args = {};
+  const pid_t global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_args);
+  KUNIT_ASSERT_EQ(test, get_exit_args.ret_pid, exiting_pid);
+
+  bool daemon_should_exit = true;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+  KUNIT_EXPECT_FALSE(test, agnocast_is_proc_exited(remaining_pid));
+
+  struct ioctl_get_exit_process_args second_get_args = {};
+  const pid_t no_pid = agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &second_get_args);
+  KUNIT_ASSERT_EQ(test, no_pid, (pid_t)-1);
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, no_pid, &daemon_should_exit);
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, agnocast_get_alive_proc_num(), 1);
+}
+
+// A crashed bridge process sends no REMOVE_BRIDGE, so the exit handler is what has to drop its
+// bridge_info.
+void test_case_do_exit_frees_bridge_info(struct kunit * test)
+{
+  // Arrange
+  const pid_t bridge_pid = PID_BASE;
+  setup_one_process(test, bridge_pid);
+
+  struct ioctl_add_bridge_args add_bridge_args = {0};
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_bridge(
+      TOPIC_NAME, bridge_pid, true, current->nsproxy->ipc_ns, &add_bridge_args),
+    0);
+  KUNIT_ASSERT_TRUE(test, agnocast_is_in_bridge_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+
+  // Act
+  agnocast_enqueue_exit_pid(bridge_pid);
+  msleep(20);  // wait for exit_worker_thread to handle process exit
+  KUNIT_ASSERT_TRUE(test, agnocast_is_proc_exited(bridge_pid));
+
+  // Assert
+  KUNIT_EXPECT_FALSE(test, agnocast_is_in_bridge_htable(TOPIC_NAME, current->nsproxy->ipc_ns));
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_do_exit.h
@@ -14,7 +14,10 @@
     KUNIT_CASE(test_case_do_exit_with_entry_with_subscriber_reference),                        \
     KUNIT_CASE(test_case_do_exit_with_multi_references_publisher_exit_first),                  \
     KUNIT_CASE(test_case_do_exit_with_multi_references_subscriber_exit_first),                 \
-    KUNIT_CASE(test_case_do_exit_releases_notify_context)
+    KUNIT_CASE(test_case_do_exit_releases_notify_context),                                     \
+    KUNIT_CASE(test_case_do_exit_reports_daemon_should_exit),                                  \
+    KUNIT_CASE(test_case_do_exit_keeps_daemon_alive_for_remaining_process),                    \
+    KUNIT_CASE(test_case_do_exit_frees_bridge_info)
 
 void test_case_is_agnocast_pid(struct kunit * test);
 void test_case_do_exit(struct kunit * test);
@@ -33,3 +36,6 @@ void test_case_do_exit_with_entry_with_subscriber_reference(struct kunit * test)
 void test_case_do_exit_with_multi_references_publisher_exit_first(struct kunit * test);
 void test_case_do_exit_with_multi_references_subscriber_exit_first(struct kunit * test);
 void test_case_do_exit_releases_notify_context(struct kunit * test);
+void test_case_do_exit_reports_daemon_should_exit(struct kunit * test);
+void test_case_do_exit_keeps_daemon_alive_for_remaining_process(struct kunit * test);
+void test_case_do_exit_frees_bridge_info(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -152,6 +152,43 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
+// The endpoint check has one disjunct per cell, and the case above only fills the from side. Under
+// a rename the to side differs in both name and domain, so it is the disjunct that a name-keyed
+// lookup would miss.
+void test_case_add_domain_bridge_rejected_when_target_endpoint_exists(struct kunit * test)
+{
+  // Arrange
+  setup_process_in_domain(test, 1001, 2);
+  add_publisher_named(test, 1001, RN_DST);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+// from_domain > to_domain flips the pair into canonical order, and each name has to travel with its
+// own domain: the rule is reachable from RN_DST@1, and 2 -> 1 is recorded as b_to_a.
+void test_case_add_domain_bridge_rename_reverse_order(struct kunit * test)
+{
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 2, 1, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            RN_DST, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_EQ(test, domain_a, 1);
+  KUNIT_EXPECT_EQ(test, domain_b, 2);
+  KUNIT_EXPECT_FALSE(test, a_to_b);
+  KUNIT_EXPECT_TRUE(test, b_to_a);
+}
+
 void test_case_domain_bridge_groups_wrappers(struct kunit * test)
 {
   KUNIT_ASSERT_EQ(
@@ -443,4 +480,53 @@ void test_case_domain_bridge_rename_multi_publisher(struct kunit * test)
 
   // Woken exactly once, regardless of the other publishers sharing the struct.
   KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+}
+
+// The rename counterpart of domain_bridge_exit_frees_shared_struct. Renamed wrappers land in
+// different topic_hashtable buckets, so agnocast_process_exit_cleanup walks them in an order the
+// same-name case never produces.
+void test_case_domain_bridge_rename_exit_frees_shared_struct(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_named(test, 1001, RN_DST);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(RN_DST, current->nsproxy->ipc_ns, 2), 2);
+
+  // Act
+  agnocast_enqueue_exit_pid(1000);
+  agnocast_enqueue_exit_pid(1001);
+  msleep(20);  // let exit_worker_thread drain both pids
+
+  // Assert: the shared struct goes with the second wrapper, exactly once (KASAN checks the free).
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_DST, current->nsproxy->ipc_ns, 2), 0);
+}
+
+// The exit-path counterpart of domain_bridge_partial_remove_sub_keeps_struct, under a rename rule.
+// Only the subscriber's process exits, so the released wrapper has to be picked by domain rather
+// than by name: the two wrappers share one pub/sub table but carry different names.
+void test_case_domain_bridge_rename_exit_partial_keeps_struct(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(RN_SRC, RN_DST, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, RN_SRC);
+  setup_process_in_domain(test, 1001, 2);
+  add_subscriber_named(test, 1001, RN_DST);
+  KUNIT_ASSERT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 2);
+
+  // Act
+  agnocast_enqueue_exit_pid(1001);
+  msleep(20);  // let exit_worker_thread drain the subscriber
+
+  // Assert: the shared struct survives for the domain-1 publisher that is still alive; freeing it
+  // here would be a UAF.
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_DST, current->nsproxy->ipc_ns, 2), 0);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(RN_SRC, current->nsproxy->ipc_ns, 1), 1);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -2,25 +2,29 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_DOMAIN_BRIDGE                                              \
-  KUNIT_CASE(test_case_add_domain_bridge_normal),                             \
-    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),             \
-    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),                \
-    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),            \
-    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists),    \
-    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                      \
-    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),             \
-    KUNIT_CASE(test_case_domain_bridge_direction_respected),                  \
-    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),          \
-    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),      \
-    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),             \
-    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),          \
-    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),           \
-    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher), \
-    KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),               \
-    KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),         \
-    KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),               \
-    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
+#define TEST_CASES_DOMAIN_BRIDGE                                                  \
+  KUNIT_CASE(test_case_add_domain_bridge_normal),                                 \
+    KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),                 \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),                    \
+    KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),                \
+    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_endpoint_exists),        \
+    KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                          \
+    KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),                 \
+    KUNIT_CASE(test_case_domain_bridge_direction_respected),                      \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),              \
+    KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),          \
+    KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),                 \
+    KUNIT_CASE(test_case_domain_bridge_get_subscriber_num_filtered),              \
+    KUNIT_CASE(test_case_domain_bridge_get_publisher_num_filtered),               \
+    KUNIT_CASE(test_case_domain_bridge_shm_info_skips_undelivered_publisher),     \
+    KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),                   \
+    KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),             \
+    KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),                   \
+    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher),                   \
+    KUNIT_CASE(test_case_domain_bridge_rename_exit_frees_shared_struct),          \
+    KUNIT_CASE(test_case_domain_bridge_rename_exit_partial_keeps_struct),         \
+    KUNIT_CASE(test_case_add_domain_bridge_rejected_when_target_endpoint_exists), \
+    KUNIT_CASE(test_case_add_domain_bridge_rename_reverse_order)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
@@ -40,3 +44,7 @@ void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
 void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
 void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);
+void test_case_domain_bridge_rename_exit_frees_shared_struct(struct kunit * test);
+void test_case_domain_bridge_rename_exit_partial_keeps_struct(struct kunit * test);
+void test_case_add_domain_bridge_rejected_when_target_endpoint_exists(struct kunit * test);
+void test_case_add_domain_bridge_rename_reverse_order(struct kunit * test);


### PR DESCRIPTION
## Description

Follow-up to #1503, which noted this gap as out of scope there.

#1503 drops `domain_bridge_rename_exit_cleanup_uses_canonical_name` (added in #1443) along with its subject, the exit-cleanup MQ record. That leaves no case covering process exit under a *renaming* bridge rule: `domain_bridge_exit_frees_shared_struct` only covers the same-name case. The same assertion cannot be restored, so this covers what the exit path still does under a rename — wrapper release and shared-struct refcounting — with two cases:

- `domain_bridge_rename_exit_frees_shared_struct` — the rename counterpart of `domain_bridge_exit_frees_shared_struct`. Both processes exit; both wrappers go and the shared `topic_struct` is freed exactly once.
- `domain_bridge_rename_exit_partial_keeps_struct` — the exit counterpart of `domain_bridge_partial_remove_sub_keeps_struct`. Only the renamed subscriber's process exits; its wrapper is released while the shared struct survives for the still-live domain-1 publisher.

## Related links

- Follows #1503, which is where this was split out from
- The removed case came from #1443

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

The partial case is the one carrying most of the weight. `agnocast_wrapper_has_domain_endpoints()` picks the wrapper to release out of a pub/sub table shared by both domains, keyed on `domain_id` rather than on the topic name; under a rename the two wrappers carry different names, so this is where a name-keyed regression would show up. Freeing the struct there would be a UAF for the live publisher.

The frees-shared-struct case is cheaper but not redundant: renamed wrappers hash into different `topic_hashtable` buckets, so `agnocast_process_exit_cleanup`'s `hash_for_each_safe` walks them in an order the same-name case never produces.

Tests only — no production code is touched.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` — test additions only.
