### PR TITLE
fix(agnocastlib): count service readiness across a domain bridge

### DIFF
--- a/src/agnocastlib/src/agnocast_client.cpp
+++ b/src/agnocastlib/src/agnocast_client.cpp
@@ -4,10 +4,8 @@
 #include "agnocast/node/agnocast_context.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 
-#include <array>
 #include <chrono>
 #include <cstring>
-#include <memory>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
@@ -20,28 +18,24 @@ rclcpp::Logger ClientBase::get_logger() const
   return std::visit([](auto * n) { return n->get_logger(); }, node_);
 }
 
-uint32_t get_agnocast_sub_count(const std::string & topic_name)
+uint32_t get_reachable_agnocast_sub_count(const std::string & topic_name)
 {
-  auto topic_info_buffer = std::make_unique<std::array<topic_info_ret, MAX_TOPIC_INFO_RET_NUM>>();
-
-  ioctl_topic_info_args topic_info_args = {};
-  topic_info_args.topic_name = {topic_name.c_str(), topic_name.size()};
-  topic_info_args.topic_info_ret_buffer_addr =
-    reinterpret_cast<uint64_t>(topic_info_buffer->data());
-  topic_info_args.topic_info_ret_buffer_size = MAX_TOPIC_INFO_RET_NUM;
-  topic_info_args.domain_id = get_ros_domain_id();
-  if (ioctl(agnocast_fd, AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD, &topic_info_args) < 0) {
-    RCLCPP_ERROR(logger, "AGNOCAST_GET_TOPIC_SUBSCRIBER_INFO_CMD failed: %s", strerror(errno));
+  union ioctl_get_subscriber_num_args args = {};
+  args.topic_name = {topic_name.c_str(), topic_name.size()};
+  if (ioctl(agnocast_fd, AGNOCAST_GET_SUBSCRIBER_NUM_CMD, &args) < 0) {
+    RCLCPP_ERROR(logger, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
 
-  return topic_info_args.ret_topic_info_ret_num;
+  return args.ret_same_process_subscriber_num + args.ret_other_process_subscriber_num +
+         args.ret_other_domain_subscriber_num;
 }
 
 bool service_is_ready_core(const std::string & service_name)
 {
-  uint32_t sub_count = get_agnocast_sub_count(create_service_request_topic_name(service_name));
+  const uint32_t sub_count =
+    get_reachable_agnocast_sub_count(create_service_request_topic_name(service_name));
 
   if (sub_count == 0) {
     return false;


### PR DESCRIPTION
## Description

`service_is_ready_core()` counted the request topic's subscribers in the caller's own domain, so a server reached over a domain bridge was invisible and `wait_for_service()` never returned, even though the requests would be delivered.

Read `GET_SUBSCRIBER_NUM` and add the peer-domain count #1542 introduced. The kernel module derives it with the predicate the publish path uses, so readiness cannot disagree with delivery, and bridge endpoints are already excluded because they never cross domains (#1557).

## Related links

Needs #1542 and #1557, both merged. Part of #1548.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application
- [x] `bash scripts/test/e2e_test_service.bash`
Tested with e2e tests for service domain bridge in #1548.

## Notes for reviewers

The own-domain fields keep their meaning, so `Publisher::get_subscription_count()` still reports one domain. Will address this in a separate PR.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`

