### PR TITLE
fix(agnocast_cie_thread_configurator): validate and normalize affinity CPU lists

### DIFF
--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -143,6 +143,13 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Key << "period_us" << YAML::Value << 1000000;
   out << YAML::EndMap;
 
+  // An empty list means "do not manage affinity", same as null, but it shows
+  // the shape the parser expects and stays a list through YAML round-trips
+  // that turn every scalar into a string.
+  const auto emit_unmanaged_affinity = [&out]() {
+    out << YAML::Key << "affinity" << YAML::Value << YAML::Flow << YAML::BeginSeq << YAML::EndSeq;
+  };
+
   // Add callback_groups section
   out << YAML::Key << "callback_groups";
   out << YAML::Value << YAML::BeginSeq;
@@ -151,7 +158,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     out << YAML::BeginMap;
     out << YAML::Key << "id" << YAML::Value << callback_group_id;
     out << YAML::Key << "domain_id" << YAML::Value << domain_id;
-    out << YAML::Key << "affinity" << YAML::Value << YAML::Null;
+    emit_unmanaged_affinity();
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
     out << YAML::Key << "nice" << YAML::Value << 0;
     out << YAML::EndMap;
@@ -167,7 +174,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   for (const auto & thread_name : non_ros_thread_names_) {
     out << YAML::BeginMap;
     out << YAML::Key << "name" << YAML::Value << thread_name;
-    out << YAML::Key << "affinity" << YAML::Value << YAML::Null;
+    emit_unmanaged_affinity();
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
     out << YAML::Key << "nice" << YAML::Value << 0;
     out << YAML::EndMap;

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -74,14 +74,11 @@ int parse_rt_priority(
   return value;
 }
 
-// CPU_SET(3) silently ignores CPUs outside [0, CPU_SETSIZE) and
-// sched_setaffinity(2) silently intersects away CPUs that do not exist on
-// this machine, so a typo'd "affinity: [2, 2000]" would pin to {2} yet be
-// reported as configured (and the SCHED_DEADLINE cgroup path would write the
-// raw value into cpuset.cpus); reject such values here instead. Checking
-// against the actual CPU count is valid because the config is always parsed
-// on the machine that applies it. The result is sorted and deduplicated so
-// downstream consumers see a canonical list.
+// CPU_SET(3) and sched_setaffinity(2) silently drop out-of-range or
+// nonexistent CPUs instead of failing, so reject them at parse time. The
+// machine CPU count is a valid bound because the config is always parsed on
+// the machine that applies it. The result is sorted and deduplicated so
+// downstream consumers see a canonical form.
 std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & entry_desc)
 {
   const YAML::Node affinity = entry["affinity"];

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -90,8 +90,6 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
   if (!affinity || affinity.IsNull()) {
     return cpus;
   }
-  // A scalar ("affinity: 2" or the kernel cpu-list string "0-3") iterates
-  // zero times, which would silently drop the user's setting.
   if (!affinity.IsSequence()) {
     throw std::runtime_error(
       "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + entry_desc);

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -2,6 +2,7 @@
 
 #include <linux/sched.h>
 #include <sched.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <stdexcept>
@@ -73,10 +74,13 @@ int parse_rt_priority(
   return value;
 }
 
-// CPU_SET(3) silently ignores CPUs outside [0, CPU_SETSIZE), so a typo'd
-// "affinity: [2, 2000]" would pin to {2} yet be reported as configured (and
-// the SCHED_DEADLINE cgroup path would write the raw value into cpuset.cpus);
-// reject such values here instead. The result is sorted and deduplicated so
+// CPU_SET(3) silently ignores CPUs outside [0, CPU_SETSIZE) and
+// sched_setaffinity(2) silently intersects away CPUs that do not exist on
+// this machine, so a typo'd "affinity: [2, 2000]" would pin to {2} yet be
+// reported as configured (and the SCHED_DEADLINE cgroup path would write the
+// raw value into cpuset.cpus); reject such values here instead. Checking
+// against the actual CPU count is valid because the config is always parsed
+// on the machine that applies it. The result is sorted and deduplicated so
 // downstream consumers see a canonical list.
 std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & entry_desc)
 {
@@ -92,6 +96,8 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
     throw std::runtime_error(
       "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + entry_desc);
   }
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
   for (const auto & cpu_node : affinity) {
     int cpu = 0;
     try {
@@ -101,10 +107,10 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
         "'affinity' must contain only integers for " + entry_desc + ", got '" +
         (cpu_node.IsScalar() ? cpu_node.Scalar() : std::string("<non-scalar>")) + "'");
     }
-    if (cpu < 0 || cpu >= CPU_SETSIZE) {
+    if (cpu < 0 || cpu > max_cpu) {
       throw std::runtime_error(
-        "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " +
-        std::to_string(CPU_SETSIZE - 1) + "] for " + entry_desc);
+        "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " + std::to_string(max_cpu) +
+        "] (this machine has " + std::to_string(num_cpus) + " CPUs) for " + entry_desc);
     }
     cpus.push_back(cpu);
   }

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -86,7 +86,7 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
 {
   const YAML::Node affinity = entry["affinity"];
   std::vector<int> cpus;
-  // Absent or null keeps its meaning of "do not manage affinity".
+  // Absent or null means "do not manage affinity".
   if (!affinity || affinity.IsNull()) {
     return cpus;
   }

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -3,6 +3,7 @@
 #include <linux/sched.h>
 #include <sched.h>
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -72,6 +73,44 @@ int parse_rt_priority(
   return value;
 }
 
+// CPU_SET(3) silently ignores CPUs outside [0, CPU_SETSIZE), so a typo'd
+// "affinity: [2, 2000]" would pin to {2} yet be reported as configured (and
+// the SCHED_DEADLINE cgroup path would write the raw value into cpuset.cpus);
+// reject such values here instead. The result is sorted and deduplicated so
+// downstream consumers see a canonical list.
+std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & entry_desc)
+{
+  const YAML::Node affinity = entry["affinity"];
+  std::vector<int> cpus;
+  // Absent or null keeps its meaning of "do not manage affinity".
+  if (!affinity || affinity.IsNull()) {
+    return cpus;
+  }
+  // A scalar ("affinity: 2" or the kernel cpu-list string "0-3") iterates
+  // zero times, which would silently drop the user's setting.
+  if (!affinity.IsSequence()) {
+    throw std::runtime_error(
+      "'affinity' must be a list of CPU numbers (e.g. [2, 3]) for " + entry_desc);
+  }
+  for (const auto & cpu_node : affinity) {
+    int cpu = 0;
+    try {
+      cpu = cpu_node.as<int>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error("'affinity' must contain only integers for " + entry_desc);
+    }
+    if (cpu < 0 || cpu >= CPU_SETSIZE) {
+      throw std::runtime_error(
+        "'affinity' CPU " + std::to_string(cpu) + " must be in [0, " +
+        std::to_string(CPU_SETSIZE - 1) + "] for " + entry_desc);
+    }
+    cpus.push_back(cpu);
+  }
+  std::sort(cpus.begin(), cpus.end());
+  cpus.erase(std::unique(cpus.begin(), cpus.end()), cpus.end());
+  return cpus;
+}
+
 }  // namespace
 
 const std::unordered_map<std::string, int> policy_to_sched_const = {
@@ -135,7 +174,7 @@ void parse_yaml(
       }
     }
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
-    for (auto & cpu : cg["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    cfg.affinity = parse_affinity(cg, "id=" + cfg.thread_str);
     cfg.policy = cg["policy"].as<std::string>();
 
     if (policy_to_sched_const.count(cfg.policy) == 0) {
@@ -161,7 +200,7 @@ void parse_yaml(
     auto & cfg = non_ros_threads_out[i];
 
     cfg.thread_str = nrt["name"].as<std::string>();
-    for (auto & cpu : nrt["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    cfg.affinity = parse_affinity(nrt, "name=" + cfg.thread_str);
     cfg.policy = nrt["policy"].as<std::string>();
 
     if (policy_to_sched_const.count(cfg.policy) == 0) {

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -97,7 +97,9 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
     try {
       cpu = cpu_node.as<int>();
     } catch (const YAML::Exception &) {
-      throw std::runtime_error("'affinity' must contain only integers for " + entry_desc);
+      throw std::runtime_error(
+        "'affinity' must contain only integers for " + entry_desc + ", got '" +
+        (cpu_node.IsScalar() ? cpu_node.Scalar() : std::string("<non-scalar>")) + "'");
     }
     if (cpu < 0 || cpu >= CPU_SETSIZE) {
       throw std::runtime_error(

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -23,30 +23,6 @@
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
 
-namespace
-{
-
-// parse_yaml only bounds affinity values by CPU_SETSIZE so that the parser
-// stays host-agnostic; whether a CPU actually exists can only be checked on
-// the machine that applies the config. Without this check, sched_setaffinity
-// silently intersects nonexistent CPUs away instead of failing.
-void validate_affinity_cpus_exist(
-  const std::vector<agnocast_cie_thread_configurator::ThreadConfig> & configs)
-{
-  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
-  for (const auto & cfg : configs) {
-    for (int cpu : cfg.affinity) {
-      if (cpu >= num_cpus) {
-        throw std::runtime_error(
-          "'affinity' CPU " + std::to_string(cpu) + " does not exist on this machine (" +
-          std::to_string(num_cpus) + " CPUs) for " + cfg.thread_str);
-      }
-    }
-  }
-}
-
-}  // namespace
-
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options),
   config_file_([this]() {
@@ -75,8 +51,6 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   agnocast_cie_thread_configurator::parse_yaml(
     yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
-  validate_affinity_cpus_exist(callback_group_configs_);
-  validate_affinity_cpus_exist(non_ros_thread_configs_);
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -584,8 +558,6 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   std::vector<ThreadConfig> new_nrt;
   try {
     agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
-    validate_affinity_cpus_exist(new_cb);
-    validate_affinity_cpus_exist(new_nrt);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();

--- a/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_configurator_node.cpp
@@ -23,6 +23,30 @@
 
 using agnocast_cie_thread_configurator::policy_to_sched_const;
 
+namespace
+{
+
+// parse_yaml only bounds affinity values by CPU_SETSIZE so that the parser
+// stays host-agnostic; whether a CPU actually exists can only be checked on
+// the machine that applies the config. Without this check, sched_setaffinity
+// silently intersects nonexistent CPUs away instead of failing.
+void validate_affinity_cpus_exist(
+  const std::vector<agnocast_cie_thread_configurator::ThreadConfig> & configs)
+{
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+  for (const auto & cfg : configs) {
+    for (int cpu : cfg.affinity) {
+      if (cpu >= num_cpus) {
+        throw std::runtime_error(
+          "'affinity' CPU " + std::to_string(cpu) + " does not exist on this machine (" +
+          std::to_string(num_cpus) + " CPUs) for " + cfg.thread_str);
+      }
+    }
+  }
+}
+
+}  // namespace
+
 ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & options)
 : Node("thread_configurator_node", options),
   config_file_([this]() {
@@ -51,6 +75,8 @@ ThreadConfiguratorNode::ThreadConfiguratorNode(const rclcpp::NodeOptions & optio
 
   agnocast_cie_thread_configurator::parse_yaml(
     yaml, default_domain_id_, callback_group_configs_, non_ros_thread_configs_);
+  validate_affinity_cpus_exist(callback_group_configs_);
+  validate_affinity_cpus_exist(non_ros_thread_configs_);
 
   unapplied_num_.store(
     static_cast<int>(callback_group_configs_.size() + non_ros_thread_configs_.size()));
@@ -283,6 +309,12 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
       }
       cpus_file << cpus[i];
     }
+    // The kernel rejects invalid content (e.g. a nonexistent CPU) at write(2)
+    // time, not at open, so the stream state must be checked after flushing.
+    cpus_file.flush();
+    if (!cpus_file) {
+      return false;
+    }
   } else {
     return false;
   }
@@ -297,6 +329,11 @@ bool ThreadConfiguratorNode::set_affinity_by_cgroup(
   std::string tasks_path = cgroup_path + "/tasks";
   if (std::ofstream tasks_file{tasks_path}) {
     tasks_file << thread_id;
+    // Attaching a task to an empty or invalid cpuset fails at write(2) time.
+    tasks_file.flush();
+    if (!tasks_file) {
+      return false;
+    }
   } else {
     return false;
   }
@@ -547,6 +584,8 @@ void ThreadConfiguratorNode::on_reapply_config_request(
   std::vector<ThreadConfig> new_nrt;
   try {
     agnocast_cie_thread_configurator::parse_yaml(yaml, default_domain_id_, new_cb, new_nrt);
+    validate_affinity_cpus_exist(new_cb);
+    validate_affinity_cpus_exist(new_nrt);
   } catch (const std::exception & e) {
     response->success = false;
     response->error_message = "YAML validation error for '" + config_file_ + "': " + e.what();

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -586,8 +586,8 @@ non_ros_threads:
 
 TEST(ParseYaml, NormalizesAffinityToSortedUnique)
 {
-  // Only CPUs 0 and 1 are used so the test also passes on small CI machines
-  // now that parse_affinity bounds values by the actual CPU count.
+  // parse_affinity bounds values by the machine CPU count, so only CPUs 0
+  // and 1 are used to keep this test valid on small CI machines.
   auto y = yaml_from_str(R"YAML(
 callback_groups:
   - id: my_cbg
@@ -679,8 +679,8 @@ TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
 
 TEST(ParseYaml, RejectsScalarAffinity)
 {
-  // A scalar iterates zero times, so before validation these were silently
-  // treated as "no affinity".
+  // A scalar iterates zero times and would otherwise silently mean
+  // "no affinity".
   for (const char * bad_affinity : {"2", "\"0-3\""}) {
     auto y = yaml_from_str(("callback_groups: []\n"
                             "non_ros_threads:\n"

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -579,6 +579,115 @@ non_ros_threads:
   EXPECT_EQ(nrt[0].thread_str, "worker/*");
 }
 
+// ---------- affinity validation ----------
+
+TEST(ParseYaml, NormalizesAffinityToSortedUnique)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: [3, 1, 3, 2]
+non_ros_threads:
+  - name: my_thread
+    policy: SCHED_OTHER
+    nice: 0
+    affinity: [5, 5, 0]
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].affinity, (std::vector<int>{1, 2, 3}));
+  ASSERT_EQ(nrt.size(), 1u);
+  EXPECT_EQ(nrt[0].affinity, (std::vector<int>{0, 5}));
+}
+
+TEST(ParseYaml, TreatsAbsentOrNullAffinityAsUnmanaged)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: no_key
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+  - id: null_value
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: ~
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 2u);
+  EXPECT_TRUE(cb[0].affinity.empty());
+  EXPECT_TRUE(cb[1].affinity.empty());
+}
+
+TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
+{
+  // CPU_SET(3) would silently ignore both, shrinking the mask without any
+  // error report.
+  for (const char * bad_affinity : {"[-1]", "[2, 1024]"}) {
+    auto y = yaml_from_str(("callback_groups:\n"
+                            "  - id: my_cbg\n"
+                            "    domain_id: 0\n"
+                            "    policy: SCHED_FIFO\n"
+                            "    priority: 50\n"
+                            "    affinity: " +
+                            std::string(bad_affinity) +
+                            "\n"
+                            "non_ros_threads: []\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
+      << "affinity=" << bad_affinity;
+  }
+}
+
+TEST(ParseYaml, RejectsScalarAffinity)
+{
+  // A scalar iterates zero times, so before validation these were silently
+  // treated as "no affinity".
+  for (const char * bad_affinity : {"2", "\"0-3\""}) {
+    auto y = yaml_from_str(("callback_groups: []\n"
+                            "non_ros_threads:\n"
+                            "  - name: my_thread\n"
+                            "    policy: SCHED_OTHER\n"
+                            "    nice: 0\n"
+                            "    affinity: " +
+                            std::string(bad_affinity) + "\n")
+                             .c_str());
+    std::vector<acie::ThreadConfig> cb, nrt;
+    EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
+      << "affinity=" << bad_affinity;
+  }
+}
+
+TEST(ParseYaml, ReportsEntryOnNonIntegerAffinityElement)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: [0, all]
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  try {
+    acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    const std::string what = e.what();
+    EXPECT_NE(what.find("'affinity' must contain only integers"), std::string::npos) << what;
+    EXPECT_NE(what.find("id=my_cbg"), std::string::npos) << what;
+  }
+}
+
 // ---------- extract_node_part ----------
 
 TEST(ExtractNodePart, SplitsAtFirstAtSign)

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -2,8 +2,10 @@
 
 #include <gtest/gtest.h>
 #include <sched.h>
+#include <unistd.h>
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -259,7 +261,7 @@ callback_groups:
     runtime: 1000000
     period: 5000000
     deadline: 5000000
-    affinity: [2]
+    affinity: [0]
 non_ros_threads: []
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
@@ -327,7 +329,7 @@ non_ros_threads:
   - name: worker
     policy: SCHED_RR
     priority: 30
-    affinity: [3]
+    affinity: [0]
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
   acie::parse_yaml(y, kTestDefaultDomain, cb, nrt);
@@ -435,7 +437,7 @@ callback_groups:
     domain_id: 0
     policy: SCHED_FIFO
     priority: 50
-    affinity: [2]
+    affinity: [0]
 non_ros_threads: []
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
@@ -584,25 +586,27 @@ non_ros_threads:
 
 TEST(ParseYaml, NormalizesAffinityToSortedUnique)
 {
+  // Only CPUs 0 and 1 are used so the test also passes on small CI machines
+  // now that parse_affinity bounds values by the actual CPU count.
   auto y = yaml_from_str(R"YAML(
 callback_groups:
   - id: my_cbg
     domain_id: 0
     policy: SCHED_FIFO
     priority: 50
-    affinity: [3, 1, 3, 2]
+    affinity: [1, 0, 1]
 non_ros_threads:
   - name: my_thread
     policy: SCHED_OTHER
     nice: 0
-    affinity: [5, 5, 0]
+    affinity: [1, 1, 0]
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].affinity, (std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(cb[0].affinity, (std::vector<int>{0, 1}));
   ASSERT_EQ(nrt.size(), 1u);
-  EXPECT_EQ(nrt[0].affinity, (std::vector<int>{0, 5}));
+  EXPECT_EQ(nrt[0].affinity, (std::vector<int>{0, 1}));
 }
 
 TEST(ParseYaml, TreatsAbsentOrNullAffinityAsUnmanaged)
@@ -629,10 +633,13 @@ non_ros_threads: []
 
 TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
 {
-  // CPU_SET(3) would silently ignore both, shrinking the mask without any
-  // error report.
+  // CPU_SET(3) / sched_setaffinity(2) would silently ignore all of these,
+  // shrinking the mask without any error report. The valid CPU 0 in front
+  // checks that it does not mask the error.
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
   for (const std::string & bad_affinity :
-       {std::string("[-1]"), "[2, " + std::to_string(CPU_SETSIZE) + "]"}) {
+       {std::string("[-1]"), "[0, " + std::to_string(num_cpus) + "]",
+        "[0, " + std::to_string(CPU_SETSIZE) + "]"}) {
     auto y = yaml_from_str(("callback_groups:\n"
                             "  - id: my_cbg\n"
                             "    domain_id: 0\n"
@@ -651,21 +658,23 @@ TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
 
 TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
 {
-  // Pins the accept side of the [0, CPU_SETSIZE) boundary.
+  // Pins the accept side of the [0, min(CPU_SETSIZE, num_cpus)) boundary.
+  const int max_cpu =
+    static_cast<int>(std::min<long>(CPU_SETSIZE, sysconf(_SC_NPROCESSORS_CONF))) - 1;
   auto y = yaml_from_str(("callback_groups:\n"
                           "  - id: my_cbg\n"
                           "    domain_id: 0\n"
                           "    policy: SCHED_FIFO\n"
                           "    priority: 50\n"
                           "    affinity: [" +
-                          std::to_string(CPU_SETSIZE - 1) +
+                          std::to_string(max_cpu) +
                           "]\n"
                           "non_ros_threads: []\n")
                            .c_str());
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
   ASSERT_EQ(cb.size(), 1u);
-  EXPECT_EQ(cb[0].affinity, (std::vector<int>{CPU_SETSIZE - 1}));
+  EXPECT_EQ(cb[0].affinity, (std::vector<int>{max_cpu}));
 }
 
 TEST(ParseYaml, RejectsScalarAffinity)

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -1,6 +1,7 @@
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
 #include <gtest/gtest.h>
+#include <sched.h>
 #include <yaml-cpp/yaml.h>
 
 #include <stdexcept>
@@ -630,14 +631,15 @@ TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
 {
   // CPU_SET(3) would silently ignore both, shrinking the mask without any
   // error report.
-  for (const char * bad_affinity : {"[-1]", "[2, 1024]"}) {
+  for (const std::string & bad_affinity :
+       {std::string("[-1]"), "[2, " + std::to_string(CPU_SETSIZE) + "]"}) {
     auto y = yaml_from_str(("callback_groups:\n"
                             "  - id: my_cbg\n"
                             "    domain_id: 0\n"
                             "    policy: SCHED_FIFO\n"
                             "    priority: 50\n"
                             "    affinity: " +
-                            std::string(bad_affinity) +
+                            bad_affinity +
                             "\n"
                             "non_ros_threads: []\n")
                              .c_str());
@@ -645,6 +647,25 @@ TEST(ParseYaml, RejectsAffinityCpuOutOfRange)
     EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error)
       << "affinity=" << bad_affinity;
   }
+}
+
+TEST(ParseYaml, AcceptsHighestValidAffinityCpu)
+{
+  // Pins the accept side of the [0, CPU_SETSIZE) boundary.
+  auto y = yaml_from_str(("callback_groups:\n"
+                          "  - id: my_cbg\n"
+                          "    domain_id: 0\n"
+                          "    policy: SCHED_FIFO\n"
+                          "    priority: 50\n"
+                          "    affinity: [" +
+                          std::to_string(CPU_SETSIZE - 1) +
+                          "]\n"
+                          "non_ros_threads: []\n")
+                           .c_str());
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].affinity, (std::vector<int>{CPU_SETSIZE - 1}));
 }
 
 TEST(ParseYaml, RejectsScalarAffinity)


### PR DESCRIPTION
## Description

`parse_yaml` accepted any integer in an `affinity` list without validation. This allowed two kinds of silent misconfiguration:

- **Out-of-range CPUs were silently dropped.** `CPU_SET(3)` ignores CPUs outside `[0, CPU_SETSIZE)`, so a typo'd entry like `affinity: [2, 2000]` pinned the thread to `{2}` while the configurator reported it as successfully applied. A negative CPU was likewise ignored. `sched_setaffinity(2)` also silently intersects away CPUs that do not exist on the machine, so e.g. `affinity: [2, 12]` on an 8-CPU host pinned to `{2}` alone. On the `SCHED_DEADLINE` path, the raw value was even written into `cpuset.cpus` as-is.
- **A scalar `affinity` value was silently treated as unset.** yaml-cpp iterates a scalar node zero times, so `affinity: 2` or the kernel cpu-list string form `affinity: "0-3"` (which the tool itself displays when reading `/proc`) parsed as "no affinity" without any feedback, while every other validation error in the parser throws.

This PR adds a `parse_affinity` helper used by both the `callback_groups` and `non_ros_threads` sections:

- Rejects non-sequence values (scalar, string) with an instructive message.
- Rejects non-integer elements with the entry context (`id=...` / `name=...`), matching the existing `parse_nice` / `parse_rt_priority` error style.
- Rejects CPUs outside `[0, min(CPU_SETSIZE, machine CPU count))` so mistakes fail loudly at parse time instead of silently shrinking the mask. Checking against the actual CPU count in the parser is valid because the config is always parsed on the machine that applies it (the configurator node is `parse_yaml`'s only production caller).
- Normalizes the result to a sorted, deduplicated list, so downstream consumers (the `CPU_SET` loop and the cgroup `cpuset.cpus` write) see a canonical form.

The `SCHED_DEADLINE` cgroup path additionally flushes and checks stream state after writing `cpuset.cpus` and `tasks`, because the kernel rejects invalid content at write(2) time rather than at open.

The `prerun_node` template now emits `affinity: []` instead of `affinity: ~` for both sections. Both forms mean "do not manage affinity", but the null form does not survive string-preserving YAML round-trips: a loader that keeps every scalar as a string turns `~` into the string `'~'`, which the new validation then correctly rejects as a scalar. The e2e wildcard and precedence tests rewrite the template through exactly such a round-trip, which is what surfaced this in CI. The empty list stays a list through re-serialization and also shows the list shape the parser expects.

Absent keys and null values keep their existing meaning of "do not manage affinity". Configs that previously "worked" only by having their invalid values silently ignored are now rejected at parse / reapply validation time, which is the intended behavior change.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Additionally, 6 unit tests were added to `test_thread_config` (normalization, absent/null handling, out-of-range rejection, boundary acceptance, scalar rejection, non-integer element context). Boundary values are derived from `sysconf(_SC_NPROCESSORS_CONF)` and valid CPUs are kept to 0/1 so the tests hold on small CI machines. The package test suite passes locally via `colcon test` (69 tests, 0 failures, `requires_kernel_module` tests excluded). The `thread_configurator` wildcard and precedence launch tests that failed in CI pass locally with the `prerun_node` template change (10 tests, 0 failures), and the generated `template.yaml` was inspected to confirm `affinity: []` in both sections.

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.