### PR TITLE
fix(agnocastlib): report duplicate Agnocast service names

### DIFF
--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.c
@@ -112,3 +112,31 @@ void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, args_d0.ret_topic_info_ret_num, (uint32_t)0);
 }
+
+// Two subscribers on one topic, queried with a one-entry buffer: the caller is told the buffer is
+// too small rather than being handed a truncated list. A caller that probes with a single entry
+// therefore cannot tell this apart from "no subscriber" by return value alone.
+void test_case_get_topic_sub_info_buffer_too_small(struct kunit * test)
+{
+  const pid_t pid2 = 1002;
+  union ioctl_add_subscriber_args add_sub_args;
+  union ioctl_topic_info_args topic_info_args = {0};
+  int ret;
+
+  setup_process(test, PID);
+  setup_process(test, pid2);
+
+  ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, PID, QOS_DEPTH, false, false, false, false,
+    IS_BRIDGE, -1, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+  ret = agnocast_ioctl_add_subscriber(
+    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, pid2, QOS_DEPTH, false, false, false, false,
+    IS_BRIDGE, -1, &add_sub_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  topic_info_args.topic_info_ret_buffer_size = 1;
+  ret = agnocast_ioctl_get_topic_subscriber_info(
+    TOPIC_NAME, current->nsproxy->ipc_ns, &topic_info_args);
+  KUNIT_EXPECT_EQ(test, ret, -ENOBUFS);
+}

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_topic_subscriber_info.h
@@ -2,13 +2,15 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                  \
-  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),    \
-    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers),  \
-    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found), \
-    KUNIT_CASE(test_case_get_topic_sub_info_selects_by_domain)
+#define TEST_CASES_GET_TOPIC_SUBSCRIBER_INFO                    \
+  KUNIT_CASE(test_case_get_topic_sub_info_one_subscriber),      \
+    KUNIT_CASE(test_case_get_topic_sub_info_no_subscribers),    \
+    KUNIT_CASE(test_case_get_topic_sub_info_topic_not_found),   \
+    KUNIT_CASE(test_case_get_topic_sub_info_selects_by_domain), \
+    KUNIT_CASE(test_case_get_topic_sub_info_buffer_too_small)
 
 void test_case_get_topic_sub_info_one_subscriber(struct kunit * test);
 void test_case_get_topic_sub_info_no_subscribers(struct kunit * test);
 void test_case_get_topic_sub_info_topic_not_found(struct kunit * test);
 void test_case_get_topic_sub_info_selects_by_domain(struct kunit * test);
+void test_case_get_topic_sub_info_buffer_too_small(struct kunit * test);

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
@@ -20,6 +20,7 @@ struct ServiceBridgeDeps
   std::shared_ptr<CallbackIsolatedAgnocastExecutor> executor;
   rclcpp::Logger logger;
   std::shared_ptr<BridgeLoader> bridge_loader;
+  std::shared_ptr<rclcpp::Clock> clock;
 };
 
 enum class ServiceBridgeState { NONE, PENDING, A2R, R2A };
@@ -50,7 +51,7 @@ class ServiceBridgeItem
   int get_agno_service_qos(rclcpp::QoS & qos);
 
   bool ros2_service_exists(const ServiceBridgeDeps & deps);
-  bool agno_service_exists();
+  bool agno_service_exists(const ServiceBridgeDeps & deps);
   bool agno_client_exists();
 
   int start_r2a_bridge(const ServiceBridgeDeps & deps);

--- a/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_manager.cpp
@@ -235,7 +235,7 @@ void BridgeManager::dispatch_bridge_message(const BridgeMsg & msg)
   switch (msg.type) {
     case BridgeMsgType::Service: {
       const auto & payload = msg.payload.service;
-      ServiceBridgeDeps deps{container_node_, executor_, logger_, loader_};
+      ServiceBridgeDeps deps{container_node_, executor_, logger_, loader_, clock_};
       std::string service_name = static_cast<const char *>(payload.service_name);
       ServiceBridgeItem sb_item;
 
@@ -506,7 +506,7 @@ void BridgeManager::check_and_remove_pubsub_bridges()
 
 void BridgeManager::check_and_update_service_bridges()
 {
-  ServiceBridgeDeps deps{container_node_, executor_, logger_, loader_};
+  ServiceBridgeDeps deps{container_node_, executor_, logger_, loader_, clock_};
 
   auto it = active_service_bridges_.begin();
   while (it != active_service_bridges_.end()) {

--- a/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_service_bridge.cpp
@@ -173,14 +173,38 @@ bool ServiceBridgeItem::ros2_service_exists(const ServiceBridgeDeps & deps)
   }
 }
 
-// Returns false if the target Agnocast service does not exist or if an error occurs while checking
-// it (the reason will be set in the error string).
-bool ServiceBridgeItem::agno_service_exists()
+// Returns false if the target Agnocast service does not exist, if two or more share the name, or if
+// an error occurs while checking it (the reason will be set in the error string).
+//
+// A name shared by two or more Agnocast services is not supported, and the warning below is the
+// only place that says so. An R2A bridge has to adopt its target's QoS, and with several targets
+// there is no basis for picking one, so the bridge is refused. Counting the services rather than
+// probing for one keeps that refusal distinguishable from plain absence.
+bool ServiceBridgeItem::agno_service_exists(const ServiceBridgeDeps & deps)
 {
-  // TODO(bdm-k): Add a dedicated service-liveness ioctl so we can validate target service state
-  // directly without using get_service_qos() as a probe.
-  rclcpp::QoS qos = rclcpp::ServicesQoS();
-  return get_agno_service_qos(qos) == 0;
+  const std::string request_topic_name = create_service_request_topic_name(service_name_);
+
+  SubscriberCountResult result = get_agnocast_subscriber_count(request_topic_name);
+
+  if (result.count == -1) {
+    set_error_string("Failed to fetch subscriber count from agnocast kernel module");
+    return false;
+  }
+  if (result.count == 0) {
+    set_error_string("No target Agnocast service found");
+    return false;
+  }
+  if (result.count > 1) {
+    constexpr int DUPLICATE_SERVICE_WARN_INTERVAL_MS = 10000;
+    RCLCPP_WARN_THROTTLE(
+      deps.logger, *deps.clock, DUPLICATE_SERVICE_WARN_INTERVAL_MS,
+      "Found %d Agnocast services named '%s'. Sharing a service name is not supported, so no "
+      "bridge is created for it.",
+      result.count, service_name_.c_str());
+    set_error_string("Multiple target Agnocast services found");
+    return false;
+  }
+  return true;
 }
 
 // Returns false if there is no target Agnocast client or if an error occurs while checking it (the
@@ -332,7 +356,7 @@ void ServiceBridgeItem::update_configuration(const BridgeMsgServicePayload & pay
 
 void ServiceBridgeItem::check_and_update_r2a(const ServiceBridgeDeps & deps)
 {
-  if (agno_service_exists()) {
+  if (agno_service_exists(deps)) {
     return;
   }
 
@@ -388,7 +412,7 @@ void ServiceBridgeItem::check_and_update_a2r(const ServiceBridgeDeps & deps)
 
 void ServiceBridgeItem::check_and_update_pending(const ServiceBridgeDeps & deps)
 {
-  if (may_start_r2a_bridge_ && agno_service_exists()) {
+  if (may_start_r2a_bridge_ && agno_service_exists(deps)) {
     if (start_r2a_bridge(deps) != 0) {
       RCLCPP_WARN(
         deps.logger, "Failed to start R2A service bridge for '%s': %s", service_name_.c_str(),


### PR DESCRIPTION
## Description

`ServiceBridgeItem::agno_service_exists()` probed for the target Agnocast service by fetching its
QoS through `AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD` with a **one-entry buffer**. Two or more
services sharing a name make the kmod return `-ENOBUFS`, so "too many" arrived as "none": the R2A
bridge was silently never built, and nothing said why at the default log severity.

This counts the request topic's subscribers instead, the way `agno_client_exists()` already counts
publishers, and warns (throttled) when more than one is found.

**No behavior change.** A shared service name is still refused: an R2A bridge has to adopt its
target's QoS, and with several targets there is no basis for picking one. Only the diagnosis
changes — the refusal is now reported as a collision rather than read as absence.

This also resolves the `TODO(bdm-k)` asking for a direct service-liveness check, without adding an
ioctl.

Note for reviewers who spot the difference: `service_is_ready_core()`
(`src/agnocastlib/src/agnocast_client.cpp`) warns on the same condition but returns `true`. That is
not an inconsistency — it answers "is there something to talk to?", while this answers "is there a
single well-defined service to bridge?".

Details:

- `ServiceBridgeDeps` gains a `clock`, needed for `RCLCPP_WARN_THROTTLE`. `BridgeManager` already
  owns one and already uses it for a throttled warning.
- `agno_service_exists()` takes `deps`, matching `ros2_service_exists()` / `ros2_client_exists()`.
- `get_agno_service_qos()` is unchanged and still used when a bridge is actually built; it is only
  removed from the liveness path.
- Adds a kunit case for the `-ENOBUFS` branch of `agnocast_ioctl_get_topic_subscriber_info`, which
  had no coverage. **The kernel module itself is not modified.**

## Related links

Found while verifying #1533.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

**Not yet run — draft.** Only `colcon build` for `agnocastlib` and a compile of the kunit module
have been done. Runtime verification is blocked locally by a stale DKMS-installed `agnocast.ko`
that rejects `AGNOCAST_GET_SUBSCRIBER_NUM_CMD` with `EINVAL`, so nothing on this path can be
exercised until the tree's module is loaded.

The check to run once that is sorted: start two `no_rclcpp_server` processes at once and confirm
the warning names the service and says no bridge is created, then confirm a single process still
gets its bridge.

## Notes for reviewers

None.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
