### PR TITLE
feat(agnocast_cie_thread_configurator): parse kernel_threads and irqs config sections

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -47,6 +47,11 @@ struct ThreadConfig
 // first '@' (the whole string when no '@' is present).
 std::string extract_node_part(const std::string & callback_group_id);
 
+// kworker comms embed worker-pool/CPU state that mutates at runtime, so they
+// can never be matched reliably; both the system scanner and the
+// kernel_threads parser exclude them.
+bool is_kworker_comm(const std::string & comm);
+
 // Sentinel for kernel_threads/irqs attribute values: the kernel or this tool
 // cannot manage the attribute (fixed per-CPU affinity, a policy with no YAML
 // representation), whereas YAML null means the USER chose not to. Both parse

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -4,7 +4,9 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -45,6 +47,49 @@ struct ThreadConfig
 // first '@' (the whole string when no '@' is present).
 std::string extract_node_part(const std::string & callback_group_id);
 
+// Sentinel for kernel_threads/irqs attribute values: the kernel or this tool
+// cannot manage the attribute (fixed per-CPU affinity, a policy with no YAML
+// representation), whereas YAML null means the USER chose not to. Both parse
+// to "not applied". Case-sensitive, exact match.
+inline constexpr std::string_view k_unmanageable = "UNMANAGEABLE";
+
+// Desired attributes for every kernel thread whose comm matches at apply
+// time (comms are not unique, e.g. an nfsd pool). Unset fields (YAML null,
+// absent key, or UNMANAGEABLE) are never applied.
+struct KernelThreadConfig
+{
+  std::string comm;
+  std::optional<std::string> policy;
+  int priority = 0;           // meaningful only when policy is set: nice or rt_priority
+  std::vector<int> affinity;  // empty = leave alone
+
+  // SCHED_DEADLINE only
+  unsigned int runtime = 0;
+  unsigned int period = 0;
+  unsigned int deadline = 0;
+
+  bool is_managed() const noexcept;
+};
+
+// Desired affinity for one IRQ, a hard IRQ's only schedulable attribute
+// (threaded-IRQ handler threads are plain kernel threads).
+struct IrqConfig
+{
+  int irq = -1;
+  // Expected /sys/kernel/irq/<irq>/actions content, verified before applying
+  // (guards against IRQ renumbering across boots). Empty = skip the check.
+  std::string name;
+  std::vector<int> affinity;  // empty = leave alone
+
+  bool is_managed() const noexcept;
+};
+
+// Parse the optional kernel_threads / irqs sections. Missing/null sections
+// yield empty vectors (pre-existing YAMLs keep working). Throws
+// std::runtime_error on validation error.
+std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml);
+std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml);
+
 // Mapping from the policy string in the YAML to the kernel SCHED_* constant.
 // Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
 extern const std::unordered_map<std::string, int> policy_to_sched_const;
@@ -57,7 +102,8 @@ extern const std::unordered_map<std::string, int> policy_to_sched_const;
 // callback group whose node part (before the first '@') equals the prefix,
 // within the same domain; exact entries take precedence over wildcards.
 // non_ros_threads names are always matched exactly.
-// hardware_info / rt_throttling are validated only at startup, not here.
+// hardware_info / rt_throttling are validated only at startup, not here, and
+// the kernel_threads / irqs sections have their own parsers (see above).
 void parse_yaml(
   const YAML::Node & yaml, size_t default_domain_id,
   std::vector<ThreadConfig> & callback_groups_out, std::vector<ThreadConfig> & non_ros_threads_out);

--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -60,7 +60,8 @@ struct KernelThreadConfig
 {
   std::string comm;
   std::optional<std::string> policy;
-  int priority = 0;           // meaningful only when policy is set: nice or rt_priority
+  int nice = 0;               // SCHED_OTHER/BATCH/IDLE only (-20..19)
+  int priority = 0;           // rt_priority; SCHED_FIFO/RR only (1..99)
   std::vector<int> affinity;  // empty = leave alone
 
   // SCHED_DEADLINE only

--- a/src/agnocast_cie_thread_configurator/src/system_scan.cpp
+++ b/src/agnocast_cie_thread_configurator/src/system_scan.cpp
@@ -178,7 +178,7 @@ std::optional<KernelThreadInfo> read_kernel_thread(
     return std::nullopt;
   }
   const std::string comm = stat->substr(open + 1, close - open - 1);
-  if (comm.compare(0, 8, "kworker/") == 0) {
+  if (is_kworker_comm(comm)) {
     return std::nullopt;
   }
 

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -17,6 +17,16 @@ namespace agnocast_cie_thread_configurator
 namespace
 {
 
+// Unset = the attribute must not be applied: YAML null / absent key (the
+// user's opt-out) or the UNMANAGEABLE sentinel (a kernel/tool constraint).
+bool is_unset(const YAML::Node & node)
+{
+  if (!node || node.IsNull()) {
+    return true;
+  }
+  return node.IsScalar() && node.Scalar() == k_unmanageable;
+}
+
 constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
@@ -244,6 +254,137 @@ void parse_yaml(
       throw std::runtime_error("Duplicate non_ros_thread entry: name=" + c.thread_str);
     }
   }
+}
+
+bool KernelThreadConfig::is_managed() const noexcept
+{
+  return policy.has_value() || !affinity.empty();
+}
+
+bool IrqConfig::is_managed() const noexcept
+{
+  return !affinity.empty();
+}
+
+std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
+{
+  YAML::Node section = yaml["kernel_threads"];
+  std::vector<KernelThreadConfig> result;
+  if (!section || section.IsNull()) {
+    return result;
+  }
+  result.resize(section.size());
+
+  for (size_t i = 0; i < section.size(); ++i) {
+    const auto & kt = section[i];
+    auto & cfg = result[i];
+
+    if (is_unset(kt["comm"])) {
+      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+    }
+    cfg.comm = kt["comm"].as<std::string>();
+    if (cfg.comm.empty()) {
+      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+    }
+    if (cfg.comm.compare(0, 8, "kworker/") == 0) {
+      throw std::runtime_error(
+        "kernel_threads entry '" + cfg.comm +
+        "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
+        "be matched reliably");
+    }
+
+    if (!is_unset(kt["affinity"])) {
+      for (auto & cpu : kt["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    }
+
+    const bool has_policy = !is_unset(kt["policy"]);
+    const bool has_priority = !is_unset(kt["priority"]);
+    if (!has_policy) {
+      if (has_priority) {
+        throw std::runtime_error(
+          "'priority' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
+      }
+      continue;
+    }
+
+    cfg.policy = kt["policy"].as<std::string>();
+    if (policy_to_sched_const.count(*cfg.policy) == 0) {
+      throw std::runtime_error(
+        "Unknown scheduling policy '" + *cfg.policy + "' for comm=" + cfg.comm +
+        ". Valid policies: SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_FIFO, SCHED_RR, "
+        "SCHED_DEADLINE");
+    }
+
+    if (*cfg.policy == "SCHED_DEADLINE") {
+      // Explicit check for a clear message: these fields are always
+      // hand-written (prerun never emits DEADLINE) and easy to forget.
+      if (is_unset(kt["runtime"]) || is_unset(kt["period"]) || is_unset(kt["deadline"])) {
+        throw std::runtime_error(
+          "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
+      }
+      cfg.runtime = kt["runtime"].as<unsigned int>();
+      cfg.period = kt["period"].as<unsigned int>();
+      cfg.deadline = kt["deadline"].as<unsigned int>();
+    } else {
+      if (!has_priority) {
+        throw std::runtime_error(
+          "Policy '" + *cfg.policy + "' requires 'priority' for comm=" + cfg.comm);
+      }
+      cfg.priority = kt["priority"].as<int>();
+    }
+  }
+
+  std::unordered_set<std::string> seen;
+  for (const auto & c : result) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen.insert(c.comm).second) {
+      throw std::runtime_error("Duplicate kernel_thread entry: comm=" + c.comm);
+    }
+  }
+  return result;
+}
+
+std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
+{
+  YAML::Node section = yaml["irqs"];
+  std::vector<IrqConfig> result;
+  if (!section || section.IsNull()) {
+    return result;
+  }
+  result.resize(section.size());
+
+  for (size_t i = 0; i < section.size(); ++i) {
+    const auto & iq = section[i];
+    auto & cfg = result[i];
+
+    if (is_unset(iq["irq"]) || !iq["irq"].IsScalar()) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+    try {
+      cfg.irq = iq["irq"].as<int>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+    if (cfg.irq < 0) {
+      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    }
+
+    if (!is_unset(iq["name"])) {
+      cfg.name = iq["name"].as<std::string>();
+    }
+    if (!is_unset(iq["affinity"])) {
+      for (auto & cpu : iq["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+    }
+  }
+
+  std::unordered_set<int> seen;
+  for (const auto & c : result) {
+    // cppcheck-suppress useStlAlgorithm
+    if (!seen.insert(c.irq).second) {
+      throw std::runtime_error("Duplicate irq entry: irq=" + std::to_string(c.irq));
+    }
+  }
+  return result;
 }
 
 }  // namespace agnocast_cie_thread_configurator

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -46,9 +46,7 @@ bool is_cfs_policy(const std::string & policy)
 int parse_nice(const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
 {
   const YAML::Node nice = entry["nice"];
-  // A key with an empty value ("nice:") is a defined null node, so `!nice`
-  // alone would pass it on to as<int>()'s context-free BadConversion.
-  if (!nice || nice.IsNull()) {
+  if (is_unset(nice)) {
     throw std::runtime_error("Policy '" + policy + "' requires 'nice' for " + entry_desc);
   }
   int value = 0;
@@ -71,7 +69,7 @@ int parse_rt_priority(
   const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
 {
   const YAML::Node priority = entry["priority"];
-  if (!priority || priority.IsNull()) {
+  if (is_unset(priority)) {
     throw std::runtime_error("Policy '" + policy + "' requires 'priority' for " + entry_desc);
   }
   int value = 0;
@@ -87,6 +85,19 @@ int parse_rt_priority(
   return value;
 }
 
+// A negative value also lands in the catch: yaml-cpp rejects negative
+// scalars for unsigned targets instead of wrapping them.
+unsigned int parse_deadline_field(
+  const YAML::Node & entry, const char * key, const std::string & entry_desc)
+{
+  try {
+    return entry[key].as<unsigned int>();
+  } catch (const YAML::Exception &) {
+    throw std::runtime_error(
+      "'" + std::string(key) + "' must be a non-negative integer for " + entry_desc);
+  }
+}
+
 // CPU_SET(3) and sched_setaffinity(2) silently drop out-of-range or
 // nonexistent CPUs instead of failing, so reject them at parse time. The
 // machine CPU count is a valid bound because the config is always parsed on
@@ -96,8 +107,8 @@ std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & en
 {
   const YAML::Node affinity = entry["affinity"];
   std::vector<int> cpus;
-  // Absent or null means "do not manage affinity".
-  if (!affinity || affinity.IsNull()) {
+  // Unset (absent, null, or UNMANAGEABLE) means "do not manage affinity".
+  if (is_unset(affinity)) {
     return cpus;
   }
   if (!affinity.IsSequence()) {
@@ -149,6 +160,12 @@ std::string ThreadConfig::wildcard_prefix() const
 std::string extract_node_part(const std::string & callback_group_id)
 {
   return callback_group_id.substr(0, callback_group_id.find('@'));
+}
+
+bool is_kworker_comm(const std::string & comm)
+{
+  constexpr std::string_view kworker_prefix = "kworker/";
+  return comm.compare(0, kworker_prefix.size(), kworker_prefix) == 0;
 }
 
 void parse_yaml(
@@ -286,15 +303,21 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
     auto & cfg = result[i];
     const std::string entry_pos = "kernel_threads entry #" + std::to_string(i);
 
+    if (!kt.IsMap()) {
+      throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- comm: ...')");
+    }
     if (!kt["comm"] || kt["comm"].IsNull()) {
       throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
     }
-    cfg.comm = kt["comm"].as<std::string>();
+    try {
+      cfg.comm = kt["comm"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error(entry_pos + ": 'comm' must be a string");
+    }
     if (cfg.comm.empty()) {
       throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
     }
-    constexpr std::string_view kworker_prefix = "kworker/";
-    if (cfg.comm.compare(0, kworker_prefix.size(), kworker_prefix) == 0) {
+    if (is_kworker_comm(cfg.comm)) {
       throw std::runtime_error(
         "kernel_threads entry '" + cfg.comm +
         "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
@@ -308,9 +331,7 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
         std::to_string(k_max_comm_len) + " characters");
     }
 
-    if (!is_unset(kt["affinity"])) {
-      cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm);
-    }
+    cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm);
 
     const bool has_policy = !is_unset(kt["policy"]);
     const bool has_nice = !is_unset(kt["nice"]);
@@ -327,7 +348,11 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
       continue;
     }
 
-    cfg.policy = kt["policy"].as<std::string>();
+    try {
+      cfg.policy = kt["policy"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      throw std::runtime_error("'policy' must be a string for comm=" + cfg.comm);
+    }
     if (policy_to_sched_const.count(*cfg.policy) == 0) {
       throw std::runtime_error(
         "Unknown scheduling policy '" + *cfg.policy + "' for comm=" + cfg.comm +
@@ -342,20 +367,12 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
         throw std::runtime_error(
           "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
       }
-      cfg.runtime = kt["runtime"].as<unsigned int>();
-      cfg.period = kt["period"].as<unsigned int>();
-      cfg.deadline = kt["deadline"].as<unsigned int>();
+      cfg.runtime = parse_deadline_field(kt, "runtime", "comm=" + cfg.comm);
+      cfg.period = parse_deadline_field(kt, "period", "comm=" + cfg.comm);
+      cfg.deadline = parse_deadline_field(kt, "deadline", "comm=" + cfg.comm);
     } else if (is_cfs_policy(*cfg.policy)) {
-      if (!has_nice) {
-        throw std::runtime_error(
-          "Policy '" + *cfg.policy + "' requires 'nice' for comm=" + cfg.comm);
-      }
       cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm);
     } else {
-      if (!has_priority) {
-        throw std::runtime_error(
-          "Policy '" + *cfg.policy + "' requires 'priority' for comm=" + cfg.comm);
-      }
       cfg.priority = parse_rt_priority(kt, *cfg.policy, "comm=" + cfg.comm);
     }
   }
@@ -387,24 +404,32 @@ std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
     auto & cfg = result[i];
     const std::string entry_pos = "irqs entry #" + std::to_string(i);
 
+    if (!iq.IsMap()) {
+      throw std::runtime_error(entry_pos + " must be a mapping (e.g. '- irq: ...')");
+    }
     if (!iq["irq"] || iq["irq"].IsNull()) {
       throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
     }
     try {
       cfg.irq = iq["irq"].as<int>();
     } catch (const YAML::Exception &) {
-      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
+      throw std::runtime_error(
+        entry_pos + ": 'irq' must be an integer, got '" +
+        (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
     }
     if (cfg.irq < 0) {
-      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
+      throw std::runtime_error(
+        entry_pos + ": 'irq' must be non-negative, got " + std::to_string(cfg.irq));
     }
 
     if (iq["name"] && !iq["name"].IsNull()) {
-      cfg.name = iq["name"].as<std::string>();
+      try {
+        cfg.name = iq["name"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        throw std::runtime_error("'name' must be a string for irq=" + std::to_string(cfg.irq));
+      }
     }
-    if (!is_unset(iq["affinity"])) {
-      cfg.affinity = parse_affinity(iq, "irq=" + std::to_string(cfg.irq));
-    }
+    cfg.affinity = parse_affinity(iq, "irq=" + std::to_string(cfg.irq));
   }
 
   std::unordered_set<int> seen;

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -5,6 +5,9 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -18,22 +21,26 @@ namespace
 {
 
 // Unset = the attribute must not be applied: YAML null / absent key (the
-// user's opt-out) or the UNMANAGEABLE sentinel (a kernel/tool constraint).
-bool is_unset(const YAML::Node & node)
+// user's opt-out) or, when `allow_unmanageable` is set, the UNMANAGEABLE
+// sentinel (a kernel/tool constraint). The sentinel is scoped to the
+// kernel_threads/irqs sections; elsewhere it is an ordinary invalid value.
+bool is_unset(const YAML::Node & node, bool allow_unmanageable)
 {
   if (!node || node.IsNull()) {
     return true;
   }
-  return node.IsScalar() && node.Scalar() == k_unmanageable;
+  return allow_unmanageable && node.IsScalar() && node.Scalar() == k_unmanageable;
+}
+
+bool is_unmanageable_sentinel(const YAML::Node & node)
+{
+  return node && node.IsScalar() && node.Scalar() == k_unmanageable;
 }
 
 constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
 constexpr int k_rt_priority_max = 99;
-// task->comm is truncated to TASK_COMM_LEN - 1 characters and the apply step
-// matches scanned comms exactly, so a longer configured comm can never match.
-constexpr size_t k_max_comm_len = 15;
 
 bool is_cfs_policy(const std::string & policy)
 {
@@ -43,11 +50,15 @@ bool is_cfs_policy(const std::string & policy)
 // 'nice' is required for the CFS policies (SCHED_OTHER/BATCH/IDLE);
 // parse_rt_priority is the mirror image for SCHED_FIFO/SCHED_RR. `entry_desc`
 // is the "id=..."/"name=..." fragment used in messages.
-int parse_nice(const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
+int parse_nice(
+  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc,
+  bool allow_unmanageable)
 {
   const YAML::Node nice = entry["nice"];
-  if (is_unset(nice)) {
-    throw std::runtime_error("Policy '" + policy + "' requires 'nice' for " + entry_desc);
+  if (is_unset(nice, allow_unmanageable)) {
+    throw std::runtime_error(
+      "Policy '" + policy + "' requires 'nice' for " + entry_desc +
+      (is_unmanageable_sentinel(nice) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
   int value = 0;
   try {
@@ -66,11 +77,14 @@ int parse_nice(const YAML::Node & entry, const std::string & policy, const std::
 }
 
 int parse_rt_priority(
-  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc)
+  const YAML::Node & entry, const std::string & policy, const std::string & entry_desc,
+  bool allow_unmanageable)
 {
   const YAML::Node priority = entry["priority"];
-  if (is_unset(priority)) {
-    throw std::runtime_error("Policy '" + policy + "' requires 'priority' for " + entry_desc);
+  if (is_unset(priority, allow_unmanageable)) {
+    throw std::runtime_error(
+      "Policy '" + policy + "' requires 'priority' for " + entry_desc +
+      (is_unmanageable_sentinel(priority) ? " (UNMANAGEABLE counts as unset)" : ""));
   }
   int value = 0;
   try {
@@ -85,17 +99,40 @@ int parse_rt_priority(
   return value;
 }
 
-// A negative value also lands in the catch: yaml-cpp rejects negative
-// scalars for unsigned targets instead of wrapping them.
+// yaml-cpp's as<T>() auto-detects the numeric base (YAML 1.1), so a
+// zero-padded "010" would parse as octal 8 and "0x10" as hex 16. IRQ numbers
+// and SCHED_DEADLINE parameters are hand-aligned columns where zero-padding
+// is plausible, so accept digits only and parse base-10, matching the
+// is_all_digits() + from_chars() path the system scanners use.
+template <typename T>
+std::optional<T> as_base10(const YAML::Node & node)
+{
+  if (!node || !node.IsScalar()) {
+    return std::nullopt;
+  }
+  const std::string & s = node.Scalar();
+  if (s.empty() || !std::all_of(s.begin(), s.end(), [](unsigned char c) {
+        return std::isdigit(c) != 0;
+      })) {
+    return std::nullopt;
+  }
+  T value{};
+  const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+  if (ec != std::errc() || ptr != s.data() + s.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
 unsigned int parse_deadline_field(
   const YAML::Node & entry, const char * key, const std::string & entry_desc)
 {
-  try {
-    return entry[key].as<unsigned int>();
-  } catch (const YAML::Exception &) {
+  const auto value = as_base10<unsigned int>(entry[key]);
+  if (!value) {
     throw std::runtime_error(
-      "'" + std::string(key) + "' must be a non-negative integer for " + entry_desc);
+      "'" + std::string(key) + "' must be a non-negative decimal integer for " + entry_desc);
   }
+  return *value;
 }
 
 // CPU_SET(3) and sched_setaffinity(2) silently drop out-of-range or
@@ -103,12 +140,14 @@ unsigned int parse_deadline_field(
 // machine CPU count is a valid bound because the config is always parsed on
 // the machine that applies it. The result is sorted and deduplicated so
 // downstream consumers see a canonical form.
-std::vector<int> parse_affinity(const YAML::Node & entry, const std::string & entry_desc)
+std::vector<int> parse_affinity(
+  const YAML::Node & entry, const std::string & entry_desc, bool allow_unmanageable)
 {
   const YAML::Node affinity = entry["affinity"];
   std::vector<int> cpus;
-  // Unset (absent, null, or UNMANAGEABLE) means "do not manage affinity".
-  if (is_unset(affinity)) {
+  // Unset (absent, null, or the allowed UNMANAGEABLE sentinel) means
+  // "do not manage affinity".
+  if (is_unset(affinity, allow_unmanageable)) {
     return cpus;
   }
   if (!affinity.IsSequence()) {
@@ -207,7 +246,7 @@ void parse_yaml(
       }
     }
     cfg.domain_id = cg["domain_id"] ? cg["domain_id"].as<size_t>() : default_domain_id;
-    cfg.affinity = parse_affinity(cg, "id=" + cfg.thread_str);
+    cfg.affinity = parse_affinity(cg, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     cfg.policy = cg["policy"].as<std::string>();
 
     if (policy_to_sched_const.count(cfg.policy) == 0) {
@@ -222,9 +261,10 @@ void parse_yaml(
       cfg.period = cg["period"].as<unsigned int>();
       cfg.deadline = cg["deadline"].as<unsigned int>();
     } else if (is_cfs_policy(cfg.policy)) {
-      cfg.nice = parse_nice(cg, cfg.policy, "id=" + cfg.thread_str);
+      cfg.nice = parse_nice(cg, cfg.policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
-      cfg.priority = parse_rt_priority(cg, cfg.policy, "id=" + cfg.thread_str);
+      cfg.priority =
+        parse_rt_priority(cg, cfg.policy, "id=" + cfg.thread_str, /*allow_unmanageable=*/false);
     }
   }
 
@@ -233,7 +273,7 @@ void parse_yaml(
     auto & cfg = non_ros_threads_out[i];
 
     cfg.thread_str = nrt["name"].as<std::string>();
-    cfg.affinity = parse_affinity(nrt, "name=" + cfg.thread_str);
+    cfg.affinity = parse_affinity(nrt, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     cfg.policy = nrt["policy"].as<std::string>();
 
     if (policy_to_sched_const.count(cfg.policy) == 0) {
@@ -248,9 +288,11 @@ void parse_yaml(
       cfg.period = nrt["period"].as<unsigned int>();
       cfg.deadline = nrt["deadline"].as<unsigned int>();
     } else if (is_cfs_policy(cfg.policy)) {
-      cfg.nice = parse_nice(nrt, cfg.policy, "name=" + cfg.thread_str);
+      cfg.nice =
+        parse_nice(nrt, cfg.policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     } else {
-      cfg.priority = parse_rt_priority(nrt, cfg.policy, "name=" + cfg.thread_str);
+      cfg.priority =
+        parse_rt_priority(nrt, cfg.policy, "name=" + cfg.thread_str, /*allow_unmanageable=*/false);
     }
   }
 
@@ -323,27 +365,17 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
         "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
         "be matched reliably");
     }
-    if (cfg.comm.size() > k_max_comm_len) {
-      throw std::runtime_error(
-        "kernel_threads entry '" + cfg.comm +
-        "' can never match: the kernel truncates thread "
-        "comms to " +
-        std::to_string(k_max_comm_len) + " characters");
-    }
+    cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
 
-    cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm);
-
-    const bool has_policy = !is_unset(kt["policy"]);
-    const bool has_nice = !is_unset(kt["nice"]);
-    const bool has_priority = !is_unset(kt["priority"]);
-    if (!has_policy) {
-      if (has_nice) {
-        throw std::runtime_error(
-          "'nice' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
-      }
-      if (has_priority) {
-        throw std::runtime_error(
-          "'priority' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
+    if (is_unset(kt["policy"], /*allow_unmanageable=*/true)) {
+      // Any policy-dependent field without 'policy' would otherwise be
+      // silently dead configuration (is_managed() == false).
+      for (const char * key : {"nice", "priority", "runtime", "period", "deadline"}) {
+        if (!is_unset(kt[key], /*allow_unmanageable=*/true)) {
+          throw std::runtime_error(
+            "'" + std::string(key) + "' requires 'policy' for comm=" + cfg.comm +
+            ": set both or leave both unset");
+        }
       }
       continue;
     }
@@ -363,7 +395,10 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
     if (*cfg.policy == "SCHED_DEADLINE") {
       // Explicit check for a clear message: these fields are always
       // hand-written (prerun never emits DEADLINE) and easy to forget.
-      if (is_unset(kt["runtime"]) || is_unset(kt["period"]) || is_unset(kt["deadline"])) {
+      if (
+        is_unset(kt["runtime"], /*allow_unmanageable=*/true) ||
+        is_unset(kt["period"], /*allow_unmanageable=*/true) ||
+        is_unset(kt["deadline"], /*allow_unmanageable=*/true)) {
         throw std::runtime_error(
           "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline' for comm=" + cfg.comm);
       }
@@ -371,9 +406,10 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
       cfg.period = parse_deadline_field(kt, "period", "comm=" + cfg.comm);
       cfg.deadline = parse_deadline_field(kt, "deadline", "comm=" + cfg.comm);
     } else if (is_cfs_policy(*cfg.policy)) {
-      cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm);
+      cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
     } else {
-      cfg.priority = parse_rt_priority(kt, *cfg.policy, "comm=" + cfg.comm);
+      cfg.priority =
+        parse_rt_priority(kt, *cfg.policy, "comm=" + cfg.comm, /*allow_unmanageable=*/true);
     }
   }
 
@@ -410,17 +446,13 @@ std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
     if (!iq["irq"] || iq["irq"].IsNull()) {
       throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
     }
-    try {
-      cfg.irq = iq["irq"].as<int>();
-    } catch (const YAML::Exception &) {
+    const auto irq = as_base10<int>(iq["irq"]);
+    if (!irq) {
       throw std::runtime_error(
-        entry_pos + ": 'irq' must be an integer, got '" +
+        entry_pos + ": 'irq' must be a non-negative decimal integer, got '" +
         (iq["irq"].IsScalar() ? iq["irq"].Scalar() : std::string("<non-scalar>")) + "'");
     }
-    if (cfg.irq < 0) {
-      throw std::runtime_error(
-        entry_pos + ": 'irq' must be non-negative, got " + std::to_string(cfg.irq));
-    }
+    cfg.irq = *irq;
 
     if (iq["name"] && !iq["name"].IsNull()) {
       try {
@@ -429,7 +461,8 @@ std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
         throw std::runtime_error("'name' must be a string for irq=" + std::to_string(cfg.irq));
       }
     }
-    cfg.affinity = parse_affinity(iq, "irq=" + std::to_string(cfg.irq));
+    cfg.affinity =
+      parse_affinity(iq, "irq=" + std::to_string(cfg.irq), /*allow_unmanageable=*/true);
   }
 
   std::unordered_set<int> seen;

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -31,6 +31,9 @@ constexpr int k_nice_min = -20;
 constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
 constexpr int k_rt_priority_max = 99;
+// task->comm is truncated to TASK_COMM_LEN - 1 characters and the apply step
+// matches scanned comms exactly, so a longer configured comm can never match.
+constexpr size_t k_max_comm_len = 15;
 
 bool is_cfs_policy(const std::string & policy)
 {
@@ -273,33 +276,50 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
   if (!section || section.IsNull()) {
     return result;
   }
+  if (!section.IsSequence()) {
+    throw std::runtime_error("'kernel_threads' must be a list");
+  }
   result.resize(section.size());
 
   for (size_t i = 0; i < section.size(); ++i) {
     const auto & kt = section[i];
     auto & cfg = result[i];
+    const std::string entry_pos = "kernel_threads entry #" + std::to_string(i);
 
-    if (is_unset(kt["comm"])) {
-      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+    if (!kt["comm"] || kt["comm"].IsNull()) {
+      throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
     }
     cfg.comm = kt["comm"].as<std::string>();
     if (cfg.comm.empty()) {
-      throw std::runtime_error("A kernel_threads entry is missing a non-empty 'comm'");
+      throw std::runtime_error(entry_pos + " is missing a non-empty 'comm'");
     }
-    if (cfg.comm.compare(0, 8, "kworker/") == 0) {
+    constexpr std::string_view kworker_prefix = "kworker/";
+    if (cfg.comm.compare(0, kworker_prefix.size(), kworker_prefix) == 0) {
       throw std::runtime_error(
         "kernel_threads entry '" + cfg.comm +
         "' is not manageable: kworker comms are ephemeral and mutate at runtime, so they cannot "
         "be matched reliably");
     }
+    if (cfg.comm.size() > k_max_comm_len) {
+      throw std::runtime_error(
+        "kernel_threads entry '" + cfg.comm +
+        "' can never match: the kernel truncates thread "
+        "comms to " +
+        std::to_string(k_max_comm_len) + " characters");
+    }
 
     if (!is_unset(kt["affinity"])) {
-      for (auto & cpu : kt["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+      cfg.affinity = parse_affinity(kt, "comm=" + cfg.comm);
     }
 
     const bool has_policy = !is_unset(kt["policy"]);
+    const bool has_nice = !is_unset(kt["nice"]);
     const bool has_priority = !is_unset(kt["priority"]);
     if (!has_policy) {
+      if (has_nice) {
+        throw std::runtime_error(
+          "'nice' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
+      }
       if (has_priority) {
         throw std::runtime_error(
           "'priority' requires 'policy' for comm=" + cfg.comm + ": set both or leave both unset");
@@ -325,12 +345,18 @@ std::vector<KernelThreadConfig> parse_kernel_threads(const YAML::Node & yaml)
       cfg.runtime = kt["runtime"].as<unsigned int>();
       cfg.period = kt["period"].as<unsigned int>();
       cfg.deadline = kt["deadline"].as<unsigned int>();
+    } else if (is_cfs_policy(*cfg.policy)) {
+      if (!has_nice) {
+        throw std::runtime_error(
+          "Policy '" + *cfg.policy + "' requires 'nice' for comm=" + cfg.comm);
+      }
+      cfg.nice = parse_nice(kt, *cfg.policy, "comm=" + cfg.comm);
     } else {
       if (!has_priority) {
         throw std::runtime_error(
           "Policy '" + *cfg.policy + "' requires 'priority' for comm=" + cfg.comm);
       }
-      cfg.priority = kt["priority"].as<int>();
+      cfg.priority = parse_rt_priority(kt, *cfg.policy, "comm=" + cfg.comm);
     }
   }
 
@@ -351,29 +377,33 @@ std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml)
   if (!section || section.IsNull()) {
     return result;
   }
+  if (!section.IsSequence()) {
+    throw std::runtime_error("'irqs' must be a list");
+  }
   result.resize(section.size());
 
   for (size_t i = 0; i < section.size(); ++i) {
     const auto & iq = section[i];
     auto & cfg = result[i];
+    const std::string entry_pos = "irqs entry #" + std::to_string(i);
 
-    if (is_unset(iq["irq"]) || !iq["irq"].IsScalar()) {
-      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+    if (!iq["irq"] || iq["irq"].IsNull()) {
+      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
     }
     try {
       cfg.irq = iq["irq"].as<int>();
     } catch (const YAML::Exception &) {
-      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
     }
     if (cfg.irq < 0) {
-      throw std::runtime_error("An irqs entry is missing a non-negative integer 'irq'");
+      throw std::runtime_error(entry_pos + " is missing a non-negative integer 'irq'");
     }
 
-    if (!is_unset(iq["name"])) {
+    if (iq["name"] && !iq["name"].IsNull()) {
       cfg.name = iq["name"].as<std::string>();
     }
     if (!is_unset(iq["affinity"])) {
-      for (auto & cpu : iq["affinity"]) cfg.affinity.push_back(cpu.as<int>());
+      cfg.affinity = parse_affinity(iq, "irq=" + std::to_string(cfg.irq));
     }
   }
 

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -20,6 +20,29 @@ YAML::Node yaml_from_str(const char * s)
 {
   return YAML::Load(s);
 }
+
+// EXPECT_THROW alone cannot tell WHICH validation fired (every failure path
+// derives from std::runtime_error), so the negative tests also match a
+// distinguishing fragment of the message.
+void expect_kernel_threads_error(const char * yaml, const std::string & fragment)
+{
+  try {
+    acie::parse_kernel_threads(yaml_from_str(yaml));
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos) << e.what();
+  }
+}
+
+void expect_irqs_error(const char * yaml, const std::string & fragment)
+{
+  try {
+    acie::parse_irqs(yaml_from_str(yaml));
+    FAIL() << "expected std::runtime_error";
+  } catch (const std::runtime_error & e) {
+    EXPECT_NE(std::string(e.what()).find(fragment), std::string::npos) << e.what();
+  }
+}
 }  // namespace
 
 // ---------- parse_yaml ----------
@@ -844,24 +867,24 @@ TEST(ParseKernelThreads, RejectsScalarAndOutOfRangeAffinity)
 {
   // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
   // silently mean "leave alone".
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: nfsd
     policy: ~
     priority: ~
     affinity: 0-3
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+)YAML",
+    "'affinity' must be a list");
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: nfsd
     policy: ~
     priority: ~
     affinity: [-1]
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "'affinity' CPU -1 must be in");
 }
 
 TEST(ParseKernelThreads, PolicyWithUnmanageableAffinityIsManaged)
@@ -903,67 +926,85 @@ kernel_threads:
 TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
 {
   // Only the exact uppercase sentinel disengages an attribute; anything else
-  // must fall through to the normal validation (here: unknown policy).
-  auto y = yaml_from_str(R"YAML(
+  // must fall through to the normal validation (here: unknown policy). No
+  // other attribute key is set, so a case-insensitive sentinel match would
+  // parse cleanly and fail the test.
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: unmanageable
-    priority: 0
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "Unknown scheduling policy 'unmanageable'");
 }
 
 TEST(ParseKernelThreads, RejectsMissingOrEmptyComm)
 {
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - policy: ~
     priority: ~
     affinity: ~
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+)YAML",
+    "is missing a non-empty 'comm'");
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: ""
     policy: ~
     priority: ~
     affinity: ~
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "is missing a non-empty 'comm'");
+}
+
+TEST(ParseKernelThreads, RejectsNonStringComm)
+{
+  expect_kernel_threads_error(
+    R"YAML(
+kernel_threads:
+  - comm: [a, b]
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML",
+    "'comm' must be a string");
 }
 
 TEST(ParseKernelThreads, RejectsKworkerComm)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: kworker/0:0H-events_highpri
     policy: ~
     priority: ~
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "kworker comms are ephemeral");
 }
 
 TEST(ParseKernelThreads, RejectsCommLongerThanKernelLimit)
 {
   // "agnocast_exit_worker" scans as "agnocast_exit_w", so this entry could
   // never match and would be silently dead configuration.
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: agnocast_exit_worker
     policy: ~
     priority: ~
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "can never match");
 }
 
 TEST(ParseKernelThreads, RejectsDuplicateComm)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: nfsd
     policy: ~
@@ -973,125 +1014,160 @@ kernel_threads:
     policy: ~
     priority: ~
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "Duplicate kernel_thread entry: comm=nfsd");
 }
 
 TEST(ParseKernelThreads, RejectsUnknownPolicy)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: SCHED_BOGUS
     priority: 0
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "Unknown scheduling policy 'SCHED_BOGUS'");
 }
 
 TEST(ParseKernelThreads, RejectsPriorityWithoutPolicy)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: ~
     priority: 5
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "'priority' requires 'policy'");
 }
 
 TEST(ParseKernelThreads, RejectsNiceWithoutPolicy)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: ~
     nice: 5
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "'nice' requires 'policy'");
 }
 
 TEST(ParseKernelThreads, RejectsCfsPolicyWithoutNice)
 {
   // As in callback_groups, a CFS policy takes 'nice'; 'priority' does not
   // satisfy the requirement.
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: SCHED_OTHER
     priority: 5
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "requires 'nice'");
 }
 
 TEST(ParseKernelThreads, RejectsOutOfRangeNiceAndRtPriority)
 {
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: nfsd
     policy: SCHED_OTHER
     nice: 50
     affinity: ~
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+)YAML",
+    "'nice' must be in [-20, 19]");
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: nfsd
     policy: SCHED_FIFO
     priority: 150
     affinity: ~
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "'priority' must be in [1, 99]");
 }
 
 TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
 {
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: SCHED_FIFO
     priority: ~
     affinity: ~
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "requires 'priority'");
   // The sentinel counts as unset exactly like null does.
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: rcu_preempt
     policy: SCHED_FIFO
     priority: UNMANAGEABLE
     affinity: ~
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "requires 'priority'");
 }
 
 TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_kernel_threads_error(
+    R"YAML(
 kernel_threads:
   - comm: dl_thread
     policy: SCHED_DEADLINE
     runtime: 1000000
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+)YAML",
+    "SCHED_DEADLINE requires 'runtime', 'period' and 'deadline'");
+}
+
+TEST(ParseKernelThreads, RejectsMalformedSchedDeadlineFields)
+{
+  expect_kernel_threads_error(
+    R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: -5
+    period: 5000000
+    deadline: 5000000
+    affinity: ~
+)YAML",
+    "'runtime' must be a non-negative integer for comm=dl_thread");
+  expect_kernel_threads_error(
+    R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: not_a_number
+    deadline: 5000000
+    affinity: ~
+)YAML",
+    "'period' must be a non-negative integer for comm=dl_thread");
 }
 
 TEST(ParseKernelThreads, RejectsNonListSection)
 {
   // A scalar or map section would otherwise silently parse as empty.
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str("kernel_threads: oops\n")), std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_kernel_threads(yaml_from_str("kernel_threads:\n  comm: nfsd\n")),
-    std::runtime_error);
+  expect_kernel_threads_error("kernel_threads: oops\n", "'kernel_threads' must be a list");
+  expect_kernel_threads_error("kernel_threads:\n  comm: nfsd\n", "'kernel_threads' must be a list");
+}
+
+TEST(ParseKernelThreads, RejectsScalarListEntry)
+{
+  // A plausible shorthand (a list of bare comms) must fail with the entry
+  // diagnostic, not a raw yaml-cpp BadSubscript.
+  expect_kernel_threads_error("kernel_threads: [nfsd]\n", "entry #0 must be a mapping");
 }
 
 // ---------- parse_irqs ----------
@@ -1151,65 +1227,73 @@ irqs:
 
 TEST(ParseIrqs, RejectsMissingOrNegativeOrNonIntIrq)
 {
-  EXPECT_THROW(
-    acie::parse_irqs(yaml_from_str(R"YAML(
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - name: orphan
     affinity: ~
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_irqs(yaml_from_str(R"YAML(
+)YAML",
+    "is missing a non-negative integer 'irq'");
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - irq: -1
     affinity: ~
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_irqs(yaml_from_str(R"YAML(
+)YAML",
+    "'irq' must be non-negative, got -1");
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - irq: not_a_number
     affinity: ~
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "'irq' must be an integer, got 'not_a_number'");
 }
 
 TEST(ParseIrqs, RejectsDuplicateIrq)
 {
-  auto y = yaml_from_str(R"YAML(
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - irq: 5
     affinity: ~
   - irq: 5
     affinity: ~
-)YAML");
-  EXPECT_THROW(acie::parse_irqs(y), std::runtime_error);
+)YAML",
+    "Duplicate irq entry: irq=5");
 }
 
 TEST(ParseIrqs, RejectsScalarAndOutOfRangeAffinity)
 {
   // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
   // silently mean "leave alone".
-  EXPECT_THROW(
-    acie::parse_irqs(yaml_from_str(R"YAML(
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - irq: 10
     affinity: 0-3
-)YAML")),
-    std::runtime_error);
-  EXPECT_THROW(
-    acie::parse_irqs(yaml_from_str(R"YAML(
+)YAML",
+    "'affinity' must be a list");
+  expect_irqs_error(
+    R"YAML(
 irqs:
   - irq: 10
     affinity: [-1]
-)YAML")),
-    std::runtime_error);
+)YAML",
+    "'affinity' CPU -1 must be in");
 }
 
 TEST(ParseIrqs, RejectsNonListSection)
 {
-  EXPECT_THROW(acie::parse_irqs(yaml_from_str("irqs: oops\n")), std::runtime_error);
-  EXPECT_THROW(acie::parse_irqs(yaml_from_str("irqs:\n  irq: 5\n")), std::runtime_error);
+  expect_irqs_error("irqs: oops\n", "'irqs' must be a list");
+  expect_irqs_error("irqs:\n  irq: 5\n", "'irqs' must be a list");
+}
+
+TEST(ParseIrqs, RejectsScalarListEntry)
+{
+  // A plausible shorthand (a list of bare IRQ numbers) must fail with the
+  // entry diagnostic, not a raw yaml-cpp BadSubscript.
+  expect_irqs_error("irqs: [42]\n", "entry #0 must be a mapping");
 }
 
 // ---------- new sections vs parse_yaml ----------

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -740,20 +740,39 @@ TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
 
 TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
 {
+  // CPUs 0/1 only, to keep this test valid on small CI machines; the comm is
+  // the truncated form of the kmod's "agnocast_exit_worker" thread.
   auto y = yaml_from_str(R"YAML(
 kernel_threads:
-  - comm: agnocast_exit_worker
+  - comm: agnocast_exit_w
     policy: SCHED_FIFO
     priority: 10
-    affinity: [2, 3]
+    affinity: [0, 1]
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
-  EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
+  EXPECT_EQ(result[0].comm, "agnocast_exit_w");
   ASSERT_TRUE(result[0].policy.has_value());
   EXPECT_EQ(*result[0].policy, "SCHED_FIFO");
   EXPECT_EQ(result[0].priority, 10);
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, ParsesCfsPolicyWithNice)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: SCHED_OTHER
+    nice: -10
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_EQ(*result[0].policy, "SCHED_OTHER");
+  EXPECT_EQ(result[0].nice, -10);
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -763,6 +782,7 @@ TEST(ParseKernelThreads, AllNullEntryIsUnmanaged)
 kernel_threads:
   - comm: rcu_preempt
     policy: ~
+    nice: ~
     priority: ~
     affinity: ~
 )YAML");
@@ -779,6 +799,7 @@ TEST(ParseKernelThreads, UnmanageableSentinelEqualsNull)
 kernel_threads:
   - comm: ksoftirqd/0
     policy: UNMANAGEABLE
+    nice: UNMANAGEABLE
     priority: UNMANAGEABLE
     affinity: UNMANAGEABLE
 )YAML");
@@ -793,16 +814,54 @@ TEST(ParseKernelThreads, AffinityOnlyEntryIsManaged)
 {
   auto y = yaml_from_str(R"YAML(
 kernel_threads:
-  - comm: agnocast_exit_worker
+  - comm: agnocast_exit_w
     policy: ~
     priority: ~
-    affinity: [2]
+    affinity: [1]
 )YAML");
   const auto result = acie::parse_kernel_threads(y);
   ASSERT_EQ(result.size(), 1u);
   EXPECT_FALSE(result[0].policy.has_value());
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{2}));
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{1}));
   EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, NormalizesAffinityToSortedUnique)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: [1, 0, 1]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
+}
+
+TEST(ParseKernelThreads, RejectsScalarAndOutOfRangeAffinity)
+{
+  // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
+  // silently mean "leave alone".
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: 0-3
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: [-1]
+)YAML")),
+    std::runtime_error);
 }
 
 TEST(ParseKernelThreads, PolicyWithUnmanageableAffinityIsManaged)
@@ -888,6 +947,20 @@ kernel_threads:
   EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
 }
 
+TEST(ParseKernelThreads, RejectsCommLongerThanKernelLimit)
+{
+  // "agnocast_exit_worker" scans as "agnocast_exit_w", so this entry could
+  // never match and would be silently dead configuration.
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
 TEST(ParseKernelThreads, RejectsDuplicateComm)
 {
   auto y = yaml_from_str(R"YAML(
@@ -928,6 +1001,54 @@ kernel_threads:
   EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
 }
 
+TEST(ParseKernelThreads, RejectsNiceWithoutPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: ~
+    nice: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsCfsPolicyWithoutNice)
+{
+  // As in callback_groups, a CFS policy takes 'nice'; 'priority' does not
+  // satisfy the requirement.
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_OTHER
+    priority: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsOutOfRangeNiceAndRtPriority)
+{
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: SCHED_OTHER
+    nice: 50
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: SCHED_FIFO
+    priority: 150
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
 TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
 {
   EXPECT_THROW(
@@ -963,6 +1084,16 @@ kernel_threads:
   EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
 }
 
+TEST(ParseKernelThreads, RejectsNonListSection)
+{
+  // A scalar or map section would otherwise silently parse as empty.
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str("kernel_threads: oops\n")), std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str("kernel_threads:\n  comm: nfsd\n")),
+    std::runtime_error);
+}
+
 // ---------- parse_irqs ----------
 
 TEST(ParseIrqs, MissingOrNullSectionYieldsEmpty)
@@ -978,13 +1109,13 @@ TEST(ParseIrqs, ParsesFilledAffinityAndName)
 irqs:
   - irq: 103
     name: nvidia
-    affinity: [2, 3]
+    affinity: [1, 0]
 )YAML");
   const auto result = acie::parse_irqs(y);
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0].irq, 103);
   EXPECT_EQ(result[0].name, "nvidia");
-  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{0, 1}));
   EXPECT_TRUE(result[0].is_managed());
 }
 
@@ -1055,6 +1186,32 @@ irqs:
   EXPECT_THROW(acie::parse_irqs(y), std::runtime_error);
 }
 
+TEST(ParseIrqs, RejectsScalarAndOutOfRangeAffinity)
+{
+  // A scalar (e.g. a cpu-list string copied from a scan) would otherwise
+  // silently mean "leave alone".
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: 10
+    affinity: 0-3
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: 10
+    affinity: [-1]
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseIrqs, RejectsNonListSection)
+{
+  EXPECT_THROW(acie::parse_irqs(yaml_from_str("irqs: oops\n")), std::runtime_error);
+  EXPECT_THROW(acie::parse_irqs(yaml_from_str("irqs:\n  irq: 5\n")), std::runtime_error);
+}
+
 // ---------- new sections vs parse_yaml ----------
 
 TEST(ParseYaml, IgnoresKernelThreadsAndIrqsSections)
@@ -1068,14 +1225,14 @@ callback_groups:
     affinity: []
 non_ros_threads: []
 kernel_threads:
-  - comm: agnocast_exit_worker
+  - comm: agnocast_exit_w
     policy: SCHED_FIFO
     priority: 10
-    affinity: [2]
+    affinity: [0]
 irqs:
   - irq: 103
     name: nvidia
-    affinity: [2, 3]
+    affinity: [0, 1]
 )YAML");
   std::vector<acie::ThreadConfig> cb, nrt;
   ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -763,8 +763,7 @@ TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
 
 TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
 {
-  // CPUs 0/1 only, to keep this test valid on small CI machines; the comm is
-  // the truncated form of the kmod's "agnocast_exit_worker" thread.
+  // CPUs 0/1 only, to keep this test valid on small CI machines.
   auto y = yaml_from_str(R"YAML(
 kernel_threads:
   - comm: agnocast_exit_w
@@ -986,19 +985,22 @@ kernel_threads:
     "kworker comms are ephemeral");
 }
 
-TEST(ParseKernelThreads, RejectsCommLongerThanKernelLimit)
+TEST(ParseKernelThreads, AcceptsCommLongerThan15Chars)
 {
-  // "agnocast_exit_worker" scans as "agnocast_exit_w", so this entry could
-  // never match and would be silently dead configuration.
-  expect_kernel_threads_error(
-    R"YAML(
+  // Since Linux 5.17 /proc reports a kthread's full name untruncated (e.g.
+  // the kmod's "agnocast_exit_worker"), so the scanner returns comms longer
+  // than TASK_COMM_LEN - 1 and they must round-trip through the parser.
+  auto y = yaml_from_str(R"YAML(
 kernel_threads:
   - comm: agnocast_exit_worker
     policy: ~
     priority: ~
-    affinity: ~
-)YAML",
-    "can never match");
+    affinity: [0]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
+  EXPECT_TRUE(result[0].is_managed());
 }
 
 TEST(ParseKernelThreads, RejectsDuplicateComm)
@@ -1105,7 +1107,8 @@ kernel_threads:
     affinity: ~
 )YAML",
     "requires 'priority'");
-  // The sentinel counts as unset exactly like null does.
+  // The sentinel counts as unset exactly like null does, and the message
+  // says so because the key is visibly present.
   expect_kernel_threads_error(
     R"YAML(
 kernel_threads:
@@ -1114,7 +1117,25 @@ kernel_threads:
     priority: UNMANAGEABLE
     affinity: ~
 )YAML",
-    "requires 'priority'");
+    "requires 'priority' for comm=rcu_preempt (UNMANAGEABLE counts as unset)");
+}
+
+TEST(ParseKernelThreads, RejectsDeadlineFieldsWithoutPolicy)
+{
+  // The full SCHED_DEADLINE triple with 'policy' forgotten would otherwise
+  // parse cleanly as unmanaged, the same silently dead configuration the
+  // nice/priority guard rejects.
+  expect_kernel_threads_error(
+    R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: ~
+    runtime: 1000000
+    period: 5000000
+    deadline: 5000000
+    affinity: ~
+)YAML",
+    "'runtime' requires 'policy'");
 }
 
 TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
@@ -1142,7 +1163,7 @@ kernel_threads:
     deadline: 5000000
     affinity: ~
 )YAML",
-    "'runtime' must be a non-negative integer for comm=dl_thread");
+    "'runtime' must be a non-negative decimal integer for comm=dl_thread");
   expect_kernel_threads_error(
     R"YAML(
 kernel_threads:
@@ -1153,7 +1174,37 @@ kernel_threads:
     deadline: 5000000
     affinity: ~
 )YAML",
-    "'period' must be a non-negative integer for comm=dl_thread");
+    "'period' must be a non-negative decimal integer for comm=dl_thread");
+  // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
+  expect_kernel_threads_error(
+    R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: 5000000
+    deadline: 0x10
+    affinity: ~
+)YAML",
+    "'deadline' must be a non-negative decimal integer for comm=dl_thread");
+}
+
+TEST(ParseKernelThreads, ParsesZeroPaddedDeadlineFieldAsBase10)
+{
+  // yaml-cpp's base auto-detection would read "0500000" as octal; a
+  // zero-padded column must mean decimal.
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 0500000
+    period: 5000000
+    deadline: 5000000
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].runtime, 500000u);
 }
 
 TEST(ParseKernelThreads, RejectsNonListSection)
@@ -1240,14 +1291,40 @@ irqs:
   - irq: -1
     affinity: ~
 )YAML",
-    "'irq' must be non-negative, got -1");
+    "'irq' must be a non-negative decimal integer, got '-1'");
   expect_irqs_error(
     R"YAML(
 irqs:
   - irq: not_a_number
     affinity: ~
 )YAML",
-    "'irq' must be an integer, got 'not_a_number'");
+    "'irq' must be a non-negative decimal integer, got 'not_a_number'");
+}
+
+TEST(ParseIrqs, ParsesZeroPaddedIrqAsBase10)
+{
+  // yaml-cpp's as<int>() would read "010" as octal 8 and silently target a
+  // different interrupt; a zero-padded column must mean decimal 10.
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 010
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 10);
+}
+
+TEST(ParseIrqs, RejectsHexIrq)
+{
+  // yaml-cpp would read "0x10" as 16; only plain decimal digits are valid.
+  expect_irqs_error(
+    R"YAML(
+irqs:
+  - irq: 0x10
+    affinity: ~
+)YAML",
+    "'irq' must be a non-negative decimal integer, got '0x10'");
 }
 
 TEST(ParseIrqs, RejectsDuplicateIrq)
@@ -1323,4 +1400,31 @@ irqs:
   ASSERT_EQ(cb.size(), 1u);
   EXPECT_EQ(cb[0].thread_str, "my_cbg");
   EXPECT_TRUE(nrt.empty());
+}
+
+TEST(ParseYaml, UnmanageableSentinelIsNotRecognized)
+{
+  // The sentinel is scoped to kernel_threads/irqs (the tool writes it there);
+  // in the hand-written sections it must fail like any other invalid value,
+  // not silently mean "leave the attribute alone".
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    policy: SCHED_FIFO
+    priority: 50
+    affinity: UNMANAGEABLE
+non_ros_threads: []
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  EXPECT_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt), std::runtime_error);
+
+  auto y2 = yaml_from_str(R"YAML(
+callback_groups: []
+non_ros_threads:
+  - name: my_thread
+    policy: SCHED_OTHER
+    nice: UNMANAGEABLE
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_yaml(y2, kTestDefaultDomain, cb, nrt), std::runtime_error);
 }

--- a/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/test/test_thread_config.cpp
@@ -728,3 +728,358 @@ TEST(ExtractNodePart, SplitsAtFirstAtSign)
   EXPECT_EQ(acie::extract_node_part("@Timer(1)"), "");
   EXPECT_EQ(acie::extract_node_part(""), "");
 }
+
+// ---------- parse_kernel_threads ----------
+
+TEST(ParseKernelThreads, MissingOrNullSectionYieldsEmpty)
+{
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("callback_groups: []\n")).empty());
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: ~\n")).empty());
+  EXPECT_TRUE(acie::parse_kernel_threads(yaml_from_str("kernel_threads: []\n")).empty());
+}
+
+TEST(ParseKernelThreads, ParsesPolicyPriorityAffinity)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: SCHED_FIFO
+    priority: 10
+    affinity: [2, 3]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].comm, "agnocast_exit_worker");
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_EQ(*result[0].policy, "SCHED_FIFO");
+  EXPECT_EQ(result[0].priority, 10);
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, AllNullEntryIsUnmanaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, UnmanageableSentinelEqualsNull)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ksoftirqd/0
+    policy: UNMANAGEABLE
+    priority: UNMANAGEABLE
+    affinity: UNMANAGEABLE
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_FALSE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, AffinityOnlyEntryIsManaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: ~
+    priority: ~
+    affinity: [2]
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_FALSE(result[0].policy.has_value());
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, PolicyWithUnmanageableAffinityIsManaged)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ksoftirqd/0
+    policy: SCHED_FIFO
+    priority: 5
+    affinity: UNMANAGEABLE
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_TRUE(result[0].affinity.empty());
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseKernelThreads, ParsesSchedDeadline)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    period: 5000000
+    deadline: 5000000
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_kernel_threads(y);
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_TRUE(result[0].policy.has_value());
+  EXPECT_EQ(*result[0].policy, "SCHED_DEADLINE");
+  EXPECT_EQ(result[0].runtime, 1000000u);
+  EXPECT_EQ(result[0].period, 5000000u);
+  EXPECT_EQ(result[0].deadline, 5000000u);
+}
+
+TEST(ParseKernelThreads, LowercaseSentinelIsNotRecognized)
+{
+  // Only the exact uppercase sentinel disengages an attribute; anything else
+  // must fall through to the normal validation (here: unknown policy).
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: unmanageable
+    priority: 0
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsMissingOrEmptyComm)
+{
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - policy: ~
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: ""
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsKworkerComm)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: kworker/0:0H-events_highpri
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsDuplicateComm)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: ~
+  - comm: nfsd
+    policy: ~
+    priority: ~
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsUnknownPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_BOGUS
+    priority: 0
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsPriorityWithoutPolicy)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: ~
+    priority: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsPolicyWithoutPriority)
+{
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_FIFO
+    priority: ~
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  // The sentinel counts as unset exactly like null does.
+  EXPECT_THROW(
+    acie::parse_kernel_threads(yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: rcu_preempt
+    policy: SCHED_FIFO
+    priority: UNMANAGEABLE
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseKernelThreads, RejectsSchedDeadlineMissingFields)
+{
+  auto y = yaml_from_str(R"YAML(
+kernel_threads:
+  - comm: dl_thread
+    policy: SCHED_DEADLINE
+    runtime: 1000000
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_kernel_threads(y), std::runtime_error);
+}
+
+// ---------- parse_irqs ----------
+
+TEST(ParseIrqs, MissingOrNullSectionYieldsEmpty)
+{
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("callback_groups: []\n")).empty());
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: ~\n")).empty());
+  EXPECT_TRUE(acie::parse_irqs(yaml_from_str("irqs: []\n")).empty());
+}
+
+TEST(ParseIrqs, ParsesFilledAffinityAndName)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 103
+    name: nvidia
+    affinity: [2, 3]
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0].irq, 103);
+  EXPECT_EQ(result[0].name, "nvidia");
+  EXPECT_EQ(result[0].affinity, (std::vector<int>{2, 3}));
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseIrqs, NullOrUnmanageableAffinityIsUnmanaged)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 0
+    name: timer
+    affinity: UNMANAGEABLE
+  - irq: 1
+    name: i8042
+    affinity: ~
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_FALSE(result[0].is_managed());
+  EXPECT_FALSE(result[1].is_managed());
+}
+
+TEST(ParseIrqs, MissingNameMeansNoVerification)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 42
+    affinity: [1]
+)YAML");
+  const auto result = acie::parse_irqs(y);
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_TRUE(result[0].name.empty());
+  EXPECT_TRUE(result[0].is_managed());
+}
+
+TEST(ParseIrqs, RejectsMissingOrNegativeOrNonIntIrq)
+{
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - name: orphan
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: -1
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+  EXPECT_THROW(
+    acie::parse_irqs(yaml_from_str(R"YAML(
+irqs:
+  - irq: not_a_number
+    affinity: ~
+)YAML")),
+    std::runtime_error);
+}
+
+TEST(ParseIrqs, RejectsDuplicateIrq)
+{
+  auto y = yaml_from_str(R"YAML(
+irqs:
+  - irq: 5
+    affinity: ~
+  - irq: 5
+    affinity: ~
+)YAML");
+  EXPECT_THROW(acie::parse_irqs(y), std::runtime_error);
+}
+
+// ---------- new sections vs parse_yaml ----------
+
+TEST(ParseYaml, IgnoresKernelThreadsAndIrqsSections)
+{
+  auto y = yaml_from_str(R"YAML(
+callback_groups:
+  - id: my_cbg
+    domain_id: 0
+    policy: SCHED_OTHER
+    nice: 0
+    affinity: []
+non_ros_threads: []
+kernel_threads:
+  - comm: agnocast_exit_worker
+    policy: SCHED_FIFO
+    priority: 10
+    affinity: [2]
+irqs:
+  - irq: 103
+    name: nvidia
+    affinity: [2, 3]
+)YAML");
+  std::vector<acie::ThreadConfig> cb, nrt;
+  ASSERT_NO_THROW(acie::parse_yaml(y, kTestDefaultDomain, cb, nrt));
+  ASSERT_EQ(cb.size(), 1u);
+  EXPECT_EQ(cb[0].thread_str, "my_cbg");
+  EXPECT_TRUE(nrt.empty());
+}


### PR DESCRIPTION
## Description

Part 2 of 4 splitting #1528 into reviewable units.

Adds parsers for two new optional sections in the thread configurator YAML:

- `kernel_threads` (`KernelThreadConfig`, `parse_kernel_threads()`): desired policy, nice/priority, and affinity per kernel thread comm. The schema follows `callback_groups`: CFS policies (`SCHED_OTHER`/`BATCH`/`IDLE`) take a `nice` key validated against [-20, 19], while `SCHED_FIFO`/`SCHED_RR` take a `priority` key validated against [1, 99], reusing the same helpers and rationale (the syscalls silently clamp or fail only at apply time). Validation: a non-empty `comm` of at most 15 characters is required (the kernel truncates `task->comm`, so a longer comm could never match a scanned thread), `kworker/*` comms are rejected, `nice`/`priority` require `policy` (and vice versa per policy class), `SCHED_DEADLINE` requires `runtime`/`period`/`deadline`, and duplicate comms are rejected.
- `irqs` (`IrqConfig`, `parse_irqs()`): desired affinity per IRQ number, with an optional expected `name` (the `/sys/kernel/irq/<N>/actions` content) that the apply step uses to detect IRQ renumbering across boots. A non-negative integer `irq` is required and duplicates are rejected.
- `UNMANAGEABLE` sentinel (`k_unmanageable`): marks attribute values the kernel or this tool cannot manage, as opposed to YAML null which is the user's opt-out. Both parse to "not applied". The sentinel applies only to attribute values (`policy`/`nice`/`priority`/`affinity`/`runtime`/`period`/`deadline`), not to the identity keys `comm` and `name`.

Both sections share `parse_affinity()` with the existing parsers, so affinity values must be a list, are bounds-checked against the machine CPU count, and come out sorted and deduplicated; a scalar value (e.g. a cpu-list string copied from a scan) is rejected instead of silently meaning "leave alone". A section that is present but not a list is rejected rather than parsed as empty, and error messages identify the failing entry by index when no comm/irq is available yet.

Missing or null sections yield empty vectors, so pre-existing YAML files keep working unchanged. Unit tests cover the validation rules.

The parsers gain callers in the follow-up PRs of the stack (prerun template generation and apply logic).

## Related links

- Split from #1528
- Stacked on #1543

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

The base branch is #1543 only to keep the stack linear; this PR does not use the system_scan module and can be reviewed independently.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.