### PR TITLE
feat(agnocastlib): mark bridge-owned services and clients as bridges in kmod

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -40,10 +40,23 @@ extern int agnocast_fd;
 enum class ClientRole : uint8_t {
   /// User-created client; issues an A2R bridge request.
   Default,
-  /// Used by the bridge plugin's own client; no bridge request is issued.
+  /// Used by the bridge implementation itself; marks the endpoints it creates as bridges in kmod
+  /// and issues no bridge request.
   /// Not intended for direct use by application code.
-  AgnocastOnly,
+  BridgeInternal,
 };
+
+constexpr SubscriptionRole to_subscription_role(const ClientRole role)
+{
+  return role == ClientRole::BridgeInternal ? SubscriptionRole::BridgeInternal
+                                            : SubscriptionRole::AgnocastOnly;
+}
+
+constexpr PublisherRole to_publisher_role(const ClientRole role)
+{
+  return role == ClientRole::BridgeInternal ? PublisherRole::BridgeInternal
+                                            : PublisherRole::AgnocastOnly;
+}
 
 namespace detail
 {
@@ -183,7 +196,7 @@ private:
     agnocast::PublisherOptions pub_options;
     publisher_ = std::make_shared<ServiceRequestPublisher>(
       node, create_service_request_topic_name(service_name_), qos, pub_options,
-      PublisherRole::AgnocastOnly);
+      to_publisher_role(role));
 
     auto subscriber_callback = [this, node](ipc_shared_ptr<ResponseT> && response) {
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
@@ -208,9 +221,9 @@ private:
 
     SubscriptionOptions options{group};
     std::string topic_name = create_service_response_topic_name(service_name_, node_name_);
+    const SubscriptionRole subscriber_role = to_subscription_role(role);
     subscriber_ = std::make_shared<ServiceResponseSubscriber>(
-      node, topic_name, qos, std::move(subscriber_callback), options,
-      SubscriptionRole::AgnocastOnly);
+      node, topic_name, qos, std::move(subscriber_callback), options, subscriber_role);
 
     if (role == ClientRole::Default) {
       register_service_bridge(
@@ -356,7 +369,7 @@ private:
     agnocast::PublisherOptions pub_options;
     std::string req_topic_name = create_service_request_topic_name(service_name_);
     publisher_ = std::make_shared<TypeErasedPublisher>(
-      node, req_topic_name, "", qos, pub_options, PublisherRole::AgnocastOnly);
+      node, req_topic_name, "", qos, pub_options, to_publisher_role(role));
 
     auto subscriber_callback = [this, node](ipc_shared_ptr<void> && response) {
       auto generic_response_wrapper =
@@ -385,9 +398,9 @@ private:
 
     SubscriptionOptions sub_options{group};
     std::string res_topic_name = create_service_response_topic_name(service_name_, node_name_);
+    const SubscriptionRole subscriber_role = to_subscription_role(role);
     subscriber_ = std::make_shared<Subscription<void>>(
-      node, res_topic_name, "", qos, std::move(subscriber_callback), sub_options,
-      SubscriptionRole::AgnocastOnly);
+      node, res_topic_name, "", qos, std::move(subscriber_callback), sub_options, subscriber_role);
 
     if (role == ClientRole::Default) {
       register_service_bridge(

--- a/src/agnocastlib/include/agnocast/agnocast_service.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_service.hpp
@@ -22,10 +22,24 @@ namespace agnocast
 enum class ServiceRole : uint8_t {
   /// User-created service; issues an R2A bridge request.
   Default,
-  /// Used by the bridge plugin's own service; no bridge request is issued.
+  /// Used by the bridge implementation itself; marks the endpoints it creates as bridges in kmod
+  /// and issues no bridge request. A bridge service shares the request topic with a real one, so
+  /// that mark is what tells them apart.
   /// Not intended for direct use by application code.
-  AgnocastOnly,
+  BridgeInternal,
 };
+
+constexpr SubscriptionRole to_subscription_role(const ServiceRole role)
+{
+  return role == ServiceRole::BridgeInternal ? SubscriptionRole::BridgeInternal
+                                             : SubscriptionRole::AgnocastOnly;
+}
+
+constexpr PublisherRole to_publisher_role(const ServiceRole role)
+{
+  return role == ServiceRole::BridgeInternal ? PublisherRole::BridgeInternal
+                                             : PublisherRole::AgnocastOnly;
+}
 
 // Internal implementation - users should use agnocast::Service<ServiceT> instead.
 template <typename ServiceT>
@@ -55,6 +69,7 @@ private:
   const std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string service_name_;
   const rclcpp::QoS qos_;
+  const ServiceRole role_;
   std::mutex publishers_mtx_;
   std::unordered_map<std::string, typename ServiceResponsePublisher::SharedPtr> publishers_;
   typename ServiceRequestSubscriber::SharedPtr subscriber_;
@@ -72,7 +87,7 @@ private:
             std::string topic_name = create_service_response_topic_name(service_name_, node_name);
             agnocast::PublisherOptions pub_options;
             pub = std::make_shared<ServiceResponsePublisher>(
-              node, topic_name, qos_, pub_options, PublisherRole::AgnocastOnly);
+              node, topic_name, qos_, pub_options, to_publisher_role(role_));
             publishers_[node_name] = pub;
           },
           node_);
@@ -118,7 +133,7 @@ private:
   template <typename Func, typename NodeT>
   void constructor_impl(
     NodeT * node, const std::string & service_name, Func && callback,
-    rclcpp::CallbackGroup::SharedPtr group, ServiceRole role)
+    rclcpp::CallbackGroup::SharedPtr group)
   {
     static_assert(
       is_basic_cb<Func>::value || is_deferred_cb<Func>::value,
@@ -131,19 +146,20 @@ private:
 
     SubscriptionOptions options{group};
     std::string topic_name = create_service_request_topic_name(service_name_);
+    const SubscriptionRole subscriber_role = to_subscription_role(role_);
     if constexpr (is_basic_cb<Func>::value) {
       subscriber_ = std::make_shared<ServiceRequestSubscriber>(
         node, topic_name, qos_,
         wrap_basic_service_callback_for_subscriber(std::forward<Func>(callback)), options,
-        SubscriptionRole::AgnocastOnly);
+        subscriber_role);
     } else if constexpr (is_deferred_cb<Func>::value) {
       subscriber_ = std::make_shared<ServiceRequestSubscriber>(
         node, topic_name, qos_,
         wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), options,
-        SubscriptionRole::AgnocastOnly);
+        subscriber_role);
     }
 
-    if (role == ServiceRole::Default) {
+    if (role_ == ServiceRole::Default) {
       std::optional<std::pair<std::string, std::string>> shadow_node_identity{std::nullopt};
       if constexpr (std::is_same_v<std::remove_cv_t<NodeT>, agnocast::Node>) {
         shadow_node_identity =
@@ -163,9 +179,9 @@ public:
     rclcpp::Node * node, const std::string & service_name, Func && callback,
     const rclcpp::QoS & qos, rclcpp::CallbackGroup::SharedPtr group,
     ServiceRole role = ServiceRole::Default)
-  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile()), role_(role)
   {
-    constructor_impl(node, service_name, std::forward<Func>(callback), group, role);
+    constructor_impl(node, service_name, std::forward<Func>(callback), group);
   }
 
   template <typename Func>
@@ -173,9 +189,9 @@ public:
     agnocast::Node * node, const std::string & service_name, Func && callback,
     const rclcpp::QoS & qos, rclcpp::CallbackGroup::SharedPtr group,
     ServiceRole role = ServiceRole::Default)
-  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile()), role_(role)
   {
-    constructor_impl(node, service_name, std::forward<Func>(callback), group, role);
+    constructor_impl(node, service_name, std::forward<Func>(callback), group);
   }
 
   /**
@@ -253,6 +269,7 @@ class GenericService : public std::enable_shared_from_this<GenericService>
   const std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string service_name_;
   const rclcpp::QoS qos_;
+  const ServiceRole role_;
   std::mutex publishers_mtx_;
   std::unordered_map<std::string, typename TypeErasedPublisher::SharedPtr> publishers_;
   typename Subscription<void>::SharedPtr subscriber_;
@@ -316,7 +333,7 @@ class GenericService : public std::enable_shared_from_this<GenericService>
   template <typename Func, typename NodeT>
   void constructor_impl(
     NodeT * node, const std::string & service_name, const std::string & service_type,
-    Func && callback, const rclcpp::CallbackGroup::SharedPtr & group, ServiceRole role)
+    Func && callback, const rclcpp::CallbackGroup::SharedPtr & group)
   {
     static_assert(
       is_basic_cb<Func>::value || is_deferred_cb<Func>::value,
@@ -331,19 +348,20 @@ class GenericService : public std::enable_shared_from_this<GenericService>
 
     SubscriptionOptions sub_options{group};
     std::string req_topic_name = create_service_request_topic_name(service_name_);
+    const SubscriptionRole subscriber_role = to_subscription_role(role_);
     if constexpr (is_basic_cb<Func>::value) {
       subscriber_ = std::make_shared<Subscription<void>>(
         node, req_topic_name, "", qos_,
         wrap_basic_service_callback_for_subscriber(std::forward<Func>(callback)), sub_options,
-        SubscriptionRole::AgnocastOnly);
+        subscriber_role);
     } else if constexpr (is_deferred_cb<Func>::value) {
       subscriber_ = std::make_shared<Subscription<void>>(
         node, req_topic_name, "", qos_,
         wrap_deferred_service_callback_for_subscriber(std::forward<Func>(callback)), sub_options,
-        SubscriptionRole::AgnocastOnly);
+        subscriber_role);
     }
 
-    if (role == ServiceRole::Default) {
+    if (role_ == ServiceRole::Default) {
       std::optional<std::pair<std::string, std::string>> shadow_node_identity{std::nullopt};
       if constexpr (std::is_same_v<std::remove_cv_t<NodeT>, agnocast::Node>) {
         shadow_node_identity =
@@ -362,9 +380,9 @@ public:
     rclcpp::Node * node, const std::string & service_name, const std::string & service_type,
     Func && callback, const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group,
     ServiceRole role = ServiceRole::Default)
-  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile()), role_(role)
   {
-    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group, role);
+    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group);
   }
 
   template <typename Func>
@@ -372,9 +390,9 @@ public:
     agnocast::Node * node, const std::string & service_name, const std::string & service_type,
     Func && callback, const rclcpp::QoS & qos, const rclcpp::CallbackGroup::SharedPtr & group,
     ServiceRole role = ServiceRole::Default)
-  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile())
+  : node_(node), qos_(rclcpp::QoS(qos).durability_volatile()), role_(role)
   {
-    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group, role);
+    constructor_impl(node, service_name, service_type, std::forward<Func>(callback), group);
   }
 
   void send_response(ipc_shared_ptr<void> && request, ipc_shared_ptr<void> && response);

--- a/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
+++ b/src/agnocastlib/include/agnocast/bridge/agnocast_service_bridge.hpp
@@ -79,9 +79,9 @@ struct ServiceBridgeDeps
 // service goes away.
 //
 // Two things escape that guard, and both let (2) destroy the item while an Agnocast service is
-// still running. may_start_r2a_bridge_ is set only by a ServiceRole::Default service, so an
-// AgnocastOnly one never guards anything; and agno_service_exists() reads at most one entry, so it
-// reports false when two or more Agnocast services share the name.
+// still running. may_start_r2a_bridge_ is set only by a ServiceRole::Default service, so a
+// BridgeInternal one never guards anything; and agno_service_exists() reads at most one entry, so
+// it reports false when two or more Agnocast services share the name.
 enum class ServiceBridgeState { NONE, PENDING, A2R, R2A };
 
 class ServiceBridgeItem

--- a/src/agnocastlib/src/agnocast_service.cpp
+++ b/src/agnocastlib/src/agnocast_service.cpp
@@ -19,7 +19,7 @@ typename TypeErasedPublisher::SharedPtr GenericService::get_or_create_publisher_
           std::string topic_name = create_service_response_topic_name(service_name_, node_name);
           agnocast::PublisherOptions pub_options;
           pub = std::make_shared<TypeErasedPublisher>(
-            node, topic_name, "", qos_, pub_options, PublisherRole::AgnocastOnly);
+            node, topic_name, "", qos_, pub_options, to_publisher_role(role_));
           publishers_[node_name] = pub;
         },
         node_);

--- a/src/agnocastlib/src/bridge/agnocast_bridge_loader.cpp
+++ b/src/agnocastlib/src/bridge/agnocast_bridge_loader.cpp
@@ -338,7 +338,7 @@ ServiceBridgeEntity BridgeLoader::create_r2a_service_bridge_generic(
   auto client_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant, false);
 
   auto agno_client = std::make_shared<agnocast::GenericClient>(
-    node.get(), service_name, service_type, qos, client_cb_group, ClientRole::AgnocastOnly);
+    node.get(), service_name, service_type, qos, client_cb_group, ClientRole::BridgeInternal);
 
   auto ros_srv = agnocast::vendor_rclcpp::GenericService::create_generic_service(
     node.get(), service_name, service_type,
@@ -427,7 +427,7 @@ ServiceBridgeEntity BridgeLoader::create_a2r_service_bridge_generic(
           service_handle->get_service_name(), e.what());
       }
     },
-    qos, srv_cbg, agnocast::ServiceRole::AgnocastOnly);
+    qos, srv_cbg, agnocast::ServiceRole::BridgeInternal);
 
   return {agno_srv, srv_cbg, client_cbg};
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
+++ b/src/ros2agnocast/ros2agnocast/templates/service_bridge_plugin.cpp.em
@@ -23,9 +23,8 @@ extern "C" ServiceBridgeEntity create_r2a_service_bridge_@(snake_type_name)(
   auto srv_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant, false);
   auto client_cb_group = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant, false);
 
-  // AgnocastOnly: this client is the bridge's own endpoint and must not itself request a bridge.
   auto agno_client = std::make_shared<AgnoClient>(
-    node.get(), service_name, qos, client_cb_group, agnocast::ClientRole::AgnocastOnly);
+    node.get(), service_name, qos, client_cb_group, agnocast::ClientRole::BridgeInternal);
 
   auto ros_srv = node->create_service<ServiceT>(
     service_name,
@@ -98,8 +97,7 @@ extern "C" ServiceBridgeEntity create_a2r_service_bridge_@(snake_type_name)(
           service_handle->get_service_name(), e.what());
       }
     },
-    // AgnocastOnly: this service is the bridge's own endpoint and must not itself request a bridge.
-    qos, srv_cb_group, agnocast::ServiceRole::AgnocastOnly);
+    qos, srv_cb_group, agnocast::ServiceRole::BridgeInternal);
 
   return {agno_srv, srv_cb_group, client_cb_group};
 }


### PR DESCRIPTION
## Description

`ServiceRole` and `ClientRole` only had `Default` and `AgnocastOnly`, and the service implementation hardcoded `SubscriptionRole::AgnocastOnly` for its internal subscriber. A bridge-owned service was therefore indistinguishable from a real one on the request topic the two share -- `create_service_request_topic_name()` is a pure function of the service name, so both land in the same table with nothing to tell them apart. The pub/sub bridge has always marked its own endpoints; the service path did not.

Rename the enumerator to `BridgeInternal` -- the only non-default users are the A2R and R2A service bridges, so it already meant "the bridge's own entity" -- and derive the internal subscriber's and publisher's roles from it instead of hardcoding them, in the generated plugin template as well.

The mark is what #1557 keys on to keep an endpoint inside its own domain, and what `decide_bridges()` keys on to leave a bridge's own endpoints out of the demand it counts.

Because the kmod now guarantees that a bridge endpoint does not communicate with an endpoint in another domain, that fact no longer has to be carried out to user space: a peer-domain counterpart of `ret_a2r_bridge_exist` would describe something no endpoint ever has to handle. Since the communication does not happen in the first place, an endpoint has no occasion to deal with another domain's bridge subscriber, so `GET_SUBSCRIBER_NUM` does not report it at all rather than reporting it for the caller to subtract. The same-domain counts are unchanged, because delivery to a bridge in one's own domain does happen: it is still counted, and `ret_a2r_bridge_exist` still tells a caller to separate it from the ROS 2 subscribers it stands for.

## Related links

Answers https://github.com/autowarefoundation/agnocast/pull/1542#discussion_r3812254853.

Was stacked on #1557, which is merged, so this now sits on `main`.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` -- no ioctl struct or command changes, so kmod and agnocastlib stay compatible.

