### PR TITLE
refactor(agnocast_kmod): split the domain bridge rule add path into helpers

### DIFF
--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -229,8 +229,8 @@ extern DECLARE_HASHTABLE(bridge_htable, TOPIC_HASH_BITS);
 
 // A domain bridge rule relays one topic between two ROS domains within one IPC
 // namespace. The pair is stored canonically (domain_a < domain_b) with the enabled
-// direction(s) in a_to_b / b_to_a. See agnocast_ioctl_add_domain_bridge for the rules
-// on adding one.
+// direction(s) in a_to_b / b_to_a. See add_domain_rule in agnocast_ioctl.c for the
+// rules on adding one.
 struct domain_bridge_rule
 {
   // Per-domain topic names. Equal when the rule does not rename; a rename pairs

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2354,10 +2354,10 @@ static int add_domain_rule(
       r_from->b_to_a = true;
     }
 
-    // Unlike the new-pair path (the fallthrough, which delegates to insert_domain_rule), this
-    // one runs after endpoints may have registered, and the direction just enabled was denied
-    // when their notify lists were built. Both cells share one topic_struct once grouped, so
-    // either wrapper reaches every publisher.
+    // Unlike the new-pair path that insert_domain_rule handles, this one runs after endpoints
+    // may have registered, and the direction just enabled was denied when their notify lists
+    // were built. Both cells share one topic_struct once grouped, so either wrapper reaches
+    // every publisher.
     struct topic_wrapper * wrapper = find_topic(topic_name_from, ipc_ns, from_domain);
     if (!wrapper) wrapper = find_topic(topic_name_to, ipc_ns, to_domain);
     if (wrapper) rebuild_all_notify_lists(wrapper);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2337,9 +2337,10 @@ static int add_domain_rule(
     r_a->a_to_b |= from_is_a;
     r_a->b_to_a |= !from_is_a;
 
-    // Unlike the paths below, this one runs after endpoints may have registered, and the
-    // direction just enabled was denied when their notify lists were built. Both cells share one
-    // topic_struct once grouped, so either wrapper reaches every publisher.
+    // Unlike the new-pair path (the fallthrough, which delegates to insert_domain_rule), this
+    // one runs after endpoints may have registered, and the direction just enabled was denied
+    // when their notify lists were built. Both cells share one topic_struct once grouped, so
+    // either wrapper reaches every publisher.
     struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
     if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
     if (wrapper) rebuild_all_notify_lists(wrapper);

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2285,8 +2285,8 @@ static struct domain_bridge_rule * find_domain_rule(
   return NULL;
 }
 
-// The caller holds global_htables_rwsem for write and has already established that neither cell
-// is taken.
+// The caller holds global_htables_rwsem for write and has verified, for both cells, that no
+// domain_bridge_rule covers it (find_domain_rule) and that no endpoint has joined it (find_topic).
 static int insert_domain_rule(
   const char * name_a, const char * name_b, const struct ipc_namespace * ipc_ns,
   const uint32_t domain_a, const uint32_t domain_b, const bool from_is_a)

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2288,9 +2288,17 @@ static struct domain_bridge_rule * find_domain_rule(
 // The caller holds global_htables_rwsem for write and has verified, for both cells, that no
 // domain_bridge_rule covers it (find_domain_rule) and that no endpoint has joined it (find_topic).
 static int insert_domain_rule(
-  const char * name_a, const char * name_b, const struct ipc_namespace * ipc_ns,
-  const uint32_t domain_a, const uint32_t domain_b, const bool from_is_a)
+  const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
+  const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
 {
+  // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
+  // (they differ on rename). Direction lives only in the a_to_b / b_to_a flags; grouping
+  // (find_grouped_topic_struct) pairs the two cells and delivery direction is enforced by
+  // domain_delivery_allowed.
+  const bool from_is_a = from_domain < to_domain;
+  const char * name_a = from_is_a ? topic_name_from : topic_name_to;
+  const char * name_b = from_is_a ? topic_name_to : topic_name_from;
+
   struct domain_bridge_rule * rule = kmalloc(sizeof(*rule), GFP_KERNEL);
   if (!rule) return -ENOMEM;
 
@@ -2303,55 +2311,60 @@ static int insert_domain_rule(
     return -ENOMEM;
   }
   rule->ipc_ns = ipc_ns;
-  rule->domain_a = domain_a;
-  rule->domain_b = domain_b;
+  rule->domain_a = from_is_a ? from_domain : to_domain;
+  rule->domain_b = from_is_a ? to_domain : from_domain;
   rule->a_to_b = from_is_a;
   rule->b_to_a = !from_is_a;
   INIT_HLIST_NODE(&rule->node);
   // find_domain_rule scans every bucket, so the hash key is only for even distribution.
   hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
 
-  // Report it the way it was declared, not in the canonical order it is stored in.
   dev_info(
-    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", from_is_a ? name_a : name_b,
-    from_is_a ? domain_a : domain_b, from_is_a ? name_b : name_a, from_is_a ? domain_b : domain_a);
+    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", topic_name_from, from_domain,
+    topic_name_to, to_domain);
   return 0;
 }
 
 // The caller holds global_htables_rwsem for write.
 static int add_domain_rule(
-  const char * name_a, const char * name_b, const struct ipc_namespace * ipc_ns,
-  const uint32_t domain_a, const uint32_t domain_b, const bool from_is_a)
+  const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
+  const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
 {
   // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
-  // exactly two cells. r_a == r_b (non-NULL) means an existing rule already pairs exactly
+  // exactly two cells. r_from == r_to (non-NULL) means an existing rule already pairs exactly
   // these two cells -- a re-declaration or the reverse direction, so just OR in the
   // direction. Any other overlap (a cell already paired with a different cell) is a
   // fan-out and is rejected. This is the one place that enforces one pair per cell.
   // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
-  struct domain_bridge_rule * r_a = find_domain_rule(name_a, ipc_ns, domain_a);
-  struct domain_bridge_rule * r_b = find_domain_rule(name_b, ipc_ns, domain_b);
-  if (r_a || r_b) {
-    if (r_a != r_b) return -EBUSY;
+  struct domain_bridge_rule * r_from = find_domain_rule(topic_name_from, ipc_ns, from_domain);
+  struct domain_bridge_rule * r_to = find_domain_rule(topic_name_to, ipc_ns, to_domain);
+  if (r_from || r_to) {
+    if (r_from != r_to) return -EBUSY;
 
-    r_a->a_to_b |= from_is_a;
-    r_a->b_to_a |= !from_is_a;
+    if (from_domain < to_domain) {
+      r_from->a_to_b = true;
+    } else {
+      r_from->b_to_a = true;
+    }
 
     // Unlike the new-pair path (the fallthrough, which delegates to insert_domain_rule), this
     // one runs after endpoints may have registered, and the direction just enabled was denied
     // when their notify lists were built. Both cells share one topic_struct once grouped, so
     // either wrapper reaches every publisher.
-    struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
-    if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
+    struct topic_wrapper * wrapper = find_topic(topic_name_from, ipc_ns, from_domain);
+    if (!wrapper) wrapper = find_topic(topic_name_to, ipc_ns, to_domain);
     if (wrapper) rebuild_all_notify_lists(wrapper);
     return 0;
   }
 
   // Grouping merges the two domains' id and entry_id spaces, which is only safe
   // before either side has allocated any; reject if an endpoint already joined.
-  if (find_topic(name_a, ipc_ns, domain_a) || find_topic(name_b, ipc_ns, domain_b)) return -EBUSY;
+  if (
+    find_topic(topic_name_from, ipc_ns, from_domain) ||
+    find_topic(topic_name_to, ipc_ns, to_domain))
+    return -EBUSY;
 
-  return insert_domain_rule(name_a, name_b, ipc_ns, domain_a, domain_b, from_is_a);
+  return insert_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, ipc_ns);
 }
 
 int agnocast_ioctl_add_domain_bridge(
@@ -2360,18 +2373,8 @@ int agnocast_ioctl_add_domain_bridge(
 {
   if (from_domain == to_domain) return -EINVAL;
 
-  // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
-  // (they differ on rename). Direction lives only in the a_to_b / b_to_a flags; grouping
-  // (find_grouped_topic_struct) pairs the two cells and delivery direction is enforced by
-  // domain_delivery_allowed.
-  const bool from_is_a = from_domain < to_domain;
-  const uint32_t domain_a = from_is_a ? from_domain : to_domain;
-  const uint32_t domain_b = from_is_a ? to_domain : from_domain;
-  const char * name_a = from_is_a ? topic_name_from : topic_name_to;
-  const char * name_b = from_is_a ? topic_name_to : topic_name_from;
-
   down_write(&global_htables_rwsem);
-  const int ret = add_domain_rule(name_a, name_b, ipc_ns, domain_a, domain_b, from_is_a);
+  const int ret = add_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, ipc_ns);
   up_write(&global_htables_rwsem);
   return ret;
 }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2285,12 +2285,78 @@ static struct domain_bridge_rule * find_domain_rule(
   return NULL;
 }
 
+// The caller holds global_htables_rwsem for write and has already established that neither cell
+// is taken.
+static int insert_domain_rule(
+  const char * name_a, const char * name_b, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_a, const uint32_t domain_b, const bool from_is_a)
+{
+  struct domain_bridge_rule * rule = kmalloc(sizeof(*rule), GFP_KERNEL);
+  if (!rule) return -ENOMEM;
+
+  rule->topic_name_a = kstrdup(name_a, GFP_KERNEL);
+  rule->topic_name_b = kstrdup(name_b, GFP_KERNEL);
+  if (!rule->topic_name_a || !rule->topic_name_b) {
+    kfree(rule->topic_name_a);
+    kfree(rule->topic_name_b);
+    kfree(rule);
+    return -ENOMEM;
+  }
+  rule->ipc_ns = ipc_ns;
+  rule->domain_a = domain_a;
+  rule->domain_b = domain_b;
+  rule->a_to_b = from_is_a;
+  rule->b_to_a = !from_is_a;
+  INIT_HLIST_NODE(&rule->node);
+  // find_domain_rule scans every bucket, so the hash key is only for even distribution.
+  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
+
+  // Report it the way it was declared, not in the canonical order it is stored in.
+  dev_info(
+    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", from_is_a ? name_a : name_b,
+    from_is_a ? domain_a : domain_b, from_is_a ? name_b : name_a, from_is_a ? domain_b : domain_a);
+  return 0;
+}
+
+// The caller holds global_htables_rwsem for write.
+static int add_domain_rule(
+  const char * name_a, const char * name_b, const struct ipc_namespace * ipc_ns,
+  const uint32_t domain_a, const uint32_t domain_b, const bool from_is_a)
+{
+  // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
+  // exactly two cells. r_a == r_b (non-NULL) means an existing rule already pairs exactly
+  // these two cells -- a re-declaration or the reverse direction, so just OR in the
+  // direction. Any other overlap (a cell already paired with a different cell) is a
+  // fan-out and is rejected. This is the one place that enforces one pair per cell.
+  // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
+  struct domain_bridge_rule * r_a = find_domain_rule(name_a, ipc_ns, domain_a);
+  struct domain_bridge_rule * r_b = find_domain_rule(name_b, ipc_ns, domain_b);
+  if (r_a || r_b) {
+    if (r_a != r_b) return -EBUSY;
+
+    r_a->a_to_b |= from_is_a;
+    r_a->b_to_a |= !from_is_a;
+
+    // Unlike the paths below, this one runs after endpoints may have registered, and the
+    // direction just enabled was denied when their notify lists were built. Both cells share one
+    // topic_struct once grouped, so either wrapper reaches every publisher.
+    struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
+    if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
+    if (wrapper) rebuild_all_notify_lists(wrapper);
+    return 0;
+  }
+
+  // Grouping merges the two domains' id and entry_id spaces, which is only safe
+  // before either side has allocated any; reject if an endpoint already joined.
+  if (find_topic(name_a, ipc_ns, domain_a) || find_topic(name_b, ipc_ns, domain_b)) return -EBUSY;
+
+  return insert_domain_rule(name_a, name_b, ipc_ns, domain_a, domain_b, from_is_a);
+}
+
 int agnocast_ioctl_add_domain_bridge(
   const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
   const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
 {
-  int ret = 0;
-
   if (from_domain == to_domain) return -EINVAL;
 
   // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
@@ -2304,67 +2370,7 @@ int agnocast_ioctl_add_domain_bridge(
   const char * name_b = from_is_a ? topic_name_to : topic_name_from;
 
   down_write(&global_htables_rwsem);
-
-  // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
-  // exactly two cells. r_a == r_b (non-NULL) means an existing rule already pairs exactly
-  // these two cells -- a re-declaration or the reverse direction, so just OR in the
-  // direction. Any other overlap (a cell already paired with a different cell) is a
-  // fan-out and is rejected. This is the one place that enforces one pair per cell.
-  // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
-  struct domain_bridge_rule * r_a = find_domain_rule(name_a, ipc_ns, domain_a);
-  struct domain_bridge_rule * r_b = find_domain_rule(name_b, ipc_ns, domain_b);
-  if (r_a || r_b) {
-    if (r_a == r_b) {
-      r_a->a_to_b |= from_is_a;
-      r_a->b_to_a |= !from_is_a;
-
-      // Unlike the paths below, this one runs after endpoints may have registered, and the
-      // direction just enabled was denied when their notify lists were built. Both cells share one
-      // topic_struct once grouped, so either wrapper reaches every publisher.
-      struct topic_wrapper * wrapper = find_topic(name_a, ipc_ns, domain_a);
-      if (!wrapper) wrapper = find_topic(name_b, ipc_ns, domain_b);
-      if (wrapper) rebuild_all_notify_lists(wrapper);
-    } else {
-      ret = -EBUSY;
-    }
-    goto unlock;
-  }
-
-  // Grouping merges the two domains' id and entry_id spaces, which is only safe
-  // before either side has allocated any; reject if an endpoint already joined.
-  if (find_topic(name_a, ipc_ns, domain_a) || find_topic(name_b, ipc_ns, domain_b)) {
-    ret = -EBUSY;
-    goto unlock;
-  }
-
-  struct domain_bridge_rule * rule = kmalloc(sizeof(*rule), GFP_KERNEL);
-  if (!rule) {
-    ret = -ENOMEM;
-    goto unlock;
-  }
-  rule->topic_name_a = kstrdup(name_a, GFP_KERNEL);
-  rule->topic_name_b = kstrdup(name_b, GFP_KERNEL);
-  if (!rule->topic_name_a || !rule->topic_name_b) {
-    kfree(rule->topic_name_a);
-    kfree(rule->topic_name_b);
-    kfree(rule);
-    ret = -ENOMEM;
-    goto unlock;
-  }
-  rule->ipc_ns = ipc_ns;
-  rule->domain_a = domain_a;
-  rule->domain_b = domain_b;
-  rule->a_to_b = from_is_a;
-  rule->b_to_a = !from_is_a;
-  INIT_HLIST_NODE(&rule->node);
-  // find_domain_rule scans every bucket, so the hash key is only for even distribution.
-  hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
-
-  dev_info(
-    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", topic_name_from, from_domain,
-    topic_name_to, to_domain);
-
-unlock:
+  const int ret = add_domain_rule(name_a, name_b, ipc_ns, domain_a, domain_b, from_is_a);
   up_write(&global_htables_rwsem);
   return ret;
 }

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2339,7 +2339,14 @@ static int add_domain_rule(
   struct domain_bridge_rule * r_from = find_domain_rule(topic_name_from, ipc_ns, from_domain);
   struct domain_bridge_rule * r_to = find_domain_rule(topic_name_to, ipc_ns, to_domain);
   if (r_from || r_to) {
-    if (r_from != r_to) return -EBUSY;
+    if (r_from != r_to) {
+      dev_warn(
+        agnocast_device,
+        "Domain bridge rule (%s@%u -> %s@%u) rejected: a cell is already paired with another "
+        "cell. (%s)\n",
+        topic_name_from, from_domain, topic_name_to, to_domain, __func__);
+      return -EBUSY;
+    }
 
     if (from_domain < to_domain) {
       r_from->a_to_b = true;
@@ -2361,8 +2368,13 @@ static int add_domain_rule(
   // before either side has allocated any; reject if an endpoint already joined.
   if (
     find_topic(topic_name_from, ipc_ns, from_domain) ||
-    find_topic(topic_name_to, ipc_ns, to_domain))
+    find_topic(topic_name_to, ipc_ns, to_domain)) {
+    dev_warn(
+      agnocast_device,
+      "Domain bridge rule (%s@%u -> %s@%u) rejected: an endpoint has already joined. (%s)\n",
+      topic_name_from, from_domain, topic_name_to, to_domain, __func__);
     return -EBUSY;
+  }
 
   return insert_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, ipc_ns);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -103,6 +103,24 @@ void test_case_add_domain_bridge_normal(struct kunit * test)
   KUNIT_EXPECT_FALSE(test, b_to_a);
 }
 
+// Declaring from the higher domain first is the only way to reach the b_to_a orientation.
+void test_case_add_domain_bridge_reverse_first_declaration(struct kunit * test)
+{
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
+
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            TOPIC_NAME, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_EQ(test, domain_a, 1);
+  KUNIT_EXPECT_EQ(test, domain_b, 2);
+  KUNIT_EXPECT_FALSE(test, a_to_b);
+  KUNIT_EXPECT_TRUE(test, b_to_a);
+}
+
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test)
 {
   int ret =

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -4,6 +4,7 @@
 
 #define TEST_CASES_DOMAIN_BRIDGE                                              \
   KUNIT_CASE(test_case_add_domain_bridge_normal),                             \
+    KUNIT_CASE(test_case_add_domain_bridge_reverse_first_declaration),        \
     KUNIT_CASE(test_case_add_domain_bridge_same_domain_rejected),             \
     KUNIT_CASE(test_case_add_domain_bridge_reverse_direction),                \
     KUNIT_CASE(test_case_add_domain_bridge_third_domain_rejected),            \
@@ -24,6 +25,7 @@
     KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
+void test_case_add_domain_bridge_reverse_first_declaration(struct kunit * test);
 void test_case_add_domain_bridge_same_domain_rejected(struct kunit * test);
 void test_case_add_domain_bridge_reverse_direction(struct kunit * test);
 void test_case_add_domain_bridge_third_domain_rejected(struct kunit * test);


### PR DESCRIPTION
## Description

`agnocast_ioctl_add_domain_bridge()` did three things in one body: validate and canonicalize the
request, decide whether the pair may be registered, and allocate the rule. This splits the last two
into `add_domain_rule()` and `insert_domain_rule()`, leaving the ioctl entry point with only the
argument handling and the lock. Canonicalization now happens in `insert_domain_rule()`, where the
storage layout is what demands it.

Delivery, return codes and lock scope are unchanged. The one deliberate behavior change is that the
two rejection paths now log which invariant was violated, which they previously did not.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] `bash scripts/test/e2e_test_domain_bridge.bash`

## Notes for reviewers

None.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`

