### PR TITLE
fix(agnocast_kmod): reject a domain bridge direction added after an endpoint joined

### DIFF
--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2358,9 +2358,9 @@ static int add_domain_rule(
 {
   // Invariant: each cell (name, domain) belongs to at most one rule, and a rule pairs
   // exactly two cells. r_from == r_to (non-NULL) means an existing rule already pairs exactly
-  // these two cells -- a re-declaration or the reverse direction, so just OR in the
-  // direction. Any other overlap (a cell already paired with a different cell) is a
-  // fan-out and is rejected. This is the one place that enforces one pair per cell.
+  // these two cells -- a re-declaration or the reverse direction. Any other overlap (a cell
+  // already paired with a different cell) is a fan-out and is rejected. This is the one place
+  // that enforces one pair per cell.
   // TODO: support >2 domains per topic by storing a domain group instead of a fixed pair.
   struct domain_bridge_rule * r_from = find_domain_rule(topic_name_from, ipc_ns, from_domain);
   struct domain_bridge_rule * r_to = find_domain_rule(topic_name_to, ipc_ns, to_domain);
@@ -2374,19 +2374,29 @@ static int add_domain_rule(
       return -EBUSY;
     }
 
-    if (from_domain < to_domain) {
+    // Re-running the registration tool with an unchanged config must succeed even after nodes
+    // started, so a declaration that enables nothing new is simply accepted.
+    const bool from_is_a = from_domain < to_domain;
+    if ((from_is_a && r_from->a_to_b) || (!from_is_a && r_from->b_to_a)) return 0;
+
+    // Endpoints that joined while this direction was denied were left out of their publishers'
+    // notify lists and skipped by set_publisher_shm_info; neither is repaired here.
+    if (
+      find_topic(topic_name_from, ipc_ns, from_domain) ||
+      find_topic(topic_name_to, ipc_ns, to_domain)) {
+      dev_warn(
+        agnocast_device,
+        "Domain bridge rule (%s@%u -> %s@%u) rejected: it adds a direction after an endpoint "
+        "joined. (%s)\n",
+        topic_name_from, from_domain, topic_name_to, to_domain, __func__);
+      return -EBUSY;
+    }
+
+    if (from_is_a) {
       r_from->a_to_b = true;
     } else {
       r_from->b_to_a = true;
     }
-
-    // Unlike the new-pair path that insert_domain_rule handles, this one runs after endpoints
-    // may have registered, and the direction just enabled was denied when their notify lists
-    // were built. Both cells share one topic_struct once grouped, so either wrapper reaches
-    // every publisher.
-    struct topic_wrapper * wrapper = find_topic(topic_name_from, ipc_ns, from_domain);
-    if (!wrapper) wrapper = find_topic(topic_name_to, ipc_ns, to_domain);
-    if (wrapper) rebuild_all_notify_lists(wrapper);
     return 0;
   }
 

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -236,34 +236,43 @@ void test_case_domain_bridge_direction_respected(struct kunit * test)
   KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 0);
 }
 
-void test_case_domain_bridge_late_reverse_direction_delivers(struct kunit * test)
+// Enabling a direction once endpoints exist cannot be made safe here: they were registered while
+// it was denied, so neither their notify lists nor their shm mappings account for it.
+void test_case_domain_bridge_late_reverse_direction_rejected(struct kunit * test)
 {
-  // Same setup as above, but 2 -> 1 is declared after both endpoints have registered, so the
-  // publisher's notify list was built while that direction was still denied.
+  // Arrange: 1 -> 2 declared, then both endpoints join.
   KUNIT_ASSERT_EQ(
     test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
     0);
-
-  agnocast_kunit_eventfd_reset();
-  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
-  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
-
+  setup_process_in_domain(test, current->tgid, 2);
+  add_publisher_for(test, current->tgid);
   setup_process_in_domain(test, 1001, 1);
-  const int eventfd = 0;
-  add_subscriber_named_with_eventfd(test, 1001, TOPIC_NAME, eventfd);
+  add_subscriber_for(test, 1001);
 
   // Act
+  const int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
+}
+
+// Re-running the registration tool with an unchanged config must keep working once nodes are up.
+void test_case_domain_bridge_redeclaration_is_idempotent(struct kunit * test)
+{
+  // Arrange
   KUNIT_ASSERT_EQ(
-    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
     0);
+  setup_process_in_domain(test, current->tgid, 1);
+  add_publisher_for(test, current->tgid);
 
-  union ioctl_publish_msg_args publish_args;
-  int ret = agnocast_ioctl_publish_msg(
-    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, &publish_args);
-  KUNIT_ASSERT_EQ(test, ret, 0);
+  // Act: the same direction again, so nothing new is enabled.
+  const int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
 
-  // Assert: the newly allowed direction reaches the domain-1 subscriber.
-  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
 }
 
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -257,6 +257,38 @@ void test_case_domain_bridge_late_reverse_direction_rejected(struct kunit * test
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
 }
 
+// Declaring 2 -> 1 as well makes the higher-to-lower direction deliver, which no other case
+// asserts: cross_domain_enumeration publishes the 1 -> 2 way round.
+void test_case_domain_bridge_bidirectional_delivers(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
+
+  // publish resolves the wrapper by the caller's domain, so the caller and the publisher are
+  // both in domain 2.
+  agnocast_kunit_eventfd_reset();
+  const uint64_t msg_addr = setup_process_in_domain(test, current->tgid, 2);
+  const topic_local_id_t pub_id = add_publisher_for(test, current->tgid);
+
+  setup_process_in_domain(test, 1001, 1);
+  const int eventfd = 0;
+  add_subscriber_named_with_eventfd(test, 1001, TOPIC_NAME, eventfd);
+
+  // Act
+  union ioctl_publish_msg_args publish_args;
+  const int ret = agnocast_ioctl_publish_msg(
+    TOPIC_NAME, current->nsproxy->ipc_ns, pub_id, msg_addr, &publish_args);
+  KUNIT_ASSERT_EQ(test, ret, 0);
+
+  // Assert: same arrangement direction_respected leaves unsignaled; here 2 -> 1 is declared.
+  KUNIT_EXPECT_EQ(test, signal_count_of(eventfd), 1);
+}
+
 // Re-running the registration tool with an unchanged config must keep working once nodes are up.
 void test_case_domain_bridge_redeclaration_is_idempotent(struct kunit * test)
 {
@@ -270,6 +302,28 @@ void test_case_domain_bridge_redeclaration_is_idempotent(struct kunit * test)
   // Act: the same direction again, so nothing new is enabled.
   const int ret =
     agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, 0);
+}
+
+// Same promise for a bidirectional config, where the re-declared direction is the one stored as
+// b_to_a rather than a_to_b.
+void test_case_domain_bridge_reverse_redeclaration_is_idempotent(struct kunit * test)
+{
+  // Arrange
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 1, 2, current->nsproxy->ipc_ns),
+    0);
+  KUNIT_ASSERT_EQ(
+    test, agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns),
+    0);
+  setup_process_in_domain(test, current->tgid, 1);
+  add_publisher_for(test, current->tgid);
+
+  // Act
+  const int ret =
+    agnocast_ioctl_add_domain_bridge(TOPIC_NAME, TOPIC_NAME, 2, 1, current->nsproxy->ipc_ns);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -12,8 +12,10 @@
     KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                      \
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),             \
     KUNIT_CASE(test_case_domain_bridge_direction_respected),                  \
+    KUNIT_CASE(test_case_domain_bridge_bidirectional_delivers),               \
     KUNIT_CASE(test_case_domain_bridge_late_reverse_direction_rejected),      \
     KUNIT_CASE(test_case_domain_bridge_redeclaration_is_idempotent),          \
+    KUNIT_CASE(test_case_domain_bridge_reverse_redeclaration_is_idempotent),  \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),          \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),      \
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),             \
@@ -34,8 +36,10 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
+void test_case_domain_bridge_bidirectional_delivers(struct kunit * test);
 void test_case_domain_bridge_late_reverse_direction_rejected(struct kunit * test);
 void test_case_domain_bridge_redeclaration_is_idempotent(struct kunit * test);
+void test_case_domain_bridge_reverse_redeclaration_is_idempotent(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.h
@@ -12,7 +12,8 @@
     KUNIT_CASE(test_case_domain_bridge_groups_wrappers),                      \
     KUNIT_CASE(test_case_domain_bridge_cross_domain_enumeration),             \
     KUNIT_CASE(test_case_domain_bridge_direction_respected),                  \
-    KUNIT_CASE(test_case_domain_bridge_late_reverse_direction_delivers),      \
+    KUNIT_CASE(test_case_domain_bridge_late_reverse_direction_rejected),      \
+    KUNIT_CASE(test_case_domain_bridge_redeclaration_is_idempotent),          \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_keeps_struct),          \
     KUNIT_CASE(test_case_domain_bridge_partial_remove_sub_keeps_struct),      \
     KUNIT_CASE(test_case_domain_bridge_exit_frees_shared_struct),             \
@@ -33,7 +34,8 @@ void test_case_add_domain_bridge_rejected_when_endpoint_exists(struct kunit * te
 void test_case_domain_bridge_groups_wrappers(struct kunit * test);
 void test_case_domain_bridge_cross_domain_enumeration(struct kunit * test);
 void test_case_domain_bridge_direction_respected(struct kunit * test);
-void test_case_domain_bridge_late_reverse_direction_delivers(struct kunit * test);
+void test_case_domain_bridge_late_reverse_direction_rejected(struct kunit * test);
+void test_case_domain_bridge_redeclaration_is_idempotent(struct kunit * test);
 void test_case_domain_bridge_partial_remove_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_partial_remove_sub_keeps_struct(struct kunit * test);
 void test_case_domain_bridge_exit_frees_shared_struct(struct kunit * test);


### PR DESCRIPTION
## Description

Declaring a domain bridge direction on an existing rule was accepted even after endpoints had joined, but nothing brought them up to date. A subscriber that joined while the direction was denied was kept out of its publishers' notify lists and skipped by `set_publisher_shm_info()`, so it never mapped the opposite-domain publisher's mempool. Once the direction was enabled it could be woken and handed entry addresses in that pool, and dereferencing them faults.

Refuse the declaration instead. This is the guarantee creating a rule already requires, so the two paths now agree, and the inconsistent state becomes unreachable rather than something to repair after the fact. A re-declaration that enables nothing new still succeeds, so re-running the registration tool with an unchanged config keeps working.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [x] `bash scripts/test/e2e_test_1to1.bash` (required)
- [x] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
