### PR TITLE
feat(ros2agnocast_discovery_agent): force the cross-domain A2R bridge from the rule config

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/agent.py
@@ -40,7 +40,10 @@ from ros2agnocast_discovery_msgs.msg import (
     AgnocastTopic,
 )
 
+import yaml
+
 from . import bridge_decider
+from . import domain_bridge_config
 from .type_registry import TypeRegistryReader
 
 
@@ -296,6 +299,41 @@ def _read_ros_domain_id() -> int:
     return value
 
 
+def _load_domain_rules(logger=None) -> list:
+    """Return the domain bridge rules from the config, or [].
+
+    Every outcome is logged: a silently empty rule list looks exactly like the
+    cross-domain deadlock this forcing exists to break. An unreadable config is a
+    warning rather than fatal, so it never takes the gossip publication down.
+    """
+    path, from_env = domain_bridge_config.resolve_config_path()
+
+    try:
+        rules, skipped = domain_bridge_config.load_domain_bridge_rules(path)
+    except FileNotFoundError:
+        if logger is not None:
+            if from_env:
+                logger.warn(
+                    f'{domain_bridge_config.CONFIG_ENV} points at {path}, which does not '
+                    'exist; no cross-domain bridge will be forced')
+            else:
+                logger.info(
+                    f'no domain bridge config at {path}; cross-domain bridge forcing '
+                    f'is off (set {domain_bridge_config.CONFIG_ENV} to use another path)')
+        return []
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as exc:
+        if logger is not None:
+            logger.warn(
+                f'cannot load {path} ({exc}); no cross-domain bridge will be forced')
+        return []
+
+    if logger is not None:
+        logger.info(f'{path}: {len(rules)} domain bridge rule(s) loaded')
+        if skipped:
+            logger.warn(f'{path}: no from_domain/to_domain for {", ".join(skipped)}')
+    return rules
+
+
 def _gossip_qos() -> QoSProfile:
     return QoSProfile(
         reliability=ReliabilityPolicy.RELIABLE,
@@ -323,7 +361,8 @@ class DiscoveryAgent(Node):
 
     Also subscribes to its own gossip topic and caches the latest snapshot per
     ``(host_uuid, ipc_ns_inode)``; each tick the bridge decider diffs that
-    against the local state and issues cross-NS bridge requests.
+    against the local state and issues cross-NS bridge requests, plus the
+    cross-domain ones implied by the domain bridge rule config.
     """
 
     def __init__(
@@ -352,6 +391,7 @@ class DiscoveryAgent(Node):
         self._clock = Clock(clock_type=ClockType.SYSTEM_TIME)
         self._registry = registry if registry is not None else TypeRegistryReader(
             self._ipc_ns_inode, logger=self.get_logger())
+        self._domain_rules = _load_domain_rules(self.get_logger())
 
         qos = _gossip_qos()
         self._pub = self.create_publisher(AgnocastDaemonState, GOSSIP_TOPIC, qos)
@@ -427,10 +467,9 @@ class DiscoveryAgent(Node):
         return msg
 
     def _dispatch_bridge_requests(self, local_state: AgnocastDaemonState) -> None:
-        if not self._remote_states:
-            return
         remote_states = {key: msg for key, (msg, _received_at) in self._remote_states.items()}
         requests = bridge_decider.decide_bridges(local_state, remote_states)
+        requests += bridge_decider.decide_domain_rule_bridges(local_state, self._domain_rules)
         if requests:
             bridge_decider.dispatch_requests(
                 requests, self._ipc_ns_inode, logger=self.get_logger())

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/bridge_decider.py
@@ -8,6 +8,8 @@ so the two reach each other through ROS 2 (DDS):
   * local publisher  + remote subscriber -> A2R bridge (publish to DDS)
   * local subscriber + remote publisher  -> R2A bridge (reinject from DDS)
 
+The domain bridge rule config is a second, gossip-independent source of requests.
+
 The request is sent as a ``BridgeMsg`` (type=DaemonPubSub) to the per-namespace
 bridge_manager over an abstract-namespace UNIX domain socket
 (``\\0agnocast_bridge_manager_<ipc_ns_inode>[_d<domain>]``).
@@ -158,6 +160,46 @@ def decide_bridges(local_state, remote_states) -> list:
     return list(requests.values())
 
 
+def decide_domain_rule_bridges(local_state, rules) -> list:
+    """Return the A2R requests implied by the registered domain bridge rules.
+
+    Only the ``from`` side is forced: there domain_bridge waits for a DDS
+    publisher while the A2R bridge waits for a DDS subscriber, so neither starts.
+    The ``to`` side is left to the ordinary on-demand check.
+
+    Forcing is unconditional: gossip never crosses domains, so there is no
+    evidence here of a subscriber in ``to_domain``.
+    """
+    requests = {}
+    local_by_topic = {(t.topic_name, t.domain_id): t for t in local_state.topics}
+
+    for from_topic, _to_topic, from_domain, to_domain in rules:
+        if from_domain == to_domain:
+            continue
+
+        local_topic = local_by_topic.get((from_topic, from_domain))
+        if local_topic is None or not local_topic.type_name:
+            continue
+
+        local_pubs = [p for p in local_topic.publishers if not p.is_bridge]
+        if not local_pubs:
+            continue
+
+        pub = local_pubs[0]
+        key = (from_topic, from_domain, DIRECTION_AGNOCAST_TO_ROS2)
+        requests.setdefault(key, BridgeRequest(
+            topic_name=from_topic,
+            type_name=local_topic.type_name,
+            direction=DIRECTION_AGNOCAST_TO_ROS2,
+            qos_depth=pub.qos_depth,
+            qos_is_transient_local=pub.qos_is_transient_local,
+            qos_is_reliable=pub.qos_is_reliable,
+            domain_id=from_domain,
+        ))
+
+    return list(requests.values())
+
+
 def _bridge_uds_addr(ipc_ns_inode: int, domain_id: int) -> str:
     name = '\x00' + _BRIDGE_UDS_BASE + '_' + str(ipc_ns_inode)
     if domain_id:
@@ -201,7 +243,8 @@ def dispatch_requests(
     ``send_request`` swallows ECONNREFUSED/ENOENT so a missing peer never
     stalls the daemon, and the request is re-issued idempotently next tick.
     """
-    for req in requests:
+    # decide_bridges and decide_domain_rule_bridges can both ask for the same bridge.
+    for req in dict.fromkeys(requests):
         err = send_request(
             _bridge_uds_addr(ipc_ns_inode, req.domain_id), serialize_request(req))
         if err is not None and logger is not None:

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -6,14 +6,26 @@ rule injection that opens same-IPC-namespace zero-copy cross-domain delivery. Th
 topic name, its ``remap`` target, and the domain pair matter here; ``type`` and
 other fields are ignored.
 """
+import os
+
 import yaml
 
 # Operators point the daemon at the config by setting this to the YAML path.
 CONFIG_ENV = 'AGNOCAST_DOMAIN_BRIDGE_CONFIG'
 
+# The agent is exec'd by an application process and inherits *its* environment, so
+# an env var set only where the registration tool runs never reaches the agent.
+DEFAULT_CONFIG_PATH = '/etc/agnocast/domain_bridge.yaml'
+
 # Domain ids cross the ioctl boundary as ctypes.c_uint32, so an out-of-range
 # value would wrap silently; reject it here instead.
 _UINT32_MAX = 0xFFFFFFFF
+
+
+def resolve_config_path():
+    """Return ``(path, from_env)`` for the config every consumer should read."""
+    path = os.environ.get(CONFIG_ENV)
+    return (path, True) if path else (DEFAULT_CONFIG_PATH, False)
 
 
 def _as_domain_id(value):
@@ -30,6 +42,7 @@ def parse_domain_bridge_config(text):
     ``rules`` is a list of ``(from_topic, to_topic, from_domain, to_domain)``
     tuples. ``to_topic`` is the per-topic ``remap`` target (same ``domain_bridge``
     field the external node honors), or the source name when ``remap`` is absent.
+    A ``bidirectional`` topic yields two tuples, one per direction.
     ``skipped`` lists the topic names dropped for lack of a resolvable domain
     pair, so the caller can surface them instead of dropping them silently.
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
@@ -70,8 +83,16 @@ def parse_domain_bridge_config(text):
         to_topic = spec.get('remap', str(topic_name))
         if not isinstance(to_topic, str):
             raise ValueError(f"'remap' for topic {topic_name!r} must be a string")
-        rules.append(
-            (str(topic_name), to_topic, _as_domain_id(from_domain), _as_domain_id(to_domain)))
+        bidirectional = spec.get('bidirectional', False)
+        if not isinstance(bidirectional, bool):
+            raise ValueError(f"'bidirectional' for topic {topic_name!r} must be a boolean")
+        from_id = _as_domain_id(from_domain)
+        to_id = _as_domain_id(to_domain)
+        rules.append((str(topic_name), to_topic, from_id, to_id))
+        if bidirectional:
+            # The external node's reverse leg swaps the domain ids and nothing else, keeping the
+            # source name on the subscribe side and the remap on the publish side.
+            rules.append((str(topic_name), to_topic, to_id, from_id))
     return rules, skipped
 
 

--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/register_domain_bridge.py
@@ -12,7 +12,6 @@ discovery agent, which is observability-only and never registers rules.
 """
 import argparse
 import ctypes
-import os
 import sys
 
 import yaml
@@ -35,14 +34,11 @@ def main(argv=None) -> int:
         description='Register Agnocast domain bridge rules with the kernel module.')
     parser.add_argument(
         '--config',
-        default=os.environ.get(domain_bridge_config.CONFIG_ENV),
+        default=domain_bridge_config.resolve_config_path()[0],
         help='path to the domain_bridge YAML '
-             f'(default: ${domain_bridge_config.CONFIG_ENV})')
+             f'(default: ${domain_bridge_config.CONFIG_ENV}, '
+             f'else {domain_bridge_config.DEFAULT_CONFIG_PATH})')
     args = parser.parse_args(argv)
-
-    if not args.config:
-        parser.error(
-            f'no config given; pass --config or set {domain_bridge_config.CONFIG_ENV}')
 
     try:
         rules, skipped = domain_bridge_config.load_domain_bridge_rules(args.config)

--- a/src/ros2agnocast_discovery_agent/systemd/README.md
+++ b/src/ros2agnocast_discovery_agent/systemd/README.md
@@ -10,8 +10,9 @@ never registers rules).
 `domain_bridge` YAML and registers each rule:
 
 ```bash
-ros2 run ros2agnocast_discovery_agent register_domain_bridge --config /etc/agnocast/domain_bridge.yaml
-# or set AGNOCAST_DOMAIN_BRIDGE_CONFIG and run it with no arguments
+ros2 run ros2agnocast_discovery_agent register_domain_bridge
+# reads /etc/agnocast/domain_bridge.yaml; override with --config or
+# AGNOCAST_DOMAIN_BRIDGE_CONFIG
 ```
 
 Run it once, ordered so that it:

--- a/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
+++ b/src/ros2agnocast_discovery_agent/systemd/agnocast-domain-bridge.service.example
@@ -21,7 +21,8 @@ Before=my-robot-apps.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Environment=AGNOCAST_DOMAIN_BRIDGE_CONFIG=/etc/agnocast/domain_bridge.yaml
+# No AGNOCAST_DOMAIN_BRIDGE_CONFIG: an Environment= here reaches this unit only,
+# never the agent, which the applications exec. See README.md to move the config.
 # Source ROS 2 and the workspace so `ros2 run` resolves, then register.
 ExecStart=/bin/bash -lc 'source /opt/ros/$ROS_DISTRO/setup.bash && ros2 run ros2agnocast_discovery_agent register_domain_bridge'
 

--- a/src/ros2agnocast_discovery_agent/test/test_agent.py
+++ b/src/ros2agnocast_discovery_agent/test/test_agent.py
@@ -14,6 +14,7 @@ import pytest
 
 from rclpy.executors import ExternalShutdownException
 
+from ros2agnocast_discovery_agent import domain_bridge_config
 from ros2agnocast_discovery_agent.agent import (
     DiscoveryAgent,
     EXIT_WHEN_IDLE_ENV,
@@ -23,9 +24,16 @@ from ros2agnocast_discovery_agent.agent import (
     TopicInfoRet,
     _exit_when_idle_enabled,
     _ioctl_to_endpoint,
+    _load_domain_rules,
     _read_host_uuid,
     read_local_topics,
 )
+from ros2agnocast_discovery_agent.bridge_decider import (
+    BridgeRequest,
+    DIRECTION_AGNOCAST_TO_ROS2,
+)
+from ros2agnocast_discovery_agent.domain_bridge_config import CONFIG_ENV
+from ros2agnocast_discovery_msgs.msg import AgnocastDaemonState
 
 
 def _make_info(node_name: str, qos_depth: int = 10,
@@ -402,6 +410,102 @@ def test_idle_exit_tracker_resets_on_activity():
 def test_idle_exit_tracker_threshold_floor():
     # A non-positive threshold is clamped to 1, so a single idle tick fires.
     assert IdleExitTracker(threshold=0).update(True) is True
+
+
+def test_dispatch_issues_domain_rule_bridges_without_any_remote_agent(monkeypatch):
+    """The cross-domain path has no gossip peer, so it must not be gated on one."""
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    forced = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 10, False, True, domain_id=1)
+    monkeypatch.setattr(bd, 'decide_domain_rule_bridges', lambda state, rules: [forced])
+    sent = []
+    monkeypatch.setattr(bd, 'dispatch_requests', lambda reqs, ns, logger=None: sent.extend(reqs))
+
+    fake_self = SimpleNamespace(
+        _remote_states={}, _domain_rules=[('/x', '/x', 1, 2)], _ipc_ns_inode=7,
+        get_logger=lambda: MagicMock())
+    DiscoveryAgent._dispatch_bridge_requests(fake_self, AgnocastDaemonState())
+
+    assert sent == [forced]
+
+
+def test_load_domain_rules_returns_empty_when_no_config_exists(monkeypatch, tmp_path):
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    monkeypatch.setattr(
+        domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(tmp_path / 'absent.yaml'))
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == []
+    logger.info.assert_called_once()
+    logger.warn.assert_not_called()
+
+
+def test_load_domain_rules_falls_back_to_the_default_path(monkeypatch, tmp_path):
+    config = tmp_path / 'domain_bridge.yaml'
+    config.write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    monkeypatch.setattr(domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(config))
+
+    assert _load_domain_rules() == [('/x', '/x', 1, 2)]
+
+
+def test_load_domain_rules_warns_when_the_configured_path_is_absent(monkeypatch, tmp_path):
+    """An env var pointing at nothing is a misconfiguration; a missing default is not."""
+    monkeypatch.setenv(CONFIG_ENV, str(tmp_path / 'absent.yaml'))
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == []
+    logger.warn.assert_called_once()
+
+
+def test_load_domain_rules_logs_what_it_loaded(monkeypatch, tmp_path):
+    config = tmp_path / 'domain_bridge.yaml'
+    config.write_text('from_domain: 1\nto_domain: 2\ntopics:\n  /x:\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+    logger = MagicMock()
+
+    _load_domain_rules(logger)
+
+    logger.info.assert_called_once()
+    assert str(config) in logger.info.call_args[0][0]
+
+
+def test_load_domain_rules_parses_the_configured_yaml(monkeypatch, tmp_path):
+    config = tmp_path / 'domain_bridge.yaml'
+    config.write_text(
+        'from_domain: 1\n'
+        'to_domain: 2\n'
+        'topics:\n'
+        '  /x:\n'
+        '    type: std_msgs/msg/Int32\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+
+    assert _load_domain_rules() == [('/x', '/x', 1, 2)]
+
+
+def test_load_domain_rules_warns_about_topics_without_a_domain_pair(monkeypatch, tmp_path):
+    config = tmp_path / 'domain_bridge.yaml'
+    config.write_text(
+        'topics:\n'
+        '  /x:\n'
+        '    from_domain: 1\n'
+        '    to_domain: 2\n'
+        '  /y:\n'
+        '    type: std_msgs/msg/Int32\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == [('/x', '/x', 1, 2)]
+    assert '/y' in logger.warn.call_args[0][0]
+
+
+def test_load_domain_rules_warns_and_returns_empty_on_a_broken_config(monkeypatch, tmp_path):
+    config = tmp_path / 'domain_bridge.yaml'
+    config.write_text('topics: [not, a, mapping]\n')
+    monkeypatch.setenv(CONFIG_ENV, str(config))
+    logger = MagicMock()
+
+    assert _load_domain_rules(logger) == []
+    logger.warn.assert_called_once()
 
 
 def test_exit_when_idle_enabled_via_env(monkeypatch):

--- a/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
+++ b/src/ros2agnocast_discovery_agent/test/test_bridge_decider.py
@@ -11,6 +11,7 @@ import struct
 from ros2agnocast_discovery_agent.bridge_decider import (
     BridgeRequest,
     decide_bridges,
+    decide_domain_rule_bridges,
     DIRECTION_AGNOCAST_TO_ROS2,
     DIRECTION_ROS2_TO_AGNOCAST,
     dispatch_requests,
@@ -173,6 +174,55 @@ def test_decide_collapses_duplicates_across_remotes():
     assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
 
 
+def test_domain_rule_forces_a2r_on_the_from_side():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=1)])
+    reqs = decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)])
+    assert len(reqs) == 1
+    assert reqs[0].topic_name == '/x'
+    assert reqs[0].direction == DIRECTION_AGNOCAST_TO_ROS2
+    assert reqs[0].domain_id == 1
+
+
+def test_domain_rule_leaves_the_to_side_to_the_on_demand_path():
+    local = _state(topics=[_topic('/x', subs=[_endpoint('/ls')], domain=2)])
+    assert decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)]) == []
+
+
+def test_domain_rule_uses_the_from_side_name_when_renamed():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=1)])
+    reqs = decide_domain_rule_bridges(local, [('/x', '/y', 1, 2)])
+    assert len(reqs) == 1
+    assert reqs[0].topic_name == '/x'
+
+
+def test_domain_rule_skips_when_no_local_publisher():
+    local = _state(topics=[_topic('/x', subs=[_endpoint('/ls')], domain=1)])
+    assert decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)]) == []
+
+
+def test_domain_rule_skips_bridge_only_publisher():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp', is_bridge=True)], domain=1)])
+    assert decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)]) == []
+
+
+def test_domain_rule_skips_when_type_unknown():
+    local = _state(topics=[_topic('/x', type_name='', pubs=[_endpoint('/lp')], domain=1)])
+    assert decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)]) == []
+
+
+def test_domain_rule_skips_rule_that_does_not_cross_domains():
+    local = _state(topics=[_topic('/x', pubs=[_endpoint('/lp')], domain=1)])
+    assert decide_domain_rule_bridges(local, [('/x', '/x', 1, 1)]) == []
+
+
+def test_domain_rule_carries_publisher_qos():
+    local = _state(topics=[
+        _topic('/x', pubs=[_endpoint('/lp', depth=3, transient=True, reliable=False)], domain=1)])
+    reqs = decide_domain_rule_bridges(local, [('/x', '/x', 1, 2)])
+    assert (reqs[0].qos_depth, reqs[0].qos_is_transient_local, reqs[0].qos_is_reliable) == \
+        (3, True, False)
+
+
 def test_serialize_matches_cpp_struct_size():
     req = BridgeRequest('/x', 'std_msgs/msg/Int32', DIRECTION_AGNOCAST_TO_ROS2,
                         10, False, True)
@@ -206,6 +256,17 @@ def test_dispatch_targets_per_namespace_uds(monkeypatch):
 
     req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
     dispatch_requests([req], ipc_ns_inode=12345)
+
+    assert sent == ['\x00agnocast_bridge_manager_12345']
+
+
+def test_dispatch_sends_one_datagram_per_distinct_request(monkeypatch):
+    from ros2agnocast_discovery_agent import bridge_decider as bd
+    sent = []
+    monkeypatch.setattr(bd, 'send_request', lambda addr, payload: sent.append(addr) or None)
+
+    req = BridgeRequest('/x', 'T', DIRECTION_AGNOCAST_TO_ROS2, 1, False, True)
+    dispatch_requests([req, req], ipc_ns_inode=12345)
 
     assert sent == ['\x00agnocast_bridge_manager_12345']
 

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -1,10 +1,12 @@
-"""Unit tests for parsing the domain_bridge YAML into kmod rule tuples.
+"""Unit tests for locating and parsing the domain_bridge YAML.
 
-These exercise the pure parser only; no kmod, DDS, or file I/O is involved.
+These exercise path resolution and the pure parser; no kmod, DDS, or file I/O
+is involved.
 """
 
 import pytest
 
+from ros2agnocast_discovery_agent import domain_bridge_config
 from ros2agnocast_discovery_agent.domain_bridge_config import parse_domain_bridge_config
 
 
@@ -167,3 +169,65 @@ topics:
   chatter:
 """
     assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+
+
+def test_bidirectional_topic_yields_both_directions():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: true
+"""
+    rules, skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/chatter', 1, 2), ('/chatter', '/chatter', 2, 1)]
+    assert skipped == []
+
+
+def test_bidirectional_reverse_leg_swaps_only_the_domains():
+    """Mirrors the external node, whose reverse leg keeps the source and remap names."""
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    remap: /renamed
+    bidirectional: true
+"""
+    rules, _skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/renamed', 1, 2), ('/chatter', '/renamed', 2, 1)]
+
+
+def test_bidirectional_false_yields_one_direction():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: false
+"""
+    rules, _skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/chatter', 1, 2)]
+
+
+def test_non_boolean_bidirectional_is_rejected():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: yes please
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)
+
+
+def test_resolve_config_path_prefers_the_env_var(monkeypatch):
+    monkeypatch.setenv(domain_bridge_config.CONFIG_ENV, '/somewhere/else.yaml')
+    assert domain_bridge_config.resolve_config_path() == ('/somewhere/else.yaml', True)
+
+
+def test_resolve_config_path_falls_back_to_the_default(monkeypatch):
+    monkeypatch.delenv(domain_bridge_config.CONFIG_ENV, raising=False)
+    assert domain_bridge_config.resolve_config_path() == (
+        domain_bridge_config.DEFAULT_CONFIG_PATH, False)

--- a/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
+++ b/src/ros2agnocast_discovery_agent/test/test_register_domain_bridge.py
@@ -1,6 +1,7 @@
 """Tests for the standalone domain bridge rule injector."""
 import pytest
 
+from ros2agnocast_discovery_agent import domain_bridge_config
 from ros2agnocast_discovery_agent import register_domain_bridge
 from ros2agnocast_discovery_agent.domain_bridge_config import CONFIG_ENV
 
@@ -25,10 +26,26 @@ def _write_config(tmp_path, text):
     return str(path)
 
 
-def test_no_config_is_usage_error(monkeypatch):
+def test_missing_config_is_reported_and_registers_nothing(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
     monkeypatch.delenv(CONFIG_ENV, raising=False)
-    with pytest.raises(SystemExit):
-        register_domain_bridge.main([])
+    monkeypatch.setattr(
+        domain_bridge_config, 'DEFAULT_CONFIG_PATH', str(tmp_path / 'absent.yaml'))
+
+    assert register_domain_bridge.main([]) == 1
+    assert fake.calls == []
+
+
+def test_default_config_path_is_used_when_env_unset(tmp_path, monkeypatch):
+    fake = FakeAddRule()
+    monkeypatch.setattr(register_domain_bridge, '_load_add_rule_symbol', lambda: fake)
+    monkeypatch.delenv(CONFIG_ENV, raising=False)
+    cfg = _write_config(tmp_path, 'from_domain: 1\nto_domain: 2\ntopics:\n  chatter:\n')
+    monkeypatch.setattr(domain_bridge_config, 'DEFAULT_CONFIG_PATH', cfg)
+
+    assert register_domain_bridge.main([]) == 0
+    assert fake.calls == [('chatter', 'chatter', 1, 2)]
 
 
 def test_registers_every_rule(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

A topic split across **both** an IPC namespace and a ROS domain never flows, silently: `domain_bridge` waits for a DDS publisher in `from_domain` before subscribing, while the A2R bridge waits for a DDS subscriber before publishing.

The agent now reads the domain bridge YAML and forces the A2R bridge on every topic whose own domain is a rule's `from` side, giving `domain_bridge` a publisher to attach to; the `to` side needs no force. `bidirectional: true` yields both directions, so the external node's reverse leg gets a forced publisher too. Config path: `AGNOCAST_DOMAIN_BRIDGE_CONFIG`, else `/etc/agnocast/domain_bridge.yaml`; the default matters because agnocastlib `execv`s the agent from an application process. With no config, behavior is unchanged.

## Related links

#1570 could replace this force with a real demand check, but that needs gossip to cross domains; this PR is the smallest change that fixes it within the current design.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`pytest` in `src/ros2agnocast_discovery_agent`: 100 passed, guards mutation-checked. The required suites and a two-namespace/two-domain runtime check are outstanding.

## Notes for reviewers

- The forced bridge is not demand-driven (#1570): a listed topic is serialized onto DDS whenever it has a local publisher.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

