### PR TITLE
test(agnocastlib): pin the service wire layout shared by typed and generic wrappers

### DIFF
--- a/src/agnocastlib/CMakeLists.txt
+++ b/src/agnocastlib/CMakeLists.txt
@@ -162,10 +162,11 @@ if(BUILD_TESTING)
     test/unit/test_daemon_bridge_uds.cpp
     test/unit/test_agnocast_bridge_uds.cpp
     test/unit/test_discovery_agent_auto_fork.cpp
-    test/unit/test_bridge_node_name.cpp)
+    test/unit/test_bridge_node_name.cpp
+    test/unit/test_service_wire_type.cpp)
   target_include_directories(test_unit_${PROJECT_NAME} PRIVATE include src)
   target_link_libraries(test_unit_${PROJECT_NAME} agnocast)
-  ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)
+  ament_target_dependencies(test_unit_${PROJECT_NAME} std_msgs std_srvs diagnostic_msgs diagnostic_updater rosidl_typesupport_cpp)
   set_tests_properties(test_unit_${PROJECT_NAME} PROPERTIES
     ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe"
   )

--- a/src/agnocastlib/test/unit/test_service_wire_type.cpp
+++ b/src/agnocastlib/test/unit/test_service_wire_type.cpp
@@ -1,0 +1,67 @@
+#include "agnocast/internal/service_wire_type.hpp"
+
+#include "std_srvs/srv/empty.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+// The typed and generic wrappers describe the same buffer from two directions:
+// ServiceRequestWrapper<ServiceT> derives from ServiceT::Request, while GenericRequestWrapper
+// locates the metadata at `buffer + offsetof_meta(size_of_)`. The static_asserts in
+// service_wire_type.hpp only pin the total size, so the offsets themselves are checked here.
+
+namespace
+{
+
+template <typename ServiceT>
+void expect_request_layout_agrees()
+{
+  agnocast::ServiceRequestWrapper<ServiceT> wrapper;
+  const auto * base = reinterpret_cast<const char *>(&wrapper);
+
+  const auto * payload = static_cast<const typename ServiceT::Request *>(&wrapper);
+  EXPECT_EQ(reinterpret_cast<const char *>(payload), base)
+    << "the payload base must start the buffer: the generic path treats the buffer start as the "
+       "payload";
+
+  const auto * meta = static_cast<const agnocast::RequestMeta *>(&wrapper);
+  EXPECT_EQ(
+    reinterpret_cast<const char *>(meta) - base,
+    static_cast<std::ptrdiff_t>(offsetof_meta(sizeof(typename ServiceT::Request))))
+    << "metadata must sit where GenericRequestWrapper::get_meta_ptr computes it";
+}
+
+template <typename ServiceT>
+void expect_response_layout_agrees()
+{
+  agnocast::ServiceResponseWrapper<ServiceT> wrapper;
+  const auto * base = reinterpret_cast<const char *>(&wrapper);
+
+  const auto * payload = static_cast<const typename ServiceT::Response *>(&wrapper);
+  EXPECT_EQ(reinterpret_cast<const char *>(payload), base);
+
+  const auto * meta = static_cast<const agnocast::ResponseMeta *>(&wrapper);
+  EXPECT_EQ(
+    reinterpret_cast<const char *>(meta) - base,
+    static_cast<std::ptrdiff_t>(offsetof_meta(sizeof(typename ServiceT::Response))));
+}
+
+}  // namespace
+
+TEST(ServiceWireTypeTest, RequestLayoutAgreesBetweenTypedAndGenericWrappers)
+{
+  expect_request_layout_agrees<std_srvs::srv::SetBool>();
+}
+
+TEST(ServiceWireTypeTest, ResponseLayoutAgreesBetweenTypedAndGenericWrappers)
+{
+  expect_response_layout_agrees<std_srvs::srv::SetBool>();
+}
+
+TEST(ServiceWireTypeTest, EmptyPayloadLayoutAgreesBetweenTypedAndGenericWrappers)
+{
+  expect_request_layout_agrees<std_srvs::srv::Empty>();
+  expect_response_layout_agrees<std_srvs::srv::Empty>();
+}


### PR DESCRIPTION
## Description

The typed and generic service wrappers describe the same buffer from two directions. `ServiceRequestWrapper<ServiceT>` derives from `ServiceT::Request` and `RequestMeta`, while `GenericRequestWrapper::get_meta_ptr()` locates the metadata at `buffer + offsetof_meta(size_of_)`, which assumes the payload starts at offset 0.

The `static_assert`s in `service_wire_type.hpp` pin only the total size, so the offsets themselves were unverified: a layout change that kept the size but moved a subobject would make the typed and generic paths disagree at runtime, silently.

This adds a unit test for the offsets. It is a test rather than a `static_assert` because the wrappers have two non-empty bases and so are not standard-layout, which rules out getting the base offsets in a constant expression.

Requires no kernel module.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

3 cases pass on Humble and Jazzy. Checked that the assertions are not vacuous: for `SetBool` the metadata offset compared is 16 while the payload offset is 0, so a layout change would fail the test rather than pass trivially.

## Notes for reviewers

Split out of #1551 so it can be reviewed without any service-introspection context. Test-only; touches no production code.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
