### PR TITLE
fix(bridge): capture response_copier by value in generic A2R service bridge

### DIFF
--- a/src/agnocastlib/src/bridge/agnocast_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_loader.cpp
@@ -401,7 +401,7 @@ ServiceBridgeEntity BridgeLoader::create_a2r_service_bridge_generic(
         ros_client->async_send_request(
           ros_req_ptr,
           [service_handle = std::move(service_handle), agno_req = std::move(agno_req),
-           &response_copier](const agnocast::vendor_rclcpp::GenericClient::SharedFuture & future) {
+           response_copier](const agnocast::vendor_rclcpp::GenericClient::SharedFuture & future) {
             const auto & ros_res = future.get();
             auto agno_res = service_handle->borrow_loaned_response(agno_req);
 


### PR DESCRIPTION
## Description

This PR fixes a use-after-free error found in the generic A2R service bridge implementation. Previously, the response callback (the one invoked when the response arrives from the ROS 2 world) captured `response_copier` by reference. This PR fixes the callback to capture it by value.

### Callback lifetime

The response callback captures `response_copier` from the outer lambda, which is the request callback invoked on receiving a request from the Agnocast world. The request callback has `response_copier` as part of its environment. Although the original request callback is stored inside `id2_callback_info` and stays alive as long as the A2R service bridge, **it is not the one that gets run**; a copy of the original callback is created every time, and the copy is the one that gets run. Note that the copy is destroyed soon after a run is finished. To summarize:

1. A temporary copy (not the stored original) of the request callback is run.
2. In the run, the response callback lambda captures `response_copier` by reference.
3. The `response_copier` reference will dangle once the temporary copy of the request callback gets destroyed.

> When I first implemented it, I incorrectly assumed that the saved original request callback would be run.

### Follow-ups

If we plan to support mutable callbacks (#1445), the current behavior of copying the callback before every run will become a problem. If we store `shared_ptr<CallbackInfo>` instead of raw `CallbackInfo`, it will be possible to run the very callback stored in `id2_callback_info`, allowing for mutable callback support.
```cpp
std::unordered_map<uint32_t, std::shared_ptr<CallbackInfo>> id2_callback_info(callback_map_bkt_cnt);
```

## Related links

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [x] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)