### PR TITLE
feat(agnocastlib): add client GID to service request metadata

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <future>
 #include <memory>
@@ -217,6 +218,12 @@ private:
     }
   }
 
+  // Return the GID of this client.
+  //
+  // It is the same as the GID of the underlying publisher. Because every client has a distinct
+  // publisher that is not observable to users, we can safely reuse the GID for the client.
+  const rmw_gid_t & get_gid() const { return publisher_->get_gid(); }
+
 public:
   Client(
     rclcpp::Node * node, const std::string & service_name, const rclcpp::QoS & qos_arg,
@@ -238,8 +245,11 @@ public:
   ipc_shared_ptr<typename ServiceT::Request> borrow_loaned_request()
   {
     auto request = publisher_->borrow_loaned_message();
-    request->node_name = node_name_;
+
     request->seqno = next_sequence_number_.fetch_add(1);
+    std::memcpy(request->client_gid, get_gid().data, RMW_GID_STORAGE_SIZE);
+    request->node_name = node_name_;
+
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
 
@@ -385,6 +395,12 @@ private:
         service_type, service_name_, BridgeDirection::AGNOCAST_TO_ROS2, std::nullopt);
     }
   }
+
+  // Return the GID of this client.
+  //
+  // It is the same as the GID of the underlying publisher. Because every client has a distinct
+  // publisher that is not observable to users, we can safely reuse the GID for the client.
+  const rmw_gid_t & get_gid() const { return publisher_->get_gid(); }
 
 public:
   GenericClient(

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -188,7 +188,7 @@ private:
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
       /* --- critical section begin --- */
       // Get the corresponding ResponseCallInfo and remove it from the map
-      auto it = seqno2_response_call_info_.find(response->seqno);
+      auto it = seqno2_response_call_info_.find(response->ResponseMeta::seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
         RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
@@ -246,9 +246,9 @@ public:
   {
     auto request = publisher_->borrow_loaned_message();
 
-    request->seqno = next_sequence_number_.fetch_add(1);
-    std::memcpy(request->client_gid, get_gid().data, RMW_GID_STORAGE_SIZE);
-    request->node_name = node_name_;
+    request->RequestMeta::seqno = next_sequence_number_.fetch_add(1);
+    std::memcpy(request->RequestMeta::client_gid, get_gid().data, RMW_GID_STORAGE_SIZE);
+    request->RequestMeta::node_name = node_name_;
 
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
@@ -266,7 +266,7 @@ public:
   {
     SharedFuture shared_future;
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->seqno;
+    int64_t seqno = internal_request->RequestMeta::seqno;
 
     {
       std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
@@ -287,7 +287,7 @@ public:
   {
     Future future;
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->seqno;
+    int64_t seqno = internal_request->RequestMeta::seqno;
 
     {
       std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);

--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -247,7 +247,9 @@ public:
     auto request = publisher_->borrow_loaned_message();
 
     request->RequestMeta::seqno = next_sequence_number_.fetch_add(1);
-    std::memcpy(request->RequestMeta::client_gid, get_gid().data, RMW_GID_STORAGE_SIZE);
+    std::memcpy(
+      static_cast<void *>(request->RequestMeta::client_gid),
+      static_cast<const void *>(get_gid().data), RMW_GID_STORAGE_SIZE);
     request->RequestMeta::node_name = node_name_;
 
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -86,10 +86,10 @@ private:
   auto wrap_basic_service_callback_for_subscriber(Func && callback)
   {
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<RequestT> && request) {
-      auto publisher = this->get_or_create_publisher_for(request->node_name);
+      auto publisher = this->get_or_create_publisher_for(request->RequestMeta::node_name);
 
       ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
-      response->seqno = request->seqno;
+      response->ResponseMeta::seqno = request->RequestMeta::seqno;
 
       ipc_shared_ptr<typename ServiceT::Response> response_double(response);
 
@@ -195,7 +195,7 @@ public:
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
     auto internal_response = static_ipc_shared_ptr_cast<ResponseT>(std::move(response));
-    auto publisher = get_or_create_publisher_for(internal_request->node_name);
+    auto publisher = get_or_create_publisher_for(internal_request->RequestMeta::node_name);
     publisher->publish(std::move(internal_response));
   }
 
@@ -214,9 +214,9 @@ public:
     const ipc_shared_ptr<typename ServiceT::Request> & request)
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(request);
-    auto publisher = get_or_create_publisher_for(internal_request->node_name);
+    auto publisher = get_or_create_publisher_for(internal_request->RequestMeta::node_name);
     ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
-    response->seqno = internal_request->seqno;
+    response->ResponseMeta::seqno = internal_request->RequestMeta::seqno;
     return ipc_shared_ptr<typename ServiceT::Response>(std::move(response));
   }
 

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -1,16 +1,19 @@
 // On-the-wire layout of Agnocast service request/response messages.
 //
-// ┌───────────┬────────────────────────┐
-// │           │  correlation metadata  │
-// │  payload  ├─────────┬──────────────┤
-// │           │  seqno  │  node_name   │
-// └───────────┼─────────┴──────────────┘
+// ┌───────────┬────────────────────────────────────┐
+// │           │        correlation metadata        │
+// │  payload  ├─────────┬──────────────┬───────────┤
+// │           │  seqno  │  client_gid  │ node_name │
+// └───────────┼─────────┴──────────────┴───────────┘
 //             └ 16-byte aligned
 //
 // payload: request/response payload (ServiceT::Request or ServiceT::Response).
 //
 // seqno: A sequence number to identify each service call (int64_t). To avoid nastiness that may be
 // caused by compiler-inserted padding, this field is conservatively aligned to 16 bytes.
+//
+// client_gid: The client GID (uint8_t array of length RMW_GID_STORAGE_SIZE). This field only exists
+// in the request.
 //
 // node_name: The node name of the caller (std::string). This field only exists in the request.
 
@@ -44,6 +47,7 @@ template <typename ServiceT>
 struct ServiceRequestWrapper : public ServiceT::Request
 {
   alignas(16) int64_t seqno;
+  uint8_t client_gid[RMW_GID_STORAGE_SIZE];
   std::string node_name;
 };
 
@@ -58,6 +62,7 @@ class GenericRequestWrapper
   struct Meta
   {
     alignas(16) int64_t seqno;
+    uint8_t client_gid[RMW_GID_STORAGE_SIZE];
     std::string node_name;
   };
 
@@ -87,6 +92,7 @@ public:
   }
 
   int64_t & seqno() { return meta_ptr_->seqno; }
+  auto client_gid() -> uint8_t (&)[RMW_GID_STORAGE_SIZE] { return meta_ptr_->client_gid; }
   std::string & node_name() { return meta_ptr_->node_name; }
 
   ipc_shared_ptr<void> && take_request() && { return std::move(request_); }
@@ -94,8 +100,8 @@ public:
   /// @brief Allocate a wire-format request buffer in shared memory.
   ///
   /// The payload buffer is initialized via the introspection init function with
-  /// MessageInitialization::SKIP. The seqno number is uninitialized (garbage), and the node_name
-  /// string is default-constructed via placement new.
+  /// MessageInitialization::SKIP. The seqno number and client_gid are uninitialized (garbage),
+  /// and the node_name string is default-constructed via placement new.
   ///
   /// @param request_members The introspection message members for the request type.
   /// @param borrow_loaned_message A callable that allocates a buffer of the given size in shared

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -60,51 +60,52 @@ struct DummyService
 namespace agnocast
 {
 
-template <typename ServiceT>
-struct ServiceRequestWrapper : public ServiceT::Request
+struct RequestMeta
 {
   alignas(16) int64_t seqno;
   uint8_t client_gid[RMW_GID_STORAGE_SIZE];
   std::string node_name;
 };
 
-template <typename ServiceT>
-struct ServiceResponseWrapper : public ServiceT::Response
+struct ResponseMeta
 {
   alignas(16) int64_t seqno;
 };
 
+template <typename ServiceT>
+struct ServiceRequestWrapper : public ServiceT::Request, public RequestMeta
+{
+};
+
+template <typename ServiceT>
+struct ServiceResponseWrapper : public ServiceT::Response, public ResponseMeta
+{
+};
+
 class GenericRequestWrapper
 {
-  struct Meta
-  {
-    alignas(16) int64_t seqno;
-    uint8_t client_gid[RMW_GID_STORAGE_SIZE];
-    std::string node_name;
-  };
-
-  // Ensure ServiceRequestWrapper and GenericRequestWrapper share the same metadata layout.
+  // sanity check: ensure template and generic versions share the same size.
   static_assert(
     sizeof(ServiceRequestWrapper<DummyService>) ==
-      offsetof_meta(sizeof(DummyRequest)) + sizeof(Meta),
-    "ServiceRequestWrapper and GenericRequestWrapper diverged (Agnocast internal error)");
+      offsetof_meta(sizeof(DummyRequest)) + sizeof(RequestMeta),
+    "ServiceRequestWrapper and GenericRequestWrapper are inconsistent (Agnocast internal error)");
 
   static constexpr size_t get_wire_size(
     const rosidl_typesupport_introspection_cpp::MessageMembers * request_members)
   {
-    return offsetof_meta(request_members->size_of_) + sizeof(Meta);
+    return offsetof_meta(request_members->size_of_) + sizeof(RequestMeta);
   }
 
-  static Meta * get_meta_ptr(
+  static RequestMeta * get_meta_ptr(
     const rosidl_typesupport_introspection_cpp::MessageMembers * request_members,
     void * request_ptr)
   {
-    return reinterpret_cast<Meta *>(
+    return reinterpret_cast<RequestMeta *>(
       static_cast<char *>(request_ptr) + offsetof_meta(request_members->size_of_));
   }
 
   ipc_shared_ptr<void> request_;
-  Meta * const meta_ptr_;
+  RequestMeta * const meta_ptr_;
 
 public:
   explicit GenericRequestWrapper(
@@ -156,7 +157,7 @@ public:
     request_members->fini_function(ptr);
 
     // Destroy node_name by calling std::destroy_at().
-    Meta * meta_ptr = get_meta_ptr(request_members, ptr);
+    RequestMeta * meta_ptr = get_meta_ptr(request_members, ptr);
     auto * node_name_ptr = &meta_ptr->node_name;
     std::destroy_at(node_name_ptr);
 
@@ -166,33 +167,28 @@ public:
 
 class GenericResponseWrapper
 {
-  struct Meta
-  {
-    alignas(16) int64_t seqno;
-  };
-
-  // Ensure ServiceResponseWrapper and GenericResponseWrapper share the same metadata layout.
+  // sanity check: ensure template and generic versions share the same size.
   static_assert(
     sizeof(ServiceResponseWrapper<DummyService>) ==
-      offsetof_meta(sizeof(DummyResponse)) + sizeof(Meta),
-    "ServiceResponseWrapper and GenericResponseWrapper diverged (Agnocast internal error)");
+      offsetof_meta(sizeof(DummyResponse)) + sizeof(ResponseMeta),
+    "ServiceResponseWrapper and GenericResponseWrapper are inconsistent (Agnocast internal error)");
 
   static constexpr size_t get_wire_size(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members)
   {
-    return offsetof_meta(response_members->size_of_) + sizeof(Meta);
+    return offsetof_meta(response_members->size_of_) + sizeof(RequestMeta);
   }
 
-  static Meta * get_meta_ptr(
+  static RequestMeta * get_meta_ptr(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
     void * response_ptr)
   {
-    return reinterpret_cast<Meta *>(
+    return reinterpret_cast<RequestMeta *>(
       static_cast<char *>(response_ptr) + offsetof_meta(response_members->size_of_));
   }
 
   ipc_shared_ptr<void> response_;
-  Meta * const meta_ptr_;
+  RequestMeta * const meta_ptr_;
 
 public:
   explicit GenericResponseWrapper(

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -72,6 +72,9 @@ struct ResponseMeta
   alignas(16) int64_t seqno;
 };
 
+// These wrappers combine the user payload with Agnocast correlation metadata. Since the payload may
+// declare fields that share names with metadata fields, accessing metadata fields always requires
+// explicit qualification (e.g. `wrapper->RequestMeta::seqno`) to avoid ambiguity.
 template <typename ServiceT>
 struct ServiceRequestWrapper : public ServiceT::Request, public RequestMeta
 {

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -179,19 +179,19 @@ class GenericResponseWrapper
   static constexpr size_t get_wire_size(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members)
   {
-    return offsetof_meta(response_members->size_of_) + sizeof(RequestMeta);
+    return offsetof_meta(response_members->size_of_) + sizeof(ResponseMeta);
   }
 
-  static RequestMeta * get_meta_ptr(
+  static ResponseMeta * get_meta_ptr(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members,
     void * response_ptr)
   {
-    return reinterpret_cast<RequestMeta *>(
+    return reinterpret_cast<ResponseMeta *>(
       static_cast<char *>(response_ptr) + offsetof_meta(response_members->size_of_));
   }
 
   ipc_shared_ptr<void> response_;
-  RequestMeta * const meta_ptr_;
+  ResponseMeta * const meta_ptr_;
 
 public:
   explicit GenericResponseWrapper(

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -24,6 +24,8 @@
 #include <rosidl_runtime_cpp/message_initialization.hpp>
 #include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
 
+#include <rmw/types.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -37,6 +39,21 @@ constexpr size_t offsetof_meta(size_t base_size)
 {
   return (base_size + 15) & (~15);
 }
+
+// Dummy types used only for compile-time layout verification.
+struct DummyRequest
+{
+  int32_t value;
+};
+struct DummyResponse
+{
+  int32_t value;
+};
+struct DummyService
+{
+  using Request = DummyRequest;
+  using Response = DummyResponse;
+};
 
 }  // namespace
 
@@ -65,6 +82,12 @@ class GenericRequestWrapper
     uint8_t client_gid[RMW_GID_STORAGE_SIZE];
     std::string node_name;
   };
+
+  // Ensure ServiceRequestWrapper and GenericRequestWrapper share the same metadata layout.
+  static_assert(
+    sizeof(ServiceRequestWrapper<DummyService>) ==
+      offsetof_meta(sizeof(DummyRequest)) + sizeof(Meta),
+    "ServiceRequestWrapper and GenericRequestWrapper diverged (Agnocast internal error)");
 
   static constexpr size_t get_wire_size(
     const rosidl_typesupport_introspection_cpp::MessageMembers * request_members)
@@ -147,6 +170,12 @@ class GenericResponseWrapper
   {
     alignas(16) int64_t seqno;
   };
+
+  // Ensure ServiceResponseWrapper and GenericResponseWrapper share the same metadata layout.
+  static_assert(
+    sizeof(ServiceResponseWrapper<DummyService>) ==
+      offsetof_meta(sizeof(DummyResponse)) + sizeof(Meta),
+    "ServiceResponseWrapper and GenericResponseWrapper diverged (Agnocast internal error)");
 
   static constexpr size_t get_wire_size(
     const rosidl_typesupport_introspection_cpp::MessageMembers * response_members)

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -128,7 +128,9 @@ ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
     request_members_, [this](size_t size) { return publisher_->borrow_loaned_message(size); });
 
   generic_request_wrapper.seqno() = next_sequence_number_.fetch_add(1);
-  std::memcpy(generic_request_wrapper.client_gid(), get_gid().data, RMW_GID_STORAGE_SIZE);
+  std::memcpy(
+    static_cast<void *>(generic_request_wrapper.client_gid()),
+    static_cast<const void *>(get_gid().data), RMW_GID_STORAGE_SIZE);
   generic_request_wrapper.node_name() = node_name_;
 
   return std::move(generic_request_wrapper).take_request();

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
 #include <memory>
 
 using namespace std::chrono;
@@ -126,8 +127,9 @@ ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
   auto generic_request_wrapper = GenericRequestWrapper::allocate(
     request_members_, [this](size_t size) { return publisher_->borrow_loaned_message(size); });
 
-  generic_request_wrapper.node_name() = node_name_;
   generic_request_wrapper.seqno() = next_sequence_number_.fetch_add(1);
+  std::memcpy(generic_request_wrapper.client_gid(), get_gid().data, RMW_GID_STORAGE_SIZE);
+  generic_request_wrapper.node_name() = node_name_;
 
   return std::move(generic_request_wrapper).take_request();
 }


### PR DESCRIPTION
## Description

This PR adds the `client_gid` field to the service request's correlation metadata, allowing the server to uniquely identify the calling client. This is required to implement the service introspection support on the server side; service event message types have the `client_gid` field and the server must populate it with the calling client's GID.

> [!note]
> Actually, the server-side `client_gid` field had not been the GID of the calling client. It had depended on the RMW implementations before the issue ros2/rmw#357 was submitted. According to the issue timeline, efforts have been made to standardize the `client_gid` field across RMW implementations so that it reliably represents the calling client's identity. **Apparently**, the current status is that rmw_connextdds (in fact correct from the beginning) and the latest version of rmw_fastrtps follow the requested semantics, while rmw_cyclonedds still requires a corresponding fix. I think Agnocast should also follow the semantics, so I decided to add the `client_gid` field to the service request's correlation metadata.

### Client GID

The client's GID is derived directly from its underlying distinct publisher. My reasoning here is that, because this internal publisher is not observable to users, it is safe to reuse its GID to represent the client's identity. But maybe that's not the case.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

Do you think it is safe to use the underlying publisher's GID as-is to present the client's identity?

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
