### PR TITLE
feat(agnocast_kmod)[need-minor-update]: count subscribers reachable across a domain bridge

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -155,6 +155,9 @@ union ioctl_get_subscriber_num_args {
     uint32_t ret_other_process_subscriber_num;
     uint32_t ret_same_process_subscriber_num;
     uint32_t ret_ros2_subscriber_num;
+    // Subscribers in the domain a bridge rule pairs this one with, counted only where the rule
+    // delivers this way round. Disjoint from the own-domain counts above.
+    uint32_t ret_other_domain_subscriber_num;
     bool ret_a2r_bridge_exist;
     bool ret_r2a_bridge_exist;
   };

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -1381,6 +1381,7 @@ int agnocast_ioctl_get_subscriber_num(
   ioctl_ret->ret_other_process_subscriber_num = 0;
   ioctl_ret->ret_same_process_subscriber_num = 0;
   ioctl_ret->ret_ros2_subscriber_num = 0;
+  ioctl_ret->ret_other_domain_subscriber_num = 0;
   ioctl_ret->ret_a2r_bridge_exist = false;
   ioctl_ret->ret_r2a_bridge_exist = false;
 
@@ -1397,16 +1398,20 @@ int agnocast_ioctl_get_subscriber_num(
 
   uint32_t inter_count = 0;
   uint32_t intra_count = 0;
+  uint32_t other_domain_count = 0;
 
-  // Match ROS 2's get_subscription_count: report only same-domain subscribers.
-  // A bridge rule still delivers cross-domain (see the publish/receive paths),
-  // but a publisher does not count subscribers in another domain. Ungrouped
-  // topics hold only one domain, so this is a no-op for them.
+  // Match ROS 2's get_subscription_count: the same/other-process counts report only same-domain
+  // subscribers. A bridge rule still delivers cross-domain (see the publish/receive paths), but a
+  // publisher does not count subscribers in another domain. Ungrouped topics hold only one domain,
+  // so this is a no-op for them.
   struct subscriber_info * sub_info;
   int bkt_sub;
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
     if (sub_info->domain_id != wrapper->domain_id) {
+      if (domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+        other_domain_count++;
+      }
       continue;
     }
     if (sub_info->is_bridge) {
@@ -1431,6 +1436,7 @@ int agnocast_ioctl_get_subscriber_num(
 
   ioctl_ret->ret_other_process_subscriber_num = inter_count;
   ioctl_ret->ret_same_process_subscriber_num = intra_count;
+  ioctl_ret->ret_other_domain_subscriber_num = other_domain_count;
   ioctl_ret->ret_ros2_subscriber_num = wrapper->topic->ros2_subscriber_num;
 
   up_read(&wrapper->topic->rwsem);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -83,6 +83,43 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
   KUNIT_ASSERT_EQ(test, ret2, 0);
 }
 
+static void setup_one_subscriber_in_domain(
+  struct kunit * test, char * topic_name, const uint32_t domain_id)
+{
+  subscriber_pid++;
+
+  union ioctl_add_process_args add_process_args;
+  int ret1 = agnocast_ioctl_add_process(
+    subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  int ret2 = agnocast_ioctl_add_subscriber(
+    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
+    &add_subscriber_args);
+
+  KUNIT_ASSERT_EQ(test, ret1, 0);
+  KUNIT_ASSERT_EQ(test, ret2, 0);
+}
+
+// The count is reported for the domain the calling process is registered in, so the publisher has
+// to belong to current->tgid.
+static void setup_current_publisher_in_domain(
+  struct kunit * test, char * topic_name, const uint32_t domain_id)
+{
+  union ioctl_add_process_args add_process_args;
+  int ret1 = agnocast_ioctl_add_process(
+    current->tgid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
+
+  union ioctl_add_publisher_args add_publisher_args;
+  int ret2 = agnocast_ioctl_add_publisher(
+    topic_name, current->nsproxy->ipc_ns, node_name, current->tgid, qos_depth,
+    qos_is_transient_local, is_bridge, &add_publisher_args);
+
+  KUNIT_ASSERT_EQ(test, ret1, 0);
+  KUNIT_ASSERT_EQ(test, ret2, 0);
+}
+
 void test_case_get_subscriber_num_normal(struct kunit * test)
 {
   char * topic_name = "/kunit_test_topic";
@@ -215,4 +252,68 @@ void test_case_get_subscriber_num_intra_process(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_process_subscriber_num, 1);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_same_process_subscriber_num, 1);
+}
+
+void test_case_get_subscriber_num_other_domain(struct kunit * test)
+{
+  // Arrange
+  char * topic_name = "/kunit_test_topic";
+  int ret_setup =
+    agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns);
+  KUNIT_ASSERT_EQ(test, ret_setup, 0);
+  setup_current_publisher_in_domain(test, topic_name, 1);
+  setup_one_subscriber_in_domain(test, topic_name, 2);
+  union ioctl_get_subscriber_num_args subscriber_num_args;
+
+  // Act
+  int ret = agnocast_ioctl_get_subscriber_num(
+    topic_name, current->nsproxy->ipc_ns, current->tgid, &subscriber_num_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 1);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_process_subscriber_num, 0);
+}
+
+// A caller in the higher domain is the canonical domain_b side, so this reads b_to_a.
+void test_case_get_subscriber_num_other_domain_reversed_pair(struct kunit * test)
+{
+  // Arrange
+  char * topic_name = "/kunit_test_topic";
+  int ret_setup =
+    agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 2, 1, current->nsproxy->ipc_ns);
+  KUNIT_ASSERT_EQ(test, ret_setup, 0);
+  setup_current_publisher_in_domain(test, topic_name, 2);
+  setup_one_subscriber_in_domain(test, topic_name, 1);
+  union ioctl_get_subscriber_num_args subscriber_num_args;
+
+  // Act
+  int ret = agnocast_ioctl_get_subscriber_num(
+    topic_name, current->nsproxy->ipc_ns, current->tgid, &subscriber_num_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 1);
+}
+
+// Grouped, so the domain-2 subscriber shares this topic_struct even though nothing published here
+// reaches it.
+void test_case_get_subscriber_num_other_domain_undelivered(struct kunit * test)
+{
+  // Arrange
+  char * topic_name = "/kunit_test_topic";
+  int ret_setup =
+    agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 2, 1, current->nsproxy->ipc_ns);
+  KUNIT_ASSERT_EQ(test, ret_setup, 0);
+  setup_current_publisher_in_domain(test, topic_name, 1);
+  setup_one_subscriber_in_domain(test, topic_name, 2);
+  union ioctl_get_subscriber_num_args subscriber_num_args;
+
+  // Act
+  int ret = agnocast_ioctl_get_subscriber_num(
+    topic_name, current->nsproxy->ipc_ns, current->tgid, &subscriber_num_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
@@ -9,7 +9,10 @@
     KUNIT_CASE(test_case_get_subscriber_num_no_subscriber),                                       \
     KUNIT_CASE(test_case_get_subscriber_num_include_ros2),                                        \
     KUNIT_CASE(test_case_get_subscriber_num_bridge_exist),                                        \
-    KUNIT_CASE(test_case_get_subscriber_num_intra_process)
+    KUNIT_CASE(test_case_get_subscriber_num_intra_process),                                       \
+    KUNIT_CASE(test_case_get_subscriber_num_other_domain),                                        \
+    KUNIT_CASE(test_case_get_subscriber_num_other_domain_reversed_pair),                          \
+    KUNIT_CASE(test_case_get_subscriber_num_other_domain_undelivered)
 
 void test_case_get_subscriber_num_normal(struct kunit * test);
 void test_case_get_subscriber_num_many(struct kunit * test);
@@ -19,3 +22,6 @@ void test_case_get_subscriber_num_no_subscriber(struct kunit * test);
 void test_case_get_subscriber_num_include_ros2(struct kunit * test);
 void test_case_get_subscriber_num_bridge_exist(struct kunit * test);
 void test_case_get_subscriber_num_intra_process(struct kunit * test);
+void test_case_get_subscriber_num_other_domain(struct kunit * test);
+void test_case_get_subscriber_num_other_domain_reversed_pair(struct kunit * test);
+void test_case_get_subscriber_num_other_domain_undelivered(struct kunit * test);

--- a/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_ioctl.hpp
@@ -191,6 +191,9 @@ union ioctl_get_subscriber_num_args {
     uint32_t ret_other_process_subscriber_num;
     uint32_t ret_same_process_subscriber_num;
     uint32_t ret_ros2_subscriber_num;
+    // Subscribers in the domain a bridge rule pairs this one with, counted only where the rule
+    // delivers this way round. Disjoint from the own-domain counts above.
+    uint32_t ret_other_domain_subscriber_num;
     bool ret_a2r_bridge_exist;
     bool ret_r2a_bridge_exist;
   };


### PR DESCRIPTION
## Description

`get_subscription_count()` reports only the caller's own domain, matching ROS 2. A publisher whose topic is covered by a domain bridge rule therefore cannot tell that its publications reach a subscriber at all: the peer's endpoints sit in the same `topic_struct` but are filtered out. A service client asking whether its server is up is the first caller that needs the other answer.

`AGNOCAST_GET_SUBSCRIBER_NUM_CMD` now also reports `ret_other_domain_subscriber_num`: the subscribers in the paired domain that this domain's publications reach. It is counted in the walk the ioctl already does, with `domain_delivery_allowed()` -- the predicate the publish path uses -- so a rule declared only in the opposite direction contributes nothing and the count cannot disagree with what delivery does. The existing fields keep their own-domain meaning, so `get_subscription_count()` is unchanged.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-minor-update`
