### PR TITLE
feat(agnocast_cie_thread_configurator): emit kernel_threads and irqs sections in prerun template

### DIFF
--- a/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
+++ b/src/agnocast_cie_thread_configurator/include/agnocast_cie_thread_configurator/thread_config.hpp
@@ -100,6 +100,11 @@ std::vector<IrqConfig> parse_irqs(const YAML::Node & yaml);
 // Defined in thread_config.cpp; both the parser and issue_syscalls() use it.
 extern const std::unordered_map<std::string, int> policy_to_sched_const;
 
+// True for the CFS policies (SCHED_OTHER/BATCH/IDLE), whose tunable is nice;
+// the RT policies' tunable is priority. The template emitter and the parser
+// must agree on this split.
+bool is_cfs_policy(const std::string & policy);
+
 // Parse the given YAML document and populate the two output vectors.
 // Throws std::runtime_error on per-entry validation error. Output ThreadConfigs
 // have thread_id=-1 and applied=false; callers that re-parse must carry

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -8,9 +8,14 @@
 
 #include "agnocast_cie_config_msgs/msg/callback_group_info.hpp"
 
+#include <sched.h>
+#include <unistd.h>
+
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -25,13 +30,32 @@ namespace
 std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> dedup_by_comm(
   std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> scanned)
 {
-  std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> result;
-  for (auto & info : scanned) {
-    if (result.empty() || result.back().comm != info.comm) {
-      result.push_back(std::move(info));
-    }
+  scanned.erase(
+    std::unique(
+      scanned.begin(), scanned.end(),
+      [](const auto & a, const auto & b) { return a.comm == b.comm; }),
+    scanned.end());
+  return scanned;
+}
+
+// The kernel prints affinity over the possible-CPU mask, which can include
+// CPUs the apply-side parser rejects (it bounds them by the present CPUs);
+// keep only acceptable CPUs so the untouched template stays loadable.
+std::optional<std::vector<int>> parse_manageable_cpu_list(const std::string & raw)
+{
+  auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(raw);
+  if (!cpus) {
+    return std::nullopt;
   }
-  return result;
+  const long num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+  const int max_cpu = static_cast<int>(std::min<long>(CPU_SETSIZE, num_cpus)) - 1;
+  cpus->erase(
+    std::remove_if(cpus->begin(), cpus->end(), [max_cpu](int cpu) { return cpu > max_cpu; }),
+    cpus->end());
+  if (cpus->empty()) {
+    return std::nullopt;
+  }
+  return cpus;
 }
 
 }  // namespace
@@ -217,6 +241,16 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   RCLCPP_INFO(
     this->get_logger(), "Scanned %zu kernel thread comms and %zu device-backed IRQs",
     kernel_threads.size(), irqs.size());
+  if (kernel_threads.empty()) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "No kernel threads found; the /proc scan likely failed (restricted /proc?)");
+  }
+  if (irqs.empty()) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "No device-backed IRQs found; is /sys/kernel/irq available (kernel >= 4.12)?");
+  }
 
   out << YAML::Key << "kernel_threads";
   out << YAML::Value << YAML::BeginSeq;
@@ -227,13 +261,12 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     const bool policy_representable =
       agnocast_cie_thread_configurator::policy_to_sched_const.count(info.policy) > 0 &&
       info.policy != "SCHED_DEADLINE";
-    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+    const auto cpus = parse_manageable_cpu_list(info.affinity);
 
     out << YAML::BeginMap;
     out << YAML::Key << "comm" << YAML::Value << info.comm;
     if (policy_representable) {
-      const bool is_cfs =
-        info.policy == "SCHED_OTHER" || info.policy == "SCHED_BATCH" || info.policy == "SCHED_IDLE";
+      const bool is_cfs = agnocast_cie_thread_configurator::is_cfs_policy(info.policy);
       out << YAML::Key << "policy" << YAML::Value << info.policy;
       if (is_cfs) {
         out << YAML::Key << "nice" << YAML::Value << info.nice;
@@ -260,7 +293,7 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
   out << YAML::Value << YAML::BeginSeq;
 
   for (const auto & info : irqs) {
-    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+    const auto cpus = parse_manageable_cpu_list(info.affinity);
 
     out << YAML::BeginMap;
     out << YAML::Key << "irq" << YAML::Value << info.irq;

--- a/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
+++ b/src/agnocast_cie_thread_configurator/src/prerun_node.cpp
@@ -1,6 +1,8 @@
 #include "agnocast_cie_thread_configurator/prerun_node.hpp"
 
 #include "agnocast_cie_thread_configurator/cie_thread_configurator.hpp"
+#include "agnocast_cie_thread_configurator/system_scan.hpp"
+#include "agnocast_cie_thread_configurator/thread_config.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "yaml-cpp/yaml.h"
 
@@ -12,6 +14,27 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
+
+namespace
+{
+
+// One template entry per comm (it manages every thread sharing that comm).
+// The scan is sorted by (comm, tid), so the kept observed values are the
+// lowest tid's.
+std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> dedup_by_comm(
+  std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> scanned)
+{
+  std::vector<agnocast_cie_thread_configurator::KernelThreadInfo> result;
+  for (auto & info : scanned) {
+    if (result.empty() || result.back().comm != info.comm) {
+      result.push_back(std::move(info));
+    }
+  }
+  return result;
+}
+
+}  // namespace
 
 PrerunNode::PrerunNode(const rclcpp::NodeOptions & options) : Node("prerun_node", options)
 {
@@ -177,6 +200,76 @@ void PrerunNode::dump_yaml_config(std::filesystem::path path)
     emit_unmanaged_affinity();
     out << YAML::Key << "policy" << YAML::Value << "SCHED_OTHER";
     out << YAML::Key << "nice" << YAML::Value << 0;
+    out << YAML::EndMap;
+    out << YAML::Newline;
+  }
+
+  out << YAML::EndSeq;
+
+  // Add kernel_threads and irqs sections: observed values become the initial
+  // desired values (compare-before-set keeps unedited entries no-ops), and
+  // UNMANAGEABLE marks values that cannot be provided or changed (YAML null
+  // stays the user's opt-out).
+  const std::string unmanageable(agnocast_cie_thread_configurator::k_unmanageable);
+  const auto kernel_threads =
+    dedup_by_comm(agnocast_cie_thread_configurator::scan_kernel_threads());
+  const auto irqs = agnocast_cie_thread_configurator::scan_irqs();
+  RCLCPP_INFO(
+    this->get_logger(), "Scanned %zu kernel thread comms and %zu device-backed IRQs",
+    kernel_threads.size(), irqs.size());
+
+  out << YAML::Key << "kernel_threads";
+  out << YAML::Value << YAML::BeginSeq;
+
+  for (const auto & info : kernel_threads) {
+    // A policy with no YAML representation: UNKNOWN(<n>), or SCHED_DEADLINE,
+    // whose runtime/period/deadline cannot be recovered from /proc.
+    const bool policy_representable =
+      agnocast_cie_thread_configurator::policy_to_sched_const.count(info.policy) > 0 &&
+      info.policy != "SCHED_DEADLINE";
+    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+
+    out << YAML::BeginMap;
+    out << YAML::Key << "comm" << YAML::Value << info.comm;
+    if (policy_representable) {
+      const bool is_cfs =
+        info.policy == "SCHED_OTHER" || info.policy == "SCHED_BATCH" || info.policy == "SCHED_IDLE";
+      out << YAML::Key << "policy" << YAML::Value << info.policy;
+      if (is_cfs) {
+        out << YAML::Key << "nice" << YAML::Value << info.nice;
+      } else {
+        out << YAML::Key << "priority" << YAML::Value << info.rt_priority;
+      }
+    } else {
+      out << YAML::Key << "policy" << YAML::Value << unmanageable;
+      out << YAML::Key << "priority" << YAML::Value << unmanageable;
+    }
+    if (info.no_setaffinity || !cpus) {
+      out << YAML::Key << "affinity" << YAML::Value << unmanageable;
+    } else {
+      out << YAML::Key << "affinity" << YAML::Value << YAML::Flow << *cpus;
+    }
+    out << YAML::EndMap;
+    out << YAML::Newline;
+  }
+
+  out << YAML::EndSeq;
+
+  // Add irqs section
+  out << YAML::Key << "irqs";
+  out << YAML::Value << YAML::BeginSeq;
+
+  for (const auto & info : irqs) {
+    const auto cpus = agnocast_cie_thread_configurator::parse_cpu_list(info.affinity);
+
+    out << YAML::BeginMap;
+    out << YAML::Key << "irq" << YAML::Value << info.irq;
+    out << YAML::Key << "name" << YAML::Value << info.name;
+    if (cpus) {
+      out << YAML::Key << "affinity" << YAML::Value << YAML::Flow << *cpus;
+    } else {
+      out << YAML::Key << "affinity" << YAML::Value << unmanageable;
+    }
     out << YAML::EndMap;
     out << YAML::Newline;
   }

--- a/src/agnocast_cie_thread_configurator/src/thread_config.cpp
+++ b/src/agnocast_cie_thread_configurator/src/thread_config.cpp
@@ -42,11 +42,6 @@ constexpr int k_nice_max = 19;
 constexpr int k_rt_priority_min = 1;
 constexpr int k_rt_priority_max = 99;
 
-bool is_cfs_policy(const std::string & policy)
-{
-  return policy == "SCHED_OTHER" || policy == "SCHED_BATCH" || policy == "SCHED_IDLE";
-}
-
 // 'nice' is required for the CFS policies (SCHED_OTHER/BATCH/IDLE);
 // parse_rt_priority is the mirror image for SCHED_FIFO/SCHED_RR. `entry_desc`
 // is the "id=..."/"name=..." fragment used in messages.
@@ -183,6 +178,11 @@ const std::unordered_map<std::string, int> policy_to_sched_const = {
   {"SCHED_OTHER", SCHED_OTHER}, {"SCHED_BATCH", SCHED_BATCH}, {"SCHED_IDLE", SCHED_IDLE},
   {"SCHED_FIFO", SCHED_FIFO},   {"SCHED_RR", SCHED_RR},       {"SCHED_DEADLINE", SCHED_DEADLINE},
 };
+
+bool is_cfs_policy(const std::string & policy)
+{
+  return policy == "SCHED_OTHER" || policy == "SCHED_BATCH" || policy == "SCHED_IDLE";
+}
 
 bool ThreadConfig::is_wildcard() const noexcept
 {


### PR DESCRIPTION
## Description

Part 3 of 4 splitting #1528 into reviewable units.

`prerun_node` now appends `kernel_threads` and `irqs` sections to the generated YAML template:

- Kernel threads are scanned via the system_scan module (#1543) and deduplicated by comm, since one template entry manages every thread sharing that comm. The scan is sorted by (comm, tid), so the kept observed values are the lowest tid's.
- Observed values become the initial desired values. Combined with compare-before-set in the apply step (part 4), unedited template entries stay no-ops.
- Values that cannot be represented or changed are emitted as `UNMANAGEABLE` (#1544): for policy/priority, unmapped policies and `SCHED_DEADLINE` (whose runtime/period/deadline cannot be recovered from `/proc`); for affinity, `PF_NO_SETAFFINITY` per-CPU kthreads and unreadable CPU lists. YAML null remains the user's explicit opt-out.

## Related links

- Split from #1528
- Stacked on #1544 (depends on both #1543 and #1544)

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

Please add **exactly one** of the following labels to this PR:

- `need-major-update`: User API breaking changes
- `need-minor-update`: Internal API breaking changes (kmod/agnocastlib compatibility)
- `need-patch-update`: Bug fixes and other changes

**Important notes:**

- If you need `need-major-update` or `need-minor-update`, please include this in the PR title as well.
  - Example: `fix(foo)[needs major version update]: bar` or `feat(baz)[needs minor version update]: qux`

See [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed versioning rules.