### PR TITLE
refactor(agnocastlib): let the service client hold its node

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -85,13 +85,18 @@ class ClientBase
 {
 protected:
   std::atomic<int64_t> next_sequence_number_{0};
+  std::variant<rclcpp::Node *, agnocast::Node *> node_;
   std::string node_name_;
   std::string service_name_;
   std::function<bool()> check_context_ok_;
 
+  // Defined in the .cpp: agnocast::Node is only forward-declared here.
+  rclcpp::Logger get_logger() const;
+
   template <typename NodeT>
   void init_base(NodeT * node, const std::string & service_name)
   {
+    node_ = node;
     node_name_ = node->get_fully_qualified_name();
     service_name_ = node->get_node_services_interface()->resolve_service_name(service_name);
 
@@ -198,14 +203,14 @@ private:
       node, create_service_request_topic_name(service_name_), qos, pub_options,
       to_publisher_role(role));
 
-    auto subscriber_callback = [this, node](ipc_shared_ptr<ResponseT> && response) {
+    auto subscriber_callback = [this](ipc_shared_ptr<ResponseT> && response) {
       std::unique_lock<std::mutex> lock(seqno2_response_call_info_mtx_);
       /* --- critical section begin --- */
       // Get the corresponding ResponseCallInfo and remove it from the map
       auto it = seqno2_response_call_info_.find(response->ResponseMeta::seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
-        RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
+        RCLCPP_ERROR(get_logger(), "Agnocast internal implementation error: bad entry id");
         return;
       }
       ResponseCallInfo info = std::move(it->second);
@@ -371,7 +376,7 @@ private:
     publisher_ = std::make_shared<TypeErasedPublisher>(
       node, req_topic_name, "", qos, pub_options, to_publisher_role(role));
 
-    auto subscriber_callback = [this, node](ipc_shared_ptr<void> && response) {
+    auto subscriber_callback = [this](ipc_shared_ptr<void> && response) {
       auto generic_response_wrapper =
         GenericResponseWrapper(service_ts_bundle_.response_members, std::move(response));
       int64_t response_seqno = generic_response_wrapper.seqno();
@@ -382,7 +387,7 @@ private:
       auto it = seqno2_response_call_info_.find(response_seqno);
       if (it == seqno2_response_call_info_.end()) {
         lock.unlock();
-        RCLCPP_ERROR(node->get_logger(), "Agnocast internal implementation error: bad entry id");
+        RCLCPP_ERROR(get_logger(), "Agnocast internal implementation error: bad entry id");
         return;
       }
       ResponseCallInfo info = std::move(it->second);

--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -15,6 +15,11 @@ using namespace std::chrono_literals;
 namespace agnocast
 {
 
+rclcpp::Logger ClientBase::get_logger() const
+{
+  return std::visit([](auto * n) { return n->get_logger(); }, node_);
+}
+
 uint32_t get_agnocast_sub_count(const std::string & topic_name)
 {
   auto topic_info_buffer = std::make_unique<std::array<topic_info_ret, MAX_TOPIC_INFO_RET_NUM>>();


### PR DESCRIPTION
## Description

`Client` and `GenericClient` captured a raw node pointer in their response callback only to reach a logger. That callback is stored in the subscription, so the pointer is held for the client's whole lifetime.

`BasicService` already keeps the node as a `std::variant<rclcpp::Node *, agnocast::Node *>` member, so this makes the client side match: `ClientBase` holds the node and exposes `get_logger()`, and the callbacks capture only `this`. `get_logger()` is defined in the `.cpp` because `agnocast::Node` is only forward-declared in `agnocast_client.hpp`.

No behavior change.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Built for Humble and Jazzy with `BUILD_TESTING=ON`; no new warnings.

## Notes for reviewers

Split out of #1551 so it can be reviewed without any service-introspection context. The introspection work needs the client to hold its node, but nothing in this PR depends on that.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
