### PR TITLE
fix(agnocastlib): honor NodeOptions::automatically_declare_parameters_from_overrides()

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -244,6 +244,8 @@ This provides equivalent functionality to rclcpp's `rclcpp::detail::resolve_para
 2. `local_args` (from NodeOptions::arguments())
 3. `global_args` (from command line)
 
+`NodeOptions::automatically_declare_parameters_from_overrides()` is honored: when enabled, resolved overrides that are not already declared are declared in the constructor.
+
 ### 3.3 Topic Name Resolution
 
 | Feature | agnocast | Support Level | Planned |

--- a/src/agnocastlib/include/agnocast/node/node_interfaces/node_parameters.hpp
+++ b/src/agnocastlib/include/agnocast/node/node_interfaces/node_parameters.hpp
@@ -40,10 +40,18 @@ public:
   using CallbacksContainerType =
     std::list<rclcpp::node_interfaces::OnSetParametersCallbackHandle::WeakPtr>;
 
+  /// Constructor.
+  /**
+   * If using automatically_declare_parameters_from_overrides, overrides of
+   * get_parameter_overrides(), has_parameter(), declare_parameter() will not be respected.
+   * If this is an issue, pass false for automatically_declare_parameters_from_overrides and
+   * invoke perform_automatically_declare_parameters_from_overrides() manually after construction.
+   */
   explicit NodeParameters(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     const std::vector<rclcpp::Parameter> & parameter_overrides, const rcl_arguments_t * local_args,
-    bool use_global_arguments = true, bool allow_undeclared_parameters = false);
+    bool use_global_arguments = true, bool allow_undeclared_parameters = false,
+    bool automatically_declare_parameters_from_overrides = false);
 
   virtual ~NodeParameters() = default;
 
@@ -117,6 +125,9 @@ public:
 #endif
 
   const std::map<std::string, rclcpp::ParameterValue> & get_parameter_overrides() const override;
+
+protected:
+  void perform_automatically_declare_parameters_from_overrides();
 
 private:
   friend class agnocast::Node;

--- a/src/agnocastlib/src/node/agnocast_node.cpp
+++ b/src/agnocastlib/src/node/agnocast_node.cpp
@@ -27,7 +27,8 @@ Node::Node(
   node_services_(std::make_shared<node_interfaces::NodeServices>(node_base_)),
   node_parameters_(std::make_shared<node_interfaces::NodeParameters>(
     node_base_, options.parameter_overrides(), local_args_.get(), options.use_global_arguments(),
-    options.allow_undeclared_parameters())),
+    options.allow_undeclared_parameters(),
+    options.automatically_declare_parameters_from_overrides())),
   node_clock_(std::make_shared<node_interfaces::NodeClock>(RCL_ROS_TIME)),
   node_time_source_(std::make_shared<node_interfaces::NodeTimeSource>(
     node_clock_, this, options.clock_qos(), options.use_clock_thread())),

--- a/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
@@ -367,7 +367,7 @@ NodeParameters::NodeParameters(
   // but did not get declared explicitly by this point.
   if (automatically_declare_parameters_from_overrides) {
     local_perform_automatically_declare_parameters_from_overrides(
-      this->get_parameter_overrides(),
+      parameter_overrides_,
       [this](const std::string & name) { return NodeParameters::has_parameter(name); },
       [this](
         const std::string & name, const rclcpp::ParameterValue & default_value,

--- a/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <sstream>
 #include <utility>
@@ -19,6 +20,22 @@ namespace
 {
 
 using CallbacksContainerType = NodeParameters::CallbacksContainerType;
+
+void local_perform_automatically_declare_parameters_from_overrides(
+  const std::map<std::string, rclcpp::ParameterValue> & parameter_overrides,
+  const std::function<bool(const std::string &)> & has_parameter,
+  const std::function<void(
+    const std::string &, const rclcpp::ParameterValue &,
+    const rcl_interfaces::msg::ParameterDescriptor &, bool)> & declare_parameter)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.dynamic_typing = true;
+  for (const auto & pair : parameter_overrides) {
+    if (!has_parameter(pair.first)) {
+      declare_parameter(pair.first, pair.second, descriptor, true);
+    }
+  }
+}
 
 // Forward declaration
 rcl_interfaces::msg::SetParametersResult declare_parameter_common(
@@ -330,7 +347,8 @@ auto find_parameter_by_name(ParameterVectorType & parameters, const std::string 
 NodeParameters::NodeParameters(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   const std::vector<rclcpp::Parameter> & parameter_overrides, const rcl_arguments_t * local_args,
-  bool use_global_arguments, bool allow_undeclared_parameters)
+  bool use_global_arguments, bool allow_undeclared_parameters,
+  bool automatically_declare_parameters_from_overrides)
 : node_base_(std::move(node_base)), allow_undeclared_(allow_undeclared_parameters)
 {
   const rcl_arguments_t * global_args = nullptr;
@@ -344,6 +362,33 @@ NodeParameters::NodeParameters(
   std::string combined_name = node_base_->get_fully_qualified_name();
   parameter_overrides_ =
     resolve_parameter_overrides(combined_name, parameter_overrides, local_args, global_args);
+
+  // If asked, initialize any parameters that ended up in the initial parameter values,
+  // but did not get declared explcitily by this point.
+  if (automatically_declare_parameters_from_overrides) {
+    local_perform_automatically_declare_parameters_from_overrides(
+      this->get_parameter_overrides(),
+      [this](const std::string & name) { return NodeParameters::has_parameter(name); },
+      [this](
+        const std::string & name, const rclcpp::ParameterValue & default_value,
+        const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor,
+        bool ignore_override) {
+        NodeParameters::declare_parameter(
+          name, default_value, parameter_descriptor, ignore_override);
+      });
+  }
+}
+
+void NodeParameters::perform_automatically_declare_parameters_from_overrides()
+{
+  local_perform_automatically_declare_parameters_from_overrides(
+    this->get_parameter_overrides(),
+    [this](const std::string & name) { return this->has_parameter(name); },
+    [this](
+      const std::string & name, const rclcpp::ParameterValue & default_value,
+      const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor, bool ignore_override) {
+      this->declare_parameter(name, default_value, parameter_descriptor, ignore_override);
+    });
 }
 
 void NodeParameters::start_parameter_services(agnocast::Node * node)

--- a/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_parameters.cpp
@@ -364,7 +364,7 @@ NodeParameters::NodeParameters(
     resolve_parameter_overrides(combined_name, parameter_overrides, local_args, global_args);
 
   // If asked, initialize any parameters that ended up in the initial parameter values,
-  // but did not get declared explcitily by this point.
+  // but did not get declared explicitly by this point.
   if (automatically_declare_parameters_from_overrides) {
     local_perform_automatically_declare_parameters_from_overrides(
       this->get_parameter_overrides(),

--- a/src/agnocastlib/test/integration/test_agnocast_node.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_node.cpp
@@ -7,8 +7,10 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace
 {
@@ -125,6 +127,69 @@ TEST_F(AgnocastNodeConstructionTest, allow_undeclared_parameters_false_rejects_u
   EXPECT_THROW(
     { node->get_parameter("undeclared_param"); },
     rclcpp::exceptions::ParameterNotDeclaredException);
+}
+
+// Verifies that agnocast::Node forwards
+// NodeOptions::automatically_declare_parameters_from_overrides() to NodeParameters: overrides that
+// no declare_parameter() call claimed become declared parameters, so prefix lookups find them.
+TEST_F(AgnocastNodeConstructionTest, automatically_declare_parameters_from_overrides_declares_them)
+{
+  // Arrange
+  agnocast::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.automatically_declare_parameters_from_overrides(true);
+  options.parameter_overrides(
+    {rclcpp::Parameter("group.first", 1), rclcpp::Parameter("group.second", "two")});
+
+  // Act
+  auto node = std::make_shared<agnocast::Node>("test_node_auto_declare_on", options);
+
+  // Assert: the overrides are declared and keep their values.
+  EXPECT_EQ(node->get_parameter("group.first").as_int(), 1);
+  EXPECT_EQ(node->get_parameter("group.second").as_string(), "two");
+
+  // Assert: the point of the option is that a caller which does not know the names can still
+  // enumerate them, with the prefix stripped from the keys.
+  std::map<std::string, rclcpp::Parameter> values;
+  ASSERT_TRUE(node->get_parameters("group", values));
+  ASSERT_EQ(values.size(), 2u);
+  EXPECT_EQ(values.at("first").as_int(), 1);
+  EXPECT_EQ(values.at("second").as_string(), "two");
+}
+
+// Overrides are declared with a dynamically typed descriptor, so a later set() may change the type.
+TEST_F(
+  AgnocastNodeConstructionTest, automatically_declare_parameters_from_overrides_uses_dynamic_typing)
+{
+  // Arrange
+  agnocast::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.automatically_declare_parameters_from_overrides(true);
+  options.parameter_overrides({rclcpp::Parameter("group.first", 1)});
+  auto node = std::make_shared<agnocast::Node>("test_node_auto_declare_dynamic", options);
+
+  // Act
+  const auto descriptor = node->describe_parameter("group.first");
+
+  // Assert
+  EXPECT_TRUE(descriptor.dynamic_typing);
+}
+
+TEST_F(AgnocastNodeConstructionTest, automatically_declare_parameters_from_overrides_off_by_default)
+{
+  // Arrange
+  agnocast::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("group.first", 1)});
+
+  // Act
+  auto node = std::make_shared<agnocast::Node>("test_node_auto_declare_off", options);
+
+  // Assert: the override was resolved but never declared, so it is invisible to lookups.
+  EXPECT_FALSE(node->has_parameter("group.first"));
+  std::map<std::string, rclcpp::Parameter> values;
+  EXPECT_FALSE(node->get_parameters("group", values));
+  EXPECT_TRUE(values.empty());
 }
 
 // agnocast::Node must forward `options.use_clock_thread()` to NodeTimeSource, which creates


### PR DESCRIPTION
## Description

`agnocast::Node` resolves its parameter overrides but never declares the ones that no explicit `declare_parameter()` call claimed, because the constructor does not pass `NodeOptions::automatically_declare_parameters_from_overrides()` down to `NodeParameters`. Every other flag on that path (`allow_undeclared_parameters`, `use_global_arguments`, `parameter_overrides`) is forwarded — this one was simply missed.

`get_parameters(prefix, map)`, `list_parameters()` and the parameter services all enumerate declared parameters, so an override that was resolved but not declared is invisible to them. Nothing throws and nothing is logged; the caller just gets an empty result.

## Changes

- `node_interfaces::NodeParameters` takes `automatically_declare_parameters_from_overrides` (defaulted to `false` and appended last, so no existing call site changes).
- `agnocast::Node`'s constructor forwards `options.automatically_declare_parameters_from_overrides()`.
- The declaration loop lives in `local_perform_automatically_declare_parameters_from_overrides()`, following the jazzy rclcpp shape. The constructor binds `NodeParameters::` directly, since the object is still under construction there; the new protected `perform_automatically_declare_parameters_from_overrides()` binds through `this`, so a subclass that overrides `declare_parameter()` can have its override respected by calling it after construction.
- `docs/agnocast_node_interface_comparison.md`: note in §3.2 that the option is honored.

## Related links

- The same logic in rclcpp (jazzy, 28.1.18): [`local_perform_automatically_declare_parameters_from_overrides()`](https://github.com/ros2/rclcpp/blob/4321b44ef1a3cc7b46e844c6f2bf148ae5ad2869/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L42-L65), and its two call sites — the [constructor](https://github.com/ros2/rclcpp/blob/4321b44ef1a3cc7b46e844c6f2bf148ae5ad2869/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L126-L144) and [`perform_automatically_declare_parameters_from_overrides()`](https://github.com/ros2/rclcpp/blob/4321b44ef1a3cc7b46e844c6f2bf148ae5ad2869/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L146-L165).

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Integration tests are added to `test/integration/test_agnocast_node.cpp`, next to the existing per-`NodeOptions`-flag tests:

- with the option on, two overrides under a common prefix become declared parameters, keep their values, and are found by `get_parameters(prefix, map)` under the prefix-stripped keys;
- the declared descriptor has `dynamic_typing` set;
- with the option left at its default, the same override is neither declared nor visible to a prefix lookup;
- the constructor path declares the overrides without dispatching to a subclass override of `declare_parameter()`, while `perform_automatically_declare_parameters_from_overrides()` does.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
