### PR TITLE
test(agnocast_e2e_test): pick the launched node's callback group in reapply tests

### DIFF
--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -25,6 +25,10 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, 'template.yaml')
 
 REAPPLY_SERVICE = '/thread_configurator_node/reapply_config'
 
+# The node this test launches itself, and the only one whose callback groups
+# are guaranteed to still be running when reapply is called.
+TARGET_NODE = '/test_publisher_component'
+
 
 def _run_prerun():
     """Run prerun_node alongside test_cie_publisher to generate config YAML."""
@@ -90,6 +94,24 @@ def _read_config():
 def _write_config(cfg):
     with open(CONFIG_FILE, 'w') as f:
         yaml.safe_dump(cfg, f)
+
+
+def _target_node_entries(cfg):
+    """Return the prerun entries announced by TARGET_NODE.
+
+    prerun also captures callback groups from every other node alive in the
+    same ROS domain, and the CallbackGroupInfo topic is transient_local, so a
+    leftover bridge daemon replays groups whose threads have already exited.
+    Those cannot be applied, and they sort ahead of the publisher's entries
+    ('Client(' < 'Service(' < 'Subscription('), so a test that needs a live
+    target must select TARGET_NODE instead of taking whatever comes first.
+    Its id also carries no pid, so it is stable across the prerun and launch
+    phases, unlike the bridge node's own group.
+    """
+    return [
+        e for e in cfg.get('callback_groups', [])
+        if e['id'].split('@', 1)[0] == TARGET_NODE
+    ]
 
 
 def _call_reapply(timeout_sec=10.0):
@@ -200,16 +222,17 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         )
 
         cfg = _read_config()
+        target_entries = _target_node_entries(cfg)
         self.assertGreater(
-            len(cfg.get('callback_groups', [])), 0,
-            'prerun must produce at least one callback_group',
+            len(target_entries), 0,
+            f'prerun must produce a callback_group for {TARGET_NODE}',
         )
-        first = cfg['callback_groups'][0]
+        target = target_entries[0]
         # SCHED_OTHER + positive nice value: lowering priority needs no
         # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
-        first['policy'] = 'SCHED_OTHER'
-        first['priority'] = 10
-        first.setdefault('affinity', [])
+        target['policy'] = 'SCHED_OTHER'
+        target['priority'] = 10
+        target.setdefault('affinity', [])
         _write_config(cfg)
 
         response = _call_reapply()
@@ -229,9 +252,9 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             len(cfg['callback_groups']),
             'reapply must visit every callback_group entry exactly once',
         )
-        first_key = f"{first['domain_id']}:{first['id']}"
+        target_key = f"{target['domain_id']}:{target['id']}"
         self.assertIn(
-            first_key, list(response.applied_callback_groups),
+            target_key, list(response.applied_callback_groups),
             'modified callback_group must appear in applied_callback_groups',
         )
 
@@ -278,11 +301,16 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         )
 
         cfg = _read_config()
+        target_entries = _target_node_entries(cfg)
         self.assertGreater(
-            len(cfg.get('callback_groups', [])), 0,
-            'prerun must produce at least one callback_group',
+            len(target_entries), 0,
+            f'prerun must produce a callback_group for {TARGET_NODE}',
         )
-        removed = cfg['callback_groups'].pop(0)
+        # Removing an announced, still-running group is what makes the
+        # assertions below meaningful: a dead foreign entry would be absent
+        # from every outcome array anyway.
+        removed = target_entries[0]
+        cfg['callback_groups'].remove(removed)
         _write_config(cfg)
 
         response = _call_reapply()
@@ -369,9 +397,12 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         )
 
         cfg = _read_config()
-        if len(cfg.get('callback_groups', [])) == 0:
-            self.skipTest('no callback_groups produced by prerun')
-        cfg['callback_groups'][0]['policy'] = 'NOT_A_POLICY'
+        target_entries = _target_node_entries(cfg)
+        self.assertGreater(
+            len(target_entries), 0,
+            f'prerun must produce a callback_group for {TARGET_NODE}',
+        )
+        target_entries[0]['policy'] = 'NOT_A_POLICY'
         _write_config(cfg)
 
         response = _call_reapply()


### PR DESCRIPTION
## Description

`test_thread_configurator_reapply_launch.py` took `callback_groups[0]` from the prerun-generated
config and asserted that entry lands in `applied_callback_groups`. `prerun_node` records every
`CallbackGroupInfo` announced in the ROS domain, and that topic is `transient_local`, so a bridge
daemon left over from earlier tests replays callback groups whose threads have already exited.
Those entries sort ahead of the publisher's (`Client(` < `Service(` < `Subscription(`), so index 0
is a foreign, already-dead group: `sched_setscheduler` on its tid returns `ESRCH`, reapply reports
it as skipped, and the assertion fails.

```
AssertionError: '0:/agnocast_bridge_node_<ns>_<pid>@Client(/agnocast_only_dummy_node/describe_parameters)'
not found in [...] : modified callback_group must appear in applied_callback_groups
```

The three sites that used index 0 now select `/test_publisher_component`, the node the test
launches itself, with the same filtering idiom as
`test_thread_configurator_{precedence,wildcard}_launch.py`. That id carries no pid, unlike the
bridge node's own group, so it is also stable across the prerun and launch phases. Removing an
entry that the configurator actually knows about additionally makes
`test_zz_reapply_accepts_removed_entry` meaningful, since a dead foreign entry would be absent from
every outcome array regardless.

Test-only change; no product code touched.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`colcon test` over the whole workspace: **892 tests, 0 failures**. Before this change the same full
run failed on `test_reapply_after_priority_change`, because the run itself spawns a bridge daemon
(agnocastlib integration tests) that survives into `agnocast_e2e_test` and replays stale groups.

Causality was checked A/B with one such leftover daemon alive: the current test fails on that
assertion every time, the patched test passes.

The pub/sub e2e scripts above were not run, as the change is confined to one launch-test file and
touches no product code — happy to run them if reviewers prefer.

## Notes for reviewers

The daemon-side behavior is untouched here: a bridge daemon keeps latched `CallbackGroupInfo`
samples for callback groups whose threads are gone, so a prerun-generated config can still contain
entries that cannot be applied. This PR only stops the test from depending on which of those sorts
first.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
