### PR TITLE
feat(agnocast_kmod)[need-minor-update]: add prefix domain bridge rules

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -297,6 +297,16 @@ struct ioctl_add_domain_bridge_args
   uint32_t to_domain;
 };
 
+// Bridges every topic whose name starts with topic_name_prefix, pairing it with the identical
+// name in the other domain. For topic families whose full names appear only at runtime and so
+// cannot be listed in a config -- an Agnocast service's per-client response topics.
+struct ioctl_add_domain_bridge_prefix_args
+{
+  struct name_info topic_name_prefix;
+  uint32_t from_domain;
+  uint32_t to_domain;
+};
+
 #define AGNOCAST_GET_VERSION_CMD _IOR(0xA6, 1, struct ioctl_get_version_args)
 #define AGNOCAST_ADD_PROCESS_CMD _IOWR(0xA6, 2, union ioctl_add_process_args)
 #define AGNOCAST_ADD_SUBSCRIBER_CMD _IOWR(0xA6, 3, union ioctl_add_subscriber_args)
@@ -326,6 +336,8 @@ struct ioctl_add_domain_bridge_args
 #define AGNOCAST_ADD_DISCOVERY_AGENT_CMD _IOWR(0xA6, 30, struct ioctl_add_discovery_agent_args)
 #define AGNOCAST_DISCOVERY_AGENT_EXISTS_CMD \
   _IOWR(0xA6, 31, struct ioctl_discovery_agent_exists_args)
+#define AGNOCAST_ADD_DOMAIN_BRIDGE_PREFIX_CMD \
+  _IOW(0xA6, 32, struct ioctl_add_domain_bridge_prefix_args)
 
 // ================================================
 // ros2cli ioctls
@@ -469,6 +481,10 @@ int agnocast_ioctl_remove_bridge(
 int agnocast_ioctl_add_domain_bridge(
   const char * topic_name_from, const char * topic_name_to, uint32_t from_domain,
   uint32_t to_domain, const struct ipc_namespace * ipc_ns);
+
+int agnocast_ioctl_add_domain_bridge_prefix(
+  const char * topic_name_prefix, uint32_t from_domain, uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns);
 
 int agnocast_ioctl_get_version(struct ioctl_get_version_args * ioctl_ret);
 

--- a/agnocast_kmod/agnocast_internal.h
+++ b/agnocast_kmod/agnocast_internal.h
@@ -243,6 +243,10 @@ struct domain_bridge_rule
   uint32_t domain_b;
   bool a_to_b;  // deliver domain_a's publications to domain_b's subscribers
   bool b_to_a;
+  // When set, topic_name_a is a prefix rather than a whole name and topic_name_b equals it: the
+  // rule pairs every topic whose name starts with the prefix against the *same* name in the other
+  // domain, so a prefix rule never renames.
+  bool is_prefix;
   struct hlist_node node;
 };
 

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -99,6 +99,10 @@ static struct topic_struct * find_grouped_topic_struct(
     return NULL;
   }
 
+  // A prefix rule's stored names are the prefix, not a topic name; it pairs this cell with the
+  // identical name in the partner domain.
+  if (rule->is_prefix) partner_name = topic_name;
+
   struct topic_wrapper * partner = find_topic(partner_name, ipc_ns, partner_domain);
   return partner ? partner->topic : NULL;
 }
@@ -2294,6 +2298,8 @@ unlock:
 
 // A rule is keyed by cell = (name, domain). Rules are few (one per bridged topic
 // pair), so a full scan is cheaper than maintaining a dual-name hash.
+// Registration keeps prefix and exact rules disjoint, so a cell has at most one match and the
+// first one found can be returned.
 static struct domain_bridge_rule * find_domain_rule(
   const char * topic_name, const struct ipc_namespace * ipc_ns, uint32_t domain_id)
 {
@@ -2302,6 +2308,12 @@ static struct domain_bridge_rule * find_domain_rule(
   hash_for_each(domain_rule_htable, bkt, rule, node)
   {
     if (ipc_ns != rule->ipc_ns) continue;
+    if (domain_id != rule->domain_a && domain_id != rule->domain_b) continue;
+    if (rule->is_prefix) {
+      // Both names equal the prefix, so which side matched does not matter.
+      if (strncmp(rule->topic_name_a, topic_name, strlen(rule->topic_name_a)) == 0) return rule;
+      continue;
+    }
     if (
       (domain_id == rule->domain_a && strcmp(rule->topic_name_a, topic_name) == 0) ||
       (domain_id == rule->domain_b && strcmp(rule->topic_name_b, topic_name) == 0)) {
@@ -2311,11 +2323,12 @@ static struct domain_bridge_rule * find_domain_rule(
   return NULL;
 }
 
-// The caller holds global_htables_rwsem for write and has verified, for both cells, that no
-// domain_bridge_rule covers it (find_domain_rule) and that no endpoint has joined it (find_topic).
+// The caller holds global_htables_rwsem for write and has verified, over everything the new rule
+// would cover -- two cells for an exact rule, every name under the prefix for a prefix rule --
+// that no domain_bridge_rule overlaps it and that no endpoint has joined it.
 static int insert_domain_rule(
   const char * topic_name_from, const char * topic_name_to, const uint32_t from_domain,
-  const uint32_t to_domain, const struct ipc_namespace * ipc_ns)
+  const uint32_t to_domain, const bool is_prefix, const struct ipc_namespace * ipc_ns)
 {
   // Store the pair canonically (domain_a < domain_b), each domain keeping its own name
   // (they differ on rename). Direction lives only in the a_to_b / b_to_a flags; grouping
@@ -2341,13 +2354,14 @@ static int insert_domain_rule(
   rule->domain_b = from_is_a ? to_domain : from_domain;
   rule->a_to_b = from_is_a;
   rule->b_to_a = !from_is_a;
+  rule->is_prefix = is_prefix;
   INIT_HLIST_NODE(&rule->node);
   // find_domain_rule scans every bucket, so the hash key is only for even distribution.
   hash_add(domain_rule_htable, &rule->node, full_name_hash(NULL, name_a, strlen(name_a)));
 
   dev_info(
-    agnocast_device, "Domain bridge rule added (%s@%u -> %s@%u).\n", topic_name_from, from_domain,
-    topic_name_to, to_domain);
+    agnocast_device, "Domain bridge %srule added (%s@%u -> %s@%u).\n", is_prefix ? "prefix " : "",
+    topic_name_from, from_domain, topic_name_to, to_domain);
   return 0;
 }
 
@@ -2370,6 +2384,16 @@ static int add_domain_rule(
         agnocast_device,
         "Domain bridge rule (%s@%u -> %s@%u) rejected: a cell is already paired with another "
         "cell. (%s)\n",
+        topic_name_from, from_domain, topic_name_to, to_domain, __func__);
+      return -EBUSY;
+    }
+
+    // Only a prefix rule can pair a name nobody declared. Taking it as a re-declaration would let
+    // one exact declaration turn on a direction for every cell the prefix covers.
+    if (r_from->is_prefix) {
+      dev_warn(
+        agnocast_device,
+        "Domain bridge rule (%s@%u -> %s@%u) rejected: covered by a prefix rule. (%s)\n",
         topic_name_from, from_domain, topic_name_to, to_domain, __func__);
       return -EBUSY;
     }
@@ -2412,7 +2436,120 @@ static int add_domain_rule(
     return -EBUSY;
   }
 
-  return insert_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, ipc_ns);
+  return insert_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, false, ipc_ns);
+}
+
+// A prefix rule groups every cell it covers, and grouping merges id spaces, so it must be
+// declared before any of them exist.
+static bool any_topic_under_prefix(
+  const char * prefix, const struct ipc_namespace * ipc_ns, const uint32_t from_domain,
+  const uint32_t to_domain)
+{
+  const size_t prefix_len = strlen(prefix);
+  struct topic_wrapper * wrapper;
+  int bkt;
+  hash_for_each(topic_hashtable, bkt, wrapper, node)
+  {
+    if (!ipc_eq(wrapper->ipc_ns, ipc_ns)) continue;
+    if (wrapper->domain_id != from_domain && wrapper->domain_id != to_domain) continue;
+    if (strncmp(wrapper->key, prefix, prefix_len) == 0) return true;
+  }
+  return false;
+}
+
+// Registers a prefix rule, or folds a re-declaration into the identical existing one. Every other
+// overlap is rejected so find_domain_rule never has to choose between two candidates.
+// The caller holds global_htables_rwsem for write.
+static int add_prefix_domain_rule(
+  const char * prefix, const uint32_t from_domain, const uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns)
+{
+  const size_t prefix_len = strlen(prefix);
+  const uint32_t domain_a = min(from_domain, to_domain);
+  const uint32_t domain_b = max(from_domain, to_domain);
+  struct domain_bridge_rule * same = NULL;
+  struct domain_bridge_rule * rule;
+  int bkt;
+
+  hash_for_each(domain_rule_htable, bkt, rule, node)
+  {
+    if (ipc_ns != rule->ipc_ns) continue;
+
+    if (rule->is_prefix) {
+      const size_t len = strlen(rule->topic_name_a);
+      const bool nests = (len <= prefix_len) ? strncmp(rule->topic_name_a, prefix, len) == 0
+                                             : strncmp(prefix, rule->topic_name_a, prefix_len) == 0;
+      // find_domain_rule filters by domain before testing the name, so two prefix rules can both
+      // match a lookup only if their pairs share a domain; over disjoint pairs nesting is harmless.
+      const bool shares_domain = rule->domain_a == domain_a || rule->domain_a == domain_b ||
+                                 rule->domain_b == domain_a || rule->domain_b == domain_b;
+      if (!nests || !shares_domain) continue;
+
+      if (len == prefix_len) {
+        if (rule->domain_a == domain_a && rule->domain_b == domain_b) {
+          same = rule;
+          continue;
+        }
+        dev_warn(
+          agnocast_device,
+          "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: the prefix is already paired with "
+          "another domain. (%s)\n",
+          prefix, from_domain, prefix, to_domain, __func__);
+        return -EBUSY;
+      }
+
+      dev_warn(
+        agnocast_device,
+        "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: it nests with an existing prefix "
+        "rule. (%s)\n",
+        prefix, from_domain, prefix, to_domain, __func__);
+      return -EBUSY;
+    }
+
+    // An exact rule for a covered name would shadow the prefix, so keep the two disjoint.
+    if (
+      ((rule->domain_a == domain_a || rule->domain_a == domain_b) &&
+       strncmp(prefix, rule->topic_name_a, prefix_len) == 0) ||
+      ((rule->domain_b == domain_a || rule->domain_b == domain_b) &&
+       strncmp(prefix, rule->topic_name_b, prefix_len) == 0)) {
+      dev_warn(
+        agnocast_device,
+        "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: an exact rule already covers a name "
+        "under it. (%s)\n",
+        prefix, from_domain, prefix, to_domain, __func__);
+      return -EBUSY;
+    }
+  }
+
+  // A re-declaration that enables nothing new must keep working once nodes are up, so only a new
+  // direction needs the guarantee below: endpoints that joined while it was denied were left out
+  // of their publishers' notify lists and skipped by set_publisher_shm_info.
+  if (same) {
+    const bool from_is_a = from_domain < to_domain;
+    if ((from_is_a && same->a_to_b) || (!from_is_a && same->b_to_a)) return 0;
+    if (any_topic_under_prefix(prefix, ipc_ns, from_domain, to_domain)) {
+      dev_warn(
+        agnocast_device,
+        "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: it adds a direction after a covered "
+        "endpoint joined. (%s)\n",
+        prefix, from_domain, prefix, to_domain, __func__);
+      return -EBUSY;
+    }
+    same->a_to_b |= from_is_a;
+    same->b_to_a |= !from_is_a;
+    return 0;
+  }
+
+  if (any_topic_under_prefix(prefix, ipc_ns, from_domain, to_domain)) {
+    dev_warn(
+      agnocast_device,
+      "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: an endpoint under it has already "
+      "joined. (%s)\n",
+      prefix, from_domain, prefix, to_domain, __func__);
+    return -EBUSY;
+  }
+
+  return insert_domain_rule(prefix, prefix, from_domain, to_domain, true, ipc_ns);
 }
 
 int agnocast_ioctl_add_domain_bridge(
@@ -2423,6 +2560,19 @@ int agnocast_ioctl_add_domain_bridge(
 
   down_write(&global_htables_rwsem);
   const int ret = add_domain_rule(topic_name_from, topic_name_to, from_domain, to_domain, ipc_ns);
+  up_write(&global_htables_rwsem);
+  return ret;
+}
+
+int agnocast_ioctl_add_domain_bridge_prefix(
+  const char * topic_name_prefix, const uint32_t from_domain, const uint32_t to_domain,
+  const struct ipc_namespace * ipc_ns)
+{
+  if (from_domain == to_domain) return -EINVAL;
+  if (topic_name_prefix[0] != '/' || topic_name_prefix[1] == '\0') return -EINVAL;
+
+  down_write(&global_htables_rwsem);
+  const int ret = add_prefix_domain_rule(topic_name_prefix, from_domain, to_domain, ipc_ns);
   up_write(&global_htables_rwsem);
   return ret;
 }
@@ -3138,6 +3288,21 @@ static long add_domain_bridge_cmd(struct ioctl_add_domain_bridge_args __user * a
     ipc_ns);
 }
 
+static long add_domain_bridge_prefix_cmd(struct ioctl_add_domain_bridge_prefix_args __user * arg)
+{
+  const struct ipc_namespace * ipc_ns = current->nsproxy->ipc_ns;
+
+  struct ioctl_add_domain_bridge_prefix_args prefix_args;
+  if (copy_from_user(&prefix_args, arg, sizeof(prefix_args))) return -EFAULT;
+
+  char prefix_buf[TOPIC_NAME_BUFFER_SIZE];
+  int ret = copy_name_from_user(prefix_buf, sizeof(prefix_buf), &prefix_args.topic_name_prefix);
+  if (ret) return ret;
+
+  return agnocast_ioctl_add_domain_bridge_prefix(
+    prefix_buf, prefix_args.from_domain, prefix_args.to_domain, ipc_ns);
+}
+
 static long remove_bridge_cmd(struct ioctl_remove_bridge_args __user * arg)
 {
   int ret = 0;
@@ -3320,6 +3485,8 @@ long agnocast_ioctl(struct file * file, unsigned int cmd, unsigned long arg)
       return add_discovery_agent_cmd((struct ioctl_add_discovery_agent_args __user *)arg);
     case AGNOCAST_DISCOVERY_AGENT_EXISTS_CMD:
       return discovery_agent_exists_cmd((struct ioctl_discovery_agent_exists_args __user *)arg);
+    case AGNOCAST_ADD_DOMAIN_BRIDGE_PREFIX_CMD:
+      return add_domain_bridge_prefix_cmd((struct ioctl_add_domain_bridge_prefix_args __user *)arg);
     default:
       return -EINVAL;
   }

--- a/agnocast_kmod/agnocast_kunit/Makefile.inc
+++ b/agnocast_kmod/agnocast_kunit/Makefile.inc
@@ -16,6 +16,7 @@ KUNIT_TEST_OBJS := \
   agnocast_kunit_add_bridge.o \
   agnocast_kunit_remove_bridge.o \
   agnocast_kunit_domain_bridge.o \
+  agnocast_kunit_add_domain_bridge_prefix.o \
   agnocast_kunit_discovery_agent.o \
   agnocast_kunit_set_ros2_subscriber_num.o \
   agnocast_kunit_set_ros2_publisher_num.o \

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.c
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
+#include "agnocast_kunit_add_domain_bridge_prefix.h"
+
+#include "../agnocast.h"
+
+#include <kunit/test.h>
+
+// A prefix rule bridges every name under PFX, pairing each with the identical name in the other
+// domain. PFX_A stands for a caller's response topic; OUTSIDE lies beyond the prefix.
+static const char * PFX = "/kunit_test_add_domain_bridge_prefix_";
+static const char * PFX_A = "/kunit_test_add_domain_bridge_prefix_clientA";
+static const char * OUTSIDE = "/kunit_test_add_domain_bridge_outside";
+
+static void setup_process_in_domain(struct kunit * test, const pid_t pid, const uint32_t domain_id)
+{
+  union ioctl_add_process_args args;
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &args), 0);
+}
+
+static void add_publisher_named(struct kunit * test, const pid_t pid, const char * topic_name)
+{
+  union ioctl_add_publisher_args args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      topic_name, current->nsproxy->ipc_ns, "/kunit_node", pid, 1, false, false, &args),
+    0);
+}
+
+void test_case_add_domain_bridge_prefix_normal(struct kunit * test)
+{
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            PFX_A, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_EQ(test, domain_a, 1);
+  KUNIT_EXPECT_EQ(test, domain_b, 2);
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_FALSE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_prefix_same_domain_rejected(struct kunit * test)
+{
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 3, 3, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_prefix_empty_rejected(struct kunit * test)
+{
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix("", 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_prefix_root_rejected(struct kunit * test)
+{
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix("/", 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_prefix_relative_rejected(struct kunit * test)
+{
+  // Act: the same prefix without its leading '/'.
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX + 1, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_prefix_redeclaration_is_idempotent(struct kunit * test)
+{
+  // Arrange: a covered endpoint has joined.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, PFX_A);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_reverse_direction(struct kunit * test)
+{
+  // Arrange: no endpoint yet, so the reverse direction is still free to be added.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 2, 1, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  uint32_t domain_a = 0, domain_b = 0;
+  bool a_to_b = false, b_to_a = false;
+  KUNIT_ASSERT_TRUE(
+    test, agnocast_get_domain_rule(
+            PFX_A, current->nsproxy->ipc_ns, 1, &domain_a, &domain_b, &a_to_b, &b_to_a));
+  KUNIT_EXPECT_TRUE(test, a_to_b);
+  KUNIT_EXPECT_TRUE(test, b_to_a);
+}
+
+void test_case_add_domain_bridge_prefix_accepted_beside_a_disjoint_prefix(struct kunit * test)
+{
+  // Arrange: neither prefix is a prefix of the other.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(OUTSIDE, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_accepted_beside_an_exact_rule(struct kunit * test)
+{
+  // Arrange: an exact rule on a name outside the prefix.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(OUTSIDE, OUTSIDE, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_accepted_with_a_topic_outside_it(struct kunit * test)
+{
+  // Arrange: an endpoint has joined, but on a name the prefix does not cover.
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, OUTSIDE);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_accepted_with_a_covered_topic_elsewhere(struct kunit * test)
+{
+  // Arrange: a covered name has an endpoint, but in a domain this rule does not bridge.
+  setup_process_in_domain(test, 1000, 3);
+  add_publisher_named(test, 1000, PFX_A);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_nested_over_disjoint_domains(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX_A, 3, 4, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+void test_case_add_domain_bridge_prefix_repointed_pair_rejected(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act: the same prefix, pointed at a different partner domain.
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 3, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_nested_rejected(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act: a longer prefix, nesting inside the one already registered.
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX_A, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_nested_rejected_either_order(struct kunit * test)
+{
+  // Arrange: the longer prefix first, so the shorter one is the newcomer.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX_A, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_late_reverse_direction_rejected(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, PFX_A);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 2, 1, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_rejected_when_covered_endpoint_exists(struct kunit * test)
+{
+  // Arrange
+  setup_process_in_domain(test, 1000, 1);
+  add_publisher_named(test, 1000, PFX_A);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_over_exact_rejected(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(PFX_A, PFX_A, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+void test_case_add_domain_bridge_prefix_over_exact_rename_rejected(struct kunit * test)
+{
+  // Arrange: only the rule's destination cell falls under the prefix.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(OUTSIDE, PFX_A, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
+#pragma once
+#include <kunit/test.h>
+
+#define TEST_CASES_ADD_DOMAIN_BRIDGE_PREFIX                                                 \
+  KUNIT_CASE(test_case_add_domain_bridge_prefix_normal),                                    \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_same_domain_rejected),                    \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_empty_rejected),                          \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_root_rejected),                           \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_relative_rejected),                       \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_redeclaration_is_idempotent),             \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_reverse_direction),                       \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_accepted_beside_a_disjoint_prefix),       \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_accepted_beside_an_exact_rule),           \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_accepted_with_a_topic_outside_it),        \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_accepted_with_a_covered_topic_elsewhere), \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_nested_over_disjoint_domains),            \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_repointed_pair_rejected),                 \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_nested_rejected),                         \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_nested_rejected_either_order),            \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_late_reverse_direction_rejected),         \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_rejected_when_covered_endpoint_exists),   \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_over_exact_rejected),                     \
+    KUNIT_CASE(test_case_add_domain_bridge_prefix_over_exact_rename_rejected)
+
+void test_case_add_domain_bridge_prefix_normal(struct kunit * test);
+void test_case_add_domain_bridge_prefix_same_domain_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_empty_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_root_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_relative_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_redeclaration_is_idempotent(struct kunit * test);
+void test_case_add_domain_bridge_prefix_reverse_direction(struct kunit * test);
+void test_case_add_domain_bridge_prefix_accepted_beside_a_disjoint_prefix(struct kunit * test);
+void test_case_add_domain_bridge_prefix_accepted_beside_an_exact_rule(struct kunit * test);
+void test_case_add_domain_bridge_prefix_accepted_with_a_topic_outside_it(struct kunit * test);
+void test_case_add_domain_bridge_prefix_accepted_with_a_covered_topic_elsewhere(
+  struct kunit * test);
+void test_case_add_domain_bridge_prefix_nested_over_disjoint_domains(struct kunit * test);
+void test_case_add_domain_bridge_prefix_repointed_pair_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_nested_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_nested_rejected_either_order(struct kunit * test);
+void test_case_add_domain_bridge_prefix_late_reverse_direction_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_rejected_when_covered_endpoint_exists(struct kunit * test);
+void test_case_add_domain_bridge_prefix_over_exact_rejected(struct kunit * test);
+void test_case_add_domain_bridge_prefix_over_exact_rename_rejected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -14,6 +14,13 @@ static const char * TOPIC_NAME = "/kunit_test_domain_bridge_topic";
 static const char * RN_SRC = "/kunit_test_domain_bridge_rename_src";
 static const char * RN_DST = "/kunit_test_domain_bridge_rename_dst";
 
+// A prefix rule bridges every name under PFX, pairing each with the identical name in the other
+// domain. PFX_A / PFX_B stand for two callers' response topics; OUTSIDE lies beyond the prefix.
+static const char * PFX = "/kunit_test_domain_bridge_prefix_";
+static const char * PFX_A = "/kunit_test_domain_bridge_prefix_clientA";
+static const char * PFX_B = "/kunit_test_domain_bridge_prefix_clientB";
+static const char * OUTSIDE = "/kunit_test_domain_bridge_outside";
+
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
 // Returns the process's mempool base address, used as a valid publish address.
@@ -554,4 +561,117 @@ void test_case_domain_bridge_rename_multi_publisher(struct kunit * test)
 
   // Woken exactly once, regardless of the other publishers sharing the struct.
   KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+}
+void test_case_domain_bridge_prefix_groups_wrappers(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  setup_process_in_domain(test, 1001, 2);
+
+  // Act: a name the rule never mentioned, in each of the two bridged domains.
+  add_publisher_named(test, 1000, PFX_A);
+  add_subscriber_named(test, 1001, PFX_A);
+
+  // Assert: both cells share one topic_struct.
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(PFX_A, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(PFX_A, current->nsproxy->ipc_ns, 2), 2);
+}
+
+void test_case_domain_bridge_prefix_leaves_other_topics_alone(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  setup_process_in_domain(test, 1001, 2);
+
+  // Act
+  add_publisher_named(test, 1000, OUTSIDE);
+  add_subscriber_named(test, 1001, OUTSIDE);
+
+  // Assert: outside the prefix, so each domain keeps its own topic_struct.
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(OUTSIDE, current->nsproxy->ipc_ns, 1), 1);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(OUTSIDE, current->nsproxy->ipc_ns, 2), 1);
+}
+
+// This is what keeps one caller's responses out of another's: each response topic gets its own
+// struct, so a refcnt of 2 rather than 4 is the assertion that matters.
+void test_case_domain_bridge_prefix_pairs_each_name_separately(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+  setup_process_in_domain(test, 1000, 1);
+  setup_process_in_domain(test, 1001, 2);
+
+  // Act: two names under the one prefix.
+  add_publisher_named(test, 1000, PFX_A);
+  add_publisher_named(test, 1000, PFX_B);
+  add_subscriber_named(test, 1001, PFX_A);
+  add_subscriber_named(test, 1001, PFX_B);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(PFX_A, current->nsproxy->ipc_ns, 1), 2);
+  KUNIT_EXPECT_EQ(test, agnocast_topic_wrapper_refcnt(PFX_B, current->nsproxy->ipc_ns, 1), 2);
+}
+
+void test_case_domain_bridge_prefix_cross_domain_delivery(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  agnocast_kunit_eventfd_reset();
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 1);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, PFX_A);
+  setup_process_in_domain(test, 1001, 2);
+  const int eventfd = 0;
+  add_subscriber_named_with_eventfd(test, 1001, PFX_A, eventfd);
+
+  // Act
+  union ioctl_publish_msg_args publish_args;
+  const int ret =
+    agnocast_ioctl_publish_msg(PFX_A, current->nsproxy->ipc_ns, pub_id, msg_addr, &publish_args);
+
+  // Assert
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+}
+
+void test_case_domain_bridge_prefix_direction_respected(struct kunit * test)
+{
+  // Arrange: only 1 -> 2 is declared, and the publisher sits in domain 2.
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  agnocast_kunit_eventfd_reset();
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
+  const topic_local_id_t pub_id = add_publisher_named(test, current->tgid, PFX_A);
+  setup_process_in_domain(test, 1001, 1);
+  const int eventfd = 0;
+  add_subscriber_named_with_eventfd(test, 1001, PFX_A, eventfd);
+
+  // Act
+  union ioctl_publish_msg_args publish_args;
+  const int ret =
+    agnocast_ioctl_publish_msg(PFX_A, current->nsproxy->ipc_ns, pub_id, msg_addr, &publish_args);
+
+  // Assert: no 2 -> 1, so the domain-1 subscriber is not woken.
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
+}
+
+void test_case_domain_bridge_exact_under_prefix_rejected(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge_prefix(PFX, 1, 2, current->nsproxy->ipc_ns), 0);
+
+  // Act
+  const int ret = agnocast_ioctl_add_domain_bridge(PFX_A, PFX_A, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -25,7 +25,13 @@
     KUNIT_CASE(test_case_domain_bridge_rename_groups_wrappers),               \
     KUNIT_CASE(test_case_domain_bridge_rename_cross_domain_delivery),         \
     KUNIT_CASE(test_case_domain_bridge_rename_fanout_rejected),               \
-    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher)
+    KUNIT_CASE(test_case_domain_bridge_rename_multi_publisher),               \
+    KUNIT_CASE(test_case_domain_bridge_prefix_groups_wrappers),               \
+    KUNIT_CASE(test_case_domain_bridge_prefix_leaves_other_topics_alone),     \
+    KUNIT_CASE(test_case_domain_bridge_prefix_pairs_each_name_separately),    \
+    KUNIT_CASE(test_case_domain_bridge_prefix_cross_domain_delivery),         \
+    KUNIT_CASE(test_case_domain_bridge_prefix_direction_respected),           \
+    KUNIT_CASE(test_case_domain_bridge_exact_under_prefix_rejected)
 
 void test_case_add_domain_bridge_normal(struct kunit * test);
 void test_case_add_domain_bridge_reverse_first_declaration(struct kunit * test);
@@ -50,3 +56,9 @@ void test_case_domain_bridge_rename_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_rename_cross_domain_delivery(struct kunit * test);
 void test_case_domain_bridge_rename_fanout_rejected(struct kunit * test);
 void test_case_domain_bridge_rename_multi_publisher(struct kunit * test);
+void test_case_domain_bridge_prefix_groups_wrappers(struct kunit * test);
+void test_case_domain_bridge_prefix_leaves_other_topics_alone(struct kunit * test);
+void test_case_domain_bridge_prefix_pairs_each_name_separately(struct kunit * test);
+void test_case_domain_bridge_prefix_cross_domain_delivery(struct kunit * test);
+void test_case_domain_bridge_prefix_direction_respected(struct kunit * test);
+void test_case_domain_bridge_exact_under_prefix_rejected(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit_main.c
+++ b/agnocast_kmod/agnocast_kunit_main.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
 #include "agnocast.h"
 #include "agnocast_kunit/agnocast_kunit_add_bridge.h"
+#include "agnocast_kunit/agnocast_kunit_add_domain_bridge_prefix.h"
 #include "agnocast_kunit/agnocast_kunit_add_process.h"
 #include "agnocast_kunit/agnocast_kunit_add_publisher.h"
 #include "agnocast_kunit/agnocast_kunit_add_subscriber.h"
@@ -56,6 +57,7 @@ struct kunit_case agnocast_test_cases[] = {
   TEST_CASES_ADD_BRIDGE,
   TEST_CASES_REMOVE_BRIDGE,
   TEST_CASES_DOMAIN_BRIDGE,
+  TEST_CASES_ADD_DOMAIN_BRIDGE_PREFIX,
   TEST_CASES_SET_ROS2_SUBSCRIBER_NUM,
   TEST_CASES_SET_ROS2_PUBLISHER_NUM,
   TEST_CASES_DO_EXIT,


### PR DESCRIPTION
## Description

A domain bridge rule names both cells it pairs, so every bridged topic has to be known when the rule is declared. That does not hold for a topic family whose members appear as processes start: an Agnocast service gives each caller its own response topic, named after the caller, and no configuration can list them in advance. Declaring the rule later does not work either, because grouping merges the two domains' id spaces and is rejected once an endpoint has joined.

`AGNOCAST_ADD_DOMAIN_BRIDGE_PREFIX_CMD` covers such a family with one declaration: every topic whose name starts with the prefix is paired with the identical name in the other domain. A prefix rule cannot rename, which is what lets one rule stand for names it has never seen.

Overlaps are rejected rather than resolved by precedence — in both directions against exact rules, and against nesting prefixes — so a lookup never has to choose between two candidates.

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Nothing on the publish or receive path changes: `domain_delivery_allowed()` reads the rule cached on the shared `topic_struct` and never looks at whether it is a prefix rule.

### Alternatives considered

**One response topic per service, callers correlating by client GID.** Naming the response topic after the service alone makes its rule exact, and prefix rules stop being needed at all; ROS 2 works this way, correlating a reply through `rmw_request_id_t` (client GUID and sequence number). Rejected here as reaching beyond bridging a service across domains: it changes the service wire format and the request/response path this PR does not touch, so it can regress existing behaviour, and it wakes every caller of a service on every response. Still an option to take later for the simpler design it gives.

**Each caller declaring the rule for its own response topic.** A caller knows the name, and could declare an exact rule synchronously before creating its subscription, keeping prefix matching out of the kmod. Rejected over what that does to rules: nothing removes a rule before module unload, so one accumulates per caller node name; a rejected declaration surfaces inside each caller's constructor instead of once at boot; and rule registration splits between the configuration and the callers.

**A domain group with an explicit name matcher.** Replacing the fixed pair with a set of domains plus a matcher (exact or prefix) subsumes this PR and lifts the two-domain limit `add_domain_rule()` carries a TODO for. Rejected as more than this use case needs -- grouping N domains divides one id space N ways and turns the direction check into a table -- but it remains the design to reach for if more than two domains ever have to be bridged.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-minor-update`
