### PR TITLE
fix(agnocast_kmod): keep bridge endpoints out of cross-domain delivery

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -106,10 +106,17 @@ static struct topic_struct * find_grouped_topic_struct(
 // Whether a publication in pub_domain may be delivered to a subscriber in
 // sub_domain within this topic_struct. Same domain is always allowed; crossing
 // domains requires a rule permitting that direction (from_domain -> to_domain).
+//
+// A bridge endpoint is excluded from crossing at all: it stands for one domain's ROS 2 side, and
+// relaying between domains is the external domain_bridge's job. A rule that reached one would
+// duplicate what that node already carries.
 static bool domain_delivery_allowed(
-  const struct topic_struct * topic, uint32_t pub_domain, uint32_t sub_domain)
+  const struct topic_struct * topic, const uint32_t pub_domain, const bool pub_is_bridge,
+  const uint32_t sub_domain, const bool sub_is_bridge)
 {
   if (pub_domain == sub_domain) return true;
+
+  if (pub_is_bridge || sub_is_bridge) return false;
 
   const struct domain_bridge_rule * rule = topic->rule;
   if (!rule) return false;
@@ -266,7 +273,9 @@ static void rebuild_notify_list(struct topic_wrapper * wrapper, struct publisher
   {
     // NULL exactly for take subs, which poll instead of being woken.
     if (!sub_info->notify_ctx) continue;
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id))
+    if (!domain_delivery_allowed(
+          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
+          sub_info->is_bridge))
       continue;
     if (sub_info->ignore_local_publications && sub_info->pid == pub_info->pid) continue;
 
@@ -687,7 +696,7 @@ static int insert_message_entry(
 }
 
 static int set_publisher_shm_info(
-  const struct topic_wrapper * wrapper, const pid_t subscriber_pid,
+  const struct topic_wrapper * wrapper, const pid_t subscriber_pid, const bool sub_is_bridge,
   struct publisher_shm_info * pub_shm_infos, uint32_t pub_shm_infos_size,
   uint32_t * ret_pub_shm_num)
 {
@@ -702,7 +711,9 @@ static int set_publisher_shm_info(
 
     // A subscriber only reads from publishers that deliver to it; a one-way
     // bridge rule can exclude opposite-domain publishers, so skip mapping them.
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, wrapper->domain_id)) {
+    if (!domain_delivery_allowed(
+          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, wrapper->domain_id,
+          sub_is_bridge)) {
       continue;
     }
 
@@ -1151,7 +1162,9 @@ static int receive_msg_core(
       continue;
     }
 
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(
+          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
+          sub_info->is_bridge)) {
       continue;
     }
 
@@ -1243,7 +1256,8 @@ int agnocast_ioctl_receive_msg(
   }
 
   ret = set_publisher_shm_info(
-    wrapper, sub_info->pid, pub_shm_infos, pub_shm_infos_size, &ioctl_ret->ret_pub_shm_num);
+    wrapper, sub_info->pid, sub_info->is_bridge, pub_shm_infos, pub_shm_infos_size,
+    &ioctl_ret->ret_pub_shm_num);
   if (ret < 0) {
     goto unlock_all;
   }
@@ -1325,7 +1339,9 @@ int agnocast_ioctl_take_msg(
       continue;
     }
 
-    if (!domain_delivery_allowed(wrapper->topic, pub_info->domain_id, sub_info->domain_id)) {
+    if (!domain_delivery_allowed(
+          wrapper->topic, pub_info->domain_id, pub_info->is_bridge, sub_info->domain_id,
+          sub_info->is_bridge)) {
       continue;
     }
 
@@ -1356,7 +1372,8 @@ int agnocast_ioctl_take_msg(
   }
 
   ret = set_publisher_shm_info(
-    wrapper, sub_info->pid, pub_shm_infos, pub_shm_infos_size, &ioctl_ret->ret_pub_shm_num);
+    wrapper, sub_info->pid, sub_info->is_bridge, pub_shm_infos, pub_shm_infos_size,
+    &ioctl_ret->ret_pub_shm_num);
   if (ret < 0) {
     goto unlock_all;
   }
@@ -1409,7 +1426,10 @@ int agnocast_ioctl_get_subscriber_num(
   hash_for_each(wrapper->topic->sub_info_htable, bkt_sub, sub_info, node)
   {
     if (sub_info->domain_id != wrapper->domain_id) {
-      if (domain_delivery_allowed(wrapper->topic, wrapper->domain_id, sub_info->domain_id)) {
+      // The ioctl names a topic, not a publisher, so the asking side is assumed not to be a
+      // bridge. A bridge publisher asking would be over-counted: nothing it publishes crosses.
+      if (domain_delivery_allowed(
+            wrapper->topic, wrapper->domain_id, false, sub_info->domain_id, sub_info->is_bridge)) {
         other_domain_count++;
       }
       continue;

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.c
@@ -13,40 +13,33 @@ bool is_take_sub = false;
 bool ignore_local_publications = false;
 bool is_bridge = false;
 
-static void setup_one_subscriber(struct kunit * test, char * topic_name)
+static void setup_one_subscriber_impl(
+  struct kunit * test, char * topic_name, const uint32_t domain_id, const bool sub_is_bridge)
 {
   subscriber_pid++;
 
   union ioctl_add_process_args add_process_args;
   int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+    subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
 
   union ioctl_add_subscriber_args add_subscriber_args;
   int ret2 = agnocast_ioctl_add_subscriber(
     topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
-    &add_subscriber_args);
+    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, sub_is_bridge,
+    -1, &add_subscriber_args);
 
   KUNIT_ASSERT_EQ(test, ret1, 0);
   KUNIT_ASSERT_EQ(test, ret2, 0);
 }
 
+static void setup_one_subscriber(struct kunit * test, char * topic_name)
+{
+  setup_one_subscriber_impl(test, topic_name, 0, false);
+}
+
 static void setup_one_subscriber_with_bridge(struct kunit * test, char * topic_name)
 {
-  subscriber_pid++;
-
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
-
-  union ioctl_add_subscriber_args add_subscriber_args;
-  int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, true, -1,
-    &add_subscriber_args);
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+  setup_one_subscriber_impl(test, topic_name, 0, true);
 }
 
 static void setup_one_publisher(struct kunit * test, char * topic_name)
@@ -86,20 +79,13 @@ static void setup_one_intra_subscriber(struct kunit * test, char * topic_name)
 static void setup_one_subscriber_in_domain(
   struct kunit * test, char * topic_name, const uint32_t domain_id)
 {
-  subscriber_pid++;
+  setup_one_subscriber_impl(test, topic_name, domain_id, false);
+}
 
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args);
-
-  union ioctl_add_subscriber_args add_subscriber_args;
-  int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
-    &add_subscriber_args);
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+static void setup_one_subscriber_in_domain_with_bridge(
+  struct kunit * test, char * topic_name, const uint32_t domain_id)
+{
+  setup_one_subscriber_impl(test, topic_name, domain_id, true);
 }
 
 // The count is reported for the domain the calling process is registered in, so the publisher has
@@ -316,4 +302,50 @@ void test_case_get_subscriber_num_other_domain_undelivered(struct kunit * test)
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
   KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 0);
+}
+
+// The bridge drops out of the reachable count, the real subscriber beside it does not.
+void test_case_get_subscriber_num_other_domain_bridge_not_counted(struct kunit * test)
+{
+  // Arrange
+  char * topic_name = "/kunit_test_topic";
+  int ret_setup =
+    agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns);
+  KUNIT_ASSERT_EQ(test, ret_setup, 0);
+  setup_current_publisher_in_domain(test, topic_name, 1);
+  setup_one_subscriber_in_domain_with_bridge(test, topic_name, 2);
+  setup_one_subscriber_in_domain(test, topic_name, 2);
+  union ioctl_get_subscriber_num_args subscriber_num_args;
+
+  // Act
+  int ret = agnocast_ioctl_get_subscriber_num(
+    topic_name, current->nsproxy->ipc_ns, current->tgid, &subscriber_num_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 1);
+}
+
+// The exclusion is about crossing, not about being a bridge.
+void test_case_get_subscriber_num_same_domain_bridge_still_counted(struct kunit * test)
+{
+  // Arrange
+  char * topic_name = "/kunit_test_topic";
+  int ret_setup =
+    agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns);
+  KUNIT_ASSERT_EQ(test, ret_setup, 0);
+  setup_current_publisher_in_domain(test, topic_name, 1);
+  setup_one_subscriber_in_domain_with_bridge(test, topic_name, 1);
+  setup_one_subscriber_in_domain(test, topic_name, 2);
+  union ioctl_get_subscriber_num_args subscriber_num_args;
+
+  // Act
+  int ret = agnocast_ioctl_get_subscriber_num(
+    topic_name, current->nsproxy->ipc_ns, current->tgid, &subscriber_num_args);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_process_subscriber_num, 1);
+  KUNIT_EXPECT_EQ(test, subscriber_num_args.ret_other_domain_subscriber_num, 1);
+  KUNIT_EXPECT_TRUE(test, subscriber_num_args.ret_a2r_bridge_exist);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_get_subscriber_num.h
@@ -12,7 +12,9 @@
     KUNIT_CASE(test_case_get_subscriber_num_intra_process),                                       \
     KUNIT_CASE(test_case_get_subscriber_num_other_domain),                                        \
     KUNIT_CASE(test_case_get_subscriber_num_other_domain_reversed_pair),                          \
-    KUNIT_CASE(test_case_get_subscriber_num_other_domain_undelivered)
+    KUNIT_CASE(test_case_get_subscriber_num_other_domain_undelivered),                            \
+    KUNIT_CASE(test_case_get_subscriber_num_other_domain_bridge_not_counted),                     \
+    KUNIT_CASE(test_case_get_subscriber_num_same_domain_bridge_still_counted)
 
 void test_case_get_subscriber_num_normal(struct kunit * test);
 void test_case_get_subscriber_num_many(struct kunit * test);
@@ -25,3 +27,5 @@ void test_case_get_subscriber_num_intra_process(struct kunit * test);
 void test_case_get_subscriber_num_other_domain(struct kunit * test);
 void test_case_get_subscriber_num_other_domain_reversed_pair(struct kunit * test);
 void test_case_get_subscriber_num_other_domain_undelivered(struct kunit * test);
+void test_case_get_subscriber_num_other_domain_bridge_not_counted(struct kunit * test);
+void test_case_get_subscriber_num_same_domain_bridge_still_counted(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -723,8 +723,10 @@ void test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified(struct
   topic_local_id_t publisher_id;
   uint64_t ret_addr;
   setup_publisher_in_domain(test, current->tgid, 1, is_bridge, &publisher_id, &ret_addr);
-  const int eventfd = 0;
-  setup_one_subscriber_in_domain_with_eventfd(test, 2, true, eventfd, false);
+  const int bridge_eventfd = 0;
+  const int plain_eventfd = 1;
+  setup_one_subscriber_in_domain_with_eventfd(test, 2, true, bridge_eventfd, false);
+  setup_one_subscriber_in_domain_with_eventfd(test, 2, is_bridge, plain_eventfd, false);
   union ioctl_publish_msg_args ioctl_publish_msg_ret;
 
   // Act
@@ -733,7 +735,9 @@ void test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified(struct
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
-  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(bridge_eventfd), 0);
+  // The non-bridge subscriber is the control: it reads zero too if the two cells never grouped.
+  KUNIT_EXPECT_EQ(test, signal_count_of(plain_eventfd), 1);
 }
 
 void test_case_publish_msg_bridge_publisher_does_not_notify_other_domain(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.c
@@ -19,65 +19,28 @@ static pid_t common_pid = 3000;
 static bool is_take_sub = false;
 static bool is_bridge = false;
 
-static void setup_one_subscriber(
-  struct kunit * test, topic_local_id_t * subscriber_id, bool ignore_local_publications)
-{
-  subscriber_pid++;
-
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
-
-  union ioctl_add_subscriber_args add_subscriber_args;
-  int ret2 = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, subscriber_pid, qos_depth,
-    qos_is_transient_local, qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, -1,
-    &add_subscriber_args);
-  *subscriber_id = add_subscriber_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
-}
-
-static void setup_one_publisher(
-  struct kunit * test, topic_local_id_t * publisher_id, uint64_t * ret_addr)
-{
-  publisher_pid++;
-
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
-  *ret_addr = add_process_args.ret_addr;
-
-  union ioctl_add_publisher_args add_publisher_args;
-  int ret2 = agnocast_ioctl_add_publisher(
-    topic_name, current->nsproxy->ipc_ns, node_name, publisher_pid, qos_depth,
-    qos_is_transient_local, is_bridge, &add_publisher_args);
-  *publisher_id = add_publisher_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
-}
-
-// The setup helpers above pass -1, which the fake maps to its unobserved slot: the subscriber
-// still enters the publishers' notify lists and is signaled on publish, but no assertion can see
-// it. Cases that assert on delivery need a real fd instead.
+// The helpers below pass -1 for the eventfd unless a case needs to observe delivery: the fake maps
+// -1 to its unobserved slot, so the subscriber still enters the notify lists and is signaled, but
+// no assertion can see it.
 static topic_local_id_t add_subscriber_with_eventfd(
-  struct kunit * test, const pid_t pid, const int eventfd, const bool ignore_local_publications)
+  struct kunit * test, const pid_t pid, const int eventfd, const bool ignore_local_publications,
+  const bool sub_is_bridge)
 {
   union ioctl_add_subscriber_args add_subscriber_args;
-  int ret = agnocast_ioctl_add_subscriber(
-    topic_name, current->nsproxy->ipc_ns, node_name, pid, qos_depth, qos_is_transient_local,
-    qos_is_reliable, is_take_sub, ignore_local_publications, is_bridge, eventfd,
-    &add_subscriber_args);
-
-  KUNIT_ASSERT_EQ(test, ret, 0);
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      topic_name, current->nsproxy->ipc_ns, node_name, pid, qos_depth, qos_is_transient_local,
+      qos_is_reliable, is_take_sub, ignore_local_publications, sub_is_bridge, eventfd,
+      &add_subscriber_args),
+    0);
   return add_subscriber_args.ret_id;
 }
 
-// Same, but in a process of its own.
-static topic_local_id_t setup_one_subscriber_with_eventfd(
-  struct kunit * test, const int eventfd, const bool ignore_local_publications)
+// Same, but in a process of its own, registered in the given domain.
+static topic_local_id_t setup_one_subscriber_in_domain_with_eventfd(
+  struct kunit * test, const uint32_t domain_id, const bool sub_is_bridge, const int eventfd,
+  const bool ignore_local_publications)
 {
   subscriber_pid++;
 
@@ -85,9 +48,52 @@ static topic_local_id_t setup_one_subscriber_with_eventfd(
   KUNIT_ASSERT_EQ(
     test,
     agnocast_ioctl_add_process(
-      subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
+      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
     0);
-  return add_subscriber_with_eventfd(test, subscriber_pid, eventfd, ignore_local_publications);
+  return add_subscriber_with_eventfd(
+    test, subscriber_pid, eventfd, ignore_local_publications, sub_is_bridge);
+}
+
+static void setup_one_subscriber(
+  struct kunit * test, topic_local_id_t * subscriber_id, bool ignore_local_publications)
+{
+  *subscriber_id =
+    setup_one_subscriber_in_domain_with_eventfd(test, 0, is_bridge, -1, ignore_local_publications);
+}
+
+static topic_local_id_t setup_one_subscriber_with_eventfd(
+  struct kunit * test, const int eventfd, const bool ignore_local_publications)
+{
+  return setup_one_subscriber_in_domain_with_eventfd(
+    test, 0, is_bridge, eventfd, ignore_local_publications);
+}
+
+static void setup_publisher_in_domain(
+  struct kunit * test, const pid_t pid, const uint32_t domain_id, const bool pub_is_bridge,
+  topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
+  union ioctl_add_process_args add_process_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    0);
+  *ret_addr = add_process_args.ret_addr;
+
+  union ioctl_add_publisher_args add_publisher_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      topic_name, current->nsproxy->ipc_ns, node_name, pid, qos_depth, qos_is_transient_local,
+      pub_is_bridge, &add_publisher_args),
+    0);
+  *publisher_id = add_publisher_args.ret_id;
+}
+
+static void setup_one_publisher(
+  struct kunit * test, topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
+  publisher_pid++;
+  setup_publisher_in_domain(test, publisher_pid, 0, is_bridge, publisher_id, ret_addr);
 }
 
 // One process holding both, which is what makes ignore_local_publications observable.
@@ -97,23 +103,8 @@ static void setup_pub_sub_same_process_with_eventfd(
 {
   common_pid++;
 
-  union ioctl_add_process_args add_process_args;
-  KUNIT_ASSERT_EQ(
-    test,
-    agnocast_ioctl_add_process(common_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
-    0);
-  *ret_addr = add_process_args.ret_addr;
-
-  union ioctl_add_publisher_args add_publisher_args;
-  KUNIT_ASSERT_EQ(
-    test,
-    agnocast_ioctl_add_publisher(
-      topic_name, current->nsproxy->ipc_ns, node_name, common_pid, qos_depth,
-      qos_is_transient_local, is_bridge, &add_publisher_args),
-    0);
-  *publisher_id = add_publisher_args.ret_id;
-
-  add_subscriber_with_eventfd(test, common_pid, eventfd, ignore_local_publications);
+  setup_publisher_in_domain(test, common_pid, 0, is_bridge, publisher_id, ret_addr);
+  add_subscriber_with_eventfd(test, common_pid, eventfd, ignore_local_publications, is_bridge);
 }
 
 static uint32_t signal_count_of(const int eventfd)
@@ -464,7 +455,7 @@ void test_case_publish_msg_does_not_signal_take_sub(struct kunit * test)
       qos_is_transient_local, qos_is_reliable, true /* is_take_sub */, false, is_bridge,
       take_eventfd, &take_sub_args),
     0);
-  add_subscriber_with_eventfd(test, subscriber_pid, notify_eventfd, false);
+  add_subscriber_with_eventfd(test, subscriber_pid, notify_eventfd, false, is_bridge);
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret = {0};
 
@@ -495,7 +486,7 @@ void test_case_publish_msg_signals_large_fanout(struct kunit * test)
       subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args),
     0);
   for (int eventfd = 0; eventfd < subscriber_num; eventfd++) {
-    add_subscriber_with_eventfd(test, subscriber_pid, eventfd, false);
+    add_subscriber_with_eventfd(test, subscriber_pid, eventfd, false, is_bridge);
   }
 
   union ioctl_publish_msg_args ioctl_publish_msg_ret = {0};
@@ -718,4 +709,76 @@ void test_case_publish_msg_no_process(struct kunit * test)
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+// PUBLISH resolves the wrapper by the caller's domain, so the publisher of a cross-domain case
+// has to be current->tgid.
+void test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  agnocast_kunit_eventfd_reset();
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, current->tgid, 1, is_bridge, &publisher_id, &ret_addr);
+  const int eventfd = 0;
+  setup_one_subscriber_in_domain_with_eventfd(test, 2, true, eventfd, false);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
+}
+
+void test_case_publish_msg_bridge_publisher_does_not_notify_other_domain(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  agnocast_kunit_eventfd_reset();
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, current->tgid, 1, true, &publisher_id, &ret_addr);
+  const int eventfd = 0;
+  setup_one_subscriber_in_domain_with_eventfd(test, 2, is_bridge, eventfd, false);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
+}
+
+// The exclusion is about crossing, not about being a bridge.
+void test_case_publish_msg_bridge_subscriber_in_own_domain_notified(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(topic_name, topic_name, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  agnocast_kunit_eventfd_reset();
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, current->tgid, 1, is_bridge, &publisher_id, &ret_addr);
+  const int eventfd = 0;
+  setup_one_subscriber_in_domain_with_eventfd(test, 1, true, eventfd, false);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+
+  // Act
+  int ret = agnocast_ioctl_publish_msg(
+    topic_name, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_publish_msg.h
@@ -21,7 +21,10 @@
     KUNIT_CASE(test_case_publish_msg_stops_signaling_exited_subscriber),                      \
     KUNIT_CASE(test_case_publish_msg_address_below_mempool),                                  \
     KUNIT_CASE(test_case_publish_msg_address_above_mempool),                                  \
-    KUNIT_CASE(test_case_publish_msg_no_process)
+    KUNIT_CASE(test_case_publish_msg_no_process),                                             \
+    KUNIT_CASE(test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified),         \
+    KUNIT_CASE(test_case_publish_msg_bridge_publisher_does_not_notify_other_domain),          \
+    KUNIT_CASE(test_case_publish_msg_bridge_subscriber_in_own_domain_notified)
 
 void test_case_publish_msg_no_topic(struct kunit * test);
 void test_case_publish_msg_no_publisher(struct kunit * test);
@@ -43,3 +46,6 @@ void test_case_publish_msg_stops_signaling_exited_subscriber(struct kunit * test
 void test_case_publish_msg_address_below_mempool(struct kunit * test);
 void test_case_publish_msg_address_above_mempool(struct kunit * test);
 void test_case_publish_msg_no_process(struct kunit * test);
+void test_case_publish_msg_bridge_subscriber_in_other_domain_not_notified(struct kunit * test);
+void test_case_publish_msg_bridge_publisher_does_not_notify_other_domain(struct kunit * test);
+void test_case_publish_msg_bridge_subscriber_in_own_domain_notified(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.c
@@ -17,41 +17,83 @@ static bool IS_BRIDGE = false;
 // Small buffer size for KUnit tests to avoid exceeding kernel stack frame limits.
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
+static void setup_subscriber_impl(
+  struct kunit * test, const pid_t subscriber_pid, const uint32_t qos_depth,
+  const bool is_transient_local, const uint32_t domain_id, const bool sub_is_bridge,
+  topic_local_id_t * subscriber_id)
+{
+  union ioctl_add_process_args add_process_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    0);
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, sub_is_bridge, -1,
+      &add_subscriber_args),
+    0);
+  *subscriber_id = add_subscriber_args.ret_id;
+}
+
 static void setup_one_subscriber(
   struct kunit * test, pid_t subscriber_pid, uint32_t qos_depth, bool is_transient_local,
   topic_local_id_t * subscriber_id)
 {
+  setup_subscriber_impl(
+    test, subscriber_pid, qos_depth, is_transient_local, 0, IS_BRIDGE, subscriber_id);
+}
+
+// RECEIVE resolves the wrapper by the caller's domain, so the subscriber of a cross-domain case
+// has to be current->tgid.
+static void setup_current_subscriber_in_domain(
+  struct kunit * test, const uint32_t domain_id, const bool sub_is_bridge,
+  topic_local_id_t * subscriber_id)
+{
+  setup_subscriber_impl(test, current->tgid, 1, false, domain_id, sub_is_bridge, subscriber_id);
+}
+
+static void setup_publisher_impl(
+  struct kunit * test, const pid_t publisher_pid, const uint32_t qos_depth,
+  const bool is_transient_local, const uint32_t domain_id, const bool pub_is_bridge,
+  topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      publisher_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    0);
+  *ret_addr = add_process_args.ret_addr;
 
-  union ioctl_add_subscriber_args add_subscriber_args;
-  int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
-  *subscriber_id = add_subscriber_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+  union ioctl_add_publisher_args add_publisher_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
+      pub_is_bridge, &add_publisher_args),
+    0);
+  *publisher_id = add_publisher_args.ret_id;
 }
 
 static void setup_one_publisher(
   struct kunit * test, pid_t publisher_pid, uint32_t qos_depth, bool is_transient_local,
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
-  *ret_addr = add_process_args.ret_addr;
+  setup_publisher_impl(
+    test, publisher_pid, qos_depth, is_transient_local, 0, IS_BRIDGE, publisher_id, ret_addr);
+}
 
-  union ioctl_add_publisher_args add_publisher_args;
-  int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
-  *publisher_id = add_publisher_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+static void setup_publisher_in_domain(
+  struct kunit * test, const pid_t publisher_pid, const uint32_t domain_id,
+  const bool pub_is_bridge, topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
+  setup_publisher_impl(
+    test, publisher_pid, 1, false, domain_id, pub_is_bridge, publisher_id, ret_addr);
 }
 
 void test_case_receive_msg_no_topic_when_receive(struct kunit * test)
@@ -158,7 +200,7 @@ void test_case_receive_msg_receive_one(struct kunit * test)
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_qos_depth(
+void test_case_receive_msg_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
   struct kunit * test)
 {
   // Arrange
@@ -207,7 +249,7 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_p
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_qos_depth(
+void test_case_receive_msg_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test)
 {
   // Arrange
@@ -251,7 +293,7 @@ void test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_p
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_publish_num(
+void test_case_receive_msg_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
   struct kunit * test)
 {
   // Arrange
@@ -302,7 +344,7 @@ void test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_max_receive_num(
+void test_case_receive_msg_publish_num_and_sub_qos_and_pub_qos_are_all_max_receive_num(
   struct kunit * test)
 {
   // Arrange
@@ -414,7 +456,7 @@ void test_case_receive_msg_qos_depth_larger_than_max_receive_num(struct kunit * 
     last_entry_id);
 }
 
-void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
+void test_case_receive_msg_transient_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
   struct kunit * test)
 {
   // Arrange
@@ -459,7 +501,7 @@ void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_a
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
+void test_case_receive_msg_transient_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
   struct kunit * test)
 {
   // Arrange
@@ -515,7 +557,7 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
+void test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
   struct kunit * test)
 {
   // Arrange
@@ -566,7 +608,7 @@ void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smal
   KUNIT_EXPECT_EQ(test, pub_shm_infos[0].shm_addr, ret_addr);
 }
 
-void test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
+void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test)
 {
   // Arrange
@@ -1042,4 +1084,66 @@ void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret5, 0);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 1);
   KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_ids[0], ioctl_publish_msg_ret.ret_entry_id);
+}
+
+void test_case_receive_msg_bridge_subscriber_in_other_domain_receives_nothing(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, 1000, 1, IS_BRIDGE, &publisher_id, &ret_addr);
+  topic_local_id_t subscriber_id;
+  setup_current_subscriber_in_domain(test, 2, true, &subscriber_id);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret),
+    0);
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+    &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_num, 0);
+}
+
+void test_case_receive_msg_bridge_publisher_in_other_domain_delivers_nothing(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, 1000, 1, true, &publisher_id, &ret_addr);
+  topic_local_id_t subscriber_id;
+  setup_current_subscriber_in_domain(test, 2, IS_BRIDGE, &subscriber_id);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret),
+    0);
+  union ioctl_receive_msg_args ioctl_receive_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_receive_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, pub_shm_infos, KUNIT_PUB_SHM_BUF_SIZE,
+    &ioctl_receive_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_entry_num, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_receive_msg_ret.ret_pub_shm_num, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_receive_msg.h
@@ -2,58 +2,55 @@
 #pragma once
 #include <kunit/test.h>
 
-#define TEST_CASES_RECEIVE_MSG                                                                        \
-  KUNIT_CASE(test_case_receive_msg_no_topic_when_receive),                                            \
-    KUNIT_CASE(test_case_receive_msg_no_subscriber_when_receive),                                     \
-    KUNIT_CASE(test_case_receive_msg_no_publish_nothing_to_receive),                                  \
-    KUNIT_CASE(test_case_receive_msg_receive_one),                                                    \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_qos_depth),       \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_qos_depth),       \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_publish_num),       \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_max_receive_num), \
-    KUNIT_CASE(test_case_receive_msg_qos_depth_larger_than_max_receive_num),                          \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal),       \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_than_publish_num),   \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smaller_than_pub_qos),   \
-    KUNIT_CASE(                                                                                       \
-      test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),   \
-    KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                    \
-    KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                         \
-    KUNIT_CASE(test_case_receive_msg_2pub_in_same_process),                                           \
-    KUNIT_CASE(test_case_receive_msg_2sub_in_same_process),                                           \
-    KUNIT_CASE(test_case_receive_msg_twice),                                                          \
-    KUNIT_CASE(test_case_receive_msg_with_exited_publisher),                                          \
-    KUNIT_CASE(test_case_receive_msg_pub_shm_info_buffer_too_small),                                  \
-    KUNIT_CASE(test_case_receive_msg_ignore_local_same_pid_enabled),                                  \
-    KUNIT_CASE(test_case_receive_msg_ignore_local_same_pid_disabled)
+#define TEST_CASES_RECEIVE_MSG                                                                     \
+  KUNIT_CASE(test_case_receive_msg_no_topic_when_receive),                                         \
+    KUNIT_CASE(test_case_receive_msg_no_subscriber_when_receive),                                  \
+    KUNIT_CASE(test_case_receive_msg_no_publish_nothing_to_receive),                               \
+    KUNIT_CASE(test_case_receive_msg_receive_one),                                                 \
+    KUNIT_CASE(test_case_receive_msg_sub_qos_smaller_than_publish_num_smaller_than_pub_qos),       \
+    KUNIT_CASE(test_case_receive_msg_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),       \
+    KUNIT_CASE(test_case_receive_msg_sub_qos_smaller_than_pub_qos_smaller_than_publish_num),       \
+    KUNIT_CASE(test_case_receive_msg_publish_num_and_sub_qos_and_pub_qos_are_all_max_receive_num), \
+    KUNIT_CASE(test_case_receive_msg_qos_depth_larger_than_max_receive_num),                       \
+    KUNIT_CASE(test_case_receive_msg_transient_sub_qos_and_pub_qos_and_publish_num_are_all_equal), \
+    KUNIT_CASE(                                                                                    \
+      test_case_receive_msg_transient_sub_qos_smaller_than_pub_qos_smaller_than_publish_num),      \
+    KUNIT_CASE(                                                                                    \
+      test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_than_pub_qos),      \
+    KUNIT_CASE(                                                                                    \
+      test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos),      \
+    KUNIT_CASE(test_case_receive_msg_one_new_pub),                                                 \
+    KUNIT_CASE(test_case_receive_msg_pubsub_in_same_process),                                      \
+    KUNIT_CASE(test_case_receive_msg_2pub_in_same_process),                                        \
+    KUNIT_CASE(test_case_receive_msg_2sub_in_same_process),                                        \
+    KUNIT_CASE(test_case_receive_msg_twice),                                                       \
+    KUNIT_CASE(test_case_receive_msg_with_exited_publisher),                                       \
+    KUNIT_CASE(test_case_receive_msg_pub_shm_info_buffer_too_small),                               \
+    KUNIT_CASE(test_case_receive_msg_ignore_local_same_pid_enabled),                               \
+    KUNIT_CASE(test_case_receive_msg_ignore_local_same_pid_disabled),                              \
+    KUNIT_CASE(test_case_receive_msg_bridge_subscriber_in_other_domain_receives_nothing),          \
+    KUNIT_CASE(test_case_receive_msg_bridge_publisher_in_other_domain_delivers_nothing)
 
 void test_case_receive_msg_no_topic_when_receive(struct kunit * test);
 void test_case_receive_msg_no_subscriber_when_receive(struct kunit * test);
 void test_case_receive_msg_no_publish_nothing_to_receive(struct kunit * test);
 void test_case_receive_msg_receive_one(struct kunit * test);
-void test_case_receive_msg_sub_qos_depth_smaller_than_publish_num_smaller_than_pub_qos_depth(
+void test_case_receive_msg_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
   struct kunit * test);
-void test_case_receive_msg_publish_num_smaller_than_sub_qos_depth_smaller_than_pub_qos_depth(
+void test_case_receive_msg_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test);
-void test_case_receive_msg_sub_qos_depth_smaller_than_pub_qos_depth_smaller_than_publish_num(
+void test_case_receive_msg_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
   struct kunit * test);
-void test_case_receive_msg_publish_num_and_sub_qos_depth_and_pub_qos_depth_are_all_max_receive_num(
+void test_case_receive_msg_publish_num_and_sub_qos_and_pub_qos_are_all_max_receive_num(
   struct kunit * test);
 void test_case_receive_msg_qos_depth_larger_than_max_receive_num(struct kunit * test);
-void test_case_receive_msg_transient_local_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
+void test_case_receive_msg_transient_sub_qos_and_pub_qos_and_publish_num_are_all_equal(
   struct kunit * test);
-void test_case_receive_msg_transient_local_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
+void test_case_receive_msg_transient_sub_qos_smaller_than_pub_qos_smaller_than_publish_num(
   struct kunit * test);
-void test_case_receive_msg_transient_local_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
+void test_case_receive_msg_transient_sub_qos_smaller_than_publish_num_smaller_than_pub_qos(
   struct kunit * test);
-void test_case_receive_msg_transient_local_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
+void test_case_receive_msg_transient_publish_num_smaller_than_sub_qos_smaller_than_pub_qos(
   struct kunit * test);
 void test_case_receive_msg_one_new_pub(struct kunit * test);
 void test_case_receive_msg_pubsub_in_same_process(struct kunit * test);
@@ -64,3 +61,5 @@ void test_case_receive_msg_with_exited_publisher(struct kunit * test);
 void test_case_receive_msg_pub_shm_info_buffer_too_small(struct kunit * test);
 void test_case_receive_msg_ignore_local_same_pid_enabled(struct kunit * test);
 void test_case_receive_msg_ignore_local_same_pid_disabled(struct kunit * test);
+void test_case_receive_msg_bridge_subscriber_in_other_domain_receives_nothing(struct kunit * test);
+void test_case_receive_msg_bridge_publisher_in_other_domain_delivers_nothing(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.c
@@ -17,41 +17,83 @@ static const bool IS_BRIDGE = false;
 // Small buffer size for KUnit tests to avoid exceeding kernel stack frame limits.
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 
+static void setup_subscriber_impl(
+  struct kunit * test, const pid_t subscriber_pid, const uint32_t qos_depth,
+  const bool is_transient_local, const uint32_t domain_id, const bool sub_is_bridge,
+  topic_local_id_t * subscriber_id)
+{
+  union ioctl_add_process_args add_process_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      subscriber_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    0);
+
+  union ioctl_add_subscriber_args add_subscriber_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_subscriber(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth,
+      is_transient_local, IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, sub_is_bridge, -1,
+      &add_subscriber_args),
+    0);
+  *subscriber_id = add_subscriber_args.ret_id;
+}
+
 static void setup_one_subscriber(
   struct kunit * test, pid_t subscriber_pid, uint32_t qos_depth, bool is_transient_local,
   topic_local_id_t * subscriber_id)
 {
+  setup_subscriber_impl(
+    test, subscriber_pid, qos_depth, is_transient_local, 0, IS_BRIDGE, subscriber_id);
+}
+
+// TAKE resolves the wrapper by the caller's domain, so the subscriber of a cross-domain case
+// has to be current->tgid.
+static void setup_current_subscriber_in_domain(
+  struct kunit * test, const uint32_t domain_id, const bool sub_is_bridge,
+  topic_local_id_t * subscriber_id)
+{
+  setup_subscriber_impl(test, current->tgid, 1, false, domain_id, sub_is_bridge, subscriber_id);
+}
+
+static void setup_publisher_impl(
+  struct kunit * test, const pid_t publisher_pid, const uint32_t qos_depth,
+  const bool is_transient_local, const uint32_t domain_id, const bool pub_is_bridge,
+  topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
   union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    subscriber_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_process(
+      publisher_pid, current->nsproxy->ipc_ns, false, domain_id, &add_process_args),
+    0);
+  *ret_addr = add_process_args.ret_addr;
 
-  union ioctl_add_subscriber_args add_subscriber_args;
-  int ret2 = agnocast_ioctl_add_subscriber(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, subscriber_pid, qos_depth, is_transient_local,
-    IS_RELIABLE, IS_TAKE_SUB, IGNORE_LOCAL_PUBLICATIONS, IS_BRIDGE, -1, &add_subscriber_args);
-  *subscriber_id = add_subscriber_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+  union ioctl_add_publisher_args add_publisher_args;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_add_publisher(
+      TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
+      pub_is_bridge, &add_publisher_args),
+    0);
+  *publisher_id = add_publisher_args.ret_id;
 }
 
 static void setup_one_publisher(
   struct kunit * test, pid_t publisher_pid, uint32_t qos_depth, bool is_transient_local,
   topic_local_id_t * publisher_id, uint64_t * ret_addr)
 {
-  union ioctl_add_process_args add_process_args;
-  int ret1 = agnocast_ioctl_add_process(
-    publisher_pid, current->nsproxy->ipc_ns, false, 0, &add_process_args);
-  *ret_addr = add_process_args.ret_addr;
+  setup_publisher_impl(
+    test, publisher_pid, qos_depth, is_transient_local, 0, IS_BRIDGE, publisher_id, ret_addr);
+}
 
-  union ioctl_add_publisher_args add_publisher_args;
-  int ret2 = agnocast_ioctl_add_publisher(
-    TOPIC_NAME, current->nsproxy->ipc_ns, NODE_NAME, publisher_pid, qos_depth, is_transient_local,
-    IS_BRIDGE, &add_publisher_args);
-  *publisher_id = add_publisher_args.ret_id;
-
-  KUNIT_ASSERT_EQ(test, ret1, 0);
-  KUNIT_ASSERT_EQ(test, ret2, 0);
+static void setup_publisher_in_domain(
+  struct kunit * test, const pid_t publisher_pid, const uint32_t domain_id,
+  const bool pub_is_bridge, topic_local_id_t * publisher_id, uint64_t * ret_addr)
+{
+  setup_publisher_impl(
+    test, publisher_pid, 1, false, domain_id, pub_is_bridge, publisher_id, ret_addr);
 }
 
 void test_case_take_msg_no_topic(struct kunit * test)
@@ -1078,4 +1120,66 @@ void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test)
   KUNIT_EXPECT_EQ(test, ret5, 0);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_entry_id, ioctl_publish_msg_ret.ret_entry_id);
   KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, add_process_args.ret_addr);
+}
+
+void test_case_take_msg_bridge_subscriber_in_other_domain_takes_nothing(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, 1000, 1, IS_BRIDGE, &publisher_id, &ret_addr);
+  topic_local_id_t subscriber_id;
+  setup_current_subscriber_in_domain(test, 2, true, &subscriber_id);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret),
+    0);
+  union ioctl_take_msg_args ioctl_take_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, true, pub_shm_infos,
+    KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_num, 0);
+}
+
+void test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  topic_local_id_t publisher_id;
+  uint64_t ret_addr;
+  setup_publisher_in_domain(test, 1000, 1, true, &publisher_id, &ret_addr);
+  topic_local_id_t subscriber_id;
+  setup_current_subscriber_in_domain(test, 2, IS_BRIDGE, &subscriber_id);
+  union ioctl_publish_msg_args ioctl_publish_msg_ret;
+  KUNIT_ASSERT_EQ(
+    test,
+    agnocast_ioctl_publish_msg(
+      TOPIC_NAME, current->nsproxy->ipc_ns, publisher_id, ret_addr, &ioctl_publish_msg_ret),
+    0);
+  union ioctl_take_msg_args ioctl_take_msg_ret;
+  struct publisher_shm_info pub_shm_infos[KUNIT_PUB_SHM_BUF_SIZE] = {0};
+
+  // Act
+  int ret = agnocast_ioctl_take_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, subscriber_id, true, pub_shm_infos,
+    KUNIT_PUB_SHM_BUF_SIZE, &ioctl_take_msg_ret);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_addr, 0);
+  KUNIT_EXPECT_EQ(test, ioctl_take_msg_ret.ret_pub_shm_num, 0);
 }

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_take_msg.h
@@ -30,7 +30,9 @@
     KUNIT_CASE(test_case_take_msg_2sub_in_same_process),                                          \
     KUNIT_CASE(test_case_take_msg_with_exited_publisher),                                         \
     KUNIT_CASE(test_case_take_msg_ignore_local_same_pid_enabled),                                 \
-    KUNIT_CASE(test_case_take_msg_ignore_local_same_pid_disabled)
+    KUNIT_CASE(test_case_take_msg_ignore_local_same_pid_disabled),                                \
+    KUNIT_CASE(test_case_take_msg_bridge_subscriber_in_other_domain_takes_nothing),               \
+    KUNIT_CASE(test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing)
 
 void test_case_take_msg_no_topic(struct kunit * test);
 void test_case_take_msg_no_subscriber(struct kunit * test);
@@ -62,3 +64,5 @@ void test_case_take_msg_2sub_in_same_process(struct kunit * test);
 void test_case_take_msg_with_exited_publisher(struct kunit * test);
 void test_case_take_msg_ignore_local_same_pid_enabled(struct kunit * test);
 void test_case_take_msg_ignore_local_same_pid_disabled(struct kunit * test);
+void test_case_take_msg_bridge_subscriber_in_other_domain_takes_nothing(struct kunit * test);
+void test_case_take_msg_bridge_publisher_in_other_domain_delivers_nothing(struct kunit * test);


### PR DESCRIPTION
## Description

A bridge endpoint stands for its own domain's ROS 2 side: an A2R subscriber carries that domain's Agnocast traffic out to DDS, an R2A publisher carries DDS traffic back in. Delivering to one across a domain bridge rule therefore has the kmod carry Agnocast in one domain to ROS 2 in another -- and that is the external `domain_bridge` node's job, not the kmod's, which is what `decide_bridges()` already says.

`domain_delivery_allowed()` looked only at the two domains, so a rule reached those endpoints and a publication then crossed twice: once by the rule, once through the `domain_bridge` node the same YAML entry configures.

The predicate now rejects a crossing where either endpoint carries `is_bridge`. Same-domain delivery is untouched: a bridge still takes its own domain's traffic, grouped or not.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [x] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

`ret_other_domain_subscriber_num` from #1542 now excludes bridges by construction, so the count and delivery agree again. `GET_SUBSCRIBER_NUM` names a topic, not a publisher, so the predicate is asked with `pub_is_bridge = false`; every caller today is a `ClientRole::Default` client.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update` -- the ioctl structs and commands are unchanged, so kmod and agnocastlib stay compatible.
