### PR TITLE
feat(agnocastlib): add ROS 2 service introspection to Service and Client

### DIFF
--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -153,6 +153,21 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 | `add_service()` | ✗ | **Throws Exception** | No | Use `agnocast::create_service()` or `agnocast::Node::create_service()` |
 | `resolve_service_name()` | ✓ | **Full Support** | - | |
 
+#### Service Introspection
+
+`agnocast::Service` and `agnocast::Client` provide `configure_introspection(clock, qos, state)` with the same signature and the same reconfiguration semantics as `rclcpp::ServiceBase` / `rclcpp::ClientBase`.
+
+| Item | agnocast | Notes |
+|------|----------|-------|
+| Availability | ROS 2 Iron (rclcpp 21) and later | The `ServiceT::Event` message and `rcl_service_introspection_state_t` do not exist on Humble, so the method is not declared there — the same gate `autoware_component_interface_utils` uses |
+| Event topic | ✓ | `<resolved service name>/_service_event`, the ROS 2 convention |
+| Transport | Agnocast publisher | rcl publishes these events for an rclcpp service, but agnocast services never touch rcl. The event topic is an ordinary Agnocast topic, so the ROS 2 Bridge forwards it to DDS and `ros2 service echo` works; without a bridge the events are still visible via `ros2 topic echo_agnocast` |
+| `metadata` / `contents` modes | ✓ | `contents` fills the `request` / `response` sequences, `metadata` leaves them empty |
+| `sequence_number` | ✓ | The Agnocast service call seqno |
+| `client_gid` | ⚠ | Derived from the calling node's fully-qualified name, since Agnocast has no rmw GID and the wire format carries only the node name. Both ends compute the same value. Two `Client` instances for the same service inside one node therefore share a GID while numbering sequences independently, so `(client_gid, sequence_number)` can collide between them |
+| `GenericService` / `GenericClient` | ✗ | Not supported for the type-erased service API |
+| Overhead when disabled | None beyond one relaxed atomic load per request and per response | Introspection is off unless `configure_introspection()` is called |
+
 ---
 
 ### 2.7 NodeLoggingInterface
@@ -335,6 +350,7 @@ The following tables compare methods that are **directly defined** in each class
 | `create_timer()` | ✓ | ✓ | Supports ROS_TIME (simulation time). Return type differs (`agnocast::TimerBase::SharedPtr` vs `rclcpp::TimerBase::SharedPtr`). Note: dynamic deactivation of ROS time (`use_sim_time` changed from `true` to `false` at runtime) is not yet supported. |
 | `create_client<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Client vs. agnocast::Client). |
 | `create_service<ServiceT>()` | ✓ | ✓ | Return type differs (rclcpp::Service vs. agnocast::Service). |
+| `Service`/`Client::configure_introspection()` | ✓ | ✓ | ROS 2 Iron and later only. Events are published on an Agnocast topic rather than by rcl. See [Service Introspection](#service-introspection). |
 
 #### Graph API (ROS Network Discovery)
 

--- a/docs/agnocast_node_interface_comparison.md
+++ b/docs/agnocast_node_interface_comparison.md
@@ -155,18 +155,21 @@ Each interface is accessible via getter methods such as `get_node_base_interface
 
 #### Service Introspection
 
-`agnocast::Service` and `agnocast::Client` provide `configure_introspection(clock, qos, state)` with the same signature and the same reconfiguration semantics as `rclcpp::ServiceBase` / `rclcpp::ClientBase`.
+`agnocast::Service` and `agnocast::Client` provide `configure_introspection(clock, qos, state)` with the same signature as `rclcpp::Service<ServiceT>` / `rclcpp::Client<ServiceT>`. The behaviour matches for the states themselves; the deviations are listed below.
 
 | Item | agnocast | Notes |
 |------|----------|-------|
 | Availability | ROS 2 Iron (rclcpp 21) and later | The `ServiceT::Event` message and `rcl_service_introspection_state_t` do not exist on Humble, so the method is not declared there — the same gate `autoware_component_interface_utils` uses |
-| Event topic | ✓ | `<resolved service name>/_service_event`, the ROS 2 convention |
+| Event topic | ✓ | `<resolved service name>` + `RCL_SERVICE_INTROSPECTION_TOPIC_POSTFIX`, the ROS 2 convention |
 | Transport | Agnocast publisher | rcl publishes these events for an rclcpp service, but agnocast services never touch rcl. The event topic is an ordinary Agnocast topic, so the ROS 2 Bridge forwards it to DDS and `ros2 service echo` works; without a bridge the events are still visible via `ros2 topic echo_agnocast` |
 | `metadata` / `contents` modes | ✓ | `contents` fills the `request` / `response` sequences, `metadata` leaves them empty |
 | `sequence_number` | ✓ | The Agnocast service call seqno |
-| `client_gid` | ⚠ | Derived from the calling node's fully-qualified name, since Agnocast has no rmw GID and the wire format carries only the node name. Both ends compute the same value. Two `Client` instances for the same service inside one node therefore share a GID while numbering sequences independently, so `(client_gid, sequence_number)` can collide between them |
+| `client_gid` | ⚠ | Derived from the calling node's fully-qualified name, since Agnocast has no rmw GID and the wire format carries only the node name. Both ends compute the same value. It therefore identifies a node rather than a client instance, and is stable across restarts instead of unique per session; sequence numbers are shared per node so `(client_gid, sequence_number)` still identifies one transaction |
+| Reconfiguration | ⚠ | Switching between `OFF` / `metadata` / `contents` behaves as in rclcpp, but the event publisher is created on the first enabling call and then kept for the lifetime of the service or client, whereas rcl destroys it on `OFF`. Keeping it avoids churning the ROS 2 Bridge on every toggle; the cost is that the QoS of the first enabling call wins, and a later call with a different QoS is rejected with a warning |
+| Error reporting | ⚠ | A null `clock` throws `std::invalid_argument`. rclcpp instead throws whatever `rcl` reports; there is no `rcl` call here to fail |
 | `GenericService` / `GenericClient` | ✗ | Not supported for the type-erased service API |
 | Overhead when disabled | None beyond one relaxed atomic load per request and per response | Introspection is off unless `configure_introspection()` is called |
+| Overhead when enabled | One shared-mode lock plus one event publish per request and per response | The event carries a copy of the payload in `contents` mode |
 
 ---
 

--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -49,7 +49,7 @@ add_library(agnocast SHARED
   src/node/agnocast_only_executor.cpp src/node/agnocast_only_single_threaded_executor.cpp src/node/agnocast_only_multi_threaded_executor.cpp
   src/node/agnocast_only_callback_isolated_executor.cpp src/node/agnocast_parameter_service.cpp
   src/cie_client_utils.cpp
-  src/internal/type_registry_writer.cpp
+  src/internal/type_registry_writer.cpp src/internal/service_introspection.cpp
   src/node/node_interfaces/node_base.cpp src/node/node_interfaces/node_parameters.cpp src/node/node_interfaces/node_topics.cpp src/node/node_interfaces/node_clock.cpp src/node/node_interfaces/node_time_source.cpp src/node/node_interfaces/node_services.cpp src/node/node_interfaces/node_logging.cpp src/node/node_interfaces/node_graph.cpp
   src/bridge/agnocast_bridge_utils.cpp src/bridge/agnocast_service_bridge.cpp
   src/bridge/performance/agnocast_performance_bridge_ipc_event_loop.cpp src/bridge/performance/agnocast_performance_bridge_loader.cpp src/bridge/performance/agnocast_performance_bridge_manager.cpp
@@ -161,6 +161,7 @@ if(BUILD_TESTING)
     test/unit/test_daemon_bridge_uds.cpp
     test/unit/test_agnocast_bridge_uds.cpp
     test/unit/test_discovery_agent_auto_fork.cpp
+    test/unit/test_service_introspection.cpp
     test/unit/test_bridge_node_name.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -7,11 +7,13 @@
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_utils.hpp"
+#include "agnocast/internal/service_introspection.hpp"
 #include "agnocast/internal/service_wire_type.hpp"
 #include "agnocast/node/agnocast_context.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -166,6 +168,14 @@ private:
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
+  // Retained so the introspection event publisher can be created later, on the same node.
+  internal::ServiceNodeVariant node_{static_cast<rclcpp::Node *>(nullptr)};
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+  // Declared before subscriber_ so they outlive the response callback that reads them.
+  internal::ServiceIntrospection<ServiceT> introspection_;
+  // Constant for the lifetime of the client: the GID is derived from the node name.
+  std::array<uint8_t, 16> client_gid_{};
+#endif
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
   template <typename NodeT>
@@ -174,6 +184,11 @@ private:
     rclcpp::CallbackGroup::SharedPtr group, ClientRole role)
   {
     init_base(node, service_name);
+
+    node_ = node;
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+    client_gid_ = internal::make_service_client_gid(node_name_);
+#endif
 
     // TransientLocal durability is not allowed for services.
     const rclcpp::QoS qos = rclcpp::QoS(qos_arg).durability_volatile();
@@ -197,6 +212,13 @@ private:
       seqno2_response_call_info_.erase(it);
       /* --- critical section end --- */
       lock.unlock();
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+      // Must run before the response is handed to the promise, which moves it out.
+      if (introspection_.is_enabled()) {
+        introspection_.emit_response_received(client_gid_, response->seqno, response.get());
+      }
+#endif
 
       info.promise.set_value(ipc_shared_ptr<typename ServiceT::Response>(std::move(response)));
       if (info.callback.has_value()) {
@@ -264,6 +286,13 @@ public:
       shared_future = it->second.shared_future.value();
     }
 
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+    // Must run before publish(), which invalidates `internal_request`.
+    if (introspection_.is_enabled()) {
+      introspection_.emit_request_sent(client_gid_, seqno, internal_request.get());
+    }
+#endif
+
     publisher_->publish(std::move(internal_request));
     return SharedFutureAndRequestId(std::move(shared_future), seqno);
   }
@@ -285,9 +314,41 @@ public:
       future = it->second.promise.get_future();
     }
 
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+    // Must run before publish(), which invalidates `internal_request`.
+    if (introspection_.is_enabled()) {
+      introspection_.emit_request_sent(client_gid_, seqno, internal_request.get());
+    }
+#endif
+
     publisher_->publish(std::move(internal_request));
     return FutureAndRequestId(std::move(future), seqno);
   }
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+  /**
+   * @brief Configure ROS 2 service introspection for this client.
+   *
+   * Mirrors `rclcpp::ClientBase::configure_introspection()`. Agnocast clients do not go through
+   * rcl, so the events are published by Agnocast on `<service name>/_service_event` instead of by
+   * rcl; the ROS 2 bridge forwards that topic to DDS. This client emits `REQUEST_SENT` and
+   * `RESPONSE_RECEIVED`; the matching service emits the other two.
+   *
+   * Available from ROS 2 Iron (rclcpp 21) onwards only.
+   *
+   * @param clock Clock used to stamp the events.
+   * @param qos_service_event_pub QoS of the event publisher.
+   * @param introspection_state RCL_SERVICE_INTROSPECTION_OFF, _METADATA or _CONTENTS.
+   */
+  AGNOCAST_PUBLIC
+  void configure_introspection(
+    rclcpp::Clock::SharedPtr clock, const rclcpp::QoS & qos_service_event_pub,
+    rcl_service_introspection_state_t introspection_state)
+  {
+    introspection_.configure(
+      node_, service_name_, std::move(clock), qos_service_event_pub, introspection_state);
+  }
+#endif
 };
 
 /**

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -35,6 +35,18 @@ bool wait_for_service_nanoseconds(
   const std::function<bool()> & check_context_ok, const std::string & service_name,
   std::chrono::nanoseconds timeout);
 
+/// @brief Return the sequence-number counter shared by every client reading the given response
+/// topic.
+///
+/// All clients of one service on one node share a response topic and tell responses apart by
+/// sequence number alone, so the numbers must be unique across those clients rather than per
+/// instance. This is also what makes `(client_gid, sequence_number)` a unique transaction ID for
+/// ROS 2 service introspection, since `client_gid` is derived from the node name.
+///
+/// @param response_topic_name From create_service_response_topic_name().
+/// @return Reference to the counter, valid for the lifetime of the process.
+std::atomic<int64_t> & get_service_sequence_counter(const std::string & response_topic_name);
+
 extern int agnocast_fd;
 
 enum class ClientRole : uint8_t {
@@ -71,7 +83,7 @@ struct ResponseCallInfo
 class ClientBase
 {
 protected:
-  std::atomic<int64_t> next_sequence_number_{0};
+  std::atomic<int64_t> * next_sequence_number_{nullptr};
   std::string node_name_;
   std::string service_name_;
   std::function<bool()> check_context_ok_;
@@ -81,6 +93,8 @@ protected:
   {
     node_name_ = node->get_fully_qualified_name();
     service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
+    next_sequence_number_ =
+      &get_service_sequence_counter(create_service_response_topic_name(service_name_, node_name_));
 
     check_context_ok_ = [context = node->get_node_base_interface()->get_context()]() {
       if constexpr (std::is_same_v<agnocast::Node, NodeT>) {
@@ -168,9 +182,9 @@ private:
   std::mutex seqno2_response_call_info_mtx_;
   std::unordered_map<int64_t, ResponseCallInfo> seqno2_response_call_info_;
   typename ServiceRequestPublisher::SharedPtr publisher_;
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
   // Retained so the introspection event publisher can be created later, on the same node.
   internal::ServiceNodeVariant node_{static_cast<rclcpp::Node *>(nullptr)};
-#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
   // Declared before subscriber_ so they outlive the response callback that reads them.
   internal::ServiceIntrospection<ServiceT> introspection_;
   // Constant for the lifetime of the client: the GID is derived from the node name.
@@ -185,8 +199,8 @@ private:
   {
     init_base(node, service_name);
 
-    node_ = node;
 #if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+    node_ = node;
     client_gid_ = internal::make_service_client_gid(node_name_);
 #endif
 
@@ -205,7 +219,10 @@ private:
       auto it = seqno2_response_call_info_.find(response->seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
-        RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
+        // A miss is normal: sibling clients share this response topic.
+        RCLCPP_DEBUG(
+          node->get_logger(), "Ignoring service response %ld addressed to another client",
+          response->seqno);
         return;
       }
       ResponseCallInfo info = std::move(it->second);
@@ -261,7 +278,7 @@ public:
   {
     auto request = publisher_->borrow_loaned_message();
     request->node_name = node_name_;
-    request->seqno = next_sequence_number_.fetch_add(1);
+    request->seqno = next_sequence_number_->fetch_add(1);
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
 
@@ -329,9 +346,9 @@ public:
   /**
    * @brief Configure ROS 2 service introspection for this client.
    *
-   * Mirrors `rclcpp::ClientBase::configure_introspection()`. Agnocast clients do not go through
-   * rcl, so the events are published by Agnocast on `<service name>/_service_event` instead of by
-   * rcl; the ROS 2 bridge forwards that topic to DDS. This client emits `REQUEST_SENT` and
+   * Mirrors `rclcpp::Client<ServiceT>::configure_introspection()`. Agnocast clients do not go
+   * through rcl, so the events are published by Agnocast on `<service name>/_service_event` instead
+   * of by rcl; the ROS 2 bridge forwards that topic to DDS. This client emits `REQUEST_SENT` and
    * `RESPONSE_RECEIVED`; the matching service emits the other two.
    *
    * Available from ROS 2 Iron (rclcpp 21) onwards only.
@@ -421,7 +438,10 @@ private:
       auto it = seqno2_response_call_info_.find(response_seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
-        RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
+        // A miss is normal: sibling clients share this response topic.
+        RCLCPP_DEBUG(
+          node->get_logger(), "Ignoring service response %ld addressed to another client",
+          response_seqno);
         return;
       }
       ResponseCallInfo info = std::move(it->second);

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -6,9 +6,12 @@
 #include "agnocast/agnocast_subscription.hpp"
 #include "agnocast/agnocast_utils.hpp"
 #include "agnocast/bridge/agnocast_bridge_node.hpp"
+#include "agnocast/internal/service_introspection.hpp"
 #include "agnocast/internal/service_wire_type.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -56,6 +59,10 @@ private:
   const rclcpp::QoS qos_;
   std::mutex publishers_mtx_;
   std::unordered_map<std::string, typename ServiceResponsePublisher::SharedPtr> publishers_;
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+  // Declared before subscriber_ so it outlives the request callback that reads it.
+  internal::ServiceIntrospection<ServiceT> introspection_;
+#endif
   typename ServiceRequestSubscriber::SharedPtr subscriber_;
 
   typename ServiceResponsePublisher::SharedPtr get_or_create_publisher_for(
@@ -91,10 +98,30 @@ private:
       ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
       response->seqno = request->seqno;
 
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+      // The correlation metadata has to be copied out before the callback, which consumes
+      // `request`.
+      const bool introspect = introspection_.is_enabled();
+      std::array<uint8_t, 16> client_gid{};
+      int64_t seqno = 0;
+      if (introspect) {
+        client_gid = internal::make_service_client_gid(request->node_name);
+        seqno = request->seqno;
+        introspection_.emit_request_received(client_gid, seqno, request.get());
+      }
+#endif
+
       ipc_shared_ptr<typename ServiceT::Response> response_double(response);
 
       callback(
         ipc_shared_ptr<typename ServiceT::Request>(std::move(request)), std::move(response_double));
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+      // Must run before publish(), which invalidates `response`.
+      if (introspect) {
+        introspection_.emit_response_sent(client_gid, seqno, response.get());
+      }
+#endif
 
       publisher->publish(std::move(response));
 
@@ -110,6 +137,14 @@ private:
   auto wrap_deferred_service_callback_for_subscriber(Func && callback)
   {
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<RequestT> && request) {
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+      // RESPONSE_SENT for this path is emitted by send_response(), which is where the deferred
+      // callback eventually hands the response back.
+      if (introspection_.is_enabled()) {
+        introspection_.emit_request_received(
+          internal::make_service_client_gid(request->node_name), request->seqno, request.get());
+      }
+#endif
       callback(this->shared_from_this(), std::move(request));
     };
   }
@@ -196,8 +231,41 @@ public:
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
     auto internal_response = static_ipc_shared_ptr_cast<ResponseT>(std::move(response));
     auto publisher = get_or_create_publisher_for(internal_request->node_name);
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+    // Must run before publish(), which invalidates `internal_response`.
+    if (introspection_.is_enabled()) {
+      introspection_.emit_response_sent(
+        internal::make_service_client_gid(internal_request->node_name), internal_request->seqno,
+        internal_response.get());
+    }
+#endif
     publisher->publish(std::move(internal_response));
   }
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+  /**
+   * @brief Configure ROS 2 service introspection for this service.
+   *
+   * Mirrors `rclcpp::ServiceBase::configure_introspection()`. Agnocast services do not go through
+   * rcl, so the events are published by Agnocast on `<service name>/_service_event` instead of by
+   * rcl; the ROS 2 bridge forwards that topic to DDS. This service emits `REQUEST_RECEIVED` and
+   * `RESPONSE_SENT`; the matching client emits the other two.
+   *
+   * Available from ROS 2 Iron (rclcpp 21) onwards only.
+   *
+   * @param clock Clock used to stamp the events.
+   * @param qos_service_event_pub QoS of the event publisher.
+   * @param introspection_state RCL_SERVICE_INTROSPECTION_OFF, _METADATA or _CONTENTS.
+   */
+  AGNOCAST_PUBLIC
+  void configure_introspection(
+    rclcpp::Clock::SharedPtr clock, const rclcpp::QoS & qos_service_event_pub,
+    rcl_service_introspection_state_t introspection_state)
+  {
+    introspection_.configure(
+      node_, service_name_, std::move(clock), qos_service_event_pub, introspection_state);
+  }
+#endif
 
   /**
    * @brief Allocate a service response message in shared memory. This function is expected to be

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -246,10 +246,10 @@ public:
   /**
    * @brief Configure ROS 2 service introspection for this service.
    *
-   * Mirrors `rclcpp::ServiceBase::configure_introspection()`. Agnocast services do not go through
-   * rcl, so the events are published by Agnocast on `<service name>/_service_event` instead of by
-   * rcl; the ROS 2 bridge forwards that topic to DDS. This service emits `REQUEST_RECEIVED` and
-   * `RESPONSE_SENT`; the matching client emits the other two.
+   * Mirrors `rclcpp::Service<ServiceT>::configure_introspection()`. Agnocast services do not go
+   * through rcl, so the events are published by Agnocast on `<service name>/_service_event` instead
+   * of by rcl; the ROS 2 bridge forwards that topic to DDS. This service emits `REQUEST_RECEIVED`
+   * and `RESPONSE_SENT`; the matching client emits the other two.
    *
    * Available from ROS 2 Iron (rclcpp 21) onwards only.
    *

--- a/src/agnocastlib/include/agnocast/internal/service_introspection.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_introspection.hpp
@@ -1,0 +1,220 @@
+// ROS 2 service introspection for Agnocast services.
+//
+// rclcpp implements service introspection inside rcl: Service/Client own an rcl handle, and
+// configure_introspection() asks rcl to publish a `<service name>/_service_event` topic. Agnocast
+// services never touch rcl (agnocast::Node does not even own an rcl_node_t), so the same feature is
+// re-implemented here on top of an ordinary Agnocast publisher. The event topic is created with
+// PublisherRole::Default, so the ROS 2 bridge exposes it to DDS and `ros2 service echo` sees the
+// events just like it would for an rclcpp service.
+//
+// The `ServiceT::Event` message and rcl/service_introspection.h only exist from ROS 2 Iron
+// (rclcpp 21) onwards, so everything here is gated on AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED.
+// On Humble the gate is 0 and Service/Client do not declare configure_introspection() at all,
+// matching rclcpp.
+
+#pragma once
+
+#include <rclcpp/version.h>
+
+#if RCLCPP_VERSION_GTE(21, 0, 0)
+#include <rcl/service_introspection.h>
+#define AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED 1
+#else
+#define AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED 0
+#endif
+
+#include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace agnocast
+{
+
+class Node;
+
+namespace internal
+{
+
+/// Node handle held by a Service/Client, used to create the event publisher lazily.
+using ServiceNodeVariant = std::variant<rclcpp::Node *, agnocast::Node *>;
+
+/// Return the topic name ROS 2 uses for service introspection events, i.e. the resolved service
+/// name with "/_service_event" appended.
+std::string create_service_event_topic_name(const std::string & resolved_service_name);
+
+/// Derive the 16-byte `client_gid` reported in service events from the calling node's
+/// fully-qualified name.
+///
+/// ROS 2 uses the client's rmw GID here. Agnocast has no rmw entity for a service client, and the
+/// only client identity carried on the wire is the node name (see
+/// agnocast/internal/service_wire_type.hpp), so the GID is derived from that name instead. Both
+/// ends of a call compute it independently and agree, without changing the wire format.
+///
+/// Limitation: two Client instances for the same service inside one node share a GID, while their
+/// sequence numbers are counted per instance, so (client_gid, sequence_number) can collide between
+/// them. Distinguishing them requires carrying an identifier on the wire.
+std::array<uint8_t, 16> make_service_client_gid(const std::string & node_fqn);
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+
+/// Introspection state shared by BasicService and Client.
+///
+/// Holds the configured state, the clock used for event timestamps, and the event publisher.
+/// `is_enabled()` is a single relaxed atomic load, so a service that never enables introspection
+/// pays nothing beyond that on the request/response path.
+template <typename ServiceT>
+class ServiceIntrospection
+{
+  using EventT = typename ServiceT::Event;
+  using EventPublisher = Publisher<EventT>;
+  // service_msgs::msg::ServiceEventInfo, reached through the event message so that this header
+  // needs no service_msgs include and agnocastlib needs no service_msgs dependency.
+  using EventInfoT = decltype(std::declval<EventT>().info);
+
+  // Stored as the underlying integer so it can live in an atomic.
+  std::atomic<int> state_{RCL_SERVICE_INTROSPECTION_OFF};
+  std::mutex mtx_;
+  rclcpp::Clock::SharedPtr clock_;
+  typename EventPublisher::SharedPtr publisher_;
+
+  /// @brief Publish one service event.
+  ///
+  /// `request` and `response` are only read in RCL_SERVICE_INTROSPECTION_CONTENTS mode and either
+  /// may be null; ROS 2 fills at most one of them per event. Callers must pass payloads that are
+  /// still valid, which on the publishing side means calling this before handing the message to
+  /// Publisher::publish().
+  void emit(
+    uint8_t event_type, const std::array<uint8_t, 16> & client_gid, int64_t sequence_number,
+    const typename ServiceT::Request * request, const typename ServiceT::Response * response)
+  {
+    typename EventPublisher::SharedPtr publisher;
+    rclcpp::Clock::SharedPtr clock;
+    int state = RCL_SERVICE_INTROSPECTION_OFF;
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      state = state_.load(std::memory_order_relaxed);
+      if (state == RCL_SERVICE_INTROSPECTION_OFF) {
+        return;
+      }
+      publisher = publisher_;
+      clock = clock_;
+    }
+    if (!publisher || !clock) {
+      return;
+    }
+
+    ipc_shared_ptr<EventT> event = publisher->borrow_loaned_message();
+    event->info.event_type = event_type;
+    event->info.stamp = clock->now();
+    event->info.client_gid = client_gid;
+    event->info.sequence_number = sequence_number;
+    event->request.clear();
+    event->response.clear();
+
+    if (state == RCL_SERVICE_INTROSPECTION_CONTENTS) {
+      if (request != nullptr) {
+        event->request.push_back(*request);
+      }
+      if (response != nullptr) {
+        event->response.push_back(*response);
+      }
+    }
+
+    publisher->publish(std::move(event));
+  }
+
+public:
+  /// @brief Enable, reconfigure or disable introspection. Mirrors rclcpp's semantics: passing
+  /// RCL_SERVICE_INTROSPECTION_OFF stops event publication, and passing a different state switches
+  /// modes. The event publisher is created on the first enabling call and kept afterwards, so
+  /// toggling does not tear the topic down.
+  /// @param node The node that owns the service or client.
+  /// @param resolved_service_name The service name after remapping/expansion.
+  /// @param clock Clock used to stamp events.
+  /// @param qos QoS of the event publisher.
+  /// @param state Introspection state to apply.
+  void configure(
+    const ServiceNodeVariant & node, const std::string & resolved_service_name,
+    rclcpp::Clock::SharedPtr clock, const rclcpp::QoS & qos,
+    rcl_service_introspection_state_t state)
+  {
+    std::lock_guard<std::mutex> lock(mtx_);
+
+    if (state == RCL_SERVICE_INTROSPECTION_OFF) {
+      state_.store(RCL_SERVICE_INTROSPECTION_OFF, std::memory_order_relaxed);
+      return;
+    }
+
+    clock_ = std::move(clock);
+
+    if (!publisher_) {
+      // TransientLocal durability is not allowed for services, and events follow the same rule.
+      const rclcpp::QoS event_qos = rclcpp::QoS(qos).durability_volatile();
+      const std::string topic_name = create_service_event_topic_name(resolved_service_name);
+      std::visit(
+        [this, &topic_name, &event_qos](auto * n) {
+          publisher_ = std::make_shared<EventPublisher>(
+            n, topic_name, event_qos, agnocast::PublisherOptions{}, PublisherRole::Default);
+        },
+        node);
+    }
+
+    state_.store(state, std::memory_order_relaxed);
+  }
+
+  /// @brief Whether any event should be published. Checked before doing any work on the hot path.
+  bool is_enabled() const
+  {
+    return state_.load(std::memory_order_relaxed) != RCL_SERVICE_INTROSPECTION_OFF;
+  }
+
+  /// @brief Publish a REQUEST_SENT event (client side, before the request is published).
+  /// @param client_gid GID of the calling client, from make_service_client_gid().
+  /// @param sequence_number The Agnocast seqno of the call.
+  /// @param request Request payload; only read in CONTENTS mode.
+  void emit_request_sent(
+    const std::array<uint8_t, 16> & client_gid, int64_t sequence_number,
+    const typename ServiceT::Request * request)
+  {
+    emit(EventInfoT::REQUEST_SENT, client_gid, sequence_number, request, nullptr);
+  }
+
+  /// @brief Publish a REQUEST_RECEIVED event (server side, before the user callback runs).
+  void emit_request_received(
+    const std::array<uint8_t, 16> & client_gid, int64_t sequence_number,
+    const typename ServiceT::Request * request)
+  {
+    emit(EventInfoT::REQUEST_RECEIVED, client_gid, sequence_number, request, nullptr);
+  }
+
+  /// @brief Publish a RESPONSE_SENT event (server side, before the response is published).
+  void emit_response_sent(
+    const std::array<uint8_t, 16> & client_gid, int64_t sequence_number,
+    const typename ServiceT::Response * response)
+  {
+    emit(EventInfoT::RESPONSE_SENT, client_gid, sequence_number, nullptr, response);
+  }
+
+  /// @brief Publish a RESPONSE_RECEIVED event (client side, before the future is fulfilled).
+  void emit_response_received(
+    const std::array<uint8_t, 16> & client_gid, int64_t sequence_number,
+    const typename ServiceT::Response * response)
+  {
+    emit(EventInfoT::RESPONSE_RECEIVED, client_gid, sequence_number, nullptr, response);
+  }
+};
+
+#endif  // AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+
+}  // namespace internal
+
+}  // namespace agnocast

--- a/src/agnocastlib/include/agnocast/internal/service_introspection.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_introspection.hpp
@@ -32,6 +32,8 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <variant>
@@ -47,21 +49,29 @@ namespace internal
 /// Node handle held by a Service/Client, used to create the event publisher lazily.
 using ServiceNodeVariant = std::variant<rclcpp::Node *, agnocast::Node *>;
 
+/// The suffix ROS 2 appends to a service name to form its introspection event topic. The literal is
+/// only repeated for distributions without rcl's macro, so the helper stays compilable there.
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+constexpr const char * k_service_event_topic_postfix = RCL_SERVICE_INTROSPECTION_TOPIC_POSTFIX;
+#else
+constexpr const char * k_service_event_topic_postfix = "/_service_event";
+#endif
+
 /// Return the topic name ROS 2 uses for service introspection events, i.e. the resolved service
-/// name with "/_service_event" appended.
+/// name with k_service_event_topic_postfix appended.
 std::string create_service_event_topic_name(const std::string & resolved_service_name);
 
 /// Derive the 16-byte `client_gid` reported in service events from the calling node's
 /// fully-qualified name.
 ///
-/// ROS 2 uses the client's rmw GID here. Agnocast has no rmw entity for a service client, and the
-/// only client identity carried on the wire is the node name (see
-/// agnocast/internal/service_wire_type.hpp), so the GID is derived from that name instead. Both
-/// ends of a call compute it independently and agree, without changing the wire format.
+/// ROS 2 uses the client's rmw GID here. Agnocast has no rmw entity for a service client and the
+/// wire carries only the node name, so the GID is derived from that name instead and both ends of a
+/// call compute the same value without a wire-format change.
 ///
-/// Limitation: two Client instances for the same service inside one node share a GID, while their
-/// sequence numbers are counted per instance, so (client_gid, sequence_number) can collide between
-/// them. Distinguishing them requires carrying an identifier on the wire.
+/// Consequently the GID identifies a node, not a client instance, and is stable across restarts
+/// rather than unique per session. Sequence numbers are shared per node (see
+/// get_service_sequence_counter()) so that `(client_gid, sequence_number)` still identifies one
+/// transaction.
 std::array<uint8_t, 16> make_service_client_gid(const std::string & node_fqn);
 
 #if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
@@ -82,9 +92,12 @@ class ServiceIntrospection
 
   // Stored as the underlying integer so it can live in an atomic.
   std::atomic<int> state_{RCL_SERVICE_INTROSPECTION_OFF};
-  std::mutex mtx_;
+  // Shared, so that concurrent service calls do not serialize against each other, nor behind the
+  // publisher construction configure() performs under the lock.
+  std::shared_mutex mtx_;
   rclcpp::Clock::SharedPtr clock_;
   typename EventPublisher::SharedPtr publisher_;
+  rclcpp::QoS configured_qos_{rclcpp::QoS(1)};
 
   /// @brief Publish one service event.
   ///
@@ -100,7 +113,7 @@ class ServiceIntrospection
     rclcpp::Clock::SharedPtr clock;
     int state = RCL_SERVICE_INTROSPECTION_OFF;
     {
-      std::lock_guard<std::mutex> lock(mtx_);
+      std::shared_lock<std::shared_mutex> lock(mtx_);
       state = state_.load(std::memory_order_relaxed);
       if (state == RCL_SERVICE_INTROSPECTION_OFF) {
         return;
@@ -133,13 +146,16 @@ class ServiceIntrospection
   }
 
 public:
-  /// @brief Enable, reconfigure or disable introspection. Mirrors rclcpp's semantics: passing
-  /// RCL_SERVICE_INTROSPECTION_OFF stops event publication, and passing a different state switches
-  /// modes. The event publisher is created on the first enabling call and kept afterwards, so
-  /// toggling does not tear the topic down.
+  /// @brief Enable, reconfigure or disable introspection. Passing RCL_SERVICE_INTROSPECTION_OFF
+  /// stops event publication, and passing a different state switches modes.
+  ///
+  /// Unlike rcl, the event publisher is kept once created rather than destroyed on OFF, because
+  /// tearing it down would withdraw the bridge request and churn the ROS 2 side on every toggle.
+  /// The QoS of the first enabling call therefore wins.
+  ///
   /// @param node The node that owns the service or client.
   /// @param resolved_service_name The service name after remapping/expansion.
-  /// @param clock Clock used to stamp events.
+  /// @param clock Clock used to stamp events. Must not be null.
   /// @param qos QoS of the event publisher.
   /// @param state Introspection state to apply.
   void configure(
@@ -147,18 +163,23 @@ public:
     rclcpp::Clock::SharedPtr clock, const rclcpp::QoS & qos,
     rcl_service_introspection_state_t state)
   {
-    std::lock_guard<std::mutex> lock(mtx_);
+    std::lock_guard<std::shared_mutex> lock(mtx_);
 
     if (state == RCL_SERVICE_INTROSPECTION_OFF) {
       state_.store(RCL_SERVICE_INTROSPECTION_OFF, std::memory_order_relaxed);
       return;
     }
 
-    clock_ = std::move(clock);
+    if (clock == nullptr) {
+      throw std::invalid_argument(
+        "configure_introspection() requires a non-null clock to stamp service events (service: " +
+        resolved_service_name + ")");
+    }
+
+    // TransientLocal durability is not allowed for services, and events follow the same rule.
+    const rclcpp::QoS event_qos = rclcpp::QoS(qos).durability_volatile();
 
     if (!publisher_) {
-      // TransientLocal durability is not allowed for services, and events follow the same rule.
-      const rclcpp::QoS event_qos = rclcpp::QoS(qos).durability_volatile();
       const std::string topic_name = create_service_event_topic_name(resolved_service_name);
       std::visit(
         [this, &topic_name, &event_qos](auto * n) {
@@ -166,8 +187,16 @@ public:
             n, topic_name, event_qos, agnocast::PublisherOptions{}, PublisherRole::Default);
         },
         node);
+      configured_qos_ = event_qos;
+    } else if (event_qos != configured_qos_) {
+      RCLCPP_WARN(
+        logger,
+        "configure_introspection() was already called for '%s' with a different QoS. The event "
+        "publisher keeps the QoS of the first call; the new QoS is ignored.",
+        resolved_service_name.c_str());
     }
 
+    clock_ = std::move(clock);
     state_.store(state, std::memory_order_relaxed);
   }
 

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -5,14 +5,29 @@
 #include "agnocast/node/agnocast_node.hpp"
 
 #include <array>
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
 namespace agnocast
 {
+
+std::atomic<int64_t> & get_service_sequence_counter(const std::string & response_topic_name)
+{
+  // Never erased: a counter must outlive every client holding its address.
+  static std::mutex counters_mtx;
+  static std::unordered_map<std::string, std::atomic<int64_t>> counters;
+
+  std::lock_guard<std::mutex> lock(counters_mtx);
+  return counters.try_emplace(response_topic_name).first->second;
+}
 
 uint32_t get_agnocast_sub_count(const std::string & topic_name)
 {
@@ -127,7 +142,7 @@ ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
     request_members_, [this](size_t size) { return publisher_->borrow_loaned_message(size); });
 
   generic_request_wrapper.node_name() = node_name_;
-  generic_request_wrapper.seqno() = next_sequence_number_.fetch_add(1);
+  generic_request_wrapper.seqno() = next_sequence_number_->fetch_add(1);
 
   return std::move(generic_request_wrapper).take_request();
 }

--- a/src/agnocastlib/src/internal/service_introspection.cpp
+++ b/src/agnocastlib/src/internal/service_introspection.cpp
@@ -1,0 +1,52 @@
+#include "agnocast/internal/service_introspection.hpp"
+
+#include <cstddef>
+
+namespace agnocast
+{
+
+namespace internal
+{
+
+namespace
+{
+
+constexpr uint64_t k_fnv_offset_basis = 14695981039346656037ULL;
+constexpr uint64_t k_fnv_prime = 1099511628211ULL;
+
+uint64_t fnv1a_64(const std::string & value, uint64_t basis)
+{
+  uint64_t hash = basis;
+  for (const char c : value) {
+    hash ^= static_cast<uint64_t>(static_cast<unsigned char>(c));
+    hash *= k_fnv_prime;
+  }
+  return hash;
+}
+
+}  // namespace
+
+std::string create_service_event_topic_name(const std::string & resolved_service_name)
+{
+  return resolved_service_name + "/_service_event";
+}
+
+std::array<uint8_t, 16> make_service_client_gid(const std::string & node_fqn)
+{
+  // Two FNV-1a runs with different offset bases give 16 deterministic bytes without pulling in a
+  // hash library. This is an identifier only; it is never used as a security or uniqueness
+  // guarantee.
+  const uint64_t low = fnv1a_64(node_fqn, k_fnv_offset_basis);
+  const uint64_t high = fnv1a_64(node_fqn, ~k_fnv_offset_basis);
+
+  std::array<uint8_t, 16> gid{};
+  for (size_t i = 0; i < 8; i++) {
+    gid[i] = static_cast<uint8_t>((low >> (8 * i)) & 0xFF);
+    gid[8 + i] = static_cast<uint8_t>((high >> (8 * i)) & 0xFF);
+  }
+  return gid;
+}
+
+}  // namespace internal
+
+}  // namespace agnocast

--- a/src/agnocastlib/src/internal/service_introspection.cpp
+++ b/src/agnocastlib/src/internal/service_introspection.cpp
@@ -1,6 +1,9 @@
 #include "agnocast/internal/service_introspection.hpp"
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace agnocast
 {
@@ -28,7 +31,7 @@ uint64_t fnv1a_64(const std::string & value, uint64_t basis)
 
 std::string create_service_event_topic_name(const std::string & resolved_service_name)
 {
-  return resolved_service_name + "/_service_event";
+  return resolved_service_name + k_service_event_topic_postfix;
 }
 
 std::array<uint8_t, 16> make_service_client_gid(const std::string & node_fqn)

--- a/src/agnocastlib/test/integration/test_agnocast_client.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_client.cpp
@@ -9,9 +9,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -131,6 +133,93 @@ TEST_F(ClientTest, RequestIdIsUnique)
 
 /* --- ClientTest: end --- */
 
+// Every client of one service on one node reads the same response topic and tells responses apart
+// by sequence number alone.
+class SharedResponseTopicTest : public ::testing::Test
+{
+protected:
+  using SetBool = std_srvs::srv::SetBool;
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<agnocast::SingleThreadedAgnocastExecutor> executor_;
+  std::thread spin_thread_;
+
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("shared_response_topic_test_node");
+    executor_ = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  auto create_service()
+  {
+    auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    return agnocast::create_service<SetBool>(
+      node_.get(), "shared_response_topic_service",
+      [](
+        agnocast::ipc_shared_ptr<SetBool::Request> && request,
+        agnocast::ipc_shared_ptr<SetBool::Response> && response) {
+        response->success = request->data;
+      },
+      rclcpp::ServicesQoS(), cb_group);
+  }
+
+  auto create_client()
+  {
+    auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    return agnocast::create_client<SetBool>(
+      node_.get(), "shared_response_topic_service", rclcpp::ServicesQoS(), cb_group);
+  }
+};
+
+TEST_F(SharedResponseTopicTest, SequenceNumbersDoNotCollideBetweenClientsOnTheSameNode)
+{
+  auto client1 = create_client();
+  auto client2 = create_client();
+
+  auto request1 = client1->borrow_loaned_request();
+  auto request2 = client2->borrow_loaned_request();
+  auto id1 = client1->async_send_request(std::move(request1)).request_id;
+  auto id2 = client2->async_send_request(std::move(request2)).request_id;
+
+  EXPECT_NE(id1, id2);
+}
+
+TEST_F(SharedResponseTopicTest, EachClientResolvesItsOwnResponse)
+{
+  auto client1 = create_client();
+  auto client2 = create_client();
+  auto service = create_service();
+  ASSERT_TRUE(client1->wait_for_service(1s));
+
+  auto request1 = client1->borrow_loaned_request();
+  request1->data = true;
+  auto request2 = client2->borrow_loaned_request();
+  request2->data = false;
+
+  auto future1 = client1->async_send_request(std::move(request1));
+  auto future2 = client2->async_send_request(std::move(request2));
+
+  ASSERT_EQ(future1.future.wait_for(5s), std::future_status::ready);
+  ASSERT_EQ(future2.future.wait_for(5s), std::future_status::ready);
+
+  EXPECT_TRUE(future1.future.get()->success);
+  EXPECT_FALSE(future2.future.get()->success);
+}
+
 class AgnocastNodeClientTest : public ::testing::Test
 {
   using Request = std_srvs::srv::Empty::Request;
@@ -195,7 +284,15 @@ protected:
   using EventInfo = decltype(std::declval<Event>().info);
 
   static constexpr const char * k_service_name = "introspection_service";
+  // Spelled out, so the test pins the ROS 2 convention independently of the helper.
   static constexpr const char * k_event_topic = "/introspection_service/_service_event";
+  static constexpr const char * k_deferred_service_name = "introspection_deferred_service";
+  static constexpr const char * k_deferred_event_topic =
+    "/introspection_deferred_service/_service_event";
+
+  static constexpr auto k_event_timeout = 5s;
+  // Paid in full by every test asserting an absence, so it is kept short.
+  static constexpr auto k_quiescence = 500ms;
 
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<agnocast::SingleThreadedAgnocastExecutor> executor_;
@@ -225,10 +322,10 @@ protected:
     }
   }
 
-  void subscribe_events()
+  void subscribe_events(const char * topic = k_event_topic)
   {
     event_sub_ = agnocast::create_subscription<Event>(
-      node_.get(), k_event_topic, rclcpp::QoS(10),
+      node_.get(), topic, rclcpp::QoS(10),
       [this](const agnocast::ipc_shared_ptr<const Event> & msg) {
         std::lock_guard<std::mutex> lock(events_mtx_);
         events_.push_back(*msg);
@@ -249,17 +346,51 @@ protected:
       rclcpp::ServicesQoS(), cb_group);
   }
 
-  auto create_client()
+  auto create_deferred_service()
+  {
+    auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    return agnocast::create_service<SetBool>(
+      node_.get(), k_deferred_service_name,
+      [](
+        std::shared_ptr<agnocast::Service<SetBool>> service,
+        agnocast::ipc_shared_ptr<SetBool::Request> && request) {
+        auto response = service->borrow_loaned_response(request);
+        response->success = request->data;
+        response->message = "ok";
+        service->send_response(std::move(request), std::move(response));
+      },
+      rclcpp::ServicesQoS(), cb_group);
+  }
+
+  auto create_client(const char * service_name = k_service_name)
   {
     auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     return agnocast::create_client<SetBool>(
-      node_.get(), k_service_name, rclcpp::ServicesQoS(), cb_group);
+      node_.get(), service_name, rclcpp::ServicesQoS(), cb_group);
   }
 
   std::vector<Event> collected_events()
   {
     std::lock_guard<std::mutex> lock(events_mtx_);
     return events_;
+  }
+
+  size_t event_count()
+  {
+    std::lock_guard<std::mutex> lock(events_mtx_);
+    return events_.size();
+  }
+
+  bool wait_for_events(size_t expected)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + k_event_timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (event_count() >= expected) {
+        return true;
+      }
+      std::this_thread::sleep_for(10ms);
+    }
+    return event_count() >= expected;
   }
 
   size_t count_of(uint8_t event_type)
@@ -270,30 +401,47 @@ protected:
       [event_type](const Event & e) { return e.info.event_type == event_type; }));
   }
 
-  // Issue one call and give the executor time to deliver the response and all four events.
-  void call_once(bool data)
+  void call_once(const agnocast::Client<SetBool>::SharedPtr & client, bool data, int64_t * seqno)
   {
-    auto client = create_client();
-    auto service = create_service();
-    ASSERT_TRUE(client->wait_for_service(1s));
-
     auto request = client->borrow_loaned_request();
     request->data = data;
     auto future_and_id = client->async_send_request(std::move(request));
     ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+    if (seqno != nullptr) {
+      *seqno = future_and_id.request_id;
+    }
+  }
 
-    // The events are published on the same executor, so give them a moment to arrive.
-    std::this_thread::sleep_for(500ms);
+  void enable_introspection(
+    const agnocast::Client<SetBool>::SharedPtr & client,
+    const agnocast::Service<SetBool>::SharedPtr & service, rcl_service_introspection_state_t state)
+  {
+    client->configure_introspection(node_->get_clock(), rclcpp::QoS(1), state);
+    service->configure_introspection(node_->get_clock(), rclcpp::QoS(1), state);
   }
 };
 
 TEST_F(ServiceIntrospectionTest, NoEventsWhenIntrospectionIsOff)
 {
   subscribe_events();
-  call_once(true);
 
-  EXPECT_TRUE(collected_events().empty())
+  auto client = create_client();
+  auto service = create_service();
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  call_once(client, true, nullptr);
+  std::this_thread::sleep_for(k_quiescence);
+
+  ASSERT_TRUE(collected_events().empty())
     << "introspection defaults to off, so no service events should be published";
+
+  // Positive control: an absence assertion alone would also pass if the subscription never worked.
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_METADATA);
+  call_once(client, true, nullptr);
+
+  EXPECT_TRUE(wait_for_events(4))
+    << "the same subscription must see events once introspection is enabled, otherwise the "
+       "assertion above proves nothing";
 }
 
 TEST_F(ServiceIntrospectionTest, MetadataModePublishesAllFourEventsWithoutPayload)
@@ -302,17 +450,11 @@ TEST_F(ServiceIntrospectionTest, MetadataModePublishesAllFourEventsWithoutPayloa
 
   auto client = create_client();
   auto service = create_service();
-  client->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
-  service->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_METADATA);
   ASSERT_TRUE(client->wait_for_service(1s));
 
-  auto request = client->borrow_loaned_request();
-  request->data = true;
-  auto future_and_id = client->async_send_request(std::move(request));
-  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
-  std::this_thread::sleep_for(500ms);
+  call_once(client, true, nullptr);
+  ASSERT_TRUE(wait_for_events(4)) << "one call must produce all four events";
 
   EXPECT_EQ(count_of(EventInfo::REQUEST_SENT), 1u);
   EXPECT_EQ(count_of(EventInfo::REQUEST_RECEIVED), 1u);
@@ -331,17 +473,11 @@ TEST_F(ServiceIntrospectionTest, ContentsModeCarriesPayload)
 
   auto client = create_client();
   auto service = create_service();
-  client->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_CONTENTS);
-  service->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_CONTENTS);
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_CONTENTS);
   ASSERT_TRUE(client->wait_for_service(1s));
 
-  auto request = client->borrow_loaned_request();
-  request->data = true;
-  auto future_and_id = client->async_send_request(std::move(request));
-  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
-  std::this_thread::sleep_for(500ms);
+  call_once(client, true, nullptr);
+  ASSERT_TRUE(wait_for_events(4)) << "one call must produce all four events";
 
   const auto events = collected_events();
   ASSERT_EQ(events.size(), 4u);
@@ -368,17 +504,12 @@ TEST_F(ServiceIntrospectionTest, ClientAndServerAgreeOnGidAndSequenceNumber)
 
   auto client = create_client();
   auto service = create_service();
-  client->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
-  service->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_METADATA);
   ASSERT_TRUE(client->wait_for_service(1s));
 
-  auto request = client->borrow_loaned_request();
-  request->data = false;
-  auto future_and_id = client->async_send_request(std::move(request));
-  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
-  std::this_thread::sleep_for(500ms);
+  int64_t seqno = -1;
+  call_once(client, false, &seqno);
+  ASSERT_TRUE(wait_for_events(4)) << "one call must produce all four events";
 
   const auto events = collected_events();
   ASSERT_EQ(events.size(), 4u);
@@ -388,8 +519,34 @@ TEST_F(ServiceIntrospectionTest, ClientAndServerAgreeOnGidAndSequenceNumber)
   for (const auto & event : events) {
     EXPECT_EQ(event.info.client_gid, expected_gid)
       << "all four events of one call must carry the caller's GID";
-    EXPECT_EQ(event.info.sequence_number, future_and_id.request_id)
+    EXPECT_EQ(event.info.sequence_number, seqno)
       << "all four events of one call must carry the call's sequence number";
+  }
+}
+
+// The deferred path emits RESPONSE_SENT from send_response(), a separate emission site.
+TEST_F(ServiceIntrospectionTest, DeferredCallbackPathEmitsAllFourEvents)
+{
+  subscribe_events(k_deferred_event_topic);
+
+  auto client = create_client(k_deferred_service_name);
+  auto service = create_deferred_service();
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_CONTENTS);
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  int64_t seqno = -1;
+  call_once(client, true, &seqno);
+  ASSERT_TRUE(wait_for_events(4))
+    << "a deferred-callback service must emit the same four events as a basic one";
+
+  EXPECT_EQ(count_of(EventInfo::REQUEST_SENT), 1u);
+  EXPECT_EQ(count_of(EventInfo::REQUEST_RECEIVED), 1u);
+  EXPECT_EQ(count_of(EventInfo::RESPONSE_SENT), 1u)
+    << "RESPONSE_SENT must be emitted exactly once, by send_response()";
+  EXPECT_EQ(count_of(EventInfo::RESPONSE_RECEIVED), 1u);
+
+  for (const auto & event : collected_events()) {
+    EXPECT_EQ(event.info.sequence_number, seqno);
   }
 }
 
@@ -399,37 +556,39 @@ TEST_F(ServiceIntrospectionTest, ReconfiguringToOffStopsEvents)
 
   auto client = create_client();
   auto service = create_service();
-  client->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
-  service->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_METADATA);
   ASSERT_TRUE(client->wait_for_service(1s));
 
-  {
-    auto request = client->borrow_loaned_request();
-    request->data = true;
-    auto future_and_id = client->async_send_request(std::move(request));
-    ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
-  }
-  std::this_thread::sleep_for(500ms);
-  const size_t events_while_on = collected_events().size();
+  call_once(client, true, nullptr);
+  ASSERT_TRUE(wait_for_events(4)) << "one call must produce all four events";
+  const size_t events_while_on = event_count();
   ASSERT_EQ(events_while_on, 4u);
 
-  client->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_OFF);
-  service->configure_introspection(
-    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_OFF);
+  enable_introspection(client, service, RCL_SERVICE_INTROSPECTION_OFF);
 
-  {
-    auto request = client->borrow_loaned_request();
-    request->data = true;
-    auto future_and_id = client->async_send_request(std::move(request));
-    ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
-  }
-  std::this_thread::sleep_for(500ms);
+  call_once(client, true, nullptr);
+  std::this_thread::sleep_for(k_quiescence);
 
-  EXPECT_EQ(collected_events().size(), events_while_on)
+  EXPECT_EQ(event_count(), events_while_on)
     << "no further events should be published after introspection is turned off";
+}
+
+TEST_F(ServiceIntrospectionTest, ConfigureIntrospectionRejectsNullClock)
+{
+  auto client = create_client();
+  auto service = create_service();
+
+  EXPECT_THROW(
+    client->configure_introspection(nullptr, rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA),
+    std::invalid_argument)
+    << "a null clock would silently drop every event, so it must be rejected up front";
+  EXPECT_THROW(
+    service->configure_introspection(nullptr, rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA),
+    std::invalid_argument);
+
+  // OFF needs no clock, so it must stay accepted.
+  EXPECT_NO_THROW(
+    client->configure_introspection(nullptr, rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_OFF));
 }
 
 #endif  // AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED

--- a/src/agnocastlib/test/integration/test_agnocast_client.cpp
+++ b/src/agnocastlib/test/integration/test_agnocast_client.cpp
@@ -1,14 +1,20 @@
 #include "agnocast/agnocast.hpp"
+#include "agnocast/internal/service_introspection.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "std_srvs/srv/empty.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <thread>
+#include <utility>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -174,3 +180,256 @@ TEST_F(AgnocastNodeClientTest, WaitForServiceReturnsOnShutdown)
     << "wait_for_service() should return promptly on shutdown";
   EXPECT_FALSE(future.get()) << "wait_for_service() should return false on shutdown";
 }
+
+/* --- AgnocastNodeClientTest: end --- */
+
+#if AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED
+
+// Service introspection is only available from ROS 2 Iron (rclcpp 21) onwards, since the
+// ServiceT::Event message and rcl_service_introspection_state_t do not exist before that.
+class ServiceIntrospectionTest : public ::testing::Test
+{
+protected:
+  using SetBool = std_srvs::srv::SetBool;
+  using Event = SetBool::Event;
+  using EventInfo = decltype(std::declval<Event>().info);
+
+  static constexpr const char * k_service_name = "introspection_service";
+  static constexpr const char * k_event_topic = "/introspection_service/_service_event";
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<agnocast::SingleThreadedAgnocastExecutor> executor_;
+  std::thread spin_thread_;
+
+  std::mutex events_mtx_;
+  std::vector<Event> events_;
+  agnocast::Subscription<Event>::SharedPtr event_sub_;
+
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("introspection_test_node");
+    executor_ = std::make_shared<agnocast::SingleThreadedAgnocastExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void subscribe_events()
+  {
+    event_sub_ = agnocast::create_subscription<Event>(
+      node_.get(), k_event_topic, rclcpp::QoS(10),
+      [this](const agnocast::ipc_shared_ptr<const Event> & msg) {
+        std::lock_guard<std::mutex> lock(events_mtx_);
+        events_.push_back(*msg);
+      });
+  }
+
+  auto create_service()
+  {
+    auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    return agnocast::create_service<SetBool>(
+      node_.get(), k_service_name,
+      [](
+        agnocast::ipc_shared_ptr<SetBool::Request> && request,
+        agnocast::ipc_shared_ptr<SetBool::Response> && response) {
+        response->success = request->data;
+        response->message = "ok";
+      },
+      rclcpp::ServicesQoS(), cb_group);
+  }
+
+  auto create_client()
+  {
+    auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+    return agnocast::create_client<SetBool>(
+      node_.get(), k_service_name, rclcpp::ServicesQoS(), cb_group);
+  }
+
+  std::vector<Event> collected_events()
+  {
+    std::lock_guard<std::mutex> lock(events_mtx_);
+    return events_;
+  }
+
+  size_t count_of(uint8_t event_type)
+  {
+    const auto events = collected_events();
+    return static_cast<size_t>(std::count_if(
+      events.begin(), events.end(),
+      [event_type](const Event & e) { return e.info.event_type == event_type; }));
+  }
+
+  // Issue one call and give the executor time to deliver the response and all four events.
+  void call_once(bool data)
+  {
+    auto client = create_client();
+    auto service = create_service();
+    ASSERT_TRUE(client->wait_for_service(1s));
+
+    auto request = client->borrow_loaned_request();
+    request->data = data;
+    auto future_and_id = client->async_send_request(std::move(request));
+    ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+
+    // The events are published on the same executor, so give them a moment to arrive.
+    std::this_thread::sleep_for(500ms);
+  }
+};
+
+TEST_F(ServiceIntrospectionTest, NoEventsWhenIntrospectionIsOff)
+{
+  subscribe_events();
+  call_once(true);
+
+  EXPECT_TRUE(collected_events().empty())
+    << "introspection defaults to off, so no service events should be published";
+}
+
+TEST_F(ServiceIntrospectionTest, MetadataModePublishesAllFourEventsWithoutPayload)
+{
+  subscribe_events();
+
+  auto client = create_client();
+  auto service = create_service();
+  client->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  service->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  auto request = client->borrow_loaned_request();
+  request->data = true;
+  auto future_and_id = client->async_send_request(std::move(request));
+  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+  std::this_thread::sleep_for(500ms);
+
+  EXPECT_EQ(count_of(EventInfo::REQUEST_SENT), 1u);
+  EXPECT_EQ(count_of(EventInfo::REQUEST_RECEIVED), 1u);
+  EXPECT_EQ(count_of(EventInfo::RESPONSE_SENT), 1u);
+  EXPECT_EQ(count_of(EventInfo::RESPONSE_RECEIVED), 1u);
+
+  for (const auto & event : collected_events()) {
+    EXPECT_TRUE(event.request.empty()) << "metadata mode must not carry the request payload";
+    EXPECT_TRUE(event.response.empty()) << "metadata mode must not carry the response payload";
+  }
+}
+
+TEST_F(ServiceIntrospectionTest, ContentsModeCarriesPayload)
+{
+  subscribe_events();
+
+  auto client = create_client();
+  auto service = create_service();
+  client->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_CONTENTS);
+  service->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_CONTENTS);
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  auto request = client->borrow_loaned_request();
+  request->data = true;
+  auto future_and_id = client->async_send_request(std::move(request));
+  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+  std::this_thread::sleep_for(500ms);
+
+  const auto events = collected_events();
+  ASSERT_EQ(events.size(), 4u);
+
+  for (const auto & event : events) {
+    const bool is_request_event = event.info.event_type == EventInfo::REQUEST_SENT ||
+                                  event.info.event_type == EventInfo::REQUEST_RECEIVED;
+    if (is_request_event) {
+      ASSERT_EQ(event.request.size(), 1u);
+      EXPECT_TRUE(event.request[0].data);
+      EXPECT_TRUE(event.response.empty());
+    } else {
+      ASSERT_EQ(event.response.size(), 1u);
+      EXPECT_TRUE(event.response[0].success);
+      EXPECT_EQ(event.response[0].message, "ok");
+      EXPECT_TRUE(event.request.empty());
+    }
+  }
+}
+
+TEST_F(ServiceIntrospectionTest, ClientAndServerAgreeOnGidAndSequenceNumber)
+{
+  subscribe_events();
+
+  auto client = create_client();
+  auto service = create_service();
+  client->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  service->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  auto request = client->borrow_loaned_request();
+  request->data = false;
+  auto future_and_id = client->async_send_request(std::move(request));
+  ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+  std::this_thread::sleep_for(500ms);
+
+  const auto events = collected_events();
+  ASSERT_EQ(events.size(), 4u);
+
+  const auto expected_gid =
+    agnocast::internal::make_service_client_gid(node_->get_fully_qualified_name());
+  for (const auto & event : events) {
+    EXPECT_EQ(event.info.client_gid, expected_gid)
+      << "all four events of one call must carry the caller's GID";
+    EXPECT_EQ(event.info.sequence_number, future_and_id.request_id)
+      << "all four events of one call must carry the call's sequence number";
+  }
+}
+
+TEST_F(ServiceIntrospectionTest, ReconfiguringToOffStopsEvents)
+{
+  subscribe_events();
+
+  auto client = create_client();
+  auto service = create_service();
+  client->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  service->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_METADATA);
+  ASSERT_TRUE(client->wait_for_service(1s));
+
+  {
+    auto request = client->borrow_loaned_request();
+    request->data = true;
+    auto future_and_id = client->async_send_request(std::move(request));
+    ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+  }
+  std::this_thread::sleep_for(500ms);
+  const size_t events_while_on = collected_events().size();
+  ASSERT_EQ(events_while_on, 4u);
+
+  client->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_OFF);
+  service->configure_introspection(
+    node_->get_clock(), rclcpp::QoS(1), RCL_SERVICE_INTROSPECTION_OFF);
+
+  {
+    auto request = client->borrow_loaned_request();
+    request->data = true;
+    auto future_and_id = client->async_send_request(std::move(request));
+    ASSERT_EQ(future_and_id.future.wait_for(5s), std::future_status::ready);
+  }
+  std::this_thread::sleep_for(500ms);
+
+  EXPECT_EQ(collected_events().size(), events_while_on)
+    << "no further events should be published after introspection is turned off";
+}
+
+#endif  // AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED

--- a/src/agnocastlib/test/unit/test_service_introspection.cpp
+++ b/src/agnocastlib/test/unit/test_service_introspection.cpp
@@ -1,0 +1,49 @@
+#include "agnocast/internal/service_introspection.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+TEST(ServiceIntrospectionTest, EventTopicNameFollowsRos2Convention)
+{
+  EXPECT_EQ(
+    agnocast::internal::create_service_event_topic_name("/sample/service"),
+    "/sample/service/_service_event");
+  EXPECT_EQ(
+    agnocast::internal::create_service_event_topic_name("/ns/node/srv"),
+    "/ns/node/srv/_service_event");
+}
+
+TEST(ServiceIntrospectionTest, ClientGidIsDeterministic)
+{
+  const auto first = agnocast::internal::make_service_client_gid("/ns/talker");
+  const auto second = agnocast::internal::make_service_client_gid("/ns/talker");
+
+  EXPECT_EQ(first, second)
+    << "the GID must be reproducible so the client and the server derive the same value";
+}
+
+TEST(ServiceIntrospectionTest, ClientGidDiffersBetweenNodes)
+{
+  const std::vector<std::string> node_names = {"/talker",      "/listener", "/ns/talker",
+                                               "/ns/listener", "/talker2",  ""};
+
+  std::set<std::array<uint8_t, 16>> gids;
+  for (const auto & name : node_names) {
+    gids.insert(agnocast::internal::make_service_client_gid(name));
+  }
+
+  EXPECT_EQ(gids.size(), node_names.size()) << "distinct node names must produce distinct GIDs";
+}
+
+TEST(ServiceIntrospectionTest, ClientGidUsesAllSixteenBytes)
+{
+  const auto gid = agnocast::internal::make_service_client_gid("/ns/talker");
+
+  // Both halves come from separate hash runs; neither may be left as zero padding.
+  EXPECT_TRUE(std::any_of(gid.begin(), gid.begin() + 8, [](uint8_t b) { return b != 0; }));
+  EXPECT_TRUE(std::any_of(gid.begin() + 8, gid.end(), [](uint8_t b) { return b != 0; }));
+}

--- a/src/agnocastlib/test/unit/test_service_introspection.cpp
+++ b/src/agnocastlib/test/unit/test_service_introspection.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Description

`agnocast::Service` and `agnocast::Client` gain `configure_introspection(clock, qos, state)` with the same signature as `rclcpp::Service<ServiceT>` / `rclcpp::Client<ServiceT>`, so an Agnocast service call shows up under `ros2 service echo` like an rclcpp one. All four event types are emitted: the client sends `REQUEST_SENT` / `RESPONSE_RECEIVED`, the service `REQUEST_RECEIVED` / `RESPONSE_SENT`.

**Why this cannot be delegated to rcl.** rclcpp implements introspection inside rcl: `Service`/`Client` own an rcl handle and `configure_introspection()` asks rcl to publish the `<service name>/_service_event` topic. Agnocast services never touch rcl — `agnocast::Node` does not even own an `rcl_node_t` — so the feature is re-implemented on an ordinary Agnocast publisher. The event topic uses `PublisherRole::Default`, so the ROS 2 bridge exposes it to DDS; without a bridge the events are still readable with `ros2 topic echo_agnocast`.

## Changes

**Introspection**

- `agnocast/internal/service_introspection.hpp` (+ `.cpp`): `ServiceIntrospection<ServiceT>` holding the state, the clock and the lazily-created event publisher, plus `create_service_event_topic_name()` and `make_service_client_gid()`.
- `agnocast_client.hpp` / `agnocast_service.hpp`: retain the node handle so the event publisher can be created later on the same node, hold a `ServiceIntrospection`, and emit at the four points. Emission always happens **before** `publish()` or before the response is moved into the promise, since both invalidate the payload.
- Guarded by `AGNOCAST_SERVICE_INTROSPECTION_SUPPORTED` (`RCLCPP_VERSION_GTE(21, 0, 0)`): `ServiceT::Event` and `rcl/service_introspection.h` only exist from Iron onwards. On Humble the method is **not declared at all**, matching rclcpp and matching the gate `autoware_component_interface_utils` already wraps its own calls in. The two gates must stay in sync, or ciu will call a method that is not there.
- Off by default; when disabled the cost is one relaxed atomic load per request and per response.

**Sequence-number scope** (fixes a pre-existing bug)

- Every client of one service on one node reads the same response topic (`/AGNOCAST_SRV_RESPONSE<service>_SEP_<node>`) and tells responses apart by sequence number alone, but each client numbered its requests from 0 independently. Two such clients could therefore resolve each other's responses.
- Sequence numbers now come from a counter shared per response topic (`get_service_sequence_counter()`) — the exact scope in which they have to be distinct. This also makes `(client_gid, sequence_number)` the unique transaction ID that `service_msgs/ServiceEventInfo` promises.
- A response whose sequence number is not in a client's map is now a `DEBUG` log rather than an `ERROR`: with a shared response topic, receiving a sibling's response is normal.

**Deliberate deviations from rcl**

- `client_gid` is derived from the caller's fully-qualified node name, because Agnocast has no rmw entity for a service client and the wire carries only the node name. Both ends compute the same value with no wire-format change. It therefore identifies a node rather than a client instance, and is stable across restarts instead of unique per session.
- The event publisher is created on the first enabling call and kept, whereas rcl destroys it on `OFF`. Tearing it down would withdraw the bridge request and churn the ROS 2 side on every toggle, so the QoS of the first enabling call wins; a later call with a different QoS is rejected with a warning.
- A null `clock` throws `std::invalid_argument` instead of being accepted and silently dropping every event.

**Other**

- `emit()` takes the introspection lock in shared mode, so concurrent service calls do not serialize against each other, nor behind the publisher construction `configure()` performs under the lock.
- `docs/agnocast_node_interface_comparison.md`: Service Introspection section listing what matches rclcpp and what does not.

## Related links

- Motivation: `autoware_component_interface_utils` calls `handle->configure_introspection(node->get_clock(), rclcpp::QoS(1), state)` on every service and client it creates, so this method has to exist for AD API nodes to build on an Agnocast-backed node type from Jazzy onwards. On Humble the ciu call sites compile out, which is why the Autoware-side work so far has not needed this branch.
- Wiring it through `autoware_agnocast_wrapper`'s `Client`/`Service` is a separate follow-up on the `autoware_core` side.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Done so far: built with tests on Humble and Jazzy, and `test/unit/test_service_introspection.cpp` passes on both. The Jazzy build confirms the gated code is really compiled, not preprocessed away.

Still to do: the `requires_kernel_module` tests. `test/integration/test_agnocast_client.cpp` gains introspection coverage (metadata / contents modes, the deferred-callback path, reconfiguration to `OFF`, GID and sequence-number agreement) and a `SharedResponseTopicTest` for the sequence-number fix. An end-to-end check against `ros2 service echo` is also outstanding.

## Notes for reviewers

1. `GenericService` / `GenericClient` are not supported — the type-erased API has no `ServiceT::Event`. Since these are also the ROS 2 bridge's own entities, a transaction crossing the bridge has only one half emitted by Agnocast, and the two halves carry different `client_gid` values.
2. Worth confirming the `client_gid` derivation is acceptable, or whether an identifier should go on the wire so the GID is unique per client instance and per session.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
