### PR TITLE
feat(agnocast_cie_thread_configurator): manage kernel threads and IRQ affinities

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ All scripts are intended to be invoked from the repository root unless noted oth
 | Script | Purpose |
 |---|---|
 | `dds_config.bash` | Apply CycloneDDS runtime settings (`net.core.rmem_max`, loopback multicast) required for Agnocast over CycloneDDS. Guarded by `/tmp/cycloneDDS_configured` so it runs only once per boot. |
-| `setup_thread_configurator.bash` | Grant `CAP_SYS_NICE` to `thread_configurator_node` and register library paths in `/etc/ld.so.conf.d/agnocast-cie.conf`. Required for Callback Isolated Executor. See the [integration guide](https://autowarefoundation.github.io/agnocast_doc/callback-isolated-executor/integration-guide/#step-2-set-up-the-thread-configurator). |
+| `setup_thread_configurator.bash` | Grant `CAP_SYS_NICE` and `CAP_DAC_OVERRIDE` (for writing `/proc/irq/<N>/smp_affinity_list`) to `thread_configurator_node` and register library paths in `/etc/ld.so.conf.d/agnocast-cie.conf`. Required for Callback Isolated Executor. See the [integration guide](https://autowarefoundation.github.io/agnocast_doc/callback-isolated-executor/integration-guide/#step-2-set-up-the-thread-configurator). |
 | `switch_kmod.bash` | Swap the host's `agnocast-kmod-v<ver>` to another version. For container-based setups where only the host-side kmod needs replacing; the kmod and in-container heaphook must share the same ioctl ABI version. |
 
 ### sample_application/

--- a/scripts/setup_thread_configurator.bash
+++ b/scripts/setup_thread_configurator.bash
@@ -9,7 +9,8 @@
 #   ./scripts/setup_thread_configurator.bash
 #
 # This script automates:
-#   1. Granting CAP_SYS_NICE to the thread_configurator_node binary.
+#   1. Granting CAP_SYS_NICE (scheduling syscalls) and CAP_DAC_OVERRIDE (writes
+#      to root-owned /proc/irq/<N>/smp_affinity_list) to thread_configurator_node.
 #   2. Registering required library paths in /etc/ld.so.conf.d/agnocast-cie.conf.
 
 set -euo pipefail
@@ -62,7 +63,7 @@ fi
 
 # --- Step 1: Grant capabilities --------------------------------------------
 
-echo "[1/2] Grant CAP_SYS_NICE to thread_configurator_node"
+echo "[1/2] Grant CAP_SYS_NICE and CAP_DAC_OVERRIDE to thread_configurator_node"
 
 bin_path=$(readlink -f "${thread_configurator_prefix}/lib/agnocast_cie_thread_configurator/thread_configurator_node")
 
@@ -71,12 +72,15 @@ if [ ! -f "$bin_path" ]; then
 	exit 1
 fi
 
+# getcap prints caps in numeric order: "cap_dac_override,cap_sys_nice=eip".
+# An install by an older script version carries only cap_sys_nice and must not
+# match here, or it would never be upgraded to the combined set.
 current_caps=$(getcap "$bin_path" 2>/dev/null || true)
-if echo "$current_caps" | grep -q "cap_sys_nice=eip"; then
+if echo "$current_caps" | grep -q "cap_dac_override,cap_sys_nice=eip"; then
 	echo "  Already set ($current_caps). Skipping."
 else
 	echo "  Target: $bin_path"
-	sudo setcap cap_sys_nice=eip "$bin_path"
+	sudo setcap "cap_sys_nice,cap_dac_override=eip" "$bin_path"
 	echo "  Done: $(getcap "$bin_path")"
 fi
 

--- a/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
+++ b/src/agnocast_cie_config_msgs/srv/ReapplyConfig.srv
@@ -15,6 +15,13 @@
 # by a wildcard likewise takes over at the next announcement; until then the
 # wildcard keeps applying to that instance, and from then on only the exact
 # entry does.
+#
+# kernel_threads / irqs entries are matched against a fresh /proc scan on
+# every reapply (no carry-over). Entries whose attribute values are all unset
+# (YAML null or UNMANAGEABLE) appear in no array. "applied" means ensured: an
+# entry already in the desired state counts as applied without any syscall
+# (compare-before-set). There is no skipped_irqs: an IRQ has no announce-later
+# state, so a missing IRQ is reported as failed.
 bool success                       # true iff parse + per-entry validation passed
 string error_message               # parse / validation failure reason (empty on success)
 string[] applied_callback_groups   # syscalls succeeded; format "<domain_id>:<callback_group_id>"
@@ -23,3 +30,8 @@ string[] failed_callback_groups    # syscall failed (details in configurator log
 string[] failed_non_ros_threads    # syscall failed (details in configurator log)
 string[] skipped_callback_groups   # thread_id not yet announced; will apply on next announcement
 string[] skipped_non_ros_threads
+string[] applied_kernel_threads    # in desired state; format "<comm>:<tid>", one per matched thread
+string[] failed_kernel_threads     # syscall failed or affinity requested on a per-CPU kthread
+string[] skipped_kernel_threads    # managed comm matched no running kernel thread; format "<comm>"
+string[] applied_irqs              # in desired state; decimal IRQ number
+string[] failed_irqs               # identity mismatch, missing IRQ, irqbalance running, or write error

--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(agnocast_thread_configurator SHARED
   src/util.cpp
   src/non_ros_thread_ipc.cpp
   src/thread_config.cpp
+  src/system_scan.cpp
 )
 ament_target_dependencies(agnocast_thread_configurator rclcpp agnocast_cie_config_msgs)
 target_link_libraries(agnocast_thread_configurator yaml-cpp)
@@ -85,6 +86,14 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_thread_config agnocast_thread_configurator yaml-cpp)
   target_include_directories(test_thread_config PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  ament_add_gtest(test_system_scan
+    test/test_system_scan.cpp
+  )
+  target_link_libraries(test_system_scan agnocast_thread_configurator)
+  target_include_directories(test_system_scan PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
 endif()

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// One kernel thread observed in a /proc scan (kthreads are single-threaded,
+// so top-level /proc pid dirs suffice). All fields are file-derived, so unit
+// tests can inject a fake tree.
+struct KernelThreadInfo
+{
+  int64_t tid = -1;
+  std::string comm;             // /proc/<pid>/comm, trailing newline stripped
+  std::string policy;           // "SCHED_OTHER" etc., or "UNKNOWN(<n>)" for unmapped values
+  int priority = 0;             // nice for OTHER/BATCH/IDLE, rt_priority for FIFO/RR, 0 otherwise
+  std::string affinity;         // raw Cpus_allowed_list string, e.g. "0-15"
+  bool no_setaffinity = false;  // PF_NO_SETAFFINITY: per-CPU kthread, affinity fixed by kernel
+};
+
+// One device-backed IRQ (non-empty /sys/kernel/irq/<N>/actions).
+struct IrqInfo
+{
+  int irq = -1;
+  std::string name;      // actions file content (comma-joined for shared IRQs)
+  std::string affinity;  // /proc/irq/<N>/smp_affinity_list, "" when unreadable
+};
+
+// Sorted by (comm, tid); entries that vanish mid-scan are skipped silently.
+// kworker/* are excluded: their comms mutate at runtime, so they cannot be
+// managed per-thread.
+std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root = "/proc");
+
+// Sorted by irq. Iterates numeric directories under sys_irq_root
+// (authoritative for actions); the /proc/irq affinity read is best-effort.
+std::vector<IrqInfo> scan_irqs(
+  const std::string & proc_irq_root = "/proc/irq",
+  const std::string & sys_irq_root = "/sys/kernel/irq");
+
+// nullopt when the IRQ directory or its actions file is missing/unreadable.
+std::optional<std::string> read_irq_actions(
+  int irq, const std::string & sys_irq_root = "/sys/kernel/irq");
+
+// Pointers into `scanned`, in scan order; comms are not unique (e.g. an nfsd
+// pool), so every match is returned.
+std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
+  const std::vector<KernelThreadInfo> & scanned, const std::string & comm);
+
+// True when any /proc/<pid>/comm equals `comm` (e.g. irqbalance detection).
+bool process_with_comm_exists(const std::string & comm, const std::string & proc_root = "/proc");
+
+// {2, 3} -> "2,3": the comma list accepted by /proc/irq/<N>/smp_affinity_list.
+std::string format_cpu_list(const std::vector<int> & cpus);
+
+// Kernel cpu-list format ("0-5,8") -> sorted, deduplicated {0..5,8};
+// nullopt on empty or malformed input.
+std::optional<std::vector<int>> parse_cpu_list(const std::string & s);
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -4,7 +4,9 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -44,6 +46,49 @@ struct ThreadConfig
 // first '@' (the whole string when no '@' is present).
 std::string extract_node_part(const std::string & callback_group_id);
 
+// Sentinel for kernel_threads/irqs attribute values: the kernel or this tool
+// cannot manage the attribute (fixed per-CPU affinity, a policy with no YAML
+// representation), whereas YAML null means the USER chose not to. Both parse
+// to "not applied". Case-sensitive, exact match.
+inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
+
+// Desired attributes for every kernel thread whose comm matches at apply
+// time (comms are not unique, e.g. an nfsd pool). Unset fields (YAML null,
+// absent key, or UNMANAGEABLE) are never applied.
+struct KernelThreadConfig
+{
+  std::string comm;
+  std::optional<std::string> policy;
+  int priority = 0;           // meaningful only when policy is set: nice or rt_priority
+  std::vector<int> affinity;  // empty = leave alone
+
+  // SCHED_DEADLINE only
+  unsigned int runtime = 0;
+  unsigned int period = 0;
+  unsigned int deadline = 0;
+
+  bool is_managed() const noexcept;
+};
+
+// Desired affinity for one IRQ, a hard IRQ's only schedulable attribute
+// (threaded-IRQ handler threads are plain kernel threads).
+struct IrqConfig
+{
+  int irq = -1;
+  // Expected /sys/kernel/irq/<irq>/actions content, verified before applying
+  // (guards against IRQ renumbering across boots). Empty = skip the check.
+  std::string name;
+  std::vector<int> affinity;  // empty = leave alone
+
+  bool is_managed() const noexcept;
+};
+
+// Parse the optional kernel_threads / irqs sections. Missing/null sections
+// yield empty vectors (pre-existing YAMLs keep working). Throws
+// std::runtime_error on validation error.
+std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml);
+std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml);
+
 // Mapping from the policy string in the YAML to the kernel SCHED_* constant.
 // Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
 extern const std::unordered_map<std::string, int> policy_to_sched_const;
@@ -56,7 +101,8 @@ extern const std::unordered_map<std::string, int> policy_to_sched_const;
 // callback group whose node part (before the first '@') equals the prefix,
 // within the same domain; exact entries take precedence over wildcards.
 // non_ros_threads names are always matched exactly.
-// hardware_info / rt_throttling are validated only at startup, not here.
+// hardware_info / rt_throttling are validated only at startup, not here, and
+// the kernel_threads / irqs sections have their own parsers (see above).
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,
   std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out);

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_configurator_node.hpp
@@ -18,6 +18,8 @@
 class ThreadConfiguratorNode : public rclcpp::Node
 {
   using ThreadConfig = agnocast_cie_thread_configurator::ThreadConfig;
+  using KernelThreadConfig = agnocast_cie_thread_configurator::KernelThreadConfig;
+  using IrqConfig = agnocast_cie_thread_configurator::IrqConfig;
 
   // Concurrency:
   // - callback_group_configs_ / id_to_callback_group_config_ /
@@ -27,6 +29,8 @@ class ThreadConfiguratorNode : public rclcpp::Node
   // - non_ros_thread_configs_ / id_to_non_ros_thread_config_: written by both
   //   the NonRosThreadInfoListener reader thread and the reapply handler;
   //   all access must hold non_ros_state_mutex_.
+  // - kernel_thread_configs_ / irq_configs_: written only by the constructor
+  //   (pre-spin) and the reapply handler, so no mutex is needed.
   // - print_all_unapplied(): called only after stop() + executor return, so
   //   reads need no lock.
 
@@ -39,12 +43,29 @@ public:
   const std::vector<rclcpp::Node::SharedPtr> & get_domain_nodes() const;
 
 private:
+  // One kernel-thread/IRQ apply pass. Keys: "<comm>:<tid>" (applied/failed)
+  // and "<comm>" (skipped) for kernel threads; the decimal IRQ number for
+  // IRQs. "applied" = ensured: an already-matching entry counts without
+  // syscalls (compare-before-set).
+  struct SectionApplyOutcome
+  {
+    std::vector<std::string> applied;
+    std::vector<std::string> failed;
+    std::vector<std::string> skipped;
+  };
+
   void validate_hardware_info(const YAML::Node & yaml);
   void validate_rt_throttling(const YAML::Node & yaml);
   bool set_affinity_by_cgroup(int64_t thread_id, const std::vector<int> & cpus);
   // thread_id is passed explicitly because a wildcard entry applies to many
   // threads (one per matched_tids element), not just config.thread_id.
   bool issue_syscalls(const ThreadConfig & config, int64_t thread_id);
+  bool issue_affinity_syscalls(
+    const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+    int64_t thread_id);
+  SectionApplyOutcome apply_kernel_thread_configs();
+  SectionApplyOutcome apply_irq_configs();
+  bool write_irq_affinity_file(const IrqConfig & config);
   void callback_group_callback(
     size_t domain_id, const agnocast_cie_config_msgs::msg::CallbackGroupInfo::SharedPtr msg);
   void non_ros_thread_callback(agnocast_cie_thread_configurator::NonRosThreadInfo info);
@@ -69,6 +90,9 @@ private:
   std::vector<ThreadConfig> non_ros_thread_configs_;
   // thread_name -> ThreadConfig*
   std::map<std::string, ThreadConfig *> id_to_non_ros_thread_config_;
+
+  std::vector<KernelThreadConfig> kernel_thread_configs_;
+  std::vector<IrqConfig> irq_configs_;
 
   std::atomic<int> unapplied_num_{0};
   std::atomic<int> cgroup_num_{0};

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -1,6 +1,8 @@
 #include "agnocast_cie_thread_configurator/prerun_node.hpp"
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -12,6 +14,27 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
+
+namespace
+{
+
+// One template entry per comm (it manages every thread sharing that comm).
+// The scan is sorted by (comm, tid), so the kept observed values are the
+// lowest tid's.
+std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> dedup_by_comm(
+  std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> scanned)
+{
+  std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> result;
+  for (auto & info : scanned) {
+    if (result.empty() || result.back().comm != info.comm) {
+      result.push_back(std::move(info));
+    }
+  }
+  return result;
+}
+
+}  // namespace
 
 PrerunNode::PrerunNode(const rclcpp::NodeOptions & options) : Node("prerun_node", options)
 {
@@ -170,6 +193,70 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     out << YAML::Key << "affinity" << YAML::Value << YAML::Null;
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
     out << YAML::Key << "priority" << YAML::Value << 0;
+    out << YAML::EndMap;
+    out << YAML::Newline;
+  }
+
+  out << YAML::EndSeq;
+
+  // Add kernel_threads and irqs sections: observed values become the initial
+  // desired values (compare-before-set keeps unedited entries no-ops), and
+  // UNMANAGEABLE marks values that cannot be provided or changed (YAML null
+  // stays the user's opt-out).
+  const std::string unmanageable(agnocast_cie_thread_configurator::k_unmanageable);
+  const auto kernel_threads =
+    dedup_by_comm(agnocast_cie_thread_configurator::scan_kernel_threads());
+  const auto irqs = agnocast_cie_thread_configurator::scan_irqs();
+  RCLCPP_INFO(
+    this->get_logger(), "Scanned %zu kernel thread comms and %zu device-backed IRQs",
+    kernel_threads.size(), irqs.size());
+
+  out << YAML::Key << "kernel_threads";
+  out << YAML::Value << YAML::BeginSeq;
+
+  for (const auto & info : kernel_threads) {
+    // A policy with no YAML representation: UNKNOWN(<n>), or SCHED_DEADLINE,
+    // whose runtime/period/deadline cannot be recovered from /proc.
+    const bool policy_representable =
+      agnocast_cie_thread_configurator::policy_to_sched_const.count(info.policy) > 0 &&
+      info.policy != "SCHED_DEADLINE";
+    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+
+    out << YAML::BeginMap;
+    out << YAML::Key << "comm" << YAML::Value << info.comm;
+    if (policy_representable) {
+      out << YAML::Key << "policy" << YAML::Value << info.policy;
+      out << YAML::Key << "priority" << YAML::Value << info.priority;
+    } else {
+      out << YAML::Key << "policy" << YAML::Value << unmanageable;
+      out << YAML::Key << "priority" << YAML::Value << unmanageable;
+    }
+    if (info.no_setaffinity || !cpus) {
+      out << YAML::Key << "affinity" << YAML::Value << unmanageable;
+    } else {
+      out << YAML::Key << "affinity" << YAML::Value << YAML::Flow << *cpus;
+    }
+    out << YAML::EndMap;
+    out << YAML::Newline;
+  }
+
+  out << YAML::EndSeq;
+
+  // Add irqs section
+  out << YAML::Key << "irqs";
+  out << YAML::Value << YAML::BeginSeq;
+
+  for (const auto & info : irqs) {
+    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+
+    out << YAML::BeginMap;
+    out << YAML::Key << "irq" << YAML::Value << info.irq;
+    out << YAML::Key << "name" << YAML::Value << info.name;
+    if (cpus) {
+      out << YAML::Key << "affinity" << YAML::Value << YAML::Flow << *cpus;
+    } else {
+      out << YAML::Key << "affinity" << YAML::Value << unmanageable;
+    }
     out << YAML::EndMap;
     out << YAML::Newline;
   }

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -1,0 +1,321 @@
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
+
+#include <linux/sched.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+#include <tuple>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+
+// Not exposed by uapi headers; values from include/linux/sched.h.
+constexpr unsigned long k_pf_kthread = 0x00200000;
+constexpr unsigned long k_pf_no_setaffinity = 0x04000000;
+
+// 1-based /proc/<pid>/stat field numbers (man 5 proc); see split_stat_after_comm.
+constexpr size_t k_stat_field_flags = 9;
+constexpr size_t k_stat_field_nice = 19;
+constexpr size_t k_stat_field_rt_priority = 40;
+constexpr size_t k_stat_field_policy = 41;
+
+std::optional<std::string> read_first_line(const std::filesystem::path & path)
+{
+  std::ifstream file(path);
+  if (!file) {
+    return std::nullopt;
+  }
+  std::string line;
+  std::getline(file, line);
+  if (file.bad()) {
+    return std::nullopt;
+  }
+  return line;
+}
+
+bool is_all_digits(std::string_view s)
+{
+  return !s.empty() &&
+         std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isdigit(c); });
+}
+
+template <typename T>
+std::optional<T> to_number(std::string_view s)
+{
+  T value{};
+  const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+  if (ec != std::errc() || ptr != s.data() + s.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+// The stat comm may contain spaces and parentheses (e.g. "irq/24-PCIe PME"),
+// so split at the LAST ')'. tokens[0] is field 3 (state), so field N maps to
+// tokens[N - 3].
+std::optional<std::vector<std::string>> split_stat_after_comm(const std::string & stat)
+{
+  const size_t close = stat.rfind(')');
+  if (close == std::string::npos) {
+    return std::nullopt;
+  }
+  std::istringstream rest(stat.substr(close + 1));
+  std::vector<std::string> tokens;
+  std::string token;
+  while (rest >> token) {
+    tokens.push_back(std::move(token));
+  }
+  return tokens;
+}
+
+std::optional<std::string> stat_token(const std::vector<std::string> & tokens, size_t field)
+{
+  const size_t index = field - 3;
+  if (index >= tokens.size()) {
+    return std::nullopt;
+  }
+  return tokens[index];
+}
+
+std::string policy_const_to_string(int policy)
+{
+  for (const auto & [name, value] : policy_to_sched_const) {
+    if (value == policy) {
+      return name;
+    }
+  }
+  return "UNKNOWN(" + std::to_string(policy) + ")";
+}
+
+std::optional<std::string> read_cpus_allowed_list(const std::filesystem::path & status_path)
+{
+  std::ifstream file(status_path);
+  if (!file) {
+    return std::nullopt;
+  }
+  constexpr std::string_view key = "Cpus_allowed_list:";
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.compare(0, key.size(), key) != 0) {
+      continue;
+    }
+    size_t begin = key.size();
+    while (begin < line.size() && (line[begin] == ' ' || line[begin] == '\t')) {
+      ++begin;
+    }
+    return line.substr(begin);
+  }
+  return std::nullopt;
+}
+
+std::optional<KernelThreadInfo> read_kernel_thread(
+  const std::filesystem::path & pid_dir, int64_t tid)
+{
+  const auto stat = read_first_line(pid_dir / "stat");
+  if (!stat) {
+    return std::nullopt;
+  }
+  const auto tokens = split_stat_after_comm(*stat);
+  if (!tokens) {
+    return std::nullopt;
+  }
+
+  const auto flags_str = stat_token(*tokens, k_stat_field_flags);
+  const auto nice_str = stat_token(*tokens, k_stat_field_nice);
+  const auto rt_priority_str = stat_token(*tokens, k_stat_field_rt_priority);
+  const auto policy_str = stat_token(*tokens, k_stat_field_policy);
+  if (!flags_str || !nice_str || !rt_priority_str || !policy_str) {
+    return std::nullopt;
+  }
+  const auto flags = to_number<unsigned long>(*flags_str);
+  const auto nice = to_number<int>(*nice_str);
+  const auto rt_priority = to_number<int>(*rt_priority_str);
+  const auto policy = to_number<int>(*policy_str);
+  if (!flags || !nice || !rt_priority || !policy) {
+    return std::nullopt;
+  }
+  if ((*flags & k_pf_kthread) == 0) {
+    return std::nullopt;
+  }
+
+  const auto comm = read_first_line(pid_dir / "comm");
+  if (!comm || comm->empty()) {
+    return std::nullopt;
+  }
+  if (comm->compare(0, 8, "kworker/") == 0) {
+    return std::nullopt;
+  }
+
+  const auto affinity = read_cpus_allowed_list(pid_dir / "status");
+  if (!affinity) {
+    return std::nullopt;
+  }
+
+  KernelThreadInfo info;
+  info.tid = tid;
+  info.comm = *comm;
+  info.policy = policy_const_to_string(*policy);
+  if (*policy == SCHED_FIFO || *policy == SCHED_RR) {
+    info.priority = *rt_priority;
+  } else if (*policy == SCHED_OTHER || *policy == SCHED_BATCH || *policy == SCHED_IDLE) {
+    info.priority = *nice;
+  }
+  info.affinity = *affinity;
+  info.no_setaffinity = (*flags & k_pf_no_setaffinity) != 0;
+  return info;
+}
+
+}  // namespace
+
+std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root)
+{
+  std::vector<KernelThreadInfo> result;
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+    const std::string filename = entry.path().filename().string();
+    if (!is_all_digits(filename)) {
+      continue;
+    }
+    const auto tid = to_number<int64_t>(filename);
+    if (!tid) {
+      continue;
+    }
+    if (auto info = read_kernel_thread(entry.path(), *tid)) {
+      result.push_back(std::move(*info));
+    }
+  }
+  std::sort(
+    result.begin(), result.end(), [](const KernelThreadInfo & a, const KernelThreadInfo & b) {
+      return std::tie(a.comm, a.tid) < std::tie(b.comm, b.tid);
+    });
+  return result;
+}
+
+std::vector<IrqInfo> scan_irqs(const std::string & proc_irq_root, const std::string & sys_irq_root)
+{
+  std::vector<IrqInfo> result;
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(sys_irq_root, ec)) {
+    const std::string filename = entry.path().filename().string();
+    if (!is_all_digits(filename)) {
+      continue;
+    }
+    const auto irq = to_number<int>(filename);
+    if (!irq) {
+      continue;
+    }
+    const auto actions = read_first_line(entry.path() / "actions");
+    if (!actions || actions->empty()) {
+      continue;
+    }
+
+    IrqInfo info;
+    info.irq = *irq;
+    info.name = *actions;
+    info.affinity =
+      read_first_line(std::filesystem::path(proc_irq_root) / filename / "smp_affinity_list")
+        .value_or("");
+    result.push_back(std::move(info));
+  }
+  std::sort(result.begin(), result.end(), [](const IrqInfo & a, const IrqInfo & b) {
+    return a.irq < b.irq;
+  });
+  return result;
+}
+
+std::optional<std::string> read_irq_actions(int irq, const std::string & sys_irq_root)
+{
+  return read_first_line(std::filesystem::path(sys_irq_root) / std::to_string(irq) / "actions");
+}
+
+std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
+  const std::vector<KernelThreadInfo> & scanned, const std::string & comm)
+{
+  std::vector<const KernelThreadInfo *> result;
+  for (const auto & info : scanned) {
+    if (info.comm == comm) {
+      result.push_back(&info);
+    }
+  }
+  return result;
+}
+
+bool process_with_comm_exists(const std::string & comm, const std::string & proc_root)
+{
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+    if (!is_all_digits(entry.path().filename().string())) {
+      continue;
+    }
+    const auto entry_comm = read_first_line(entry.path() / "comm");
+    if (entry_comm && *entry_comm == comm) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string format_cpu_list(const std::vector<int> & cpus)
+{
+  std::string result;
+  for (size_t i = 0; i < cpus.size(); i++) {
+    if (i > 0) {
+      result += ",";
+    }
+    result += std::to_string(cpus[i]);
+  }
+  return result;
+}
+
+std::optional<std::vector<int>> parse_cpu_list(const std::string & s)
+{
+  std::vector<int> result;
+  std::string_view rest(s);
+  // Tolerate the trailing newline that raw kernel file contents carry.
+  while (!rest.empty() && (rest.back() == '\n' || rest.back() == '\r' || rest.back() == ' ')) {
+    rest.remove_suffix(1);
+  }
+  if (rest.empty()) {
+    return std::nullopt;
+  }
+  while (!rest.empty()) {
+    const size_t comma = rest.find(',');
+    const std::string_view token = rest.substr(0, comma);
+    rest = (comma == std::string_view::npos) ? std::string_view() : rest.substr(comma + 1);
+
+    const size_t dash = token.find('-');
+    if (dash == std::string_view::npos) {
+      const auto cpu = to_number<int>(token);
+      if (!cpu || *cpu < 0) {
+        return std::nullopt;
+      }
+      result.push_back(*cpu);
+    } else {
+      const auto first = to_number<int>(token.substr(0, dash));
+      const auto last = to_number<int>(token.substr(dash + 1));
+      if (!first || !last || *first < 0 || *last < *first) {
+        return std::nullopt;
+      }
+      for (int cpu = *first; cpu <= *last; cpu++) {
+        result.push_back(cpu);
+      }
+    }
+  }
+  std::sort(result.begin(), result.end());
+  result.erase(std::unique(result.begin(), result.end()), result.end());
+  return result;
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -12,6 +12,21 @@
 namespace agnocast_cie_thread_configurator
 {
 
+namespace
+{
+
+// Unset = the attribute must not be applied: YAML null / absent key (the
+// user's opt-out) or the UNMANAGEABLE sentinel (a kernel/tool constraint).
+bool is_unset(const YAML::Node & node)
+{
+  if (!node || node.IsNull()) {
+    return true;
+  }
+  return node.IsScalar() && node.Scalar() == k_unmanageable;
+}
+
+}  // namespace
+
 const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
@@ -136,6 +151,137 @@ void parse_yaml(
       throw std::runtime_error("Duplicate non_ros_thread entry: name=" + c.thread_str);
     }
   }
+}
+
+bool KernelThreadConfig::is_managed() const noexcept
+{
+  return policy.has_value() || !affinity.empty();
+}
+
+bool IrqConfig::is_managed() const noexcept
+{
+  return !affinity.empty();
+}
+
+std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
+{
+  YAML::Node section = yaml["kernel_threads"];
+  std::vector<KernelThreadConfig> result;
+  if (!section || section.IsNull()) {
+    return result;
+  }
+  result.resize(section.size());
+
+  for (size_t i = 0; i < section.size(); ++i) {
+    const auto & kt = section[i];
+    auto & cfg = result[i];
+
+    if (is_unset(kt["comm"])) {
+      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+    }
+    cfg.comm = kt["comm"].as<std::string>();
+    if (cfg.comm.empty()) {
+      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+    }
+    if (cfg.comm.compare(0, 8, "kworker/") == 0) {
+      throw std::runtime_error(
+        "kernel_threads entry '" + cfg.comm +
+        "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
+        "be matched reliably");
+    }
+
+    if (!is_unset(kt["affinity"])) {
+      for (auto & cpu : kt["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    }
+
+    const bool has_policy = !is_unset(kt["policy"]);
+    const bool has_priority = !is_unset(kt["priority"]);
+    if (!has_policy) {
+      if (has_priority) {
+        throw std::runtime_error(
+          "'priority' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
+      }
+      continue;
+    }
+
+    cfg.policy = kt["policy"].as<std::string>();
+    if (policy_to_sched_const.count(*cfg.policy) == 0) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + *cfg.policy + "' for comm=" + cfg.comm +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
+    }
+
+    if (*cfg.policy == "SCHED_DEADLINE") {
+      // Explicit check for a clear message: these fields are always
+      // hand-written (prerun never emits DEADLINE) and easy to forget.
+      if (is_unset(kt["runtime"]) || is_unset(kt["period"]) || is_unset(kt["deadline"])) {
+        throw std::runtime_error(
+          "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
+      }
+      cfg.runtime = kt["runtime"].as<unsigned int>();
+      cfg.period = kt["period"].as<unsigned int>();
+      cfg.deadline = kt["deadline"].as<unsigned int>();
+    } else {
+      if (!has_priority) {
+        throw std::runtime_error(
+          "Policy '" + *cfg.policy + "' requires 'priority' for comm=" + cfg.comm);
+      }
+      cfg.priority = kt["priority"].as<int>();
+    }
+  }
+
+  std::unordered_set<std::string> seen;
+  for (const auto & c : result) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen.insert(c.comm).second) {
+      throw std::runtime_error("Duplicate kernel_thread entry: comm=" + c.comm);
+    }
+  }
+  return result;
+}
+
+std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
+{
+  YAML::Node section = yaml["irqs"];
+  std::vector<IrqConfig> result;
+  if (!section || section.IsNull()) {
+    return result;
+  }
+  result.resize(section.size());
+
+  for (size_t i = 0; i < section.size(); ++i) {
+    const auto & iq = section[i];
+    auto & cfg = result[i];
+
+    if (is_unset(iq["irq"]) || !iq["irq"].IsScalar()) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+    try {
+      cfg.irq = iq["irq"].as<int>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+    if (cfg.irq < 0) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+
+    if (!is_unset(iq["name"])) {
+      cfg.name = iq["name"].as<std::string>();
+    }
+    if (!is_unset(iq["affinity"])) {
+      for (auto & cpu : iq["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    }
+  }
+
+  std::unordered_set<int> seen;
+  for (const auto & c : result) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen.insert(c.irq).second) {
+      throw std::runtime_error("Duplicate irq entry: irq=" + std::to_string(c.irq));
+    }
+  }
+  return result;
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -2,6 +2,7 @@
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
 #include "agnocast_cie_thread_configurator/sched_deadline.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
@@ -10,10 +11,13 @@
 #include "agnocast_cie_config_msgs/srv/reapply_config.hpp"
 
 #include <error.h>
+#include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -22,6 +26,47 @@
 #include <utility>
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
+
+namespace
+{
+
+bool same_cpu_set(const std::vector<int> & desired, const std::optional<std::vector<int>> & current)
+{
+  if (!current) {
+    return false;
+  }
+  std::vector<int> normalized = desired;
+  std::sort(normalized.begin(), normalized.end());
+  normalized.erase(std::unique(normalized.begin(), normalized.end()), normalized.end());
+  return normalized == *current;  // parse_cpu_list output is sorted and deduplicated
+}
+
+// Compare-before-set: unedited templates (observed values as the desired
+// ones) stay no-ops, and threads the kernel refuses to modify even with
+// identical values (stop-class migration/N) are left alone. DEADLINE params
+// cannot be read back from stat, so a DEADLINE request is always applied.
+bool kernel_thread_in_sync(
+  const agnocast_cie_thread_configurator::KernelThreadConfig & config,
+  const agnocast_cie_thread_configurator::KernelThreadInfo & info)
+{
+  if (config.policy.has_value()) {
+    if (*config.policy == "SCHED_DEADLINE") {
+      return false;
+    }
+    if (*config.policy != info.policy || config.priority != info.priority) {
+      return false;
+    }
+  }
+  if (!config.affinity.empty()) {
+    if (!same_cpu_set(
+          config.affinity, agnocast_cie_thread_configurator::parse_cpu_list(info.affinity))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
 
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options),
@@ -51,6 +96,21 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   agnocast_cie_thread_configurator::parse_yaml(
     yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
+  kernel_thread_configs_ = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+  irq_configs_ = agnocast_cie_thread_configurator::parse_irqs(yaml);
+
+  // Kernel threads and IRQs never announce themselves: configure them here
+  // from a /proc scan, outside the announcement-driven accounting below.
+  {
+    const SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    const SectionApplyOutcome irq_outcome = apply_irq_configs();
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Kernel threads and IRQs configured: applied=%zu, failed=%zu, skipped=%zu",
+      kernel_thread_outcome.applied.size() + irq_outcome.applied.size(),
+      kernel_thread_outcome.failed.size() + irq_outcome.failed.size(),
+      kernel_thread_outcome.skipped.size() + irq_outcome.skipped.size());
+  }
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -368,12 +428,19 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     return false;
   }
 
-  if (config.affinity.size() > 0) {
-    if (config.policy == "SCHED_DEADLINE") {
-      if (!set_affinity_by_cgroup(thread_id, config.affinity)) {
+  return issue_affinity_syscalls(config.thread_str, config.policy, config.affinity, thread_id);
+}
+
+bool ThreadConfiguratorNode::issue_affinity_syscalls(
+  const std::string & thread_str, const std::string & policy, const std::vector<int> & affinity,
+  int64_t thread_id)
+{
+  if (affinity.size() > 0) {
+    if (policy == "SCHED_DEADLINE") {
+      if (!set_affinity_by_cgroup(thread_id, affinity)) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id,
+          thread_str.c_str(), thread_id,
           "Please disable cgroup v2 if used: "
           "`systemd.unified_cgroup_hierarchy=0`");
         return false;
@@ -381,19 +448,237 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     } else {
       cpu_set_t set;
       CPU_ZERO(&set);
-      for (int cpu : config.affinity) {
+      for (int cpu : affinity) {
         CPU_SET(cpu, &set);
       }
       if (sched_setaffinity(thread_id, sizeof(set), &set) == -1) {
         RCLCPP_ERROR(
           this->get_logger(), "Failed to configure affinity (thread=%s, tid=%ld): %s",
-          config.thread_str.c_str(), thread_id, strerror(errno));
+          thread_str.c_str(), thread_id, strerror(errno));
         return false;
       }
     }
   }
 
   return true;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_kernel_thread_configs()
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    kernel_thread_configs_.begin(), kernel_thread_configs_.end(),
+    [](const KernelThreadConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  const auto scanned = agnocast_cie_thread_configurator::scan_kernel_threads();
+  for (const auto & config : kernel_thread_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    const auto matches =
+      agnocast_cie_thread_configurator::find_kernel_threads_by_comm(scanned, config.comm);
+    if (matches.empty()) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "No running kernel thread matches comm=%s; skipping. It may appear later; call "
+        "~/reapply_config to retry.",
+        config.comm.c_str());
+      outcome.skipped.push_back(config.comm);
+      continue;
+    }
+
+    for (const auto * info : matches) {
+      std::string key = config.comm + ":" + std::to_string(info->tid);
+      if (kernel_thread_in_sync(config, *info)) {
+        outcome.applied.push_back(std::move(key));
+        continue;
+      }
+      if (!config.affinity.empty() && info->no_setaffinity) {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Failed to configure affinity (thread=%s, tid=%ld): per-CPU kernel thread "
+          "(PF_NO_SETAFFINITY); the kernel fixes its affinity. Set 'affinity' to %s for this "
+          "entry.",
+          config.comm.c_str(), info->tid,
+          std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+        outcome.failed.push_back(std::move(key));
+        continue;
+      }
+
+      bool ok = false;
+      if (config.policy.has_value()) {
+        // Reuse the announcement-path syscall code (and its error wording)
+        // verbatim by shaping the entry as a ThreadConfig.
+        ThreadConfig tmp;
+        tmp.thread_str = config.comm;
+        tmp.policy = *config.policy;
+        tmp.priority = config.priority;
+        tmp.affinity = config.affinity;
+        tmp.runtime = config.runtime;
+        tmp.period = config.period;
+        tmp.deadline = config.deadline;
+        ok = issue_syscalls(tmp, info->tid);
+      } else {
+        ok = issue_affinity_syscalls(config.comm, "", config.affinity, info->tid);
+      }
+
+      if (ok) {
+        RCLCPP_INFO(
+          this->get_logger(), "Configured kernel thread (comm=%s, tid=%ld)", config.comm.c_str(),
+          info->tid);
+        outcome.applied.push_back(std::move(key));
+      } else {
+        outcome.failed.push_back(std::move(key));
+      }
+    }
+  }
+  return outcome;
+}
+
+ThreadConfiguratorNode::SectionApplyOutcome ThreadConfiguratorNode::apply_irq_configs()
+{
+  SectionApplyOutcome outcome;
+  const bool any_managed = std::any_of(
+    irq_configs_.begin(), irq_configs_.end(),
+    [](const IrqConfig & config) { return config.is_managed(); });
+  if (!any_managed) {
+    return outcome;
+  }
+
+  // A running irqbalance would periodically rewrite smp_affinity, silently
+  // undoing whatever is applied here, so applying would only fake success.
+  if (agnocast_cie_thread_configurator::process_with_comm_exists("irqbalance")) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "IRQ affinity configuration is requested but irqbalance is running; it would periodically "
+      "overwrite the configured affinities, so nothing is applied. Disable it (sudo systemctl "
+      "disable --now irqbalance) and call ~/reapply_config to retry.");
+    for (const auto & config : irq_configs_) {
+      if (config.is_managed()) {
+        outcome.failed.push_back(std::to_string(config.irq));
+      }
+    }
+    return outcome;
+  }
+
+  for (const auto & config : irq_configs_) {
+    if (!config.is_managed()) {
+      continue;
+    }
+    std::string key = std::to_string(config.irq);
+
+    const auto actions = agnocast_cie_thread_configurator::read_irq_actions(config.irq);
+    if (!actions) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
+        "change across boots or device changes; re-run prerun_node and update the config.",
+        config.irq, config.name.c_str());
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+    if (!config.name.empty() && *actions != config.name) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "IRQ %d identity mismatch: expected actions '%s', current '%s'. IRQ numbers can change "
+        "across boots; re-run prerun_node and update the config. Skipping.",
+        config.irq, config.name.c_str(), actions->c_str());
+      outcome.failed.push_back(std::move(key));
+      continue;
+    }
+
+    std::string current;
+    {
+      std::ifstream file("/proc/irq/" + key + "/smp_affinity_list");
+      std::getline(file, current);
+    }
+    if (same_cpu_set(config.affinity, agnocast_cie_thread_configurator::parse_cpu_list(current))) {
+      // Also spares kernel-managed IRQs (which reject every write with EIO)
+      // from a spurious error when the recorded value is still current.
+      outcome.applied.push_back(std::move(key));
+      continue;
+    }
+
+    if (write_irq_affinity_file(config)) {
+      RCLCPP_INFO(
+        this->get_logger(), "Configured IRQ %d affinity to [%s]", config.irq,
+        agnocast_cie_thread_configurator::format_cpu_list(config.affinity).c_str());
+      outcome.applied.push_back(std::move(key));
+    } else {
+      outcome.failed.push_back(std::move(key));
+    }
+  }
+  return outcome;
+}
+
+bool ThreadConfiguratorNode::write_irq_affinity_file(const IrqConfig & config)
+{
+  const std::string path = "/proc/irq/" + std::to_string(config.irq) + "/smp_affinity_list";
+  const std::string value = agnocast_cie_thread_configurator::format_cpu_list(config.affinity);
+
+  // Raw open/write instead of std::ofstream: the instructive messages below
+  // depend on which errno occurred, and EIO only appears at write(2) time.
+  const int fd = ::open(path.c_str(), O_WRONLY | O_CLOEXEC);
+  if (fd == -1) {
+    if (errno == EACCES || errno == EPERM) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d affinity: %s. Writing /proc/irq/<N>/smp_affinity_list "
+        "requires CAP_DAC_OVERRIDE in addition to CAP_SYS_NICE. Re-run "
+        "scripts/setup_thread_configurator.bash to grant 'cap_sys_nice,cap_dac_override=eip' to "
+        "thread_configurator_node.",
+        config.irq, strerror(errno));
+    } else if (errno == ENOENT) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Failed to configure IRQ %d: it no longer exists (expected actions '%s'). IRQ numbers can "
+        "change across boots or device changes; re-run prerun_node and update the config.",
+        config.irq, config.name.c_str());
+    } else {
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to configure IRQ %d affinity: %s", config.irq, strerror(errno));
+    }
+    return false;
+  }
+
+  const ssize_t written = ::write(fd, value.c_str(), value.size());
+  const int write_errno = errno;
+  ::close(fd);
+  if (written == static_cast<ssize_t>(value.size())) {
+    return true;
+  }
+
+  if (written == -1 && write_errno == EIO) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel does not allow user-space affinity "
+      "changes for this IRQ (e.g. IRQ 0 timer or kernel-managed MSI-X vectors). Set 'affinity' "
+      "to %s for this entry.",
+      config.irq, strerror(write_errno),
+      std::string(agnocast_cie_thread_configurator::k_unmanageable).c_str());
+  } else if (written == -1 && (write_errno == EACCES || write_errno == EPERM)) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. Writing /proc/irq/<N>/smp_affinity_list requires "
+      "CAP_DAC_OVERRIDE in addition to CAP_SYS_NICE. Re-run "
+      "scripts/setup_thread_configurator.bash to grant 'cap_sys_nice,cap_dac_override=eip' to "
+      "thread_configurator_node.",
+      config.irq, strerror(write_errno));
+  } else if (written == -1) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to configure IRQ %d affinity: %s. The kernel rejected CPU list '%s' (offline CPUs "
+      "or no valid CPU in the mask?).",
+      config.irq, strerror(write_errno), value.c_str());
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to configure IRQ %d affinity: short write to %s", config.irq,
+      path.c_str());
+  }
+  return false;
 }
 
 const std::vector<rclcpp::Node::SharedPtr> & ThreadConfiguratorNode::get_domain_nodes() const
@@ -545,8 +830,12 @@ void ThreadConfiguratorNode::on_reapply_config_request(
 
   std::vector<ThreadConfig> new_cb;
   std::vector<ThreadConfig> new_nrt;
+  std::vector<KernelThreadConfig> new_kernel_threads;
+  std::vector<IrqConfig> new_irqs;
   try {
     agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
+    new_kernel_threads = agnocast_cie_thread_configurator::parse_kernel_threads(yaml);
+    new_irqs = agnocast_cie_thread_configurator::parse_irqs(yaml);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();
@@ -607,6 +896,11 @@ void ThreadConfiguratorNode::on_reapply_config_request(
       std::memory_order_release);
   }
 
+  // No carry-over: kernel threads and IRQs are matched against a fresh /proc
+  // scan on every apply pass.
+  kernel_thread_configs_ = std::move(new_kernel_threads);
+  irq_configs_ = std::move(new_irqs);
+
   for (auto & cfg : callback_group_configs_) {
     if (cfg.is_wildcard()) {
       // One applied/failed key per known instance; the pattern itself is
@@ -666,18 +960,33 @@ void ThreadConfiguratorNode::on_reapply_config_request(
     }
   }
 
+  {
+    SectionApplyOutcome kernel_thread_outcome = apply_kernel_thread_configs();
+    SectionApplyOutcome irq_outcome = apply_irq_configs();
+    response->applied_kernel_threads = std::move(kernel_thread_outcome.applied);
+    response->failed_kernel_threads = std::move(kernel_thread_outcome.failed);
+    response->skipped_kernel_threads = std::move(kernel_thread_outcome.skipped);
+    response->applied_irqs = std::move(irq_outcome.applied);
+    response->failed_irqs = std::move(irq_outcome.failed);
+  }
+
   response->success = true;
   RCLCPP_INFO(
     this->get_logger(), "Reapply done: applied=%zu, failed=%zu, skipped=%zu",
-    response->applied_callback_groups.size() + response->applied_non_ros_threads.size(),
-    response->failed_callback_groups.size() + response->failed_non_ros_threads.size(),
-    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size());
+    response->applied_callback_groups.size() + response->applied_non_ros_threads.size() +
+      response->applied_kernel_threads.size() + response->applied_irqs.size(),
+    response->failed_callback_groups.size() + response->failed_non_ros_threads.size() +
+      response->failed_kernel_threads.size() + response->failed_irqs.size(),
+    response->skipped_callback_groups.size() + response->skipped_non_ros_threads.size() +
+      response->skipped_kernel_threads.size());
 
   // configured_at_least_once_ is one-shot, so the "all applied" log is not
   // re-emitted on reapply; operators need a dedicated reapply-complete signal.
   if (
     response->failed_callback_groups.empty() && response->failed_non_ros_threads.empty() &&
-    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty()) {
+    response->skipped_callback_groups.empty() && response->skipped_non_ros_threads.empty() &&
+    response->failed_kernel_threads.empty() && response->skipped_kernel_threads.empty() &&
+    response->failed_irqs.empty()) {
     RCLCPP_INFO(this->get_logger(), "Reapply: all entries successfully (re-)applied.");
   }
 }

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -1,0 +1,385 @@
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace acie = agnocast_cie_thread_configurator;
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// From include/linux/sched.h (not exposed by uapi headers).
+constexpr unsigned long kPfKthread = 0x00200000;
+constexpr unsigned long kPfNoSetaffinity = 0x04000000;
+
+// Kernel SCHED_* constants as they appear in /proc/<pid>/stat field 41.
+constexpr int kPolicyOther = 0;
+constexpr int kPolicyFifo = 1;
+constexpr int kPolicyBatch = 3;
+
+// Each test builds its own fake /proc//sys tree and removes it afterwards.
+struct TempTree
+{
+  fs::path root;
+
+  TempTree()
+  {
+    static std::atomic<int> counter{0};
+    root = fs::temp_directory_path() / ("agnocast_system_scan_test_" + std::to_string(::getpid()) +
+                                        "_" + std::to_string(counter.fetch_add(1)));
+    fs::create_directories(root);
+  }
+
+  ~TempTree()
+  {
+    std::error_code ec;
+    fs::remove_all(root, ec);
+  }
+};
+
+void write_file(const fs::path & path, const std::string & content)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream file(path);
+  file << content;
+}
+
+// Layout per `man 5 proc`: pid (comm) state ppid ... ; the token after the
+// closing paren is field 3 (state), flags is field 9, nice 19, rt_priority 40,
+// policy 41.
+std::string make_stat_line(
+  int pid, const std::string & comm, unsigned long flags, int nice, int rt_priority, int policy)
+{
+  std::string line = std::to_string(pid) + " (" + comm + ") S 2 0 0 0 -1 " + std::to_string(flags);
+  line += " 0 0 0 0 0 0 0 0 20";  // fields 10-18
+  line += " " + std::to_string(nice);
+  for (int i = 0; i < 20; ++i) {  // fields 20-39
+    line += " 0";
+  }
+  line += " " + std::to_string(rt_priority) + " " + std::to_string(policy);
+  line += " 0 0 0 0 0 0 0 0 0 0";
+  return line;
+}
+
+void add_proc_entry(
+  const fs::path & proc_root, int pid, const std::string & comm, unsigned long flags, int nice,
+  int rt_priority, int policy, const std::string & cpus_allowed_list)
+{
+  const fs::path dir = proc_root / std::to_string(pid);
+  write_file(dir / "stat", make_stat_line(pid, comm, flags, nice, rt_priority, policy) + "\n");
+  write_file(dir / "comm", comm + "\n");
+  write_file(
+    dir / "status", "Name:\t" + comm + "\nCpus_allowed_list:\t" + cpus_allowed_list + "\n");
+}
+
+void add_irq_entry(
+  const fs::path & sys_root, const fs::path & proc_irq_root, int irq, const std::string & actions,
+  const std::string & affinity_list)
+{
+  const fs::path sys_dir = sys_root / std::to_string(irq);
+  write_file(sys_dir / "actions", actions + "\n");
+  // Real /sys/kernel/irq/<N> dirs carry further attribute files; one is
+  // enough to prove the scan ignores files it does not consume.
+  write_file(sys_dir / "chip_name", "IO-APIC\n");
+  write_file(proc_irq_root / std::to_string(irq) / "smp_affinity_list", affinity_list + "\n");
+}
+
+}  // namespace
+
+// ---------- scan_kernel_threads ----------
+
+TEST(ScanKernelThreads, FindsKthreadAndReadsFields)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 15, "my_kthread", kPfKthread | 0x40, 0, 50, kPolicyFifo, "0-3");
+  add_proc_entry(tree.root, 100, "user_process", 0x00400040, 0, 0, kPolicyOther, "0-3");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].tid, 15);
+  EXPECT_EQ(result[0].comm, "my_kthread");
+  EXPECT_EQ(result[0].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[0].priority, 50);
+  EXPECT_EQ(result[0].affinity, "0-3");
+  EXPECT_FALSE(result[0].no_setaffinity);
+}
+
+TEST(ScanKernelThreads, DualPriorityMeaning)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 10, "nice_thread", kPfKthread, 5, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 11, "rt_thread", kPfKthread, 0, 42, kPolicyFifo, "0");
+  add_proc_entry(tree.root, 12, "batch_thread", kPfKthread, -7, 0, kPolicyBatch, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].comm, "batch_thread");
+  EXPECT_EQ(result[0].priority, -7);
+  EXPECT_EQ(result[1].comm, "nice_thread");
+  EXPECT_EQ(result[1].priority, 5);
+  EXPECT_EQ(result[2].comm, "rt_thread");
+  EXPECT_EQ(result[2].priority, 42);
+}
+
+TEST(ScanKernelThreads, ExcludesKworkers)
+{
+  TempTree tree;
+  add_proc_entry(
+    tree.root, 8, "kworker/0:0H-events_highpri", kPfKthread | kPfNoSetaffinity, 0, 0, kPolicyOther,
+    "0");
+  add_proc_entry(tree.root, 9, "kept_thread", kPfKthread, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "kept_thread");
+}
+
+TEST(ScanKernelThreads, ParsesCommWithParensAndSpaces)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 753, "irq/24-PCIe PME", kPfKthread, 0, 50, kPolicyFifo, "0-15");
+  add_proc_entry(tree.root, 754, "a) b (c", kPfKthread, 3, 0, kPolicyOther, "1");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0].comm, "a) b (c");
+  EXPECT_EQ(result[0].priority, 3);
+  EXPECT_EQ(result[1].comm, "irq/24-PCIe PME");
+  EXPECT_EQ(result[1].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[1].priority, 50);
+}
+
+TEST(ScanKernelThreads, SetsNoSetaffinityFlag)
+{
+  TempTree tree;
+  add_proc_entry(
+    tree.root, 15, "ksoftirqd/0", kPfKthread | kPfNoSetaffinity, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0].no_setaffinity);
+}
+
+TEST(ScanKernelThreads, SortedByCommThenTid)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 30, "nfsd", kPfKthread, 0, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 10, "zeta", kPfKthread, 0, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 20, "nfsd", kPfKthread, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].comm, "nfsd");
+  EXPECT_EQ(result[0].tid, 20);
+  EXPECT_EQ(result[1].comm, "nfsd");
+  EXPECT_EQ(result[1].tid, 30);
+  EXPECT_EQ(result[2].comm, "zeta");
+}
+
+TEST(ScanKernelThreads, SkipsMalformedEntries)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 5, "good_thread", kPfKthread, 0, 0, kPolicyOther, "0");
+  fs::create_directories(tree.root / "not_a_pid");
+  fs::create_directories(tree.root / "6");  // no stat/comm/status at all
+  write_file(tree.root / "7" / "stat", "7 (truncated) S 2 0\n");
+  write_file(
+    tree.root / "8" / "stat", make_stat_line(8, "no_status_file", kPfKthread, 0, 0, 0) + "\n");
+  write_file(tree.root / "8" / "comm", "no_status_file\n");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "good_thread");
+
+  EXPECT_TRUE(acie::scan_kernel_threads((tree.root / "missing_dir").string()).empty());
+}
+
+TEST(ScanKernelThreads, RendersUnknownPolicy)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 15, "odd_thread", kPfKthread, 0, 0, 4, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].policy, "UNKNOWN(4)");
+  EXPECT_EQ(result[0].priority, 0);
+}
+
+// ---------- scan_irqs / read_irq_actions ----------
+
+TEST(ScanIrqs, OnlyDeviceBackedIrqs)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 5, "eth0", "0-3");
+  write_file(sys / "3" / "actions", "");             // present but empty
+  fs::create_directories(sys / "4");                 // no actions file
+  write_file(sys / "4" / "chip_name", "IO-APIC\n");  // still no actions
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 5);
+  EXPECT_EQ(result[0].name, "eth0");
+}
+
+TEST(ScanIrqs, ReadsAffinity)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 103, "nvidia", "0-15");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].name, "nvidia");
+  EXPECT_EQ(result[0].affinity, "0-15");
+}
+
+TEST(ScanIrqs, MissingProcAffinityYieldsEmpty)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  write_file(sys / "7" / "actions", "timer\n");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].affinity, "");
+}
+
+TEST(ScanIrqs, IgnoresNonNumericEntries)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 1, "i8042", "0");
+  write_file(sys / "default_smp_affinity", "ffff\n");
+  fs::create_directories(sys / "power");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 1);
+}
+
+TEST(ScanIrqs, SortedByIrqNumber)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 100, "snd", "0");
+  add_irq_entry(sys, proc, 24, "PCIe PME", "0");
+  add_irq_entry(sys, proc, 3, "serial", "0");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].irq, 3);
+  EXPECT_EQ(result[1].irq, 24);
+  EXPECT_EQ(result[2].irq, 100);
+}
+
+TEST(ReadIrqActions, TrimsNewlineAndReportsMissing)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  write_file(sys / "103" / "actions", "nvidia\n");
+
+  const auto present = acie::read_irq_actions(103, sys.string());
+  ASSERT_TRUE(present.has_value());
+  EXPECT_EQ(*present, "nvidia");
+
+  EXPECT_FALSE(acie::read_irq_actions(999, sys.string()).has_value());
+}
+
+// ---------- find_kernel_threads_by_comm / process_with_comm_exists ----------
+
+TEST(FindKernelThreadsByComm, MatchesAllEqualComms)
+{
+  std::vector<acie::KernelThreadInfo> scanned(3);
+  scanned[0].comm = "nfsd";
+  scanned[0].tid = 20;
+  scanned[1].comm = "nfsd";
+  scanned[1].tid = 30;
+  scanned[2].comm = "other";
+  scanned[2].tid = 40;
+
+  const auto matches = acie::find_kernel_threads_by_comm(scanned, "nfsd");
+  ASSERT_EQ(matches.size(), 2u);
+  EXPECT_EQ(matches[0]->tid, 20);
+  EXPECT_EQ(matches[1]->tid, 30);
+
+  EXPECT_TRUE(acie::find_kernel_threads_by_comm(scanned, "absent").empty());
+}
+
+TEST(ProcessWithCommExists, FindsByExactComm)
+{
+  TempTree tree;
+  write_file(tree.root / "1234" / "comm", "irqbalance\n");
+  write_file(tree.root / "1235" / "comm", "bash\n");
+
+  EXPECT_TRUE(acie::process_with_comm_exists("irqbalance", tree.root.string()));
+  EXPECT_FALSE(acie::process_with_comm_exists("irqbalanc", tree.root.string()));
+  EXPECT_FALSE(acie::process_with_comm_exists("nonexistent", tree.root.string()));
+}
+
+// ---------- format_cpu_list / parse_cpu_list ----------
+
+TEST(FormatCpuList, JoinsWithCommas)
+{
+  EXPECT_EQ(acie::format_cpu_list({2, 3}), "2,3");
+  EXPECT_EQ(acie::format_cpu_list({5}), "5");
+  EXPECT_EQ(acie::format_cpu_list({}), "");
+}
+
+TEST(ParseCpuList, ParsesRangesAndSingles)
+{
+  auto result = acie::parse_cpu_list("0-5,8");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{0, 1, 2, 3, 4, 5, 8}));
+
+  result = acie::parse_cpu_list("3");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{3}));
+
+  result = acie::parse_cpu_list("0-15");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), 16u);
+  EXPECT_EQ(result->front(), 0);
+  EXPECT_EQ(result->back(), 15);
+}
+
+TEST(ParseCpuList, ToleratesTrailingNewlineAndNormalizes)
+{
+  auto result = acie::parse_cpu_list("0-2\n");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{0, 1, 2}));
+
+  result = acie::parse_cpu_list("2,1,1");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{1, 2}));
+}
+
+TEST(ParseCpuList, RejectsMalformedInput)
+{
+  EXPECT_FALSE(acie::parse_cpu_list("").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("a-b").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("5-3").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("-1").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("1,,2").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("1,x").has_value());
+}
+
+TEST(ParseCpuList, RoundTripsWithFormat)
+{
+  const std::vector<int> cpus{0, 1, 2, 3, 4, 5, 8};
+  const auto parsed = acie::parse_cpu_list(acie::format_cpu_list(cpus));
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, cpus);
+}

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -411,3 +411,358 @@ TEST(ExtractNodePart, SplitsAtFirstAtSign)
   EXPECT_EQ(acie::extract_node_part("@Timer(1)"), "");
   EXPECT_EQ(acie::extract_node_part(""), "");
 }
+
+// ---------- parse_kernel_threads ----------
+
+TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
+{
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("callback_groups: []\n")).empty());
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: ~\n")).empty());
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: []\n")).empty());
+}
+
+TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: SCHED_FIFO
+    priority: 10
+    affinity: [2, 3]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_EQ(*result[0].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[0].priority, 10);
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, AllNullEntryIsUnmanaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, UnmanageableSentinelEqualsNull)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ksoftirqd/0
+    policy: UNMANAGEABLE
+    priority: UNMANAGEABLE
+    affinity: UNMANAGEABLE
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, AffinityOnlyEntryIsManaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: ~
+    priority: ~
+    affinity: [2]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, PolicyWithUnmanageableAffinityIsManaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ksoftirqd/0
+    policy: SCHED_FIFO
+    priority: 5
+    affinity: UNMANAGEABLE
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, ParsesSchedDeadline)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: 5000000
+    deadline: 5000000
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_EQ(*result[0].policy, "SCHED_DEADLINE");
+  EXPECT_EQ(result[0].runtime, 1000000u);
+  EXPECT_EQ(result[0].period, 5000000u);
+  EXPECT_EQ(result[0].deadline, 5000000u);
+}
+
+TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
+{
+  // Only the exact uppercase sentinel disengages an attribute; anything else
+  // must fall through to the normal validation (here: unknown policy).
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: unmanageable
+    priority: 0
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsMissingOrEmptyComm)
+{
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - policy: ~
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ""
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsKworkerComm)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: kworker/0:0H-events_highpri
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsDuplicateComm)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: ~
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsUnknownPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_BOGUS
+    priority: 0
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsPriorityWithoutPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: ~
+    priority: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
+{
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_FIFO
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  // The sentinel counts as unset exactly like null does.
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_FIFO
+    priority: UNMANAGEABLE
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+// ---------- parse_irqs ----------
+
+TEST(ParseIrqs, MissingOrNullSectionYieldsEmpty)
+{
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("callback_groups: []\n")).empty());
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: ~\n")).empty());
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: []\n")).empty());
+}
+
+TEST(ParseIrqs, ParsesFilledAffinityAndName)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 103
+    name: nvidia
+    affinity: [2, 3]
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 103);
+  EXPECT_EQ(result[0].name, "nvidia");
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseIrqs, NullOrUnmanageableAffinityIsUnmanaged)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 0
+    name: timer
+    affinity: UNMANAGEABLE
+  - irq: 1
+    name: i8042
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_FALSE(result[0].is_managed());
+  EXPECT_FALSE(result[1].is_managed());
+}
+
+TEST(ParseIrqs, MissingNameMeansNoVerification)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 42
+    affinity: [1]
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0].name.empty());
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseIrqs, RejectsMissingOrNegativeOrNonIntIrq)
+{
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - name: orphan
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: -1
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: not_a_number
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseIrqs, RejectsDuplicateIrq)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 5
+    affinity: ~
+  - irq: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_irqs(y), std::runtime_error);
+}
+
+// ---------- new sections vs parse_yaml ----------
+
+TEST(ParseYaml, IgnoresKernelThreadsAndIrqsSections)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    priority: 0
+    affinity: []
+non_ros_threads: []
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: SCHED_FIFO
+    priority: 10
+    affinity: [2]
+irqs:
+  - irq: 103
+    name: nvidia
+    affinity: [2, 3]
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].thread_str, "my_cbg");
+  EXPECT_TRUE(nrt.empty());
+}

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -92,6 +92,20 @@ def _write_config(cfg):
         yaml.safe_dump(cfg, f)
 
 
+def _irqbalance_running():
+    """Mirror the configurator's own detection (comm scan in its pid namespace)."""
+    for pid in os.listdir('/proc'):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(os.path.join('/proc', pid, 'comm')) as f:
+                if f.read().strip() == 'irqbalance':
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def _call_reapply(timeout_sec=10.0):
     """Call the reapply_config service synchronously and return the response."""
     rclpy.init()
@@ -377,6 +391,102 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         response = _call_reapply()
         self.assertFalse(response.success)
         self.assertIn('Unknown scheduling policy', response.error_message)
+
+    def test_template_contains_kernel_threads_and_irqs_sections(
+            self, proc_output, thread_configurator):
+        cfg = _read_config()
+        self.assertIn('kernel_threads', cfg)
+        self.assertIn('irqs', cfg)
+        # In CI pid namespaces host kthreads are invisible, so kernel_threads
+        # may legitimately be empty; entries that do exist must be fully
+        # formed, with observed values (never YAML null) as the initial ones.
+        for entry in cfg['kernel_threads'] or []:
+            for key in ('comm', 'policy', 'priority', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+            self.assertFalse(entry['comm'].startswith('kworker/'))
+        for entry in cfg['irqs'] or []:
+            for key in ('irq', 'name', 'affinity'):
+                self.assertIn(key, entry)
+                self.assertIsNotNone(entry[key])
+
+    def test_startup_logs_kernel_irq_summary(self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Kernel threads and IRQs configured:',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+    def test_reapply_reports_unknown_kernel_thread_as_skipped(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        added_entry = {
+            'comm': 'fictitious_kthread',
+            # SCHED_OTHER + positive nice mirrors the CI-safe pattern above;
+            # no syscall happens anyway for a comm with no live match.
+            'policy': 'SCHED_OTHER',
+            'priority': 10,
+            'affinity': None,
+        }
+        if not cfg.get('kernel_threads'):
+            cfg['kernel_threads'] = []
+        cfg['kernel_threads'].append(added_entry)
+        _write_config(cfg)
+
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        self.assertIn('fictitious_kthread', list(response.skipped_kernel_threads))
+        for arr in (response.applied_kernel_threads, response.failed_kernel_threads):
+            for key in list(arr):
+                self.assertFalse(key.startswith('fictitious_kthread:'))
+
+    def test_reapply_irq_outcome_depends_on_irqbalance(
+            self, proc_output, thread_configurator):
+        proc_output.assertWaitFor(
+            'Received CallbackGroupInfo',
+            timeout=20.0,
+            process=thread_configurator,
+        )
+
+        cfg = _read_config()
+        target = next(
+            (e for e in (cfg.get('irqs') or [])
+             if isinstance(e.get('affinity'), list)),
+            None,
+        )
+        if target is None:
+            self.skipTest('no IRQ with a readable affinity list in the template')
+
+        # The config is the untouched prerun output, so every desired value is
+        # still the observed one: without irqbalance the in-sync path must
+        # report the IRQ as applied WITHOUT writing (no privileges needed);
+        # with irqbalance running the validation must refuse the whole IRQ
+        # section and report it as failed instead.
+        response = _call_reapply()
+        self.assertTrue(
+            response.success,
+            f'reapply rejected unexpectedly: error_message={response.error_message!r}',
+        )
+        key = str(target['irq'])
+        applied = list(response.applied_irqs)
+        failed = list(response.failed_irqs)
+        self.assertEqual(
+            applied.count(key) + failed.count(key), 1,
+            'each managed IRQ must be reported exactly once',
+        )
+        if _irqbalance_running():
+            self.assertIn(key, failed)
+        else:
+            self.assertIn(key, applied)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Description

The thread configurator exists to centrally manage every scheduling-related element of the application, but until now it only covered announcement-driven application threads (callback groups and non-ROS threads). This PR brings kernel threads and device-backed IRQs under its control as well, using the same prerun-then-configure flow.

### What is added

- **New `system_scan` module** (shared library): enumerates kernel threads from `/proc` (via the `PF_KTHREAD` flag in `/proc/<pid>/stat`, parsing after the last `)` because kthread comms contain spaces and parentheses) and device-backed IRQs from `/sys/kernel/irq` + `/proc/irq`. All observed values are file-based, so both scans are fully unit-tested against fake trees.
- **New YAML sections** emitted by `prerun_node` after `non_ros_threads`:

  ```yaml
  kernel_threads:
    - comm: agnocast_exit_worker
      policy: SCHED_OTHER        # observed value as the initial desired value
      priority: 0                # nice for OTHER/BATCH/IDLE, rt_priority for FIFO/RR
      affinity: [0, 1, 2, 3]
    - comm: ksoftirqd/0
      policy: SCHED_OTHER
      priority: 0
      affinity: UNMANAGEABLE     # PF_NO_SETAFFINITY: the kernel forbids changing it
  irqs:
    - irq: 103
      name: nvidia               # /sys/kernel/irq/103/actions, verified before applying
      affinity: [0, 1, 2, 3]
  ```

- **Apply pass in `thread_configurator_node`** (at startup and on every `~/reapply_config`): matches entries against a fresh `/proc` scan (a comm matches every live instance, e.g. an nfsd pool) and converges the system to the YAML.

### Key design decisions

- **Observed values become the initial desired values with compare-before-set.** The configurator ensures each engaged attribute matches the YAML and issues syscalls/writes only on mismatch. Unedited templates therefore stay no-ops, which also structurally avoids spurious errors from entries the kernel refuses to touch even with identical values (stop-class `migration/N`, kernel-managed MSI-X IRQs that return EIO on every write).
- **`UNMANAGEABLE` sentinel vs YAML null.** Null (or an absent key) keeps its existing meaning of "the user chose not to manage this attribute". The new uppercase sentinel marks attributes whose value cannot be provided or changed by the tool, so prerun output never contains `~` and the two meanings stay distinct in the template.
- **irqbalance validation.** If any IRQ entry is managed while an `irqbalance` process is running, the whole IRQ section is refused (reported as failed) with an instructive error, because applying would only fake success until irqbalance rewrites the masks. Kernel-thread configuration is unaffected.
- **Privileges.** Kernel-thread scheduling reuses the existing `CAP_SYS_NICE` syscall paths (`issue_syscalls` already takes an arbitrary tid). Writing `/proc/irq/<N>/smp_affinity_list` additionally needs `CAP_DAC_OVERRIDE` (unlike `/proc/sys`, plain procfs files honor it), so `setup_thread_configurator.bash` now grants `cap_sys_nice,cap_dac_override=eip`. This was verified empirically: a non-root process with only `CAP_DAC_OVERRIDE` can write the file. The idempotency check was updated so binaries set up by the older script get upgraded to the combined set.
- **kworker/workqueue are deliberately out of scope.** kworker comms mutate at runtime and per-CPU instances reject affinity changes (`PF_NO_SETAFFINITY`); unbound workqueue placement was judged not worth managing. kworker entries are excluded from the scan and rejected by the parser.
- **Breaking srv change**: `ReapplyConfig.srv` gains `applied/failed/skipped_kernel_threads` and `applied/failed_irqs` response arrays (no `skipped_irqs`: an IRQ has no announce-later state). The type hash changes, so out-of-tree service clients must be rebuilt. In-tree consumers are rebuilt together.

Backward compatibility is otherwise preserved: old YAMLs without the new sections parse to empty vectors, old configurators ignore the new sections, the existing `parse_yaml` signature and the announcement-driven accounting (`unapplied_num_` etc.) are untouched.

Verified beyond CI: on a real 16-CPU machine, prerun records 174 kernel-thread comms (including the kmod's `agnocast_exit_worker`) and 80 IRQs; the configurator startup reports all kernel-thread entries in-sync without needing `CAP_SYS_NICE`, and refuses the IRQ section with the instructive error while irqbalance is running.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Additionally, `test_system_scan` (21 new unit tests) and `test_thread_config` (23 new unit tests) pass, and the thread-configurator launch tests (`reapply` with 4 new cases, `wildcard`, `restart`, `precedence`) all pass locally.

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.