### PR TITLE
refactor(agnocastlib): share the request-send path between the async_send_request overloads

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_client.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_client.hpp
@@ -183,6 +183,24 @@ private:
   typename ServiceRequestPublisher::SharedPtr publisher_;
   typename ServiceResponseSubscriber::SharedPtr subscriber_;
 
+  template <typename Func>
+  int64_t send_request_impl(
+    ipc_shared_ptr<typename ServiceT::Request> && request, ResponseCallInfo && call_info,
+    Func && take_future)
+  {
+    auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
+    const int64_t seqno = internal_request->RequestMeta::seqno;
+
+    {
+      std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
+      take_future(
+        seqno2_response_call_info_.try_emplace(seqno, std::move(call_info)).first->second);
+    }
+
+    publisher_->publish(std::move(internal_request));
+    return seqno;
+  }
+
   template <typename NodeT>
   void constructor_impl(
     NodeT * node, const std::string & service_name, const rclcpp::QoS & qos_arg,
@@ -281,16 +299,9 @@ public:
     std::function<void(SharedFuture)> callback)
   {
     SharedFuture shared_future;
-    auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->RequestMeta::seqno;
-
-    {
-      std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
-      auto it = seqno2_response_call_info_.try_emplace(seqno, std::move(callback)).first;
-      shared_future = it->second.shared_future.value();
-    }
-
-    publisher_->publish(std::move(internal_request));
+    const int64_t seqno = send_request_impl(
+      std::move(request), ResponseCallInfo(std::move(callback)),
+      [&](ResponseCallInfo & info) { shared_future = info.shared_future.value(); });
     return SharedFutureAndRequestId(std::move(shared_future), seqno);
   }
 
@@ -302,16 +313,9 @@ public:
   FutureAndRequestId async_send_request(ipc_shared_ptr<typename ServiceT::Request> && request)
   {
     Future future;
-    auto internal_request = static_ipc_shared_ptr_cast<RequestT>(std::move(request));
-    int64_t seqno = internal_request->RequestMeta::seqno;
-
-    {
-      std::lock_guard<std::mutex> lock(seqno2_response_call_info_mtx_);
-      auto it = seqno2_response_call_info_.try_emplace(seqno).first;
-      future = it->second.promise.get_future();
-    }
-
-    publisher_->publish(std::move(internal_request));
+    const int64_t seqno = send_request_impl(
+      std::move(request), ResponseCallInfo(),
+      [&](ResponseCallInfo & info) { future = info.promise.get_future(); });
     return FutureAndRequestId(std::move(future), seqno);
   }
 };


### PR DESCRIPTION
## Description

The two `Client<ServiceT>::async_send_request` overloads duplicated their whole body: cast to the wire request type, read the seqno, register the pending call under `seqno2_response_call_info_mtx_`, publish, and return. They differ only in how the map entry is built and which future is handed back.

This moves the shared part into `send_request_impl()`. The caller passes the `ResponseCallInfo` to register and a callable that takes the future out of the registered entry, so the callable runs while the mutex is still held.

No behavior change.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

Built for Humble and Jazzy with `BUILD_TESTING=ON`; no new warnings. The existing `ClientTest` cases, which cover both overloads, still build and register.

## Notes for reviewers

Split out of #1551 so it can be reviewed without any service-introspection context. Independent of #1560: both touch `agnocast_client.hpp` but in different regions, and merging them together produces no conflict.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
