### PR TITLE
refactor(agnocastlib): make PollingSubscriber wrap Subscription

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -460,7 +460,7 @@ public:
 /**
  * @brief Agnocast polling subscriber for a compile-time known message type.
  *
- * Wraps TakeSubscription<MessageT> and exposes a simple take_data() API
+ * Wraps a callback-less Subscription<MessageT> and exposes a simple take_data() API
  * that always returns the most recent message (or an empty pointer if nothing
  * has been published yet).
  *
@@ -470,7 +470,7 @@ AGNOCAST_PUBLIC
 template <typename MessageT>
 class PollingSubscriber
 {
-  typename TakeSubscription<MessageT>::SharedPtr subscriber_;
+  typename Subscription<MessageT>::SharedPtr subscriber_;
 
 public:
   using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT>>;
@@ -480,8 +480,7 @@ public:
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
     SubscriptionRole role = SubscriptionRole::Default)
   {
-    subscriber_ =
-      std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options, role);
+    subscriber_ = std::make_shared<Subscription<MessageT>>(node, topic_name, qos, options, role);
   };
 
   explicit PollingSubscriber(
@@ -489,8 +488,7 @@ public:
     agnocast::SubscriptionOptions options = agnocast::SubscriptionOptions(),
     SubscriptionRole role = SubscriptionRole::Default)
   {
-    subscriber_ =
-      std::make_shared<TakeSubscription<MessageT>>(node, topic_name, qos, options, role);
+    subscriber_ = std::make_shared<Subscription<MessageT>>(node, topic_name, qos, options, role);
   };
 
   /// @deprecated Use take_data() instead.


### PR DESCRIPTION
## Description

`PollingSubscriber<MessageT>` now holds a callback-less `Subscription<MessageT>` instead of `TakeSubscription<MessageT>`, so the last in-tree user of `TakeSubscription` outside the e2e test is gone. Pure refactor: the constructor arguments reaching the kmod, the `is_take_sub` flag and the emitted tracepoint are unchanged.

Stacked on #1522, which adds the callback-less `Subscription` constructors this depends on. Please review and merge that one first.

## Related links

- #1522

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Only built so far (`colcon build --packages-select agnocastlib agnocast_e2e_test`). The e2e runs are still to be done.

## Notes for reviewers

`TakeSubscription` itself is untouched and still compiles; its removal is tracked separately and needs a major version bump.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
