### PR TITLE
test(kmod): cover the remaining get_exit_process code paths

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2707,8 +2707,9 @@ static long get_exit_process_cmd(struct ioctl_get_exit_process_args __user * arg
   bool daemon_should_exit = false;
   agnocast_commit_exit_process(ipc_ns, global_pid, &daemon_should_exit);
 
-  // Patch ret_daemon_should_exit. Not fatal: proc_info is already freed, so -EFAULT would kill the
-  // daemon while it holds the ret_pid whose shm needs unlinking; the flag is re-derived next poll.
+  // Patch ret_daemon_should_exit. Not fatal: when a pid was returned, its proc_info has already
+  // been committed, so -EFAULT would make the daemon exit while discarding the ret_pid whose shm
+  // needs unlinking; the flag is advisory and re-derived on the next poll.
   if (copy_to_user(&arg->ret_daemon_should_exit, &daemon_should_exit, sizeof(daemon_should_exit))) {
     dev_warn(agnocast_device, "Failed to report the daemon exit flag. (%s)\n", __func__);
   }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1407,7 +1407,7 @@ pid_t agnocast_ioctl_get_exit_process(
   ioctl_ret->ret_daemon_should_exit = false;
   pid_t global_pid = -1;
 
-  down_write(&global_htables_rwsem);
+  down_read(&global_htables_rwsem);
 
   struct process_info * proc_info;
   int bkt;
@@ -1422,7 +1422,7 @@ pid_t agnocast_ioctl_get_exit_process(
     break;
   }
 
-  up_write(&global_htables_rwsem);
+  up_read(&global_htables_rwsem);
   return global_pid;
 }
 
@@ -2707,9 +2707,11 @@ static long get_exit_process_cmd(struct ioctl_get_exit_process_args __user * arg
   bool daemon_should_exit = false;
   agnocast_commit_exit_process(ipc_ns, global_pid, &daemon_should_exit);
 
-  // Patch ret_daemon_should_exit in user-space, after Phase 2 has committed.
-  if (copy_to_user(&arg->ret_daemon_should_exit, &daemon_should_exit, sizeof(daemon_should_exit)))
-    return -EFAULT;
+  // Patch ret_daemon_should_exit. Not fatal: proc_info is already freed, so -EFAULT would kill the
+  // daemon while it holds the ret_pid whose shm needs unlinking; the flag is re-derived next poll.
+  if (copy_to_user(&arg->ret_daemon_should_exit, &daemon_should_exit, sizeof(daemon_should_exit))) {
+    dev_warn(agnocast_device, "Failed to report the daemon exit flag. (%s)\n", __func__);
+  }
   return 0;
 }
 

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -8,6 +8,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_publish_msg.o \
   agnocast_kunit_receive_msg.o \
   agnocast_kunit_take_msg.o \
+  agnocast_kunit_get_exit_process.o \
   agnocast_kunit_get_publisher_num.o \
   agnocast_kunit_get_publisher_qos.o \
   agnocast_kunit_get_subscriber_num.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -84,3 +84,81 @@ void test_case_get_exit_process_commit_last_process(struct kunit * test)
   KUNIT_EXPECT_EQ(test, next_global_pid, -1);
   KUNIT_EXPECT_TRUE(test, next_daemon_should_exit);
 }
+
+// Phase 1 breaks after the first match, so several exited processes are drained one per poll. This
+// is what poll_for_unlink()'s inner do-while loop relies on: it keeps calling the ioctl until
+// ret_pid stops being positive, unlinking one shm per iteration.
+void test_case_get_exit_process_drains_one_per_poll(struct kunit * test)
+{
+  // Arrange
+  const int process_num = 3;
+  for (int i = 0; i < process_num; i++) {
+    setup_one_process(test, PID + i);
+    agnocast_process_exit_cleanup(PID + i);
+  }
+
+  // Act
+  pid_t drained[3] = {-1, -1, -1};
+  bool daemon_should_exit[3] = {true, true, true};
+  pid_t drained_ret_pid[3] = {-1, -1, -1};
+  for (int i = 0; i < process_num; i++) {
+    struct ioctl_get_exit_process_args args = {};
+    drained[i] = agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &args);
+    drained_ret_pid[i] = args.ret_pid;
+
+    agnocast_commit_exit_process(current->nsproxy->ipc_ns, drained[i], &daemon_should_exit[i]);
+  }
+
+  struct ioctl_get_exit_process_args final_args = {};
+  const pid_t final_global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &final_args);
+
+  // Assert: every pid is drained exactly once, and only the last commit empties the namespace.
+  bool seen[3] = {false, false, false};
+  for (int i = 0; i < process_num; i++) {
+    KUNIT_ASSERT_GE(test, drained[i], PID);
+    KUNIT_ASSERT_LT(test, drained[i], PID + process_num);
+    KUNIT_EXPECT_FALSE(test, seen[drained[i] - PID]);
+    seen[drained[i] - PID] = true;
+
+    // ret_pid is what user-space unlinks; under KUNIT_BUILD local_pid == global_pid.
+    KUNIT_EXPECT_EQ(test, drained_ret_pid[i], drained[i]);
+    KUNIT_EXPECT_EQ(test, daemon_should_exit[i], i == process_num - 1);
+  }
+
+  KUNIT_EXPECT_EQ(test, final_global_pid, -1);
+  KUNIT_EXPECT_EQ(test, final_args.ret_pid, -1);
+}
+
+// Phase 2 looks the pid up again under the write lock rather than trusting the caller, so a pid
+// that is no longer in the htable must be tolerated instead of dereferenced.
+void test_case_get_exit_process_commit_unknown_pid(struct kunit * test)
+{
+  // Arrange
+  const pid_t unknown_pid = PID + 999;
+
+  // Act
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, unknown_pid, &daemon_should_exit);
+
+  // Assert
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+}
+
+void test_case_get_exit_process_commit_unknown_pid_last_alive(struct kunit * test)
+{
+  // Arrange
+  setup_one_process(test, PID);
+  const pid_t unknown_pid = PID + 999;
+
+  // Act
+  bool daemon_should_exit = true;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, unknown_pid, &daemon_should_exit);
+
+  struct ioctl_get_exit_process_args args = {};
+  const pid_t global_pid = agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &args);
+
+  // Assert: the live process is not dropped by a commit for an unrelated pid.
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, global_pid, -1);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -22,65 +22,65 @@ static void setup_one_process(struct kunit * test, const pid_t pid)
 
 void test_case_get_exit_process_idle_poll_empty_namespace(struct kunit * test)
 {
-  // No process was ever added, so Phase 1 reports nothing.
+  // Arrange
   struct ioctl_get_exit_process_args get_exit_process_args = {};
+
+  // Act
   const pid_t global_pid =
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
-
-  KUNIT_EXPECT_EQ(test, global_pid, -1);
-  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
 
   bool daemon_should_exit = false;
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
 
+  // Assert
+  KUNIT_EXPECT_EQ(test, global_pid, -1);
+  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
   KUNIT_EXPECT_TRUE(test, daemon_should_exit);
 }
 
 void test_case_get_exit_process_idle_poll_process_remains(struct kunit * test)
 {
+  // Arrange
   setup_one_process(test, PID);
-
-  // The process is alive, so Phase 1 skips it and still reports nothing.
   struct ioctl_get_exit_process_args get_exit_process_args = {};
+
+  // Act
   const pid_t global_pid =
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
-
-  KUNIT_EXPECT_EQ(test, global_pid, -1);
-  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
 
   bool daemon_should_exit = true;
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
 
+  // Assert
+  KUNIT_EXPECT_EQ(test, global_pid, -1);
+  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
   KUNIT_EXPECT_FALSE(test, daemon_should_exit);
 }
 
 void test_case_get_exit_process_commit_last_process(struct kunit * test)
 {
+  // Arrange
   setup_one_process(test, PID);
   agnocast_process_exit_cleanup(PID);
 
-  // Phase 1 reports the exited pid while leaving proc_info in place.
+  // Act
   struct ioctl_get_exit_process_args get_exit_process_args = {};
   const pid_t global_pid =
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
 
-  KUNIT_EXPECT_EQ(test, global_pid, PID);
-
-  // Phase 2 drops that entry, emptying the namespace.
   bool daemon_should_exit = false;
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
 
-  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
-
-  // The committed entry is gone, so a following poll is idle and keeps deriving the flag.
   struct ioctl_get_exit_process_args next_args = {};
   const pid_t next_global_pid =
     agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &next_args);
 
-  KUNIT_EXPECT_EQ(test, next_global_pid, -1);
-
   bool next_daemon_should_exit = false;
   agnocast_commit_exit_process(current->nsproxy->ipc_ns, next_global_pid, &next_daemon_should_exit);
 
+  // Assert: the flag is still derived on the idle poll that follows the commit.
+  KUNIT_EXPECT_EQ(test, global_pid, PID);
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+  KUNIT_EXPECT_EQ(test, next_global_pid, -1);
   KUNIT_EXPECT_TRUE(test, next_daemon_should_exit);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_get_exit_process.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+static const pid_t PID = 1000;
+
+// get_exit_process_cmd tolerates a failed ret_daemon_should_exit copy_to_user because the flag is
+// re-derived on the next poll. That fallback only works if agnocast_commit_exit_process() derives
+// the flag unconditionally, including on an idle poll where Phase 1 found nothing and passes
+// global_pid == -1. These cases pin that down so gating the derivation behind global_pid >= 0
+// cannot silently strand the daemon.
+
+static void setup_one_process(struct kunit * test, const pid_t pid)
+{
+  union ioctl_add_process_args ioctl_ret;
+  int ret = agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, 0, &ioctl_ret);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+}
+
+void test_case_get_exit_process_idle_poll_empty_namespace(struct kunit * test)
+{
+  // No process was ever added, so Phase 1 reports nothing.
+  struct ioctl_get_exit_process_args get_exit_process_args = {};
+  const pid_t global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
+
+  KUNIT_EXPECT_EQ(test, global_pid, -1);
+  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
+
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+}
+
+void test_case_get_exit_process_idle_poll_process_remains(struct kunit * test)
+{
+  setup_one_process(test, PID);
+
+  // The process is alive, so Phase 1 skips it and still reports nothing.
+  struct ioctl_get_exit_process_args get_exit_process_args = {};
+  const pid_t global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
+
+  KUNIT_EXPECT_EQ(test, global_pid, -1);
+  KUNIT_EXPECT_EQ(test, get_exit_process_args.ret_pid, -1);
+
+  bool daemon_should_exit = true;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+
+  KUNIT_EXPECT_FALSE(test, daemon_should_exit);
+}
+
+void test_case_get_exit_process_commit_last_process(struct kunit * test)
+{
+  setup_one_process(test, PID);
+  agnocast_process_exit_cleanup(PID);
+
+  // Phase 1 reports the exited pid while leaving proc_info in place.
+  struct ioctl_get_exit_process_args get_exit_process_args = {};
+  const pid_t global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &get_exit_process_args);
+
+  KUNIT_EXPECT_EQ(test, global_pid, PID);
+
+  // Phase 2 drops that entry, emptying the namespace.
+  bool daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, global_pid, &daemon_should_exit);
+
+  KUNIT_EXPECT_TRUE(test, daemon_should_exit);
+
+  // The committed entry is gone, so a following poll is idle and keeps deriving the flag.
+  struct ioctl_get_exit_process_args next_args = {};
+  const pid_t next_global_pid =
+    agnocast_ioctl_get_exit_process(current->nsproxy->ipc_ns, &next_args);
+
+  KUNIT_EXPECT_EQ(test, next_global_pid, -1);
+
+  bool next_daemon_should_exit = false;
+  agnocast_commit_exit_process(current->nsproxy->ipc_ns, next_global_pid, &next_daemon_should_exit);
+
+  KUNIT_EXPECT_TRUE(test, next_daemon_should_exit);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_exit_process.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_GET_EXIT_PROCESS                                   \
+  KUNIT_CASE(test_case_get_exit_process_idle_poll_empty_namespace),   \
+    KUNIT_CASE(test_case_get_exit_process_idle_poll_process_remains), \
+    KUNIT_CASE(test_case_get_exit_process_commit_last_process),       \
+    KUNIT_CASE(test_case_get_exit_process_drains_one_per_poll),       \
+    KUNIT_CASE(test_case_get_exit_process_commit_unknown_pid),        \
+    KUNIT_CASE(test_case_get_exit_process_commit_unknown_pid_last_alive)
+
+void test_case_get_exit_process_idle_poll_empty_namespace(struct kunit * test);
+void test_case_get_exit_process_idle_poll_process_remains(struct kunit * test);
+void test_case_get_exit_process_commit_last_process(struct kunit * test);
+void test_case_get_exit_process_drains_one_per_poll(struct kunit * test);
+void test_case_get_exit_process_commit_unknown_pid(struct kunit * test);
+void test_case_get_exit_process_commit_unknown_pid_last_alive(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -10,6 +10,7 @@
 #include "agnocast_kunit/agnocast_kunit_do_exit.h"
 #include "agnocast_kunit/agnocast_kunit_domain_bridge.h"
 #include "agnocast_kunit/agnocast_kunit_exit_free_data.h"
+#include "agnocast_kunit/agnocast_kunit_get_exit_process.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_publisher_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_node_subscriber_topics.h"
 #include "agnocast_kunit/agnocast_kunit_get_publisher_num.h"
@@ -65,6 +66,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_GET_VERSION,
   TEST_CASES_INIT_MEMORY_ALLOCATOR,
   TEST_CASES_EXIT_FREE_DATA,
+  TEST_CASES_GET_EXIT_PROCESS,
   {},
 };
 


### PR DESCRIPTION
## Description

Follow-up to #1520, which added `agnocast_kunit_get_exit_process.c` covering the property that PR argues for: `agnocast_commit_exit_process()` derives `ret_daemon_should_exit` even on an idle poll (`global_pid == -1`), which is what makes the tolerated `copy_to_user` failure recoverable.

That left some branches of the two functions unexercised. This adds three cases:

- **`drains_one_per_poll`** — Phase 1 `break`s after the first match, so several exited processes are drained one per poll. `poll_for_unlink()`'s inner `do-while` loop depends on this, but no existing case set up more than one exited entry, so removing the `break` would not fail any test.
- **`commit_unknown_pid`** — Phase 2 re-looks-up the pid under the write lock; its `!proc_info` guard was never taken, because every case committed a pid Phase 1 had just returned.
- **`commit_unknown_pid_last_alive`** — the same guard while a live process remains, pinning that a commit for an unrelated pid neither drops the entry nor flips the flag.

Based on `refactor/get-exit-process-read-lock` rather than `main`, since the test file lands in #1520. Retarget to `main` once that merges.

### Not covered

Phase 1's `!ipc_eq(...)` filter. Every KUnit case runs in `current->nsproxy->ipc_ns` and the suite has no way to construct a second `ipc_namespace`; no existing test does. Cross-namespace behaviour is covered by `e2e_test_cross_ns_cli.bash`.

## Related links

- Follows #1520

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Not yet run: this machine's kernel has `CONFIG_KUNIT` unset, so `make test` skips the module and `run_kunit.bash` exits early. The new file was compiled on its own with `KUNIT_BUILD=y CONFIG_KUNIT=y CONFIG_GCOV_KERNEL=y` (`-Wall -Werror` clean), but the cases have **not** been executed. Needs a KUnit-enabled kernel before review.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` — tests only, no functional change.