### PR TITLE
feat(agnocast_cie_thread_configurator): add system scan utilities for kernel threads and IRQs

### DIFF
--- a/src/agnocast_cie_thread_configurator/CMakeLists.txt
+++ b/src/agnocast_cie_thread_configurator/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(agnocast_thread_configurator SHARED
   src/util.cpp
   src/non_ros_thread_ipc.cpp
   src/thread_config.cpp
+  src/system_scan.cpp
 )
 ament_target_dependencies(agnocast_thread_configurator rclcpp agnocast_cie_config_msgs)
 target_link_libraries(agnocast_thread_configurator yaml-cpp)
@@ -85,6 +86,14 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_thread_config agnocast_thread_configurator yaml-cpp)
   target_include_directories(test_thread_config PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  ament_add_gtest(test_system_scan
+    test/test_system_scan.cpp
+  )
+  target_link_libraries(test_system_scan agnocast_thread_configurator)
+  target_include_directories(test_system_scan PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
 endif()

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -16,7 +16,8 @@ struct KernelThreadInfo
   int64_t tid = -1;
   std::string comm;             // /proc/<pid>/comm, trailing newline stripped
   std::string policy;           // "SCHED_OTHER" etc., or "UNKNOWN(<n>)" for unmapped values
-  int priority = 0;             // nice for OTHER/BATCH/IDLE, rt_priority for FIFO/RR, 0 otherwise
+  int nice = 0;                 // stat nice; meaningful for OTHER/BATCH/IDLE
+  int rt_priority = 0;          // stat rt_priority; meaningful for FIFO/RR
   std::string affinity;         // raw Cpus_allowed_list string, e.g. "0-15"
   bool no_setaffinity = false;  // PF_NO_SETAFFINITY: per-CPU kthread, affinity fixed by kernel
 };

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace agnocast_cie_thread_configurator
+{
+
+// One kernel thread observed in a /proc scan (kthreads are single-threaded,
+// so top-level /proc pid dirs suffice). All fields are file-derived, so unit
+// tests can inject a fake tree.
+struct KernelThreadInfo
+{
+  int64_t tid = -1;
+  std::string comm;             // /proc/<pid>/comm, trailing newline stripped
+  std::string policy;           // "SCHED_OTHER" etc., or "UNKNOWN(<n>)" for unmapped values
+  int priority = 0;             // nice for OTHER/BATCH/IDLE, rt_priority for FIFO/RR, 0 otherwise
+  std::string affinity;         // raw Cpus_allowed_list string, e.g. "0-15"
+  bool no_setaffinity = false;  // PF_NO_SETAFFINITY: per-CPU kthread, affinity fixed by kernel
+};
+
+// One device-backed IRQ (non-empty /sys/kernel/irq/<N>/actions).
+struct IrqInfo
+{
+  int irq = -1;
+  std::string name;      // actions file content (comma-joined for shared IRQs)
+  std::string affinity;  // /proc/irq/<N>/smp_affinity_list, "" when unreadable
+};
+
+// Sorted by (comm, tid); entries that vanish mid-scan are skipped silently.
+// kworker/* are excluded: their comms mutate at runtime, so they cannot be
+// managed per-thread.
+std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root = "/proc");
+
+// Sorted by irq. Iterates numeric directories under sys_irq_root
+// (authoritative for actions); the /proc/irq affinity read is best-effort.
+std::vector<IrqInfo> scan_irqs(
+  const std::string & proc_irq_root = "/proc/irq",
+  const std::string & sys_irq_root = "/sys/kernel/irq");
+
+// nullopt when the IRQ directory or its actions file is missing/unreadable.
+std::optional<std::string> read_irq_actions(
+  int irq, const std::string & sys_irq_root = "/sys/kernel/irq");
+
+// Pointers into `scanned`, in scan order; comms are not unique (e.g. an nfsd
+// pool), so every match is returned.
+std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
+  const std::vector<KernelThreadInfo> & scanned, const std::string & comm);
+
+// True when any /proc/<pid>/comm equals `comm` (e.g. irqbalance detection).
+bool process_with_comm_exists(const std::string & comm, const std::string & proc_root = "/proc");
+
+// {2, 3} -> "2,3": the comma list accepted by /proc/irq/<N>/smp_affinity_list.
+std::string format_cpu_list(const std::vector<int> & cpus);
+
+// Kernel cpu-list format ("0-5,8") -> sorted, deduplicated {0..5,8};
+// nullopt on empty or malformed input.
+std::optional<std::vector<int>> parse_cpu_list(const std::string & s);
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/system_scan.hpp
@@ -40,7 +40,8 @@ std::vector<IrqInfo> scan_irqs(
   const std::string & proc_irq_root = "/proc/irq",
   const std::string & sys_irq_root = "/sys/kernel/irq");
 
-// nullopt when the IRQ directory or its actions file is missing/unreadable.
+// nullopt when the IRQ directory or its actions file is missing, unreadable,
+// or empty (the IRQ is no longer device-backed, matching scan_irqs).
 std::optional<std::string> read_irq_actions(
   int irq, const std::string & sys_irq_root = "/sys/kernel/irq");
 

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -8,9 +8,9 @@
 #include <algorithm>
 #include <cctype>
 #include <charconv>
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <string_view>
 #include <system_error>
 #include <tuple>
@@ -24,6 +24,10 @@ namespace
 // Not exposed by uapi headers; values from include/linux/sched.h.
 constexpr unsigned long k_pf_kthread = 0x00200000;
 constexpr unsigned long k_pf_no_setaffinity = 0x04000000;
+
+// Mainstream kernels cap NR_CPUS at 8192, so any larger CPU number is
+// malformed input; bounding it also keeps range expansion small.
+constexpr int k_max_cpu_number = 8191;
 
 // 1-based /proc/<pid>/stat field numbers (man 5 proc); see split_stat_after_comm.
 constexpr size_t k_stat_field_flags = 9;
@@ -64,23 +68,32 @@ std::optional<T> to_number(std::string_view s)
 
 // The stat comm may contain spaces and parentheses (e.g. "irq/24-PCIe PME"),
 // so split at the LAST ')'. tokens[0] is field 3 (state), so field N maps to
-// tokens[N - 3].
-std::optional<std::vector<std::string>> split_stat_after_comm(const std::string & stat)
+// tokens[N - 3]. The returned views point into `stat`.
+std::optional<std::vector<std::string_view>> split_stat_after_comm(std::string_view stat)
 {
   const size_t close = stat.rfind(')');
-  if (close == std::string::npos) {
+  if (close == std::string_view::npos) {
     return std::nullopt;
   }
-  std::istringstream rest(stat.substr(close + 1));
-  std::vector<std::string> tokens;
-  std::string token;
-  while (rest >> token) {
-    tokens.push_back(std::move(token));
+  std::vector<std::string_view> tokens;
+  size_t pos = close + 1;
+  while (pos < stat.size()) {
+    pos = stat.find_first_not_of(' ', pos);
+    if (pos == std::string_view::npos) {
+      break;
+    }
+    size_t end = stat.find(' ', pos);
+    if (end == std::string_view::npos) {
+      end = stat.size();
+    }
+    tokens.push_back(stat.substr(pos, end - pos));
+    pos = end;
   }
   return tokens;
 }
 
-std::optional<std::string> stat_token(const std::vector<std::string> & tokens, size_t field)
+std::optional<std::string_view> stat_token(
+  const std::vector<std::string_view> & tokens, size_t field)
 {
   const size_t index = field - 3;
   if (index >= tokens.size()) {
@@ -133,28 +146,42 @@ std::optional<KernelThreadInfo> read_kernel_thread(
   }
 
   const auto flags_str = stat_token(*tokens, k_stat_field_flags);
-  const auto nice_str = stat_token(*tokens, k_stat_field_nice);
-  const auto rt_priority_str = stat_token(*tokens, k_stat_field_rt_priority);
-  const auto policy_str = stat_token(*tokens, k_stat_field_policy);
-  if (!flags_str || !nice_str || !rt_priority_str || !policy_str) {
+  if (!flags_str) {
     return std::nullopt;
   }
   const auto flags = to_number<unsigned long>(*flags_str);
-  const auto nice = to_number<int>(*nice_str);
-  const auto rt_priority = to_number<int>(*rt_priority_str);
-  const auto policy = to_number<int>(*policy_str);
-  if (!flags || !nice || !rt_priority || !policy) {
+  if (!flags) {
     return std::nullopt;
   }
+  // Most /proc entries are user processes; gate on PF_KTHREAD before parsing
+  // the remaining fields.
   if ((*flags & k_pf_kthread) == 0) {
     return std::nullopt;
   }
 
-  const auto comm = read_first_line(pid_dir / "comm");
-  if (!comm || comm->empty()) {
+  const auto nice_str = stat_token(*tokens, k_stat_field_nice);
+  const auto rt_priority_str = stat_token(*tokens, k_stat_field_rt_priority);
+  const auto policy_str = stat_token(*tokens, k_stat_field_policy);
+  if (!nice_str || !rt_priority_str || !policy_str) {
     return std::nullopt;
   }
-  if (comm->compare(0, 8, "kworker/") == 0) {
+  const auto nice = to_number<int>(*nice_str);
+  const auto rt_priority = to_number<int>(*rt_priority_str);
+  const auto policy = to_number<int>(*policy_str);
+  if (!nice || !rt_priority || !policy) {
+    return std::nullopt;
+  }
+
+  // The comm between the first '(' and the last ')' of stat is the same
+  // task->comm that /proc/<pid>/comm reports; taking it from stat keeps all
+  // fields from a single read.
+  const size_t open = stat->find('(');
+  const size_t close = stat->rfind(')');
+  if (open == std::string::npos || close == std::string::npos || close <= open + 1) {
+    return std::nullopt;
+  }
+  const std::string comm = stat->substr(open + 1, close - open - 1);
+  if (comm.compare(0, 8, "kworker/") == 0) {
     return std::nullopt;
   }
 
@@ -165,7 +192,7 @@ std::optional<KernelThreadInfo> read_kernel_thread(
 
   KernelThreadInfo info;
   info.tid = tid;
-  info.comm = *comm;
+  info.comm = comm;
   info.policy = policy_const_to_string(*policy);
   if (*policy == SCHED_FIFO || *policy == SCHED_RR) {
     info.priority = *rt_priority;
@@ -183,7 +210,9 @@ std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root)
 {
   std::vector<KernelThreadInfo> result;
   std::error_code ec;
-  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+  std::filesystem::directory_iterator it(proc_root, ec);
+  for (; !ec && it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto & entry = *it;
     const std::string filename = entry.path().filename().string();
     if (!is_all_digits(filename)) {
       continue;
@@ -206,8 +235,11 @@ std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root)
 std::vector<IrqInfo> scan_irqs(const std::string & proc_irq_root, const std::string & sys_irq_root)
 {
   std::vector<IrqInfo> result;
+  const std::filesystem::path proc_root(proc_irq_root);
   std::error_code ec;
-  for (const auto & entry : std::filesystem::directory_iterator(sys_irq_root, ec)) {
+  std::filesystem::directory_iterator it(sys_irq_root, ec);
+  for (; !ec && it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto & entry = *it;
     const std::string filename = entry.path().filename().string();
     if (!is_all_digits(filename)) {
       continue;
@@ -225,8 +257,7 @@ std::vector<IrqInfo> scan_irqs(const std::string & proc_irq_root, const std::str
     info.irq = *irq;
     info.name = *actions;
     info.affinity =
-      read_first_line(std::filesystem::path(proc_irq_root) / filename / "smp_affinity_list")
-        .value_or("");
+      read_first_line(proc_root / std::to_string(*irq) / "smp_affinity_list").value_or("");
     result.push_back(std::move(info));
   }
   std::sort(result.begin(), result.end(), [](const IrqInfo & a, const IrqInfo & b) {
@@ -237,7 +268,12 @@ std::vector<IrqInfo> scan_irqs(const std::string & proc_irq_root, const std::str
 
 std::optional<std::string> read_irq_actions(int irq, const std::string & sys_irq_root)
 {
-  return read_first_line(std::filesystem::path(sys_irq_root) / std::to_string(irq) / "actions");
+  auto actions =
+    read_first_line(std::filesystem::path(sys_irq_root) / std::to_string(irq) / "actions");
+  if (actions && actions->empty()) {
+    return std::nullopt;
+  }
+  return actions;
 }
 
 std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
@@ -255,7 +291,9 @@ std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
 bool process_with_comm_exists(const std::string & comm, const std::string & proc_root)
 {
   std::error_code ec;
-  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+  std::filesystem::directory_iterator it(proc_root, ec);
+  for (; !ec && it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    const auto & entry = *it;
     if (!is_all_digits(entry.path().filename().string())) {
       continue;
     }
@@ -294,18 +332,21 @@ std::optional<std::vector<int>> parse_cpu_list(const std::string & s)
     const size_t comma = rest.find(',');
     const std::string_view token = rest.substr(0, comma);
     rest = (comma == std::string_view::npos) ? std::string_view() : rest.substr(comma + 1);
+    if (comma != std::string_view::npos && rest.empty()) {
+      return std::nullopt;
+    }
 
     const size_t dash = token.find('-');
     if (dash == std::string_view::npos) {
       const auto cpu = to_number<int>(token);
-      if (!cpu || *cpu < 0) {
+      if (!cpu || *cpu < 0 || *cpu > k_max_cpu_number) {
         return std::nullopt;
       }
       result.push_back(*cpu);
     } else {
       const auto first = to_number<int>(token.substr(0, dash));
       const auto last = to_number<int>(token.substr(dash + 1));
-      if (!first || !last || *first < 0 || *last < *first) {
+      if (!first || !last || *first < 0 || *last < *first || *last > k_max_cpu_number) {
         return std::nullopt;
       }
       for (int cpu = *first; cpu <= *last; cpu++) {

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -1,0 +1,321 @@
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
+
+#include <linux/sched.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+#include <tuple>
+
+namespace agnocast_cie_thread_configurator
+{
+
+namespace
+{
+
+// Not exposed by uapi headers; values from include/linux/sched.h.
+constexpr unsigned long k_pf_kthread = 0x00200000;
+constexpr unsigned long k_pf_no_setaffinity = 0x04000000;
+
+// 1-based /proc/<pid>/stat field numbers (man 5 proc); see split_stat_after_comm.
+constexpr size_t k_stat_field_flags = 9;
+constexpr size_t k_stat_field_nice = 19;
+constexpr size_t k_stat_field_rt_priority = 40;
+constexpr size_t k_stat_field_policy = 41;
+
+std::optional<std::string> read_first_line(const std::filesystem::path & path)
+{
+  std::ifstream file(path);
+  if (!file) {
+    return std::nullopt;
+  }
+  std::string line;
+  std::getline(file, line);
+  if (file.bad()) {
+    return std::nullopt;
+  }
+  return line;
+}
+
+bool is_all_digits(std::string_view s)
+{
+  return !s.empty() &&
+         std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isdigit(c); });
+}
+
+template <typename T>
+std::optional<T> to_number(std::string_view s)
+{
+  T value{};
+  const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+  if (ec != std::errc() || ptr != s.data() + s.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+// The stat comm may contain spaces and parentheses (e.g. "irq/24-PCIe PME"),
+// so split at the LAST ')'. tokens[0] is field 3 (state), so field N maps to
+// tokens[N - 3].
+std::optional<std::vector<std::string>> split_stat_after_comm(const std::string & stat)
+{
+  const size_t close = stat.rfind(')');
+  if (close == std::string::npos) {
+    return std::nullopt;
+  }
+  std::istringstream rest(stat.substr(close + 1));
+  std::vector<std::string> tokens;
+  std::string token;
+  while (rest >> token) {
+    tokens.push_back(std::move(token));
+  }
+  return tokens;
+}
+
+std::optional<std::string> stat_token(const std::vector<std::string> & tokens, size_t field)
+{
+  const size_t index = field - 3;
+  if (index >= tokens.size()) {
+    return std::nullopt;
+  }
+  return tokens[index];
+}
+
+std::string policy_const_to_string(int policy)
+{
+  for (const auto & [name, value] : policy_to_sched_const) {
+    if (value == policy) {
+      return name;
+    }
+  }
+  return "UNKNOWN(" + std::to_string(policy) + ")";
+}
+
+std::optional<std::string> read_cpus_allowed_list(const std::filesystem::path & status_path)
+{
+  std::ifstream file(status_path);
+  if (!file) {
+    return std::nullopt;
+  }
+  constexpr std::string_view key = "Cpus_allowed_list:";
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.compare(0, key.size(), key) != 0) {
+      continue;
+    }
+    size_t begin = key.size();
+    while (begin < line.size() && (line[begin] == ' ' || line[begin] == '\t')) {
+      ++begin;
+    }
+    return line.substr(begin);
+  }
+  return std::nullopt;
+}
+
+std::optional<KernelThreadInfo> read_kernel_thread(
+  const std::filesystem::path & pid_dir, int64_t tid)
+{
+  const auto stat = read_first_line(pid_dir / "stat");
+  if (!stat) {
+    return std::nullopt;
+  }
+  const auto tokens = split_stat_after_comm(*stat);
+  if (!tokens) {
+    return std::nullopt;
+  }
+
+  const auto flags_str = stat_token(*tokens, k_stat_field_flags);
+  const auto nice_str = stat_token(*tokens, k_stat_field_nice);
+  const auto rt_priority_str = stat_token(*tokens, k_stat_field_rt_priority);
+  const auto policy_str = stat_token(*tokens, k_stat_field_policy);
+  if (!flags_str || !nice_str || !rt_priority_str || !policy_str) {
+    return std::nullopt;
+  }
+  const auto flags = to_number<unsigned long>(*flags_str);
+  const auto nice = to_number<int>(*nice_str);
+  const auto rt_priority = to_number<int>(*rt_priority_str);
+  const auto policy = to_number<int>(*policy_str);
+  if (!flags || !nice || !rt_priority || !policy) {
+    return std::nullopt;
+  }
+  if ((*flags & k_pf_kthread) == 0) {
+    return std::nullopt;
+  }
+
+  const auto comm = read_first_line(pid_dir / "comm");
+  if (!comm || comm->empty()) {
+    return std::nullopt;
+  }
+  if (comm->compare(0, 8, "kworker/") == 0) {
+    return std::nullopt;
+  }
+
+  const auto affinity = read_cpus_allowed_list(pid_dir / "status");
+  if (!affinity) {
+    return std::nullopt;
+  }
+
+  KernelThreadInfo info;
+  info.tid = tid;
+  info.comm = *comm;
+  info.policy = policy_const_to_string(*policy);
+  if (*policy == SCHED_FIFO || *policy == SCHED_RR) {
+    info.priority = *rt_priority;
+  } else if (*policy == SCHED_OTHER || *policy == SCHED_BATCH || *policy == SCHED_IDLE) {
+    info.priority = *nice;
+  }
+  info.affinity = *affinity;
+  info.no_setaffinity = (*flags & k_pf_no_setaffinity) != 0;
+  return info;
+}
+
+}  // namespace
+
+std::vector<KernelThreadInfo> scan_kernel_threads(const std::string & proc_root)
+{
+  std::vector<KernelThreadInfo> result;
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+    const std::string filename = entry.path().filename().string();
+    if (!is_all_digits(filename)) {
+      continue;
+    }
+    const auto tid = to_number<int64_t>(filename);
+    if (!tid) {
+      continue;
+    }
+    if (auto info = read_kernel_thread(entry.path(), *tid)) {
+      result.push_back(std::move(*info));
+    }
+  }
+  std::sort(
+    result.begin(), result.end(), [](const KernelThreadInfo & a, const KernelThreadInfo & b) {
+      return std::tie(a.comm, a.tid) < std::tie(b.comm, b.tid);
+    });
+  return result;
+}
+
+std::vector<IrqInfo> scan_irqs(const std::string & proc_irq_root, const std::string & sys_irq_root)
+{
+  std::vector<IrqInfo> result;
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(sys_irq_root, ec)) {
+    const std::string filename = entry.path().filename().string();
+    if (!is_all_digits(filename)) {
+      continue;
+    }
+    const auto irq = to_number<int>(filename);
+    if (!irq) {
+      continue;
+    }
+    const auto actions = read_first_line(entry.path() / "actions");
+    if (!actions || actions->empty()) {
+      continue;
+    }
+
+    IrqInfo info;
+    info.irq = *irq;
+    info.name = *actions;
+    info.affinity =
+      read_first_line(std::filesystem::path(proc_irq_root) / filename / "smp_affinity_list")
+        .value_or("");
+    result.push_back(std::move(info));
+  }
+  std::sort(result.begin(), result.end(), [](const IrqInfo & a, const IrqInfo & b) {
+    return a.irq < b.irq;
+  });
+  return result;
+}
+
+std::optional<std::string> read_irq_actions(int irq, const std::string & sys_irq_root)
+{
+  return read_first_line(std::filesystem::path(sys_irq_root) / std::to_string(irq) / "actions");
+}
+
+std::vector<const KernelThreadInfo *> find_kernel_threads_by_comm(
+  const std::vector<KernelThreadInfo> & scanned, const std::string & comm)
+{
+  std::vector<const KernelThreadInfo *> result;
+  for (const auto & info : scanned) {
+    if (info.comm == comm) {
+      result.push_back(&info);
+    }
+  }
+  return result;
+}
+
+bool process_with_comm_exists(const std::string & comm, const std::string & proc_root)
+{
+  std::error_code ec;
+  for (const auto & entry : std::filesystem::directory_iterator(proc_root, ec)) {
+    if (!is_all_digits(entry.path().filename().string())) {
+      continue;
+    }
+    const auto entry_comm = read_first_line(entry.path() / "comm");
+    if (entry_comm && *entry_comm == comm) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string format_cpu_list(const std::vector<int> & cpus)
+{
+  std::string result;
+  for (size_t i = 0; i < cpus.size(); i++) {
+    if (i > 0) {
+      result += ",";
+    }
+    result += std::to_string(cpus[i]);
+  }
+  return result;
+}
+
+std::optional<std::vector<int>> parse_cpu_list(const std::string & s)
+{
+  std::vector<int> result;
+  std::string_view rest(s);
+  // Tolerate the trailing newline that raw kernel file contents carry.
+  while (!rest.empty() && (rest.back() == '\n' || rest.back() == '\r' || rest.back() == ' ')) {
+    rest.remove_suffix(1);
+  }
+  if (rest.empty()) {
+    return std::nullopt;
+  }
+  while (!rest.empty()) {
+    const size_t comma = rest.find(',');
+    const std::string_view token = rest.substr(0, comma);
+    rest = (comma == std::string_view::npos) ? std::string_view() : rest.substr(comma + 1);
+
+    const size_t dash = token.find('-');
+    if (dash == std::string_view::npos) {
+      const auto cpu = to_number<int>(token);
+      if (!cpu || *cpu < 0) {
+        return std::nullopt;
+      }
+      result.push_back(*cpu);
+    } else {
+      const auto first = to_number<int>(token.substr(0, dash));
+      const auto last = to_number<int>(token.substr(dash + 1));
+      if (!first || !last || *first < 0 || *last < *first) {
+        return std::nullopt;
+      }
+      for (int cpu = *first; cpu <= *last; cpu++) {
+        result.push_back(cpu);
+      }
+    }
+  }
+  std::sort(result.begin(), result.end());
+  result.erase(std::unique(result.begin(), result.end()), result.end());
+  return result;
+}
+
+}  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -2,9 +2,6 @@
 
 #include "agnocast_cie_thread_configurator/thread_config.hpp"
 
-#include <linux/sched.h>
-#include <sched.h>
-
 #include <algorithm>
 #include <cctype>
 #include <charconv>
@@ -194,11 +191,8 @@ std::optional<KernelThreadInfo> read_kernel_thread(
   info.tid = tid;
   info.comm = comm;
   info.policy = policy_const_to_string(*policy);
-  if (*policy == SCHED_FIFO || *policy == SCHED_RR) {
-    info.priority = *rt_priority;
-  } else if (*policy == SCHED_OTHER || *policy == SCHED_BATCH || *policy == SCHED_IDLE) {
-    info.priority = *nice;
-  }
+  info.nice = *nice;
+  info.rt_priority = *rt_priority;
   info.affinity = *affinity;
   info.no_setaffinity = (*flags & k_pf_no_setaffinity) != 0;
   return info;

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -1,0 +1,385 @@
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace acie = agnocast_cie_thread_configurator;
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// From include/linux/sched.h (not exposed by uapi headers).
+constexpr unsigned long kPfKthread = 0x00200000;
+constexpr unsigned long kPfNoSetaffinity = 0x04000000;
+
+// Kernel SCHED_* constants as they appear in /proc/<pid>/stat field 41.
+constexpr int kPolicyOther = 0;
+constexpr int kPolicyFifo = 1;
+constexpr int kPolicyBatch = 3;
+
+// Each test builds its own fake /proc//sys tree and removes it afterwards.
+struct TempTree
+{
+  fs::path root;
+
+  TempTree()
+  {
+    static std::atomic<int> counter{0};
+    root = fs::temp_directory_path() / ("agnocast_system_scan_test_" + std::to_string(::getpid()) +
+                                        "_" + std::to_string(counter.fetch_add(1)));
+    fs::create_directories(root);
+  }
+
+  ~TempTree()
+  {
+    std::error_code ec;
+    fs::remove_all(root, ec);
+  }
+};
+
+void write_file(const fs::path & path, const std::string & content)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream file(path);
+  file << content;
+}
+
+// Layout per `man 5 proc`: pid (comm) state ppid ... ; the token after the
+// closing paren is field 3 (state), flags is field 9, nice 19, rt_priority 40,
+// policy 41.
+std::string make_stat_line(
+  int pid, const std::string & comm, unsigned long flags, int nice, int rt_priority, int policy)
+{
+  std::string line = std::to_string(pid) + " (" + comm + ") S 2 0 0 0 -1 " + std::to_string(flags);
+  line += " 0 0 0 0 0 0 0 0 20";  // fields 10-18
+  line += " " + std::to_string(nice);
+  for (int i = 0; i < 20; ++i) {  // fields 20-39
+    line += " 0";
+  }
+  line += " " + std::to_string(rt_priority) + " " + std::to_string(policy);
+  line += " 0 0 0 0 0 0 0 0 0 0";
+  return line;
+}
+
+void add_proc_entry(
+  const fs::path & proc_root, int pid, const std::string & comm, unsigned long flags, int nice,
+  int rt_priority, int policy, const std::string & cpus_allowed_list)
+{
+  const fs::path dir = proc_root / std::to_string(pid);
+  write_file(dir / "stat", make_stat_line(pid, comm, flags, nice, rt_priority, policy) + "\n");
+  write_file(dir / "comm", comm + "\n");
+  write_file(
+    dir / "status", "Name:\t" + comm + "\nCpus_allowed_list:\t" + cpus_allowed_list + "\n");
+}
+
+void add_irq_entry(
+  const fs::path & sys_root, const fs::path & proc_irq_root, int irq, const std::string & actions,
+  const std::string & affinity_list)
+{
+  const fs::path sys_dir = sys_root / std::to_string(irq);
+  write_file(sys_dir / "actions", actions + "\n");
+  // Real /sys/kernel/irq/<N> dirs carry further attribute files; one is
+  // enough to prove the scan ignores files it does not consume.
+  write_file(sys_dir / "chip_name", "IO-APIC\n");
+  write_file(proc_irq_root / std::to_string(irq) / "smp_affinity_list", affinity_list + "\n");
+}
+
+}  // namespace
+
+// ---------- scan_kernel_threads ----------
+
+TEST(ScanKernelThreads, FindsKthreadAndReadsFields)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 15, "my_kthread", kPfKthread | 0x40, 0, 50, kPolicyFifo, "0-3");
+  add_proc_entry(tree.root, 100, "user_process", 0x00400040, 0, 0, kPolicyOther, "0-3");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].tid, 15);
+  EXPECT_EQ(result[0].comm, "my_kthread");
+  EXPECT_EQ(result[0].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[0].priority, 50);
+  EXPECT_EQ(result[0].affinity, "0-3");
+  EXPECT_FALSE(result[0].no_setaffinity);
+}
+
+TEST(ScanKernelThreads, DualPriorityMeaning)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 10, "nice_thread", kPfKthread, 5, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 11, "rt_thread", kPfKthread, 0, 42, kPolicyFifo, "0");
+  add_proc_entry(tree.root, 12, "batch_thread", kPfKthread, -7, 0, kPolicyBatch, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].comm, "batch_thread");
+  EXPECT_EQ(result[0].priority, -7);
+  EXPECT_EQ(result[1].comm, "nice_thread");
+  EXPECT_EQ(result[1].priority, 5);
+  EXPECT_EQ(result[2].comm, "rt_thread");
+  EXPECT_EQ(result[2].priority, 42);
+}
+
+TEST(ScanKernelThreads, ExcludesKworkers)
+{
+  TempTree tree;
+  add_proc_entry(
+    tree.root, 8, "kworker/0:0H-events_highpri", kPfKthread | kPfNoSetaffinity, 0, 0, kPolicyOther,
+    "0");
+  add_proc_entry(tree.root, 9, "kept_thread", kPfKthread, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "kept_thread");
+}
+
+TEST(ScanKernelThreads, ParsesCommWithParensAndSpaces)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 753, "irq/24-PCIe PME", kPfKthread, 0, 50, kPolicyFifo, "0-15");
+  add_proc_entry(tree.root, 754, "a) b (c", kPfKthread, 3, 0, kPolicyOther, "1");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0].comm, "a) b (c");
+  EXPECT_EQ(result[0].priority, 3);
+  EXPECT_EQ(result[1].comm, "irq/24-PCIe PME");
+  EXPECT_EQ(result[1].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[1].priority, 50);
+}
+
+TEST(ScanKernelThreads, SetsNoSetaffinityFlag)
+{
+  TempTree tree;
+  add_proc_entry(
+    tree.root, 15, "ksoftirqd/0", kPfKthread | kPfNoSetaffinity, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0].no_setaffinity);
+}
+
+TEST(ScanKernelThreads, SortedByCommThenTid)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 30, "nfsd", kPfKthread, 0, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 10, "zeta", kPfKthread, 0, 0, kPolicyOther, "0");
+  add_proc_entry(tree.root, 20, "nfsd", kPfKthread, 0, 0, kPolicyOther, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].comm, "nfsd");
+  EXPECT_EQ(result[0].tid, 20);
+  EXPECT_EQ(result[1].comm, "nfsd");
+  EXPECT_EQ(result[1].tid, 30);
+  EXPECT_EQ(result[2].comm, "zeta");
+}
+
+TEST(ScanKernelThreads, SkipsMalformedEntries)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 5, "good_thread", kPfKthread, 0, 0, kPolicyOther, "0");
+  fs::create_directories(tree.root / "not_a_pid");
+  fs::create_directories(tree.root / "6");  // no stat/comm/status at all
+  write_file(tree.root / "7" / "stat", "7 (truncated) S 2 0\n");
+  write_file(
+    tree.root / "8" / "stat", make_stat_line(8, "no_status_file", kPfKthread, 0, 0, 0) + "\n");
+  write_file(tree.root / "8" / "comm", "no_status_file\n");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "good_thread");
+
+  EXPECT_TRUE(acie::scan_kernel_threads((tree.root / "missing_dir").string()).empty());
+}
+
+TEST(ScanKernelThreads, RendersUnknownPolicy)
+{
+  TempTree tree;
+  add_proc_entry(tree.root, 15, "odd_thread", kPfKthread, 0, 0, 4, "0");
+
+  const auto result = acie::scan_kernel_threads(tree.root.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].policy, "UNKNOWN(4)");
+  EXPECT_EQ(result[0].priority, 0);
+}
+
+// ---------- scan_irqs / read_irq_actions ----------
+
+TEST(ScanIrqs, OnlyDeviceBackedIrqs)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 5, "eth0", "0-3");
+  write_file(sys / "3" / "actions", "");             // present but empty
+  fs::create_directories(sys / "4");                 // no actions file
+  write_file(sys / "4" / "chip_name", "IO-APIC\n");  // still no actions
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 5);
+  EXPECT_EQ(result[0].name, "eth0");
+}
+
+TEST(ScanIrqs, ReadsAffinity)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 103, "nvidia", "0-15");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].name, "nvidia");
+  EXPECT_EQ(result[0].affinity, "0-15");
+}
+
+TEST(ScanIrqs, MissingProcAffinityYieldsEmpty)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  write_file(sys / "7" / "actions", "timer\n");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].affinity, "");
+}
+
+TEST(ScanIrqs, IgnoresNonNumericEntries)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 1, "i8042", "0");
+  write_file(sys / "default_smp_affinity", "ffff\n");
+  fs::create_directories(sys / "power");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 1);
+}
+
+TEST(ScanIrqs, SortedByIrqNumber)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  const fs::path proc = tree.root / "proc";
+  add_irq_entry(sys, proc, 100, "snd", "0");
+  add_irq_entry(sys, proc, 24, "PCIe PME", "0");
+  add_irq_entry(sys, proc, 3, "serial", "0");
+
+  const auto result = acie::scan_irqs(proc.string(), sys.string());
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0].irq, 3);
+  EXPECT_EQ(result[1].irq, 24);
+  EXPECT_EQ(result[2].irq, 100);
+}
+
+TEST(ReadIrqActions, TrimsNewlineAndReportsMissing)
+{
+  TempTree tree;
+  const fs::path sys = tree.root / "sys";
+  write_file(sys / "103" / "actions", "nvidia\n");
+
+  const auto present = acie::read_irq_actions(103, sys.string());
+  ASSERT_TRUE(present.has_value());
+  EXPECT_EQ(*present, "nvidia");
+
+  EXPECT_FALSE(acie::read_irq_actions(999, sys.string()).has_value());
+}
+
+// ---------- find_kernel_threads_by_comm / process_with_comm_exists ----------
+
+TEST(FindKernelThreadsByComm, MatchesAllEqualComms)
+{
+  std::vector<acie::KernelThreadInfo> scanned(3);
+  scanned[0].comm = "nfsd";
+  scanned[0].tid = 20;
+  scanned[1].comm = "nfsd";
+  scanned[1].tid = 30;
+  scanned[2].comm = "other";
+  scanned[2].tid = 40;
+
+  const auto matches = acie::find_kernel_threads_by_comm(scanned, "nfsd");
+  ASSERT_EQ(matches.size(), 2u);
+  EXPECT_EQ(matches[0]->tid, 20);
+  EXPECT_EQ(matches[1]->tid, 30);
+
+  EXPECT_TRUE(acie::find_kernel_threads_by_comm(scanned, "absent").empty());
+}
+
+TEST(ProcessWithCommExists, FindsByExactComm)
+{
+  TempTree tree;
+  write_file(tree.root / "1234" / "comm", "irqbalance\n");
+  write_file(tree.root / "1235" / "comm", "bash\n");
+
+  EXPECT_TRUE(acie::process_with_comm_exists("irqbalance", tree.root.string()));
+  EXPECT_FALSE(acie::process_with_comm_exists("irqbalanc", tree.root.string()));
+  EXPECT_FALSE(acie::process_with_comm_exists("nonexistent", tree.root.string()));
+}
+
+// ---------- format_cpu_list / parse_cpu_list ----------
+
+TEST(FormatCpuList, JoinsWithCommas)
+{
+  EXPECT_EQ(acie::format_cpu_list({2, 3}), "2,3");
+  EXPECT_EQ(acie::format_cpu_list({5}), "5");
+  EXPECT_EQ(acie::format_cpu_list({}), "");
+}
+
+TEST(ParseCpuList, ParsesRangesAndSingles)
+{
+  auto result = acie::parse_cpu_list("0-5,8");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{0, 1, 2, 3, 4, 5, 8}));
+
+  result = acie::parse_cpu_list("3");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{3}));
+
+  result = acie::parse_cpu_list("0-15");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), 16u);
+  EXPECT_EQ(result->front(), 0);
+  EXPECT_EQ(result->back(), 15);
+}
+
+TEST(ParseCpuList, ToleratesTrailingNewlineAndNormalizes)
+{
+  auto result = acie::parse_cpu_list("0-2\n");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{0, 1, 2}));
+
+  result = acie::parse_cpu_list("2,1,1");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, (std::vector<int>{1, 2}));
+}
+
+TEST(ParseCpuList, RejectsMalformedInput)
+{
+  EXPECT_FALSE(acie::parse_cpu_list("").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("a-b").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("5-3").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("-1").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("1,,2").has_value());
+  EXPECT_FALSE(acie::parse_cpu_list("1,x").has_value());
+}
+
+TEST(ParseCpuList, RoundTripsWithFormat)
+{
+  const std::vector<int> cpus{0, 1, 2, 3, 4, 5, 8};
+  const auto parsed = acie::parse_cpu_list(acie::format_cpu_list(cpus));
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, cpus);
+}

--- a/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_system_scan.cpp
@@ -106,12 +106,13 @@ TEST(ScanKernelThreads, FindsKthreadAndReadsFields)
   EXPECT_EQ(result[0].tid, 15);
   EXPECT_EQ(result[0].comm, "my_kthread");
   EXPECT_EQ(result[0].policy, "SCHED_FIFO");
-  EXPECT_EQ(result[0].priority, 50);
+  EXPECT_EQ(result[0].nice, 0);
+  EXPECT_EQ(result[0].rt_priority, 50);
   EXPECT_EQ(result[0].affinity, "0-3");
   EXPECT_FALSE(result[0].no_setaffinity);
 }
 
-TEST(ScanKernelThreads, DualPriorityMeaning)
+TEST(ScanKernelThreads, CapturesNiceAndRtPriority)
 {
   TempTree tree;
   add_proc_entry(tree.root, 10, "nice_thread", kPfKthread, 5, 0, kPolicyOther, "0");
@@ -121,11 +122,14 @@ TEST(ScanKernelThreads, DualPriorityMeaning)
   const auto result = acie::scan_kernel_threads(tree.root.string());
   ASSERT_EQ(result.size(), 3u);
   EXPECT_EQ(result[0].comm, "batch_thread");
-  EXPECT_EQ(result[0].priority, -7);
+  EXPECT_EQ(result[0].nice, -7);
+  EXPECT_EQ(result[0].rt_priority, 0);
   EXPECT_EQ(result[1].comm, "nice_thread");
-  EXPECT_EQ(result[1].priority, 5);
+  EXPECT_EQ(result[1].nice, 5);
+  EXPECT_EQ(result[1].rt_priority, 0);
   EXPECT_EQ(result[2].comm, "rt_thread");
-  EXPECT_EQ(result[2].priority, 42);
+  EXPECT_EQ(result[2].nice, 0);
+  EXPECT_EQ(result[2].rt_priority, 42);
 }
 
 TEST(ScanKernelThreads, ExcludesKworkers)
@@ -150,10 +154,10 @@ TEST(ScanKernelThreads, ParsesCommWithParensAndSpaces)
   const auto result = acie::scan_kernel_threads(tree.root.string());
   ASSERT_EQ(result.size(), 2u);
   EXPECT_EQ(result[0].comm, "a) b (c");
-  EXPECT_EQ(result[0].priority, 3);
+  EXPECT_EQ(result[0].nice, 3);
   EXPECT_EQ(result[1].comm, "irq/24-PCIe PME");
   EXPECT_EQ(result[1].policy, "SCHED_FIFO");
-  EXPECT_EQ(result[1].priority, 50);
+  EXPECT_EQ(result[1].rt_priority, 50);
 }
 
 TEST(ScanKernelThreads, SetsNoSetaffinityFlag)
@@ -204,12 +208,13 @@ TEST(ScanKernelThreads, SkipsMalformedEntries)
 TEST(ScanKernelThreads, RendersUnknownPolicy)
 {
   TempTree tree;
-  add_proc_entry(tree.root, 15, "odd_thread", kPfKthread, 0, 0, 4, "0");
+  add_proc_entry(tree.root, 15, "odd_thread", kPfKthread, -3, 7, 4, "0");
 
   const auto result = acie::scan_kernel_threads(tree.root.string());
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].policy, "UNKNOWN(4)");
-  EXPECT_EQ(result[0].priority, 0);
+  EXPECT_EQ(result[0].nice, -3);
+  EXPECT_EQ(result[0].rt_priority, 7);
 }
 
 // ---------- scan_irqs / read_irq_actions ----------


### PR DESCRIPTION
## Description

Part 1 of 4 splitting #1528 into reviewable units.

Adds a self-contained `system_scan` module to `agnocast_cie_thread_configurator` that observes kernel threads and device-backed IRQs:

- `scan_kernel_threads()`: walks top-level `/proc` pid directories (kthreads are single-threaded) and collects tid, comm, scheduling policy and priority, `Cpus_allowed_list`, and the `PF_NO_SETAFFINITY` flag. `kworker/*` threads are excluded because their comms mutate at runtime and cannot be matched reliably.
- `scan_irqs()` / `read_irq_actions()`: enumerate `/sys/kernel/irq/<N>` entries with a non-empty `actions` file (authoritative for device-backed IRQs) and read `/proc/irq/<N>/smp_affinity_list` best-effort.
- Helpers: `find_kernel_threads_by_comm()` (comms are not unique, e.g. an nfsd pool), `process_with_comm_exists()` (irqbalance detection), and `parse_cpu_list()` / `format_cpu_list()` for the kernel cpu-list format.

All scan roots are parameterized so the unit tests inject a fake `/proc` and `/sys` tree (21 tests).

These utilities gain callers in the follow-up PRs of the stack (prerun template generation and apply logic).

## Related links

- Split from #1528

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.