### PR TITLE
fix(agnocast_cie_thread_configurator): take 'nice' instead of 'priority' for CFS policies

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -20,7 +20,8 @@ struct ThreadConfig
   int64_t thread_id = -1;  // -1 until announced by the target application
   std::vector<int> affinity;
   std::string policy;
-  int priority = 0;
+  int nice = 0;      // SCHED_OTHER/BATCH/IDLE only (-20..19)
+  int priority = 0;  // rt_priority; SCHED_FIFO/RR only (1..99)
 
   // SCHED_DEADLINE only
   unsigned int runtime = 0;

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -153,7 +153,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     out << YAML::Key << "domain_id" << YAML::Value << domain_id;
     out << YAML::Key << "affinity" << YAML::Value << YAML::Null;
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
-    out << YAML::Key << "priority" << YAML::Value << 0;
+    out << YAML::Key << "nice" << YAML::Value << 0;
     out << YAML::EndMap;
     out << YAML::Newline;
   }
@@ -169,7 +169,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     out << YAML::Key << "name" << YAML::Value << thread_name;
     out << YAML::Key << "affinity" << YAML::Value << YAML::Null;
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
-    out << YAML::Key << "priority" << YAML::Value << 0;
+    out << YAML::Key << "nice" << YAML::Value << 0;
     out << YAML::EndMap;
     out << YAML::Newline;
   }

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -31,10 +31,17 @@ bool is_cfs_policy(const std::string & policy)
 int parse_nice(const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
 {
   const YAML::Node nice = entry["nice"];
-  if (!nice) {
+  // A key with an empty value ("nice:") is a defined null node, so `!nice`
+  // alone would pass it on to as<int>()'s context-free BadConversion.
+  if (!nice || nice.IsNull()) {
     throw std::runtime_error("Policy '" + policy + "' requires 'nice' for " + entry_desc);
   }
-  const int value = nice.as<int>();
+  int value = 0;
+  try {
+    value = nice.as<int>();
+  } catch (const YAML::Exception &) {
+    throw std::runtime_error("'nice' must be an integer for " + entry_desc);
+  }
   if (value < k_nice_min || value > k_nice_max) {
     // setpriority(2) would silently clamp an out-of-range value to
     // [-20, 19]; reject it here so a misunderstanding of the scale
@@ -49,10 +56,15 @@ int parse_rt_priority(
   const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
 {
   const YAML::Node priority = entry["priority"];
-  if (!priority) {
+  if (!priority || priority.IsNull()) {
     throw std::runtime_error("Policy '" + policy + "' requires 'priority' for " + entry_desc);
   }
-  const int value = priority.as<int>();
+  int value = 0;
+  try {
+    value = priority.as<int>();
+  } catch (const YAML::Exception &) {
+    throw std::runtime_error("'priority' must be an integer for " + entry_desc);
+  }
   if (value < k_rt_priority_min || value > k_rt_priority_max) {
     throw std::runtime_error(
       "'priority' must be in [1, 99] for " + entry_desc + ", got " + std::to_string(value));

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -12,6 +12,56 @@
 namespace agnocast_cie_thread_configurator
 {
 
+namespace
+{
+
+constexpr int k_nice_min = -20;
+constexpr int k_nice_max = 19;
+constexpr int k_rt_priority_min = 1;
+constexpr int k_rt_priority_max = 99;
+
+bool is_cfs_policy(const std::string & policy)
+{
+  return policy == "SCHED_OTHER" || policy == "SCHED_BATCH" || policy == "SCHED_IDLE";
+}
+
+// 'nice' is required for the CFS policies (SCHED_OTHER/BATCH/IDLE);
+// parse_rt_priority is the mirror image for SCHED_FIFO/SCHED_RR. `entry_desc`
+// is the "id=..."/"name=..." fragment used in messages.
+int parse_nice(const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
+{
+  const YAML::Node nice = entry["nice"];
+  if (!nice) {
+    throw std::runtime_error("Policy '" + policy + "' requires 'nice' for " + entry_desc);
+  }
+  const int value = nice.as<int>();
+  if (value < k_nice_min || value > k_nice_max) {
+    // setpriority(2) would silently clamp an out-of-range value to
+    // [-20, 19]; reject it here so a misunderstanding of the scale
+    // (e.g. an rt_priority-style 50) fails loudly instead.
+    throw std::runtime_error(
+      "'nice' must be in [-20, 19] for " + entry_desc + ", got " + std::to_string(value));
+  }
+  return value;
+}
+
+int parse_rt_priority(
+  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
+{
+  const YAML::Node priority = entry["priority"];
+  if (!priority) {
+    throw std::runtime_error("Policy '" + policy + "' requires 'priority' for " + entry_desc);
+  }
+  const int value = priority.as<int>();
+  if (value < k_rt_priority_min || value > k_rt_priority_max) {
+    throw std::runtime_error(
+      "'priority' must be in [1, 99] for " + entry_desc + ", got " + std::to_string(value));
+  }
+  return value;
+}
+
+}  // namespace
+
 const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
@@ -87,8 +137,10 @@ void parse_yaml(
       cfg.runtime = cg["runtime"].as<unsigned int>();
       cfg.period = cg["period"].as<unsigned int>();
       cfg.deadline = cg["deadline"].as<unsigned int>();
+    } else if (is_cfs_policy(cfg.policy)) {
+      cfg.nice = parse_nice(cg, cfg.policy, "id=" + cfg.thread_str);
     } else {
-      cfg.priority = cg["priority"].as<int>();
+      cfg.priority = parse_rt_priority(cg, cfg.policy, "id=" + cfg.thread_str);
     }
   }
 
@@ -111,8 +163,10 @@ void parse_yaml(
       cfg.runtime = nrt["runtime"].as<unsigned int>();
       cfg.period = nrt["period"].as<unsigned int>();
       cfg.deadline = nrt["deadline"].as<unsigned int>();
+    } else if (is_cfs_policy(cfg.policy)) {
+      cfg.nice = parse_nice(nrt, cfg.policy, "name=" + cfg.thread_str);
     } else {
-      cfg.priority = nrt["priority"].as<int>();
+      cfg.priority = parse_rt_priority(nrt, cfg.policy, "name=" + cfg.thread_str);
     }
   }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -320,7 +320,7 @@ bool ThreadConfiguratorNode::issue_syscalls(const ThreadConfig & config, int64_t
     }
 
     // Specify nice value
-    if (setpriority(PRIO_PROCESS, thread_id, config.priority) == -1) {
+    if (setpriority(PRIO_PROCESS, thread_id, config.nice) == -1) {
       RCLCPP_ERROR(
         this->get_logger(), "Failed to configure nice value (thread=%s, tid=%ld): %s",
         config.thread_str.c_str(), thread_id, strerror(errno));

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -135,14 +135,77 @@ TEST(ParseYaml, RejectsNiceOutOfRange)
   }
 }
 
-TEST(ParseYaml, RejectsNiceKeyOnRtPolicy)
+TEST(ParseYaml, TreatsNullNiceAsMissing)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    nice:
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  try {
+    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    EXPECT_NE(std::string(e.what()).find("requires 'nice'"), std::string::npos) << e.what();
+  }
+}
+
+TEST(ParseYaml, ReportsEntryOnNonIntegerNice)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    nice: low
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  try {
+    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    const std::string what = e.what();
+    EXPECT_NE(what.find("'nice' must be an integer"), std::string::npos) << what;
+    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
+  }
+}
+
+TEST(ParseYaml, ReportsEntryOnNonIntegerRtPriority)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
   - id: my_cbg
     domain_id: 0
     policy: SCHED_FIFO
-    nice: 0
+    priority: high
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  try {
+    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    const std::string what = e.what();
+    EXPECT_NE(what.find("'priority' must be an integer"), std::string::npos) << what;
+    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
+  }
+}
+
+TEST(ParseYaml, RejectsMissingPriorityOnRtPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_FIFO
     affinity: []
 non_ros_threads: []
 )YAML");

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -54,13 +54,128 @@ non_ros_threads: []
   EXPECT_FALSE(cb[0].is_wildcard());
 }
 
+TEST(ParseYaml, ParsesNiceForCfsPolicies)
+{
+  for (const char * policy : {"SCHED_OTHER", "SCHED_BATCH", "SCHED_IDLE"}) {
+    auto y = yaml_from_str(("callback_groups:\n"
+                            "  - id: my_cbg\n"
+                            "    domain_id: 0\n"
+                            "    policy: " +
+                            std::string(policy) +
+                            "\n"
+                            "    nice: -10\n"
+                            "    affinity: []\n"
+                            "non_ros_threads: []\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt)) << policy;
+    ASSERT_EQ(cb.size(), 1u);
+    EXPECT_EQ(cb[0].nice, -10) << policy;
+    EXPECT_EQ(cb[0].priority, 0) << policy;
+  }
+}
+
+TEST(ParseYaml, IgnoresStrayKeyOfTheOtherPolicyClass)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: cfs_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    nice: -5
+    priority: 50
+    affinity: []
+  - id: rt_cbg
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+    nice: 10
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 2u);
+  EXPECT_EQ(cb[0].nice, -5);
+  EXPECT_EQ(cb[0].priority, 0);
+  EXPECT_EQ(cb[1].priority, 50);
+  EXPECT_EQ(cb[1].nice, 0);
+}
+
+TEST(ParseYaml, RejectsMissingNiceOnSchedOther)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsNiceOutOfRange)
+{
+  for (const char * bad_nice : {"-21", "20", "50"}) {
+    auto y = yaml_from_str(("callback_groups:\n"
+                            "  - id: my_cbg\n"
+                            "    domain_id: 0\n"
+                            "    policy: SCHED_OTHER\n"
+                            "    nice: " +
+                            std::string(bad_nice) +
+                            "\n"
+                            "    affinity: []\n"
+                            "non_ros_threads: []\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
+      << "nice=" << bad_nice;
+  }
+}
+
+TEST(ParseYaml, RejectsNiceKeyOnRtPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_FIFO
+    nice: 0
+    affinity: []
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+}
+
+TEST(ParseYaml, RejectsRtPriorityOutOfRange)
+{
+  for (const char * bad_priority : {"0", "100", "-1"}) {
+    auto y = yaml_from_str(("callback_groups:\n"
+                            "  - id: my_cbg\n"
+                            "    domain_id: 0\n"
+                            "    policy: SCHED_FIFO\n"
+                            "    priority: " +
+                            std::string(bad_priority) +
+                            "\n"
+                            "    affinity: []\n"
+                            "non_ros_threads: []\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
+      << "priority=" << bad_priority;
+  }
+}
+
 TEST(ParseYaml, FallsBackToDefaultDomainId)
 {
   auto y = yaml_from_str(R"YAML(
 callback_groups:
   - id: my_cbg
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -165,7 +280,7 @@ callback_groups:
   - id: alpha
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -178,7 +293,7 @@ callback_groups:
   - id: beta
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -194,12 +309,12 @@ callback_groups:
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -214,12 +329,12 @@ callback_groups:
   - id: cg
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - id: cg
     domain_id: 1
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -235,11 +350,11 @@ callback_groups: []
 non_ros_threads:
   - name: t
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - name: t
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
@@ -275,7 +390,7 @@ callback_groups:
   - id: /*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -293,7 +408,7 @@ TEST(ParseYaml, RejectsStrayAsteriskInId)
                             "\"\n"
                             "    domain_id: 0\n"
                             "    policy: SCHED_OTHER\n"
-                            "    priority: 0\n"
+                            "    nice: 0\n"
                             "    affinity: []\n"
                             "non_ros_threads: []\n")
                              .c_str());
@@ -311,7 +426,7 @@ callback_groups:
   - id: /node@Timer(100)/*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -326,12 +441,12 @@ callback_groups:
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -346,12 +461,12 @@ callback_groups:
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - id: /node/*
     domain_id: 1
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 non_ros_threads: []
 )YAML");
@@ -367,7 +482,7 @@ callback_groups:
   - id: /node/*
     domain_id: 0
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
   - id: /node@Timer(100)
     domain_id: 0
@@ -392,7 +507,7 @@ callback_groups: []
 non_ros_threads:
   - name: worker/*
     policy: SCHED_OTHER
-    priority: 0
+    nice: 0
     affinity: []
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_precedence_launch.py
@@ -115,7 +115,7 @@ def _add_wildcard_alongside_exact_entries():
         'id': WILDCARD_ID,
         'domain_id': _PUBLISHER_ENTRIES[0].get('domain_id', 0),
         'policy': 'SCHED_OTHER',
-        'priority': 0,
+        'nice': 0,
         'affinity': [],
     }
     cfg['callback_groups'] = cfg['callback_groups'] + [wildcard_entry]

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_reapply_launch.py
@@ -192,7 +192,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             process=thread_configurator,
         )
 
-    def test_reapply_after_priority_change(self, proc_output, thread_configurator):
+    def test_reapply_after_nice_change(self, proc_output, thread_configurator):
         proc_output.assertWaitFor(
             'Received CallbackGroupInfo',
             timeout=20.0,
@@ -208,7 +208,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         # SCHED_OTHER + positive nice value: lowering priority needs no
         # CAP_SYS_NICE, which is not guaranteed in CI sandboxes.
         first['policy'] = 'SCHED_OTHER'
-        first['priority'] = 10
+        first['nice'] = 10
         first.setdefault('affinity', [])
         _write_config(cfg)
 
@@ -253,7 +253,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             'id': 'fictitious_unannounced_cbg',
             'domain_id': 0,
             'policy': 'SCHED_OTHER',
-            'priority': 0,
+            'nice': 0,
             'affinity': [],
         }
         cfg.setdefault('callback_groups', []).append(added_entry)
@@ -298,7 +298,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
         ):
             self.assertNotIn(removed_key, list(arr))
 
-    def test_reapply_non_ros_thread_priority_change(self, proc_output, thread_configurator):
+    def test_reapply_non_ros_thread_nice_change(self, proc_output, thread_configurator):
         proc_output.assertWaitFor(
             'Received NonRosThreadInfo',
             timeout=20.0,
@@ -315,7 +315,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
                 'prerun did not produce test_non_ros_worker non_ros_thread entry'
             )
         target['policy'] = 'SCHED_OTHER'
-        target['priority'] = 10
+        target['nice'] = 10
         target.setdefault('affinity', [])
         _write_config(cfg)
 
@@ -342,7 +342,7 @@ class TestThreadConfiguratorReapply(unittest.TestCase):
             'id': '/fictitious_node/*',
             'domain_id': 0,
             'policy': 'SCHED_OTHER',
-            'priority': 0,
+            'nice': 0,
             'affinity': [],
         }
         cfg.setdefault('callback_groups', []).append(added_entry)

--- a/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
+++ b/src/agnocast_e2e_test/test/functional/test_thread_configurator_wildcard_launch.py
@@ -137,7 +137,7 @@ def _replace_publisher_entries_with_wildcard():
         'id': WILDCARD_ID,
         'domain_id': _WILDCARD_DOMAIN_ID,
         'policy': 'SCHED_OTHER',
-        'priority': 10,
+        'nice': 10,
         'affinity': [],
     }
     cfg['callback_groups'] = kept + [wildcard_entry]
@@ -262,7 +262,7 @@ class TestThreadConfiguratorWildcard(unittest.TestCase):
             e for e in cfg.get('callback_groups', []) if e['id'] == WILDCARD_ID
         ]
         self.assertEqual(len(wildcard_entries), 1)
-        wildcard_entries[0]['priority'] = 11
+        wildcard_entries[0]['nice'] = 11
         _write_config(cfg)
 
         response = _call_reapply()
@@ -307,7 +307,7 @@ class TestThreadConfiguratorWildcard(unittest.TestCase):
         cfg = _read_config()
         exact_entry = dict(_PUBLISHER_ENTRIES[0])
         exact_entry['policy'] = 'SCHED_OTHER'
-        exact_entry['priority'] = 15
+        exact_entry['nice'] = 15
         exact_entry['affinity'] = []
         cfg['callback_groups'] = cfg['callback_groups'] + [exact_entry]
         _write_config(cfg)
@@ -348,7 +348,7 @@ class TestThreadConfiguratorWildcard(unittest.TestCase):
         cfg = _read_config()
         exact_entry = dict(_PUBLISHER_ENTRIES[0])
         exact_entry['policy'] = 'SCHED_OTHER'
-        exact_entry['priority'] = 15
+        exact_entry['nice'] = 15
         exact_entry['affinity'] = []
         cfg['callback_groups'] = [exact_entry] + cfg['callback_groups']
         _write_config(cfg)


### PR DESCRIPTION
## Description

For `SCHED_OTHER` / `SCHED_BATCH` / `SCHED_IDLE` entries, the value configured under the `priority` key has always been applied as a nice value via `setpriority(2)` (the `sched_priority` passed to `sched_setscheduler(2)` is fixed to 0 for these policies). Reusing the `priority` key for that was misleading and error-prone:

- For `SCHED_FIFO` / `SCHED_RR`, `priority` means rt_priority (1..99, higher is stronger), while nice runs the opposite way (-20..19, lower is stronger). The same key name flips its meaning depending on the policy.
- `setpriority(2)` silently clamps out-of-range values to [-20, 19], so writing an rt_priority-style value (e.g. `priority: 50`) on a CFS entry demoted the thread to the lowest priority without any error.
- The kernel API itself separates the two fields (`sched_attr.sched_nice` vs `sched_attr.sched_priority`).

This PR makes the scheduling-parameter key policy-dependent:

- `SCHED_OTHER` / `SCHED_BATCH` / `SCHED_IDLE` entries now take `nice`, validated against [-20, 19].
- `SCHED_FIFO` / `SCHED_RR` entries keep `priority`, now validated against [1, 99] (previously unvalidated).
- `SCHED_DEADLINE` entries are unchanged (`runtime` / `period` / `deadline`).
- A missing key is rejected with a message naming the required one; a stray key of the other policy class is simply ignored, like any other unknown key.
- `ThreadConfig` mirrors the split: it now carries separate `nice` and `priority` fields instead of one field whose meaning depended on the policy.

**Breaking change**: there is no compatibility alias. Existing YAMLs that set `priority` on a `SCHED_OTHER` / `SCHED_BATCH` / `SCHED_IDLE` entry are rejected at startup and must rename the key to `nice` (the value itself is unchanged; it was always a nice value).

Other changes:

- `prerun_node` now emits `nice: 0` for the `SCHED_OTHER` entries in the generated template.
- Unit tests are updated to the new key and extended with cases for nice parsing across the three CFS policies, missing keys, both range validations, and stray other-class keys being ignored.
- The thread-configurator E2E launch tests now mutate `nice` instead of `priority`, following the prerun-generated template they rewrite.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.
