### PR TITLE
feat(agnocastlib): key the service response topic by the calling client

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -88,6 +88,7 @@ protected:
   std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string node_name_;
   std::string service_name_;
+  std::string response_topic_name_;
   std::function<bool()> check_context_ok_;
 
   // Defined in the .cpp: agnocast::Node is only forward-declared here.
@@ -221,6 +222,9 @@ private:
       node, create_service_request_topic_name(service_name_), qos, pub_options,
       to_publisher_role(role));
 
+    response_topic_name_ =
+      create_service_response_topic_name(service_name_, node_name_, publisher_->get_id());
+
     auto subscriber_callback = [this](ipc_shared_ptr<ResponseT> && response) {
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
       /* --- critical section begin --- */
@@ -243,10 +247,9 @@ private:
     };
 
     SubscriptionOptions options{group};
-    std::string topic_name = create_service_response_topic_name(service_name_, node_name_);
     const SubscriptionRole subscriber_role = to_subscription_role(role);
     subscriber_ = std::make_shared<ServiceResponseSubscriber>(
-      node, topic_name, qos, std::move(subscriber_callback), options, subscriber_role);
+      node, response_topic_name_, qos, std::move(subscriber_callback), options, subscriber_role);
 
     if (role == ClientRole::Default) {
       register_service_bridge(
@@ -287,7 +290,7 @@ public:
     std::memcpy(
       static_cast<void *>(request->RequestMeta::client_gid),
       static_cast<const void *>(get_gid().data), RMW_GID_STORAGE_SIZE);
-    request->RequestMeta::node_name = node_name_;
+    request->RequestMeta::response_topic_name = response_topic_name_;
 
     return ipc_shared_ptr<typename ServiceT::Request>(std::move(request));
   }
@@ -380,6 +383,9 @@ private:
     publisher_ = std::make_shared<TypeErasedPublisher>(
       node, req_topic_name, "", qos, pub_options, to_publisher_role(role));
 
+    response_topic_name_ =
+      create_service_response_topic_name(service_name_, node_name_, publisher_->get_id());
+
     auto subscriber_callback = [this](ipc_shared_ptr<void> && response) {
       auto generic_response_wrapper =
         GenericResponseWrapper(service_ts_bundle_.response_members, std::move(response));
@@ -406,10 +412,10 @@ private:
     };
 
     SubscriptionOptions sub_options{group};
-    std::string res_topic_name = create_service_response_topic_name(service_name_, node_name_);
     const SubscriptionRole subscriber_role = to_subscription_role(role);
     subscriber_ = std::make_shared<Subscription<void>>(
-      node, res_topic_name, "", qos, std::move(subscriber_callback), sub_options, subscriber_role);
+      node, response_topic_name_, "", qos, std::move(subscriber_callback), sub_options,
+      subscriber_role);
 
     if (role == ClientRole::Default) {
       register_service_bridge(

--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -110,6 +110,13 @@ public:
   const rmw_gid_t & get_gid() const { return gid_; }
 
   /**
+   * @brief Return the per-topic id the kernel module assigned to this publisher.
+   * @return Publisher id.
+   */
+  AGNOCAST_PUBLIC
+  topic_local_id_t get_id() const { return id_; }
+
+  /**
    * @brief Return the total subscriber count for this topic (Agnocast + ROS 2 via bridge).
    * @return Total subscriber count.
    */

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -75,20 +75,19 @@ private:
   typename ServiceRequestSubscriber::SharedPtr subscriber_;
 
   typename ServiceResponsePublisher::SharedPtr get_or_create_publisher_for(
-    const std::string & node_name)
+    const std::string & response_topic_name)
   {
     typename ServiceResponsePublisher::SharedPtr pub;
     {
       std::lock_guard<std::mutex> lock(publishers_mtx_);
-      auto it = publishers_.find(node_name);
+      auto it = publishers_.find(response_topic_name);
       if (it == publishers_.end()) {
         std::visit(
-          [this, &pub, &node_name](auto * node) {
-            std::string topic_name = create_service_response_topic_name(service_name_, node_name);
+          [this, &pub, &response_topic_name](auto * node) {
             agnocast::PublisherOptions pub_options;
             pub = std::make_shared<ServiceResponsePublisher>(
-              node, topic_name, qos_, pub_options, to_publisher_role(role_));
-            publishers_[node_name] = pub;
+              node, response_topic_name, qos_, pub_options, to_publisher_role(role_));
+            publishers_[response_topic_name] = pub;
           },
           node_);
       } else {
@@ -102,7 +101,7 @@ private:
   auto wrap_basic_service_callback_for_subscriber(Func && callback)
   {
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<RequestT> && request) {
-      auto publisher = this->get_or_create_publisher_for(request->RequestMeta::node_name);
+      auto publisher = this->get_or_create_publisher_for(request->RequestMeta::response_topic_name);
 
       ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
       response->ResponseMeta::seqno = request->RequestMeta::seqno;
@@ -212,7 +211,8 @@ public:
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
     auto internal_response = static_ipc_shared_ptr_cast<ResponseT>(std::move(response));
-    auto publisher = get_or_create_publisher_for(internal_request->RequestMeta::node_name);
+    auto publisher =
+      get_or_create_publisher_for(internal_request->RequestMeta::response_topic_name);
     publisher->publish(std::move(internal_response));
   }
 
@@ -231,7 +231,8 @@ public:
     const ipc_shared_ptr<typename ServiceT::Request> & request)
   {
     auto internal_request = static_ipc_shared_ptr_cast<RequestT>(request);
-    auto publisher = get_or_create_publisher_for(internal_request->RequestMeta::node_name);
+    auto publisher =
+      get_or_create_publisher_for(internal_request->RequestMeta::response_topic_name);
     ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
     response->ResponseMeta::seqno = internal_request->RequestMeta::seqno;
     return ipc_shared_ptr<typename ServiceT::Response>(std::move(response));
@@ -277,7 +278,7 @@ class GenericService : public std::enable_shared_from_this<GenericService>
   ServiceTsBundle service_ts_bundle_;
 
   typename TypeErasedPublisher::SharedPtr get_or_create_publisher_for(
-    const std::string & node_name);
+    const std::string & response_topic_name);
 
   template <typename Func>
   auto wrap_basic_service_callback_for_subscriber(Func && callback)
@@ -285,7 +286,7 @@ class GenericService : public std::enable_shared_from_this<GenericService>
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<void> && request) {
       auto req_wrapper =
         GenericRequestWrapper(service_ts_bundle_.request_members, std::move(request));
-      auto publisher = this->get_or_create_publisher_for(req_wrapper.node_name());
+      auto publisher = this->get_or_create_publisher_for(req_wrapper.response_topic_name());
 
       auto res_wrapper = GenericResponseWrapper::allocate(
         service_ts_bundle_.response_members,

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -74,6 +74,11 @@ private:
   std::unordered_map<std::string, typename ServiceResponsePublisher::SharedPtr> publishers_;
   typename ServiceRequestSubscriber::SharedPtr subscriber_;
 
+  rclcpp::Logger get_logger() const
+  {
+    return std::visit([](auto * n) { return n->get_logger(); }, node_);
+  }
+
   typename ServiceResponsePublisher::SharedPtr get_or_create_publisher_for(
     const std::string & response_topic_name)
   {
@@ -101,7 +106,16 @@ private:
   auto wrap_basic_service_callback_for_subscriber(Func && callback)
   {
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<RequestT> && request) {
-      auto publisher = this->get_or_create_publisher_for(request->RequestMeta::response_topic_name);
+      // The name comes from the request, so a bad one is the caller's fault.
+      typename ServiceResponsePublisher::SharedPtr publisher;
+      try {
+        publisher = this->get_or_create_publisher_for(request->RequestMeta::response_topic_name);
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Dropping a request for service %s: response topic name %s: %s",
+          service_name_.c_str(), request->RequestMeta::response_topic_name.c_str(), e.what());
+        return;
+      }
 
       ipc_shared_ptr<ResponseT> response = publisher->borrow_loaned_message();
       response->ResponseMeta::seqno = request->RequestMeta::seqno;
@@ -277,6 +291,9 @@ class GenericService : public std::enable_shared_from_this<GenericService>
 
   ServiceTsBundle service_ts_bundle_;
 
+  // Defined in the .cpp: agnocast::Node is only forward-declared here.
+  rclcpp::Logger get_logger() const;
+
   typename TypeErasedPublisher::SharedPtr get_or_create_publisher_for(
     const std::string & response_topic_name);
 
@@ -286,7 +303,16 @@ class GenericService : public std::enable_shared_from_this<GenericService>
     return [this, callback = std::forward<Func>(callback)](ipc_shared_ptr<void> && request) {
       auto req_wrapper =
         GenericRequestWrapper(service_ts_bundle_.request_members, std::move(request));
-      auto publisher = this->get_or_create_publisher_for(req_wrapper.response_topic_name());
+      // The name comes from the request, so a bad one is the caller's fault.
+      typename TypeErasedPublisher::SharedPtr publisher;
+      try {
+        publisher = this->get_or_create_publisher_for(req_wrapper.response_topic_name());
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Dropping a request for service %s: response topic name %s: %s",
+          service_name_.c_str(), req_wrapper.response_topic_name().c_str(), e.what());
+        return;
+      }
 
       auto res_wrapper = GenericResponseWrapper::allocate(
         service_ts_bundle_.response_members,

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -91,7 +91,10 @@ uint64_t get_self_ipc_ns_inode();
 std::string create_service_request_topic_name(const std::string & service_name);
 // A domain bridge merges two domains, where the same fully qualified node name may legitimately
 // appear twice, into one response topic. The publisher id separates such clients: it comes from a
-// counter the kernel module keeps per request topic, and the bridge merges that counter too.
+// counter the kernel module keeps per request topic.
+// This requires the *request* topic's own bridge rule: that rule is what makes the two domains
+// share one counter. Without it each domain counts from 0 and two clients with the same node name
+// compute the same name -- unchecked, so register the response rule only alongside the request one.
 std::string create_service_response_topic_name(
   const std::string & service_name, const std::string & client_node_name,
   topic_local_id_t client_publisher_id);

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -89,8 +89,12 @@ std::string create_shm_name(const pid_t pid);
 // `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/`.
 uint64_t get_self_ipc_ns_inode();
 std::string create_service_request_topic_name(const std::string & service_name);
+// A domain bridge merges two domains, where the same fully qualified node name may legitimately
+// appear twice, into one response topic. The publisher id separates such clients: it comes from a
+// counter the kernel module keeps per request topic, and the bridge merges that counter too.
 std::string create_service_response_topic_name(
-  const std::string & service_name, const std::string & client_node_name);
+  const std::string & service_name, const std::string & client_node_name,
+  topic_local_id_t client_publisher_id);
 uint64_t agnocast_get_timestamp();
 
 // Returns a pointer to the inner node handle that can be used for the TRACEPOINT macro.

--- a/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
+++ b/src/agnocastlib/include/agnocast/internal/service_wire_type.hpp
@@ -1,10 +1,10 @@
 // On-the-wire layout of Agnocast service request/response messages.
 //
-// ┌───────────┬────────────────────────────────────┐
-// │           │        correlation metadata        │
-// │  payload  ├─────────┬──────────────┬───────────┤
-// │           │  seqno  │  client_gid  │ node_name │
-// └───────────┼─────────┴──────────────┴───────────┘
+// ┌───────────┬───────────────────────────────────────────────┐
+// │           │             correlation metadata              │
+// │  payload  ├─────────┬──────────────┬──────────────────────┤
+// │           │  seqno  │  client_gid  │ response_topic_name  │
+// └───────────┼─────────┴──────────────┴──────────────────────┘
 //             └ 16-byte aligned
 //
 // payload: request/response payload (ServiceT::Request or ServiceT::Response).
@@ -15,7 +15,9 @@
 // client_gid: The client GID (uint8_t array of length RMW_GID_STORAGE_SIZE). This field only exists
 // in the request.
 //
-// node_name: The node name of the caller (std::string). This field only exists in the request.
+// response_topic_name: The topic the caller listens for its response on (std::string). This field
+// only exists in the request. A renaming domain bridge gives the two sides different service names,
+// so the server publishes to this name rather than deriving one.
 
 #pragma once
 
@@ -64,7 +66,7 @@ struct RequestMeta
 {
   alignas(16) int64_t seqno;
   uint8_t client_gid[RMW_GID_STORAGE_SIZE];
-  std::string node_name;
+  std::string response_topic_name;
 };
 
 struct ResponseMeta
@@ -120,7 +122,7 @@ public:
 
   int64_t & seqno() { return meta_ptr_->seqno; }
   auto client_gid() -> uint8_t (&)[RMW_GID_STORAGE_SIZE] { return meta_ptr_->client_gid; }
-  std::string & node_name() { return meta_ptr_->node_name; }
+  std::string & response_topic_name() { return meta_ptr_->response_topic_name; }
 
   ipc_shared_ptr<void> && take_request() && { return std::move(request_); }
 
@@ -128,7 +130,7 @@ public:
   ///
   /// The payload buffer is initialized via the introspection init function with
   /// MessageInitialization::SKIP. The seqno number and client_gid are uninitialized (garbage),
-  /// and the node_name string is default-constructed via placement new.
+  /// and the response_topic_name string is default-constructed via placement new.
   ///
   /// @param request_members The introspection message members for the request type.
   /// @param borrow_loaned_message A callable that allocates a buffer of the given size in shared
@@ -144,9 +146,9 @@ public:
     request_members->init_function(
       wrapper.request_.get(), rosidl_runtime_cpp::MessageInitialization::SKIP);
 
-    // Use placement new to construct node_name.
-    auto * node_name_ptr = &wrapper.node_name();
-    new (node_name_ptr) std::string{};
+    // Use placement new to construct response_topic_name.
+    auto * response_topic_name_ptr = &wrapper.response_topic_name();
+    new (response_topic_name_ptr) std::string{};
 
     return wrapper;
   }
@@ -159,10 +161,10 @@ public:
   {
     request_members->fini_function(ptr);
 
-    // Destroy node_name by calling std::destroy_at().
+    // Destroy response_topic_name by calling std::destroy_at().
     RequestMeta * meta_ptr = get_meta_ptr(request_members, ptr);
-    auto * node_name_ptr = &meta_ptr->node_name;
-    std::destroy_at(node_name_ptr);
+    auto * response_topic_name_ptr = &meta_ptr->response_topic_name;
+    std::destroy_at(response_topic_name_ptr);
 
     ::operator delete(ptr);
   }

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -110,7 +110,7 @@ ipc_shared_ptr<void> GenericClient::borrow_loaned_request()
   std::memcpy(
     static_cast<void *>(generic_request_wrapper.client_gid()),
     static_cast<const void *>(get_gid().data), RMW_GID_STORAGE_SIZE);
-  generic_request_wrapper.node_name() = node_name_;
+  generic_request_wrapper.response_topic_name() = response_topic_name_;
 
   return std::move(generic_request_wrapper).take_request();
 }

--- a/src/agnocastlib/src/agnocast_service.cpp
+++ b/src/agnocastlib/src/agnocast_service.cpp
@@ -7,20 +7,19 @@ namespace agnocast
 {
 
 typename TypeErasedPublisher::SharedPtr GenericService::get_or_create_publisher_for(
-  const std::string & node_name)
+  const std::string & response_topic_name)
 {
   typename TypeErasedPublisher::SharedPtr pub;
   {
     std::lock_guard<std::mutex> lock(publishers_mtx_);
-    auto it = publishers_.find(node_name);
+    auto it = publishers_.find(response_topic_name);
     if (it == publishers_.end()) {
       std::visit(
-        [this, &pub, &node_name](auto * node) {
-          std::string topic_name = create_service_response_topic_name(service_name_, node_name);
+        [this, &pub, &response_topic_name](auto * node) {
           agnocast::PublisherOptions pub_options;
           pub = std::make_shared<TypeErasedPublisher>(
-            node, topic_name, "", qos_, pub_options, to_publisher_role(role_));
-          publishers_[node_name] = pub;
+            node, response_topic_name, "", qos_, pub_options, to_publisher_role(role_));
+          publishers_[response_topic_name] = pub;
         },
         node_);
     } else {
@@ -35,7 +34,7 @@ void GenericService::send_response(
 {
   auto req_wrapper =
     GenericRequestWrapper(this->service_ts_bundle_.request_members, std::move(request));
-  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+  auto publisher = get_or_create_publisher_for(req_wrapper.response_topic_name());
   publisher->publish(std::move(response), [this](void * p) {
     GenericResponseWrapper::free(p, this->service_ts_bundle_.response_members);
   });
@@ -46,7 +45,7 @@ void GenericService::cancel_response(
 {
   auto req_wrapper =
     GenericRequestWrapper(this->service_ts_bundle_.request_members, std::move(request));
-  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+  auto publisher = get_or_create_publisher_for(req_wrapper.response_topic_name());
   publisher->cancel_message(std::move(response), [this](void * p) {
     GenericResponseWrapper::free(p, this->service_ts_bundle_.response_members);
   });
@@ -56,7 +55,7 @@ ipc_shared_ptr<void> GenericService::borrow_loaned_response(const ipc_shared_ptr
 {
   auto req_wrapper =
     GenericRequestWrapper(this->service_ts_bundle_.request_members, ipc_shared_ptr<void>(request));
-  auto publisher = get_or_create_publisher_for(req_wrapper.node_name());
+  auto publisher = get_or_create_publisher_for(req_wrapper.response_topic_name());
 
   auto res_wrapper = GenericResponseWrapper::allocate(
     this->service_ts_bundle_.response_members,

--- a/src/agnocastlib/src/agnocast_service.cpp
+++ b/src/agnocastlib/src/agnocast_service.cpp
@@ -2,9 +2,15 @@
 
 #include "agnocast/agnocast_publisher.hpp"
 #include "agnocast/internal/service_wire_type.hpp"
+#include "agnocast/node/agnocast_node.hpp"
 
 namespace agnocast
 {
+
+rclcpp::Logger GenericService::get_logger() const
+{
+  return std::visit([](auto * n) { return n->get_logger(); }, node_);
+}
 
 typename TypeErasedPublisher::SharedPtr GenericService::get_or_create_publisher_for(
   const std::string & response_topic_name)

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -114,9 +114,11 @@ std::string create_service_request_topic_name(const std::string & service_name)
 }
 
 std::string create_service_response_topic_name(
-  const std::string & service_name, const std::string & client_node_name)
+  const std::string & service_name, const std::string & client_node_name,
+  const topic_local_id_t client_publisher_id)
 {
-  return "/AGNOCAST_SRV_RESPONSE" + service_name + "_SEP_" + client_node_name;
+  return "/AGNOCAST_SRV_RESPONSE" + service_name + "_SEP_" + client_node_name + "_SEP_" +
+         std::to_string(client_publisher_id);
 }
 
 uint64_t agnocast_get_timestamp()

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -235,3 +235,10 @@ TEST(AgnocastUtilsTest, validate_subscription_qos_liveliness_lease_duration_warn
   EXPECT_EQ(captured_warn_count, 1);
   EXPECT_NE(captured_log.find("liveliness_lease_duration"), std::string::npos) << captured_log;
 }
+
+TEST(AgnocastUtilsTest, create_service_response_topic_name_appends_client_identity)
+{
+  EXPECT_EQ(
+    agnocast::create_service_response_topic_name("/srv/add", "/client_node", 7),
+    "/AGNOCAST_SRV_RESPONSE/srv/add_SEP_/client_node_SEP_7");
+}


### PR DESCRIPTION
## Description

A service response rides on a topic named after the service and the calling node. Both sides derived that name independently, so the client and the server had to agree on the rule. The bridge plugins are separately built shared libraries carrying their own copy of it, which makes the agreement a versioning constraint.

Send the name the caller already computed for its own subscription in the request instead, and have the server publish to whatever it is told. `RequestMeta::node_name` becomes `response_topic_name`.

Agnocast assumes fully qualified node names are unique, so the node name was enough to tell callers apart. A domain bridge breaks that: two ROS domains may legitimately hold the same node name, and the bridge merges the two response topics into one. Append the caller's id of its request publisher so the name stays per-client. The bridge merges the request topic's id space across both domains, which is what makes that id unique there.

## Related links

Builds on #1535, which introduced `RequestMeta` and the `client_gid` field beside the renamed one. Groundwork for the service domain bridge (#1547).

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] `bash scripts/test/e2e_test_service.bash`

## Notes for reviewers

The field keeps its type and position in `RequestMeta`, so the wire layout is unchanged; only its meaning moves from "who is calling" to "where the answer goes". Mixed-vintage binaries therefore fail silently rather than loudly: an older client writes a node name where the newer server reads a topic name, and the call hangs with no error.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
