### PR TITLE
feat(agnocastlib): unify Subscription and TakeSubscription

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -278,6 +278,19 @@ if(BUILD_TESTING)
     LABELS "requires_kernel_module;requires_heaphook"
   )
 
+  # Subscription take() integration test (requires kernel module, no mock).
+  # Covers callback-less construction, the take() polling paths and the guard that keeps
+  # callback delivery and take() from sharing one kernel-side reference.
+  ament_add_gmock(test_integration_agnocast_subscription_take_${PROJECT_NAME}
+    test/integration/test_agnocast_subscription_take.cpp)
+  target_link_libraries(test_integration_agnocast_subscription_take_${PROJECT_NAME} agnocast)
+  ament_target_dependencies(test_integration_agnocast_subscription_take_${PROJECT_NAME} std_msgs)
+  set_tests_properties(test_integration_agnocast_subscription_take_${PROJECT_NAME} PROPERTIES
+    ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe;LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libagnocast_heaphook.so:$ENV{LD_PRELOAD}"
+    TIMEOUT 60
+    LABELS "requires_kernel_module;requires_heaphook"
+  )
+
   # Parameter service integration test (requires kernel module, no mock).
   ament_add_gmock(test_integration_agnocast_parameter_service_${PROJECT_NAME}
     test/integration/test_agnocast_parameter_service.cpp)

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -278,9 +278,7 @@ if(BUILD_TESTING)
     LABELS "requires_kernel_module;requires_heaphook"
   )
 
-  # Subscription take() integration test (requires kernel module, no mock).
-  # Covers callback-less construction, the take() polling paths and the guard that keeps
-  # callback delivery and take() from sharing one kernel-side reference.
+  # Subscription take() integration test (requires kernel module, no mock)
   ament_add_gmock(test_integration_agnocast_subscription_take_${PROJECT_NAME}
     test/integration/test_agnocast_subscription_take.cpp)
   target_link_libraries(test_integration_agnocast_subscription_take_${PROJECT_NAME} agnocast)

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -17,7 +17,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <type_traits>
 
 namespace agnocast
 {
@@ -33,6 +35,14 @@ void map_read_only_area(const pid_t pid, const uint64_t shm_addr, const uint64_t
 rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(agnocast::Node * node);
 const void * get_node_base_address(Node * node);
 const void * get_node_base_address(rclcpp::Node * node);
+
+// rclcpp overload of the above, so callback-less subscription construction can be written once
+// for both node types. rclcpp::Node needs no out-of-line definition to break an include cycle.
+inline rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(
+  rclcpp::Node * node)
+{
+  return node->get_node_base_interface()->get_default_callback_group();
+}
 
 /**
  * @brief Options for configuring an Agnocast subscription.
@@ -107,7 +117,9 @@ class SubscriptionBase
 protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
-  int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for take subscriptions)
+  int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for callback-less subscriptions)
+  // Effective QoS after any qos_overriding_options are applied. Set by init_base().
+  rclcpp::QoS actual_qos_{1};
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     SubscriptionRole role, const std::string & node_name, const std::string & type_name);
@@ -129,6 +141,15 @@ public:
   const char * get_topic_name() const { return topic_name_.c_str(); }
 
   uint32_t get_publisher_count() const { return get_publisher_count_core(topic_name_); }
+
+  /**
+   * @brief Return the effective QoS of this subscription.
+   *
+   * Mirrors `rclcpp::SubscriptionBase::get_actual_qos()`. This is the QoS passed at construction
+   * with any `SubscriptionOptions::qos_overriding_options` applied.
+   */
+  AGNOCAST_PUBLIC
+  rclcpp::QoS get_actual_qos() const { return actual_qos_; }
 
   virtual ~SubscriptionBase()
   {
@@ -164,7 +185,15 @@ AGNOCAST_PUBLIC
 template <typename MessageT>
 class Subscription : public SubscriptionBase
 {
-  uint32_t callback_info_id_;
+  // Empty when the subscription was constructed without a callback. That case is what the kmod
+  // calls a "take subscription": no eventfd is registered and publishers skip it when signalling.
+  std::optional<uint32_t> callback_info_id_;
+
+  // Cached pointer from the most recent take(allow_same_message=true) call.
+  // When the same entry is returned again, a copy sharing the same control_block is returned
+  // so that the kernel-side reference is not released until all userspace copies are destroyed.
+  agnocast::ipc_shared_ptr<const MessageT> last_taken_ptr_;
+  std::mutex last_taken_ptr_mtx_;
 
   // Returns rosidl message name for MessageT, or empty string if MessageT is not a rosidl message
   // type.
@@ -174,6 +203,30 @@ class Subscription : public SubscriptionBase
       return rosidl_generator_traits::name<MessageT>();
     }
     return std::string{};
+  }
+
+  // A 4th positional argument of type SubscriptionOptions selects the callback-less overload
+  // below, so it must not be deduced as a callback here.
+  template <typename Func>
+  static constexpr bool is_callback_arg_v =
+    !std::is_same_v<std::decay_t<Func>, agnocast::SubscriptionOptions>;
+
+  template <typename NodeT>
+  void constructor_impl_no_callback(
+    NodeT * node, const std::string & type_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options, SubscriptionRole role)
+  {
+    const rclcpp::QoS actual_qos = init_base(node, qos, type_name, true, options, role);
+
+    {
+      auto default_cbg = get_default_callback_group_for_tracepoint(node);
+      auto dummy_cb = []() {};
+      std::string dummy_cb_symbols = "dummy_take" + topic_name_;
+      TRACEPOINT(
+        agnocast_subscription_init, static_cast<const void *>(this), get_node_base_address(node),
+        static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
+        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
+    }
   }
 
   template <typename NodeT, typename Func>
@@ -195,7 +248,7 @@ class Subscription : public SubscriptionBase
       callback_group);
 
     {
-      uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | callback_info_id_;
+      uint64_t pid_callback_info_id = (static_cast<uint64_t>(getpid()) << 32) | *callback_info_id_;
       TRACEPOINT(
         agnocast_subscription_init, static_cast<const void *>(this), get_node_base_address(node),
         callback_addr, static_cast<const void *>(callback_group.get()), callback_symbol,
@@ -206,7 +259,7 @@ class Subscription : public SubscriptionBase
 public:
   using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
 
-  template <typename Func>
+  template <typename Func, std::enable_if_t<is_callback_arg_v<Func>, int> = 0>
   Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     agnocast::SubscriptionOptions options, SubscriptionRole role = SubscriptionRole::Default)
@@ -216,7 +269,7 @@ public:
       node, get_message_type_name(), qos, std::forward<Func>(callback), options, role);
   }
 
-  template <typename Func>
+  template <typename Func, std::enable_if_t<is_callback_arg_v<Func>, int> = 0>
   Subscription(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
     Func && callback, agnocast::SubscriptionOptions options,
@@ -225,6 +278,29 @@ public:
   {
     constructor_impl(
       node, get_message_type_name(), qos, std::forward<Func>(callback), options, role);
+  }
+
+  /// Construct without a callback. Messages are then retrieved by polling take(), and the
+  /// subscription registers no eventfd so publishers skip it when signalling. Mirrors the
+  /// rclcpp idiom of a subscription whose callback group is never spun.
+  Subscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : SubscriptionBase(node, topic_name)
+  {
+    constructor_impl_no_callback(node, get_message_type_name(), qos, options, role);
+  }
+
+  /// @copydoc Subscription(rclcpp::Node*, const std::string&, const rclcpp::QoS&,
+  ///          agnocast::SubscriptionOptions, SubscriptionRole)
+  Subscription(
+    agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : SubscriptionBase(node, topic_name)
+  {
+    constructor_impl_no_callback(node, get_message_type_name(), qos, options, role);
   }
 
   template <typename Func, typename U = MessageT, std::enable_if_t<std::is_void_v<U>, int> = 0>
@@ -247,103 +323,14 @@ public:
     constructor_impl(node, type_name, qos, std::forward<Func>(callback), options, role);
   }
 
-  ~Subscription()
-  {
-    // Remove from callback info map to prevent stale references on re-subscription and to avoid
-    // fd reuse conflicts. ~SubscriptionBase() closes the eventfd once this body returns, after
-    // which the OS may reuse the same fd number for a new subscription. If the old entry remained
-    // in id2_callback_info, adding the new fd to epoll (EPOLL_CTL_ADD) could fail with EEXIST
-    // because epoll would still associate that fd number with the stale entry.
-    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-    id2_callback_info.erase(callback_info_id_);
-  }
-};
-
-// NOTE on Subscription<void>:
-//   Subscription<void> is the subscription counterpart of TypeErasedPublisher. We do not create a
-//   separate TypeErasedSubscription class because it would share most of its code with
-//   Subscription<MessageT>, making a void specialization the cleaner choice.
-
-/**
- * @brief Agnocast polling take-subscription for a compile-time known message type.
- *
- * Does not use a callback; the caller retrieves the latest message by calling
- * take(). Use PollingSubscriber<MessageT> for a higher-level wrapper.
- *
- * @tparam MessageT  ROS message type.
- */
-AGNOCAST_PUBLIC
-template <typename MessageT>
-class TakeSubscription : public SubscriptionBase
-{
-private:
-  // Cached pointer from the most recent take(allow_same_message=true) call.
-  // When the same entry is returned again, a copy sharing the same control_block is returned
-  // so that the kernel-side reference is not released until all userspace copies are destroyed.
-  agnocast::ipc_shared_ptr<const MessageT> last_taken_ptr_;
-  std::mutex last_taken_ptr_mtx_;
-
-  template <typename NodeT>
-  rclcpp::QoS constructor_impl(
-    NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options,
-    SubscriptionRole role)
-  {
-    // Gated to message types — service types pulled in by
-    // BasicService<ServiceT> have no rosidl message name. The empty string
-    // signals "skip registry" to initialize().
-    std::string type_name;
-    if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
-      type_name = rosidl_generator_traits::name<MessageT>();
-    }
-    return init_base(node, qos, type_name, true, options, role);
-  }
-
-public:
-  using SharedPtr = std::shared_ptr<TakeSubscription<MessageT>>;
-
-  TakeSubscription(
-    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
-    SubscriptionRole role = SubscriptionRole::Default)
-  : SubscriptionBase(node, topic_name)
-  {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
-
-    {
-      auto default_cbg = node->get_node_base_interface()->get_default_callback_group();
-      auto dummy_cb = []() {};
-      std::string dummy_cb_symbols = "dummy_take" + topic_name_;
-      TRACEPOINT(
-        agnocast_subscription_init, static_cast<const void *>(this),
-        static_cast<const void *>(
-          node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
-        static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
-        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
-    }
-  }
-
-  TakeSubscription(
-    agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
-    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
-    SubscriptionRole role = SubscriptionRole::Default)
-  : SubscriptionBase(node, topic_name)
-  {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
-
-    {
-      auto default_cbg = get_default_callback_group_for_tracepoint(node);
-      auto dummy_cb = []() {};
-      std::string dummy_cb_symbols = "dummy_take" + topic_name_;
-      TRACEPOINT(
-        agnocast_subscription_init, static_cast<const void *>(this),
-        static_cast<const void *>(get_node_base_address(node)),
-        static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
-        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
-    }
-  }
-
   /**
-   * @brief Retrieve the latest message from the topic.
+   * @brief Retrieve the latest message from the topic without going through the callback.
+   *
+   * Mirrors `rclcpp::Subscription::take()` in that it is available on every subscription, not
+   * just callback-less ones. Note the same caveat as rclcpp: if this subscription also has a
+   * callback that is being spun by an executor, the callback and take() consume from the same
+   * per-subscriber cursor and will steal messages from each other. Use one or the other.
+   *
    * @param allow_same_message  If true, may return the same message as the previous call
    *                            (useful for always having the latest value). If false, returns
    *                            only new messages since the last take.
@@ -412,6 +399,61 @@ public:
 
     MessageT * ptr = reinterpret_cast<MessageT *>(take_args.ret_addr);
     return agnocast::ipc_shared_ptr<const MessageT>(ptr, topic_name_, id_, take_args.ret_entry_id);
+  }
+
+  ~Subscription()
+  {
+    // Nothing to erase when constructed without a callback: no entry was ever registered and
+    // no eventfd was opened.
+    if (!callback_info_id_.has_value()) {
+      return;
+    }
+
+    // Remove from callback info map to prevent stale references on re-subscription and to avoid
+    // fd reuse conflicts. ~SubscriptionBase() closes the eventfd once this body returns, after
+    // which the OS may reuse the same fd number for a new subscription. If the old entry remained
+    // in id2_callback_info, adding the new fd to epoll (EPOLL_CTL_ADD) could fail with EEXIST
+    // because epoll would still associate that fd number with the stale entry.
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+    id2_callback_info.erase(*callback_info_id_);
+  }
+};
+
+// NOTE on Subscription<void>:
+//   Subscription<void> is the subscription counterpart of TypeErasedPublisher. We do not create a
+//   separate TypeErasedSubscription class because it would share most of its code with
+//   Subscription<MessageT>, making a void specialization the cleaner choice.
+
+/**
+ * @brief Backwards-compatible spelling of a callback-less Subscription<MessageT>.
+ *
+ * Retained so existing call sites keep compiling. `Subscription<MessageT>` now supports both
+ * callback delivery and take(), mirroring `rclcpp::Subscription`, so prefer constructing a
+ * `Subscription<MessageT>` without a callback instead of using this class.
+ *
+ * @tparam MessageT  ROS message type.
+ */
+AGNOCAST_PUBLIC
+template <typename MessageT>
+class TakeSubscription : public Subscription<MessageT>
+{
+public:
+  using SharedPtr = std::shared_ptr<TakeSubscription<MessageT>>;
+
+  TakeSubscription(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : Subscription<MessageT>(node, topic_name, qos, options, role)
+  {
+  }
+
+  TakeSubscription(
+    agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
+    agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
+    SubscriptionRole role = SubscriptionRole::Default)
+  : Subscription<MessageT>(node, topic_name, qos, options, role)
+  {
   }
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 
@@ -118,7 +119,6 @@ protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
   int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for callback-less subscriptions)
-  // Effective QoS after any qos_overriding_options are applied. Set by init_base().
   rclcpp::QoS actual_qos_{1};
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
@@ -175,9 +175,15 @@ public:
 /**
  * @brief Agnocast subscription for a compile-time known message type.
  *
- * Delivers messages via a callback that is invoked each time a publisher
- * writes to the topic. Allocate instances with
- * `agnocast::create_subscription<MessageT>()` or construct directly.
+ * A subscription delivers messages in exactly one of two modes, fixed at construction:
+ *   - constructed **with** a callback: the callback is invoked by the executor each time a
+ *     publisher writes to the topic. Allocate with `agnocast::create_subscription<MessageT>()`
+ *     or construct directly.
+ *   - constructed **without** a callback: the caller polls with take(). See
+ *     PollingSubscriber<MessageT> for a higher-level wrapper.
+ *
+ * The modes are mutually exclusive: take() throws on a subscription that has a callback. See
+ * take() for why.
  *
  * @tparam MessageT  ROS message type.
  */
@@ -280,9 +286,7 @@ public:
       node, get_message_type_name(), qos, std::forward<Func>(callback), options, role);
   }
 
-  /// Construct without a callback. Messages are then retrieved by polling take(), and the
-  /// subscription registers no eventfd so publishers skip it when signalling. Mirrors the
-  /// rclcpp idiom of a subscription whose callback group is never spun.
+  /// Construct without a callback. Messages are retrieved by polling take().
   Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
@@ -324,21 +328,33 @@ public:
   }
 
   /**
-   * @brief Retrieve the latest message from the topic without going through the callback.
+   * @brief Retrieve the latest message from the topic by polling.
    *
-   * Mirrors `rclcpp::Subscription::take()` in that it is available on every subscription, not
-   * just callback-less ones. Note the same caveat as rclcpp: if this subscription also has a
-   * callback that is being spun by an executor, the callback and take() consume from the same
-   * per-subscriber cursor and will steal messages from each other. Use one or the other.
+   * Only usable on a subscription constructed without a callback. Unlike
+   * `rclcpp::Subscription::take()`, which copies the message into caller-provided storage and can
+   * therefore coexist with callback delivery, this hands out a reference-counted pointer into
+   * shared memory, and the kmod tracks at most one outstanding reference per
+   * (subscriber, message). Callback delivery and take() would each build their own
+   * `ipc_shared_ptr` on top of that single reference, so whichever is destroyed first would
+   * release it while the other still points at memory the publisher may reuse.
    *
    * @param allow_same_message  If true, may return the same message as the previous call
    *                            (useful for always having the latest value). If false, returns
    *                            only new messages since the last take.
    * @return Shared pointer to the message, or empty if unavailable.
+   * @throws std::runtime_error if the subscription was constructed with a callback.
    */
   AGNOCAST_PUBLIC
   agnocast::ipc_shared_ptr<const MessageT> take(bool allow_same_message = false)
   {
+    if (callback_info_id_.has_value()) {
+      throw std::runtime_error(
+        "take() was called on the subscription for topic '" + topic_name_ +
+        "', which was constructed with a callback. A subscription delivers messages either "
+        "through its callback or through take(), never both. Construct the subscription without "
+        "a callback to poll it with take().");
+    }
+
     publisher_shm_info pub_shm_infos[MAX_PUBLISHER_NUM]{};
 
     union ioctl_take_msg_args take_args;
@@ -403,8 +419,6 @@ public:
 
   ~Subscription()
   {
-    // Nothing to erase when constructed without a callback: no entry was ever registered and
-    // no eventfd was opened.
     if (!callback_info_id_.has_value()) {
       return;
     }
@@ -425,11 +439,10 @@ public:
 //   Subscription<MessageT>, making a void specialization the cleaner choice.
 
 /**
- * @brief Backwards-compatible spelling of a callback-less Subscription<MessageT>.
+ * @brief Deprecated spelling of a callback-less Subscription<MessageT>.
  *
- * Retained so existing call sites keep compiling. `Subscription<MessageT>` now supports both
- * callback delivery and take(), mirroring `rclcpp::Subscription`, so prefer constructing a
- * `Subscription<MessageT>` without a callback instead of using this class.
+ * Construct a `Subscription<MessageT>` without a callback instead. Scheduled for removal
+ * (autowarefoundation/agnocast#1532).
  *
  * @tparam MessageT  ROS message type.
  */

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -37,8 +37,8 @@ rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(agnoc
 const void * get_node_base_address(Node * node);
 const void * get_node_base_address(rclcpp::Node * node);
 
-// rclcpp overload of the above, so callback-less subscription construction can be written once
-// for both node types. rclcpp::Node needs no out-of-line definition to break an include cycle.
+// Unlike the agnocast::Node overload, rclcpp::Node needs no out-of-line definition to break the
+// include cycle.
 inline rclcpp::CallbackGroup::SharedPtr get_default_callback_group_for_tracepoint(
   rclcpp::Node * node)
 {
@@ -181,8 +181,8 @@ AGNOCAST_PUBLIC
 template <typename MessageT>
 class Subscription : public SubscriptionBase
 {
-  // Empty when the subscription was constructed without a callback. That case is what the kmod
-  // calls a "take subscription": no eventfd is registered and publishers skip it when signalling.
+  // Empty is what the kmod calls a "take subscription": no eventfd is registered and publishers
+  // skip it when signalling.
   std::optional<uint32_t> callback_info_id_;
 
   // Cached pointer from the most recent take(allow_same_message=true) call.
@@ -191,8 +191,8 @@ class Subscription : public SubscriptionBase
   agnocast::ipc_shared_ptr<const MessageT> last_taken_ptr_;
   std::mutex last_taken_ptr_mtx_;
 
-  // Returns rosidl message name for MessageT, or empty string if MessageT is not a rosidl message
-  // type.
+  // Gated to message types — service types pulled in by BasicService<ServiceT> have no rosidl
+  // message name. The empty string signals "skip registry" to initialize().
   static std::string get_message_type_name()
   {
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
@@ -204,7 +204,7 @@ class Subscription : public SubscriptionBase
   template <typename NodeT>
   void constructor_impl_no_callback(
     NodeT * node, const std::string & type_name, const rclcpp::QoS & qos,
-    agnocast::SubscriptionOptions options, SubscriptionRole role)
+    const agnocast::SubscriptionOptions & options, SubscriptionRole role)
   {
     const rclcpp::QoS actual_qos = init_base(node, qos, type_name, true, options, role);
 
@@ -220,7 +220,7 @@ class Subscription : public SubscriptionBase
   template <typename NodeT, typename Func>
   void constructor_impl(
     NodeT * node, const std::string & type_name, const rclcpp::QoS & qos, Func && callback,
-    agnocast::SubscriptionOptions options, SubscriptionRole role)
+    const agnocast::SubscriptionOptions & options, SubscriptionRole role)
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
 
@@ -307,6 +307,21 @@ public:
   : SubscriptionBase(node, topic_name)
   {
     constructor_impl(node, type_name, qos, std::forward<Func>(callback), options, role);
+  }
+
+  ~Subscription()
+  {
+    if (!callback_info_id_.has_value()) {
+      return;
+    }
+
+    // Remove from callback info map to prevent stale references on re-subscription and to avoid
+    // fd reuse conflicts. ~SubscriptionBase() closes the eventfd once this body returns, after
+    // which the OS may reuse the same fd number for a new subscription. If the old entry remained
+    // in id2_callback_info, adding the new fd to epoll (EPOLL_CTL_ADD) could fail with EEXIST
+    // because epoll would still associate that fd number with the stale entry.
+    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
+    id2_callback_info.erase(*callback_info_id_);
   }
 
   /**
@@ -397,21 +412,6 @@ public:
 
     MessageT * ptr = reinterpret_cast<MessageT *>(take_args.ret_addr);
     return agnocast::ipc_shared_ptr<const MessageT>(ptr, topic_name_, id_, take_args.ret_entry_id);
-  }
-
-  ~Subscription()
-  {
-    if (!callback_info_id_.has_value()) {
-      return;
-    }
-
-    // Remove from callback info map to prevent stale references on re-subscription and to avoid
-    // fd reuse conflicts. ~SubscriptionBase() closes the eventfd once this body returns, after
-    // which the OS may reuse the same fd number for a new subscription. If the old entry remained
-    // in id2_callback_info, adding the new fd to epoll (EPOLL_CTL_ADD) could fail with EEXIST
-    // because epoll would still associate that fd number with the stale entry.
-    std::lock_guard<std::mutex> lock(id2_callback_info_mtx);
-    id2_callback_info.erase(*callback_info_id_);
   }
 };
 

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -119,7 +119,6 @@ protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
   int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for callback-less subscriptions)
-  rclcpp::QoS actual_qos_{1};
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     SubscriptionRole role, const std::string & node_name, const std::string & type_name);
@@ -141,15 +140,6 @@ public:
   const char * get_topic_name() const { return topic_name_.c_str(); }
 
   uint32_t get_publisher_count() const { return get_publisher_count_core(topic_name_); }
-
-  /**
-   * @brief Return the effective QoS of this subscription.
-   *
-   * Mirrors `rclcpp::SubscriptionBase::get_actual_qos()`. This is the QoS passed at construction
-   * with any `SubscriptionOptions::qos_overriding_options` applied.
-   */
-  AGNOCAST_PUBLIC
-  rclcpp::QoS get_actual_qos() const { return actual_qos_; }
 
   virtual ~SubscriptionBase()
   {
@@ -211,12 +201,6 @@ class Subscription : public SubscriptionBase
     return std::string{};
   }
 
-  // A 4th positional argument of type SubscriptionOptions selects the callback-less overload
-  // below, so it must not be deduced as a callback here.
-  template <typename Func>
-  static constexpr bool is_callback_arg_v =
-    !std::is_same_v<std::decay_t<Func>, agnocast::SubscriptionOptions>;
-
   template <typename NodeT>
   void constructor_impl_no_callback(
     NodeT * node, const std::string & type_name, const rclcpp::QoS & qos,
@@ -224,15 +208,13 @@ class Subscription : public SubscriptionBase
   {
     const rclcpp::QoS actual_qos = init_base(node, qos, type_name, true, options, role);
 
-    {
-      auto default_cbg = get_default_callback_group_for_tracepoint(node);
-      auto dummy_cb = []() {};
-      std::string dummy_cb_symbols = "dummy_take" + topic_name_;
-      TRACEPOINT(
-        agnocast_subscription_init, static_cast<const void *>(this), get_node_base_address(node),
-        static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
-        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
-    }
+    auto default_cbg = get_default_callback_group_for_tracepoint(node);
+    auto dummy_cb = []() {};
+    std::string dummy_cb_symbols = "dummy_take" + topic_name_;
+    TRACEPOINT(
+      agnocast_subscription_init, static_cast<const void *>(this), get_node_base_address(node),
+      static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
+      dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
   }
 
   template <typename NodeT, typename Func>
@@ -265,7 +247,7 @@ class Subscription : public SubscriptionBase
 public:
   using SharedPtr = std::shared_ptr<Subscription<MessageT>>;
 
-  template <typename Func, std::enable_if_t<is_callback_arg_v<Func>, int> = 0>
+  template <typename Func>
   Subscription(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     agnocast::SubscriptionOptions options, SubscriptionRole role = SubscriptionRole::Default)
@@ -275,7 +257,7 @@ public:
       node, get_message_type_name(), qos, std::forward<Func>(callback), options, role);
   }
 
-  template <typename Func, std::enable_if_t<is_callback_arg_v<Func>, int> = 0>
+  template <typename Func>
   Subscription(
     agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
     Func && callback, agnocast::SubscriptionOptions options,

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -105,6 +105,7 @@ rclcpp::QoS SubscriptionBase::init_base(
   initialize(
     actual_qos, is_take_sub, options.ignore_local_publications, role, node_name, type_name);
 
+  actual_qos_ = actual_qos;
   return actual_qos;
 }
 

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -105,7 +105,6 @@ rclcpp::QoS SubscriptionBase::init_base(
   initialize(
     actual_qos, is_take_sub, options.ignore_local_publications, role, node_name, type_name);
 
-  actual_qos_ = actual_qos;
   return actual_qos;
 }
 

--- a/src/agnocastlib/test/integration/test_agnocast_subscription_take.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_subscription_take.cpp
@@ -1,0 +1,129 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/node/agnocast_node.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using StringMsg = std_msgs::msg::String;
+
+class SubscriptionTakeIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    agnocast::init(0, nullptr);
+    rclcpp::NodeOptions options;
+    options.start_parameter_services(false);
+    node_ = std::make_shared<agnocast::Node>("test_subscription_take", options);
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    if (agnocast::ok()) {
+      agnocast::shutdown();
+    }
+  }
+
+  void publish(const agnocast::Publisher<StringMsg>::SharedPtr & pub, const std::string & data)
+  {
+    auto message = pub->borrow_loaned_message();
+    message->data = data;
+    pub->publish(std::move(message));
+  }
+
+  std::shared_ptr<agnocast::Node> node_;
+};
+
+TEST_F(SubscriptionTakeIntegrationTest, take_returns_empty_before_anything_is_published)
+{
+  agnocast::Subscription<StringMsg> sub(node_.get(), "/test_take_empty", rclcpp::QoS{1});
+
+  EXPECT_FALSE(sub.take());
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_returns_the_published_message)
+{
+  const std::string topic = "/test_take_roundtrip";
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  agnocast::Subscription<StringMsg> sub(node_.get(), topic, rclcpp::QoS{1});
+
+  publish(pub, "hello");
+
+  const auto taken = sub.take();
+  ASSERT_TRUE(taken);
+  EXPECT_EQ(taken->data, "hello");
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_without_allow_same_message_does_not_repeat)
+{
+  const std::string topic = "/test_take_no_repeat";
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  agnocast::Subscription<StringMsg> sub(node_.get(), topic, rclcpp::QoS{1});
+
+  publish(pub, "once");
+
+  ASSERT_TRUE(sub.take());
+  EXPECT_FALSE(sub.take());
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_with_allow_same_message_returns_the_same_entry_again)
+{
+  const std::string topic = "/test_take_allow_same";
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  agnocast::Subscription<StringMsg> sub(node_.get(), topic, rclcpp::QoS{1});
+
+  publish(pub, "same");
+
+  const auto first = sub.take(true);
+  const auto second = sub.take(true);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(first.get_entry_id(), second.get_entry_id());
+  EXPECT_EQ(second->data, "same");
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_throws_on_a_subscription_constructed_with_a_callback)
+{
+  auto sub = node_->create_subscription<StringMsg>(
+    "/test_take_with_callback", rclcpp::QoS{1},
+    [](const agnocast::ipc_shared_ptr<const StringMsg> &) {});
+
+  EXPECT_THROW(sub->take(), std::runtime_error);
+  EXPECT_THROW(sub->take(true), std::runtime_error);
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_subscription_still_polls_through_its_new_base)
+{
+  const std::string topic = "/test_take_subscription_compat";
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  agnocast::TakeSubscription<StringMsg> sub(node_.get(), topic, rclcpp::QoS{1});
+
+  publish(pub, "compat");
+
+  const auto taken = sub.take();
+  ASSERT_TRUE(taken);
+  EXPECT_EQ(taken->data, "compat");
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, polling_subscriber_keeps_returning_the_latest_message)
+{
+  const std::string topic = "/test_polling_subscriber";
+  auto pub = node_->create_publisher<StringMsg>(topic, 1);
+  agnocast::PollingSubscriber<StringMsg> sub(node_.get(), topic);
+
+  publish(pub, "latest");
+
+  const auto first = sub.take_data();
+  ASSERT_TRUE(first);
+  EXPECT_EQ(first->data, "latest");
+
+  const auto second = sub.take_data();
+  ASSERT_TRUE(second);
+  EXPECT_EQ(second->data, "latest");
+}

--- a/src/agnocastlib/test/integration/test_agnocast_subscription_take.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_subscription_take.cpp
@@ -1,11 +1,15 @@
 #include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_callback_info.hpp"
 #include "agnocast/node/agnocast_node.hpp"
+#include "rclcpp/serialized_message.hpp"
 
 #include "std_msgs/msg/string.hpp"
 
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <mutex>
+#include <set>
 #include <stdexcept>
 #include <string>
 
@@ -111,7 +115,8 @@ TEST_F(SubscriptionTakeIntegrationTest, take_subscription_still_polls_through_it
   EXPECT_EQ(taken->data, "compat");
 }
 
-TEST_F(SubscriptionTakeIntegrationTest, polling_subscriber_keeps_returning_the_latest_message)
+// Wiring check: take_data() must call take(true), not take(false).
+TEST_F(SubscriptionTakeIntegrationTest, polling_subscriber_is_wired_to_take_with_allow_same_message)
 {
   const std::string topic = "/test_polling_subscriber";
   auto pub = node_->create_publisher<StringMsg>(topic, 1);
@@ -119,11 +124,79 @@ TEST_F(SubscriptionTakeIntegrationTest, polling_subscriber_keeps_returning_the_l
 
   publish(pub, "latest");
 
-  const auto first = sub.take_data();
-  ASSERT_TRUE(first);
-  EXPECT_EQ(first->data, "latest");
-
+  ASSERT_TRUE(sub.take_data());
   const auto second = sub.take_data();
   ASSERT_TRUE(second);
   EXPECT_EQ(second->data, "latest");
+}
+
+TEST_F(SubscriptionTakeIntegrationTest, take_throws_on_a_type_erased_subscription)
+{
+  agnocast::GenericSubscription sub(
+    node_.get(), "/test_take_generic", "std_msgs/msg/String", rclcpp::QoS{1},
+    [](std::shared_ptr<rclcpp::SerializedMessage>) {});
+
+  EXPECT_THROW(sub.take(), std::runtime_error);
+}
+
+// Destroying a callback-less subscription must not touch id2_callback_info: it never registered
+// an entry, and erasing a default-constructed id would evict a live callback instead.
+TEST_F(SubscriptionTakeIntegrationTest, destroying_a_callback_less_subscription_spares_the_registry)
+{
+  const auto registry_keys = []() {
+    std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+    std::set<uint32_t> keys;
+    for (const auto & entry : agnocast::id2_callback_info) {
+      keys.insert(entry.first);
+    }
+    return keys;
+  };
+
+  const uint32_t callback_id = agnocast::next_callback_info_id.load();
+  auto callback_sub = node_->create_subscription<StringMsg>(
+    "/test_registry_callback", rclcpp::QoS{1},
+    [](const agnocast::ipc_shared_ptr<const StringMsg> &) {});
+  const std::set<uint32_t> before = registry_keys();
+  ASSERT_EQ(before.count(callback_id), 1u);
+
+  {
+    agnocast::Subscription<StringMsg> take_sub(node_.get(), "/test_registry_take", rclcpp::QoS{1});
+  }
+
+  EXPECT_EQ(registry_keys(), before);
+}
+
+// The rclcpp::Node overload of the callback-less constructor takes a different tracepoint path
+// than the agnocast::Node one, so it needs its own coverage.
+class SubscriptionTakeRclcppNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_subscription_take_rclcpp");
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+};
+
+TEST_F(SubscriptionTakeRclcppNodeTest, take_returns_the_published_message)
+{
+  const std::string topic = "/test_take_rclcpp_node";
+  auto pub = agnocast::create_publisher<StringMsg>(node_.get(), topic, 1);
+  agnocast::Subscription<StringMsg> sub(node_.get(), topic, rclcpp::QoS{1});
+
+  auto message = pub->borrow_loaned_message();
+  message->data = "from_rclcpp_node";
+  pub->publish(std::move(message));
+
+  const auto taken = sub.take();
+  ASSERT_TRUE(taken);
+  EXPECT_EQ(taken->data, "from_rclcpp_node");
 }


### PR DESCRIPTION
## Description

`Subscription<MessageT>` can now be constructed without a callback and polled with `take()`, replacing the `Subscription` / `TakeSubscription` split. The mode is fixed at construction and the two are exclusive: `take()` throws `std::runtime_error` on a subscription that has a callback.

That exclusivity is a kernel constraint. `entry_node::referencing_subscribers` is a bitmap with **one bit per (subscriber, entry)**, so the callback path and the take path would each build their own `ipc_shared_ptr` on top of that single bit — whichever is destroyed first clears it while the other still points into the publisher's shared memory. `rclcpp::Subscription::take()` can coexist with a callback only because it copies into caller-provided storage; Agnocast hands out a reference.

`callback_info_id_` becomes `std::optional` and `is_take_sub` is derived from it rather than passed in. `TakeSubscription` becomes a deprecated shim over a callback-less `Subscription`, with its constructor signatures, `::SharedPtr` type, runtime behaviour and tracepoint arguments unchanged. **No kmod change.**

## Motivation

`autoware::agnocast_wrapper::AgnocastSubscription<MessageT>` holds a single `agnocast::Subscription<MessageT>::SharedPtr`. For one wrapper type to serve both callback delivery and polling, that member has to hold either kind — today the callback-less object is an unrelated `TakeSubscription` / `PollingSubscriber`, which would force a variant member or a second implementation class.

Trade-off: the two modes used to be exclusive at compile time; the check is now a runtime `throw`.

## Related links

- #1531 — switches `PollingSubscriber` to `Subscription`, stacked on this branch
- #1532 — removes `TakeSubscription` (needs a major version bump)
- autowarefoundation/autoware_core#1364 — the consumer

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

New integration test `test/integration/test_agnocast_subscription_take.cpp` (10 cases, `requires_kernel_module;requires_heaphook`) passes against a loaded kmod, covering both node overloads, the take paths, the throw on callback subscriptions (typed and type-erased), the callback-registry invariant on destruction, and the `TakeSubscription` / `PollingSubscriber` shims. Disabling the guard makes exactly the three throw cases fail. The e2e runs above are still to be done.

## Notes for reviewers

Spinning a callback and calling `take()` on one subscription now fails loudly instead of corrupting shared memory. No in-tree call site does this.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
