### PR TITLE
feat(agnocastlib): add get_actual_qos() to subscriptions and publishers

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -158,6 +158,7 @@ if(BUILD_TESTING)
     test/unit/test_diagnostic_updater.cpp
     test/unit/test_type_registry_writer.cpp
     test/unit/test_agnocast_generic_publisher.cpp
+    test/unit/test_agnocast_publisher.cpp
     test/unit/test_daemon_bridge_uds.cpp
     test/unit/test_agnocast_bridge_uds.cpp
     test/unit/test_discovery_agent_auto_fork.cpp

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -83,9 +83,11 @@ protected:
   topic_local_id_t id_ = -1;
   std::string topic_name_;
   rmw_gid_t gid_;
+  // The depth is a placeholder: rclcpp::QoS has no default constructor.
+  rclcpp::QoS actual_qos_{1};
 
   template <typename NodeT>
-  rclcpp::QoS init_base(
+  void init_base(
     NodeT * node, const std::string & topic_name, const std::string & type_name,
     const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role);
 
@@ -123,6 +125,18 @@ public:
   {
     return get_intra_subscription_count_core(topic_name_);
   }
+
+  /**
+   * @brief Return the QoS passed at construction with any `qos_overriding_options` applied.
+   *
+   * Unlike `rclcpp::PublisherBase::get_actual_qos()`, the value is not RMW-resolved:
+   * there is no DDS entity to query, so `SystemDefault` and the policies Agnocast ignores are
+   * reported as requested.
+   *
+   * @return Effective QoS of this publisher.
+   */
+  AGNOCAST_PUBLIC
+  rclcpp::QoS get_actual_qos() const { return actual_qos_; }
 };
 
 /**
@@ -137,7 +151,7 @@ template <typename MessageT>
 class Publisher : public PublisherBase
 {
   template <typename NodeT>
-  rclcpp::QoS constructor_impl(
+  void constructor_impl(
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos,
     const PublisherOptions & options, const PublisherRole role)
   {
@@ -149,7 +163,7 @@ class Publisher : public PublisherBase
       type_name = rosidl_generator_traits::name<MessageT>();
     }
 
-    return this->init_base(node, topic_name, type_name, qos, options, role);
+    this->init_base(node, topic_name, type_name, qos, options, role);
   }
 
 public:
@@ -159,13 +173,13 @@ public:
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos,
     const PublisherOptions & options, const PublisherRole role = PublisherRole::Default)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, role);
+    constructor_impl(node, topic_name, qos, options, role);
 
     TRACEPOINT(
       agnocast_publisher_init, static_cast<const void *>(this),
       static_cast<const void *>(
         node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
-      topic_name_.c_str(), actual_qos.depth());
+      topic_name_.c_str(), actual_qos_.depth());
   }
 
   Publisher(
@@ -173,12 +187,12 @@ public:
     const PublisherOptions & options = PublisherOptions{},
     const PublisherRole role = PublisherRole::Default)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, topic_name, qos, options, role);
+    constructor_impl(node, topic_name, qos, options, role);
 
     TRACEPOINT(
       agnocast_publisher_init, static_cast<const void *>(this),
       static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
-      actual_qos.depth());
+      actual_qos_.depth());
   }
 
   /**

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -128,11 +128,14 @@ public:
   /**
    * @brief Return the QoS passed at construction with any `qos_overriding_options` applied.
    *
-   * Counterpart of `rclcpp::SubscriptionBase::get_actual_qos()`.
+   * Unlike `rclcpp::SubscriptionBase::get_actual_qos()`, the value is not RMW-resolved:
+   * there is no DDS entity to query, so `SystemDefault` and the policies Agnocast ignores are
+   * reported as requested.
+   *
    * @return Effective QoS of this subscription.
    */
   AGNOCAST_PUBLIC
-  const rclcpp::QoS & get_actual_qos() const { return actual_qos_; }
+  rclcpp::QoS get_actual_qos() const { return actual_qos_; }
 
   virtual ~SubscriptionBase()
   {

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -183,7 +183,7 @@ class Subscription : public SubscriptionBase
   template <typename NodeT, typename Func>
   void constructor_impl(
     NodeT * node, const std::string & type_name, const rclcpp::QoS & qos, Func && callback,
-    agnocast::SubscriptionOptions options, SubscriptionRole role)
+    const agnocast::SubscriptionOptions & options, SubscriptionRole role)
   {
     rclcpp::CallbackGroup::SharedPtr callback_group = get_valid_callback_group(node, options);
 
@@ -289,7 +289,7 @@ private:
 
   template <typename NodeT>
   void constructor_impl(
-    NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options,
+    NodeT * node, const rclcpp::QoS & qos, const agnocast::SubscriptionOptions & options,
     SubscriptionRole role)
   {
     // Gated to message types — service types pulled in by

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -101,12 +101,13 @@ protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
   int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for take subscriptions)
+  rclcpp::QoS actual_qos_{1};
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,
     SubscriptionRole role, const std::string & node_name, const std::string & type_name);
 
   template <typename NodeT>
-  rclcpp::QoS init_base(
+  void init_base(
     NodeT * node, const rclcpp::QoS & qos, const std::string & type_name, bool is_take_sub,
     const SubscriptionOptions & options, SubscriptionRole role);
 
@@ -122,6 +123,15 @@ public:
   const char * get_topic_name() const { return topic_name_.c_str(); }
 
   uint32_t get_publisher_count() const { return get_publisher_count_core(topic_name_); }
+
+  /**
+   * @brief Return the QoS passed at construction with any `qos_overriding_options` applied.
+   *
+   * Counterpart of `rclcpp::SubscriptionBase::get_actual_qos()`.
+   * @return Effective QoS of this subscription.
+   */
+  AGNOCAST_PUBLIC
+  const rclcpp::QoS & get_actual_qos() const { return actual_qos_; }
 
   virtual ~SubscriptionBase()
   {
@@ -179,10 +189,10 @@ class Subscription : public SubscriptionBase
     const void * callback_addr = static_cast<const void *>(&callback);
     const char * callback_symbol = tracetools::get_symbol(callback);
 
-    const rclcpp::QoS actual_qos = init_base(node, qos, type_name, false, options, role);
+    init_base(node, qos, type_name, false, options, role);
 
     const bool is_transient_local =
-      actual_qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
+      actual_qos_.durability() == rclcpp::DurabilityPolicy::TransientLocal;
     callback_info_id_ = agnocast::register_callback<MessageT>(
       std::forward<Func>(callback), topic_name_, id_, is_transient_local, notify_eventfd_,
       callback_group);
@@ -192,7 +202,7 @@ class Subscription : public SubscriptionBase
       TRACEPOINT(
         agnocast_subscription_init, static_cast<const void *>(this), get_node_base_address(node),
         callback_addr, static_cast<const void *>(callback_group.get()), callback_symbol,
-        topic_name_.c_str(), actual_qos.depth(), pid_callback_info_id);
+        topic_name_.c_str(), actual_qos_.depth(), pid_callback_info_id);
     }
   }
 
@@ -277,7 +287,7 @@ private:
   std::mutex last_taken_ptr_mtx_;
 
   template <typename NodeT>
-  rclcpp::QoS constructor_impl(
+  void constructor_impl(
     NodeT * node, const rclcpp::QoS & qos, agnocast::SubscriptionOptions options,
     SubscriptionRole role)
   {
@@ -288,7 +298,7 @@ private:
     if constexpr (rosidl_generator_traits::is_message<MessageT>::value) {
       type_name = rosidl_generator_traits::name<MessageT>();
     }
-    return init_base(node, qos, type_name, true, options, role);
+    init_base(node, qos, type_name, true, options, role);
   }
 
 public:
@@ -300,7 +310,7 @@ public:
     SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
+    constructor_impl(node, qos, options, role);
 
     {
       auto default_cbg = node->get_node_base_interface()->get_default_callback_group();
@@ -311,7 +321,7 @@ public:
         static_cast<const void *>(
           node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
         static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
-        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
+        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos_.depth(), 0);
     }
   }
 
@@ -321,7 +331,7 @@ public:
     SubscriptionRole role = SubscriptionRole::Default)
   : SubscriptionBase(node, topic_name)
   {
-    const rclcpp::QoS actual_qos = constructor_impl(node, qos, options, role);
+    constructor_impl(node, qos, options, role);
 
     {
       auto default_cbg = get_default_callback_group_for_tracepoint(node);
@@ -331,7 +341,7 @@ public:
         agnocast_subscription_init, static_cast<const void *>(this),
         static_cast<const void *>(get_node_base_address(node)),
         static_cast<const void *>(&dummy_cb), static_cast<const void *>(default_cbg.get()),
-        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos.depth(), 0);
+        dummy_cb_symbols.c_str(), topic_name_.c_str(), actual_qos_.depth(), 0);
     }
   }
 

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -468,6 +468,12 @@ public:
   /// @return Shared pointer to the latest message.
   AGNOCAST_PUBLIC
   const agnocast::ipc_shared_ptr<const MessageT> take_data() { return subscriber_->take(true); };
+
+  /// @brief Return the QoS of the wrapped take-subscription. See
+  /// SubscriptionBase::get_actual_qos() for the contract.
+  /// @return Effective QoS of this subscriber.
+  AGNOCAST_PUBLIC
+  rclcpp::QoS get_actual_qos() const { return subscriber_->get_actual_qos(); }
 };
 
 /// @brief Mirrors `rclcpp::GenericSubscription` semantics: the topic type is supplied

--- a/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_subscription.hpp
@@ -101,6 +101,7 @@ protected:
   topic_local_id_t id_{-1};
   const std::string topic_name_;
   int notify_eventfd_ = -1;  // publish-notification eventfd (-1 for take subscriptions)
+  // The depth is a placeholder: rclcpp::QoS has no default constructor.
   rclcpp::QoS actual_qos_{1};
   void initialize(
     const rclcpp::QoS & qos, const bool is_take_sub, const bool ignore_local_publications,

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -137,7 +137,7 @@ uint32_t get_intra_subscription_count_core(const std::string & topic_name)
 }
 
 template <typename NodeT>
-rclcpp::QoS PublisherBase::init_base(
+void PublisherBase::init_base(
   NodeT * node, const std::string & topic_name, const std::string & type_name,
   const rclcpp::QoS & qos, const PublisherOptions & options, const PublisherRole role)
 {
@@ -151,17 +151,17 @@ rclcpp::QoS PublisherBase::init_base(
   topic_name_ = node->get_node_topics_interface()->resolve_topic_name(topic_name);
 
   auto node_parameters = node->get_node_parameters_interface();
-  const rclcpp::QoS actual_qos = !options.qos_overriding_options.get_policy_kinds().empty()
-                                   ? rclcpp::detail::declare_qos_parameters(
-                                       options.qos_overriding_options, node_parameters, topic_name_,
-                                       qos, rclcpp::detail::PublisherQosParametersTraits{})
-                                   : qos;
+  actual_qos_ = !options.qos_overriding_options.get_policy_kinds().empty()
+                  ? rclcpp::detail::declare_qos_parameters(
+                      options.qos_overriding_options, node_parameters, topic_name_, qos,
+                      rclcpp::detail::PublisherQosParametersTraits{})
+                  : qos;
 
-  validate_publisher_qos(actual_qos);
+  validate_publisher_qos(actual_qos_);
 
   const bool is_bridge = (role == PublisherRole::BridgeInternal);
   const std::string node_name = node->get_fully_qualified_name();
-  id_ = initialize_publisher(topic_name_, node_name, actual_qos, is_bridge, type_name);
+  id_ = initialize_publisher(topic_name_, node_name, actual_qos_, is_bridge, type_name);
   generate_gid();
 
   if (role == PublisherRole::Default) {
@@ -176,14 +176,12 @@ rclcpp::QoS PublisherBase::init_base(
         topic_name_.c_str());
     }
   }
-
-  return actual_qos;
 }
 
-template rclcpp::QoS PublisherBase::init_base<rclcpp::Node>(
+template void PublisherBase::init_base<rclcpp::Node>(
   rclcpp::Node *, const std::string &, const std::string &, const rclcpp::QoS &,
   const PublisherOptions &, PublisherRole);
-template rclcpp::QoS PublisherBase::init_base<agnocast::Node>(
+template void PublisherBase::init_base<agnocast::Node>(
   agnocast::Node *, const std::string &, const std::string &, const rclcpp::QoS &,
   const PublisherOptions &, PublisherRole);
 
@@ -238,24 +236,24 @@ TypeErasedPublisher::TypeErasedPublisher(
   rclcpp::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
 {
-  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
+  this->init_base(node, topic_name, topic_type, qos, options, role);
 
   TRACEPOINT(
     agnocast_publisher_init, static_cast<const void *>(this),
     static_cast<const void *>(node->get_node_base_interface()->get_shared_rcl_node_handle().get()),
-    topic_name_.c_str(), actual_qos.depth());
+    topic_name_.c_str(), actual_qos_.depth());
 }
 
 TypeErasedPublisher::TypeErasedPublisher(
   agnocast::Node * node, const std::string & topic_name, const std::string & topic_type,
   const rclcpp::QoS & qos, const agnocast::PublisherOptions & options, const PublisherRole role)
 {
-  const rclcpp::QoS actual_qos = this->init_base(node, topic_name, topic_type, qos, options, role);
+  this->init_base(node, topic_name, topic_type, qos, options, role);
 
   TRACEPOINT(
     agnocast_publisher_init, static_cast<const void *>(this),
     static_cast<const void *>(get_node_base_address(node)), topic_name_.c_str(),
-    actual_qos.depth());
+    actual_qos_.depth());
 }
 
 ipc_shared_ptr<void> TypeErasedPublisher::borrow_loaned_message(size_t size)

--- a/src/agnocastlib/src/agnocast_subscription.cpp
+++ b/src/agnocastlib/src/agnocast_subscription.cpp
@@ -86,33 +86,30 @@ void SubscriptionBase::initialize(
 }
 
 template <typename NodeT>
-rclcpp::QoS SubscriptionBase::init_base(
+void SubscriptionBase::init_base(
   NodeT * node, const rclcpp::QoS & qos, const std::string & type_name, bool is_take_sub,
   const SubscriptionOptions & options, SubscriptionRole role)
 {
   const bool override_qos = !options.qos_overriding_options.get_policy_kinds().empty();
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters =
     override_qos ? node->get_node_parameters_interface() : nullptr;
-  const rclcpp::QoS actual_qos = override_qos
-                                   ? rclcpp::detail::declare_qos_parameters(
-                                       options.qos_overriding_options, node_parameters, topic_name_,
-                                       qos, rclcpp::detail::SubscriptionQosParametersTraits{})
-                                   : qos;
+  actual_qos_ = override_qos ? rclcpp::detail::declare_qos_parameters(
+                                 options.qos_overriding_options, node_parameters, topic_name_, qos,
+                                 rclcpp::detail::SubscriptionQosParametersTraits{})
+                             : qos;
 
-  validate_subscription_qos(actual_qos);
+  validate_subscription_qos(actual_qos_);
 
   const std::string node_name = node->get_fully_qualified_name();
   initialize(
-    actual_qos, is_take_sub, options.ignore_local_publications, role, node_name, type_name);
-
-  return actual_qos;
+    actual_qos_, is_take_sub, options.ignore_local_publications, role, node_name, type_name);
 }
 
-template rclcpp::QoS SubscriptionBase::init_base<rclcpp::Node>(
+template void SubscriptionBase::init_base<rclcpp::Node>(
   rclcpp::Node *, const rclcpp::QoS &, const std::string &, bool, const SubscriptionOptions &,
   SubscriptionRole);
 
-template rclcpp::QoS SubscriptionBase::init_base<agnocast::Node>(
+template void SubscriptionBase::init_base<agnocast::Node>(
   agnocast::Node *, const rclcpp::QoS &, const std::string &, bool, const SubscriptionOptions &,
   SubscriptionRole);
 

--- a/src/agnocastlib/test/unit/test_agnocast_publisher.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_publisher.cpp
@@ -1,0 +1,82 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_publisher.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+// Defined in test_mocked_agnocast.cpp, which mocks initialize_publisher() so a publisher can
+// be constructed without a kernel module.
+extern size_t initialize_publisher_mock_last_qos_depth;
+
+using StringMsg = std_msgs::msg::String;
+
+class PublisherGetActualQosTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+  void TearDown() override { rclcpp::shutdown(); }
+};
+
+TEST_F(PublisherGetActualQosTest, get_actual_qos_reports_the_qos_passed_at_construction)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_pub_actual_qos");
+  const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(7)).transient_local();
+
+  // Act
+  auto pub = agnocast::create_publisher<StringMsg>(node.get(), "/test_pub_actual_qos", qos);
+
+  // Assert
+  EXPECT_EQ(pub->get_actual_qos(), qos);
+}
+
+TEST_F(PublisherGetActualQosTest, get_actual_qos_reports_the_qos_of_a_generic_publisher)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_generic_pub_actual_qos");
+  const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(3));
+
+  // Act
+  agnocast::GenericPublisher pub(
+    node.get(), "/test_generic_pub_actual_qos", "std_msgs/msg/String", qos);
+
+  // Assert
+  EXPECT_EQ(pub.get_actual_qos(), qos);
+}
+
+TEST_F(PublisherGetActualQosTest, get_actual_qos_reflects_a_qos_parameter_override)
+{
+  // Arrange
+  rclcpp::NodeOptions node_options;
+  node_options.parameter_overrides(
+    {rclcpp::Parameter("qos_overrides./test_pub_actual_qos_override.publisher.depth", 9)});
+  auto node = std::make_shared<rclcpp::Node>("test_pub_actual_qos_override", node_options);
+
+  agnocast::PublisherOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions({rclcpp::QosPolicyKind::Depth});
+
+  // Act: depth 1 is expected to be replaced by the override.
+  auto pub = agnocast::create_publisher<StringMsg>(
+    node.get(), "/test_pub_actual_qos_override", rclcpp::QoS{1}, options);
+
+  // Assert
+  EXPECT_EQ(pub->get_actual_qos().depth(), 9u);
+}
+
+TEST_F(PublisherGetActualQosTest, the_resolved_qos_reaches_the_kernel_registration)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_pub_actual_qos_registration");
+  initialize_publisher_mock_last_qos_depth = 0;
+
+  // Act
+  auto pub = agnocast::create_publisher<StringMsg>(
+    node.get(), "/test_pub_actual_qos_registration", rclcpp::QoS(rclcpp::KeepLast(6)));
+
+  // Assert
+  EXPECT_EQ(initialize_publisher_mock_last_qos_depth, 6u);
+}

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -131,6 +131,19 @@ TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_take_subscription)
   EXPECT_EQ(sub.get_actual_qos(), qos);
 }
 
+TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_polling_subscriber)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos_polling");
+  const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(5)).best_effort();
+
+  // Act
+  auto sub = agnocast::create_subscription<StringMsg>(node.get(), "/test_actual_qos_polling", qos);
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos(), qos);
+}
+
 TEST_F(GetActualQosTest, get_actual_qos_reflects_a_qos_parameter_override)
 {
   // Arrange: a node that overrides the subscription depth to 9.

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -1,6 +1,27 @@
+#include "agnocast/agnocast.hpp"
+#include "agnocast/agnocast_callback_info.hpp"
 #include "agnocast/agnocast_subscription.hpp"
 
+#include "std_msgs/msg/string.hpp"
+
 #include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace agnocast
+{
+// Stubbed so a subscription can be constructed without a kernel module. init_base(), which
+// resolves the QoS, still runs for real and calls this with its result. id_ is left at -1 so
+// ~SubscriptionBase() issues no ioctl either.
+void SubscriptionBase::initialize(
+  const rclcpp::QoS &, const bool, const bool, SubscriptionRole, const std::string &,
+  const std::string &)
+{
+}
+}  // namespace agnocast
 
 class GetValidCallbackGroupTest : public ::testing::Test
 {
@@ -46,4 +67,93 @@ TEST_F(GetValidCallbackGroupTest, get_valid_callback_group_nullptr)
 
   auto result = agnocast::get_valid_callback_group(node.get(), options);
   EXPECT_EQ(result, node->get_node_base_interface()->get_default_callback_group());
+}
+
+using StringMsg = std_msgs::msg::String;
+
+class GetActualQosTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // SubscriptionBase's constructor calls validate_ld_preload(), which exits the process when
+    // the variable is unset. It cannot be stubbed here because test_agnocast_utils.cpp tests the
+    // real one in this same binary, so satisfy it instead -- it only inspects the variable.
+    setenv("LD_PRELOAD", "libagnocast_heaphook.so", 1);
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    unsetenv("LD_PRELOAD");
+  }
+};
+
+TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_passed_at_construction)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos");
+  const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(7)).best_effort();
+
+  // Act
+  auto sub = agnocast::create_subscription<StringMsg>(
+    node.get(), "/test_actual_qos", qos, [](const agnocast::ipc_shared_ptr<const StringMsg> &) {});
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos(), qos);
+}
+
+TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_take_subscription)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos_take");
+  const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(4)).best_effort();
+
+  // Act
+  agnocast::TakeSubscription<StringMsg> sub(node.get(), "/test_actual_qos_take", qos);
+
+  // Assert
+  EXPECT_EQ(sub.get_actual_qos(), qos);
+}
+
+TEST_F(GetActualQosTest, get_actual_qos_reflects_a_qos_parameter_override)
+{
+  // Arrange: a node that overrides the subscription depth to 9.
+  rclcpp::NodeOptions node_options;
+  node_options.parameter_overrides(
+    {rclcpp::Parameter("qos_overrides./test_actual_qos_override.subscription.depth", 9)});
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos_override", node_options);
+
+  agnocast::SubscriptionOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions({rclcpp::QosPolicyKind::Depth});
+
+  // Act: construct with depth 1, which the override is expected to replace.
+  auto sub = agnocast::create_subscription<StringMsg>(
+    node.get(), "/test_actual_qos_override", rclcpp::QoS{1},
+    [](const agnocast::ipc_shared_ptr<const StringMsg> &) {}, options);
+
+  // Assert
+  EXPECT_EQ(sub->get_actual_qos().depth(), 9u);
+}
+
+TEST_F(GetActualQosTest, the_resolved_durability_reaches_the_callback_registry)
+{
+  // Arrange
+  const std::string topic = "/test_actual_qos_durability";
+  auto node = std::make_shared<rclcpp::Node>("test_actual_qos_durability");
+
+  // Act
+  auto sub = agnocast::create_subscription<StringMsg>(
+    node.get(), topic, rclcpp::QoS(rclcpp::KeepLast(1)).transient_local(),
+    [](const agnocast::ipc_shared_ptr<const StringMsg> &) {});
+
+  // Assert: register_callback() consumed the resolved QoS during construction. The other cases
+  // read it back afterwards, so they cannot tell when it was stored.
+  std::lock_guard<std::mutex> lock(agnocast::id2_callback_info_mtx);
+  const auto entry = std::find_if(
+    agnocast::id2_callback_info.begin(), agnocast::id2_callback_info.end(),
+    [&topic](const auto & e) { return e.second.topic_name == topic; });
+  ASSERT_NE(entry, agnocast::id2_callback_info.end());
+  EXPECT_TRUE(entry->second.is_transient_local);
 }

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -80,6 +80,11 @@ protected:
     // SubscriptionBase's constructor calls validate_ld_preload(), which exits the process when
     // the variable is unset. It cannot be stubbed here because test_agnocast_utils.cpp tests the
     // real one in this same binary, so satisfy it instead -- it only inspects the variable.
+    const char * old_ld_preload = getenv("LD_PRELOAD");
+    if (old_ld_preload != nullptr) {
+      had_ld_preload_ = true;
+      old_ld_preload_ = old_ld_preload;
+    }
     setenv("LD_PRELOAD", "libagnocast_heaphook.so", 1);
     rclcpp::init(0, nullptr);
   }
@@ -87,8 +92,16 @@ protected:
   void TearDown() override
   {
     rclcpp::shutdown();
-    unsetenv("LD_PRELOAD");
+    if (had_ld_preload_) {
+      setenv("LD_PRELOAD", old_ld_preload_.c_str(), 1);
+    } else {
+      unsetenv("LD_PRELOAD");
+    }
   }
+
+private:
+  bool had_ld_preload_ = false;
+  std::string old_ld_preload_;
 };
 
 TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_passed_at_construction)

--- a/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_subscription.cpp
@@ -138,10 +138,10 @@ TEST_F(GetActualQosTest, get_actual_qos_reports_the_qos_of_a_polling_subscriber)
   const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(5)).best_effort();
 
   // Act
-  auto sub = agnocast::create_subscription<StringMsg>(node.get(), "/test_actual_qos_polling", qos);
+  agnocast::PollingSubscriber<StringMsg> sub(node.get(), "/test_actual_qos_polling", qos);
 
   // Assert
-  EXPECT_EQ(sub->get_actual_qos(), qos);
+  EXPECT_EQ(sub.get_actual_qos(), qos);
 }
 
 TEST_F(GetActualQosTest, get_actual_qos_reflects_a_qos_parameter_override)

--- a/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
+++ b/src/agnocastlib/test/unit/test_mocked_agnocast.cpp
@@ -14,6 +14,7 @@ using namespace agnocast;
 int release_subscriber_reference_mock_called_count = 0;
 int publish_core_mock_called_count = 0;
 uint32_t mock_borrowed_publisher_num = 0;
+size_t initialize_publisher_mock_last_qos_depth = 0;
 
 extern "C" uint32_t agnocast_get_borrowed_publisher_num()
 {
@@ -40,8 +41,10 @@ void increment_borrowed_publisher_num()
 }
 
 topic_local_id_t initialize_publisher(
-  const std::string &, const std::string &, const rclcpp::QoS &, const bool, const std::string &)
+  const std::string &, const std::string &, const rclcpp::QoS & qos, const bool,
+  const std::string &)
 {
+  initialize_publisher_mock_last_qos_depth = qos.depth();
   return 0;  // Dummy value
 }
 union ioctl_publish_msg_args publish_core(


### PR DESCRIPTION
## Description

Adds `get_actual_qos()` to `SubscriptionBase`, `PollingSubscriber` and `PublisherBase`, the counterpart of the same accessor on `rclcpp::SubscriptionBase` / `rclcpp::PublisherBase`. Both a subscription and a publisher already resolve their effective QoS at construction — `qos_overriding_options` can replace the QoS passed by the caller with a declared parameter — but that result was discarded after `init_base()`, so callers had no way to read it back.

`init_base()` now stores the resolved QoS in `actual_qos_` and returns `void`; the constructors read the member instead of the former return value. No behavior change beyond the new accessors.

Unlike the rclcpp counterparts, the returned QoS is not RMW-resolved: Agnocast has no DDS entity to query, so `SystemDefault` and the policies Agnocast ignores are reported as requested. This is documented on the accessors.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Nine cases added: `test/unit/test_agnocast_subscription.cpp` covers `Subscription`, `TakeSubscription`, `PollingSubscriber`, the `qos_overriding_options` path, and that the resolved durability still reaches `register_callback()`. `test/unit/test_agnocast_publisher.cpp` covers `Publisher`, `GenericPublisher`, the override path, and that the resolved QoS still reaches `initialize_publisher()`. `ctest -R test_unit_agnocastlib` passes.

## Notes for reviewers

None.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
