### PR TITLE
fix(agnocastlib): count cross-domain and same-process subscribers

### DIFF
--- a/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_publisher.hpp
@@ -29,6 +29,9 @@ union ioctl_publish_msg_args publish_core(
   const topic_local_id_t publisher_id, const uint64_t msg_virtual_address);
 uint32_t get_subscription_count_core(const std::string & topic_name);
 uint32_t get_intra_subscription_count_core(const std::string & topic_name);
+// Every subscriber on the topic, matching rcl_count_subscribers rather than the publisher-side
+// split that leaves out the caller's own process.
+uint32_t count_subscribers_core(const std::string & topic_name);
 void increment_borrowed_publisher_num();
 void decrement_borrowed_publisher_num();
 

--- a/src/agnocastlib/src/agnocast_publisher.cpp
+++ b/src/agnocastlib/src/agnocast_publisher.cpp
@@ -98,7 +98,10 @@ union ioctl_publish_msg_args publish_core(
   return publish_msg_args;
 }
 
-uint32_t get_subscription_count_core(const std::string & topic_name)
+namespace
+{
+
+union ioctl_get_subscriber_num_args query_subscriber_num(const std::string & topic_name)
 {
   union ioctl_get_subscriber_num_args args = {};
   args.topic_name = {topic_name.c_str(), topic_name.size()};
@@ -107,7 +110,13 @@ uint32_t get_subscription_count_core(const std::string & topic_name)
     close(agnocast_fd);
     exit(EXIT_FAILURE);
   }
+  return args;
+}
 
+// The kernel module reports other-domain subscribers only when a bridge rule delivers to them, and
+// already leaves out bridge-owned ones.
+uint32_t reachable_outside_process(const union ioctl_get_subscriber_num_args & args)
+{
   uint32_t inter_count = args.ret_other_process_subscriber_num;
   // If an A2R bridge exists, exclude the agnocast subscriber created by the bridge
   if (args.ret_a2r_bridge_exist && inter_count > 0) {
@@ -120,20 +129,25 @@ uint32_t get_subscription_count_core(const std::string & topic_name)
     ros2_count--;
   }
 
-  return inter_count + ros2_count;
+  return inter_count + ros2_count + args.ret_other_domain_subscriber_num;
+}
+
+}  // namespace
+
+uint32_t get_subscription_count_core(const std::string & topic_name)
+{
+  return reachable_outside_process(query_subscriber_num(topic_name));
 }
 
 uint32_t get_intra_subscription_count_core(const std::string & topic_name)
 {
-  union ioctl_get_subscriber_num_args get_subscriber_count_args = {};
-  get_subscriber_count_args.topic_name = {topic_name.c_str(), topic_name.size()};
-  if (ioctl(agnocast_fd, AGNOCAST_GET_SUBSCRIBER_NUM_CMD, &get_subscriber_count_args) < 0) {
-    RCLCPP_ERROR(logger, "AGNOCAST_GET_SUBSCRIBER_NUM_CMD failed: %s", strerror(errno));
-    close(agnocast_fd);
-    exit(EXIT_FAILURE);
-  }
+  return query_subscriber_num(topic_name).ret_same_process_subscriber_num;
+}
 
-  return get_subscriber_count_args.ret_same_process_subscriber_num;
+uint32_t count_subscribers_core(const std::string & topic_name)
+{
+  const union ioctl_get_subscriber_num_args args = query_subscriber_num(topic_name);
+  return args.ret_same_process_subscriber_num + reachable_outside_process(args);
 }
 
 template <typename NodeT>

--- a/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
+++ b/src/agnocastlib/src/node/node_interfaces/node_graph.cpp
@@ -84,11 +84,6 @@ std::vector<std::pair<std::string, std::string>> NodeGraph::get_node_names_and_n
 // Counts agnocast and ROS 2 endpoints, excluding the ones created by bridges.
 // agnocast::Node::count_publishers()/count_subscribers() delegate here, so the resolution and the
 // bridge bookkeeping live in one place.
-//
-// Note that count_subscribers() does not see agnocast subscribers in the caller's own process:
-// get_subscription_count_core() reports ret_other_process_subscriber_num, because its original
-// caller (agnocast::Publisher::get_subscription_count()) asks how many peers receive a published
-// message. count_publishers() has no such split.
 size_t NodeGraph::count_publishers(const std::string & topic_name) const
 {
   return get_publisher_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
@@ -96,7 +91,7 @@ size_t NodeGraph::count_publishers(const std::string & topic_name) const
 
 size_t NodeGraph::count_subscribers(const std::string & topic_name) const
 {
-  return get_subscription_count_core(node_base_->resolve_topic_or_service_name(topic_name, false));
+  return count_subscribers_core(node_base_->resolve_topic_or_service_name(topic_name, false));
 }
 
 const rcl_guard_condition_t * NodeGraph::get_graph_guard_condition() const


### PR DESCRIPTION
## Description

Three APIs answer questions about subscribers on a topic, and two of them under-reported.

`Publisher::get_subscription_count()` left out subscribers in a bridged domain, so a publisher whose only subscriber sits across a domain bridge reported zero while its publications were delivered. The kernel module already reports that count restricted to subscribers a bridge rule delivers to and with bridge-owned ones excluded, so it is now added in.

`Node::count_subscribers()` shared the publisher-side helper and therefore left out agnocast subscribers in the caller's own process, unlike `rcl_count_subscribers()`. It now counts every subscriber on the topic.

The two helpers each issued the same ioctl with the same error handling; that is now one call site, and `count_subscribers()` needs a single ioctl.

## Related links

None.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

Still to add: `agnocast_ioctl.c` says a publisher does not count subscribers in another domain, which this change makes false. The edit is ready but the kunit pre-commit hook needs the module unloaded.

`Publisher::get_intra_subscription_count()` keeps its meaning; it mirrors `rclcpp::PublisherBase::get_intra_process_subscription_count()`, which rclcpp also keeps separate from `get_subscription_count()`.

Two callers change behaviour under a bridge: `src/agnocast_e2e_test/src/test_publisher.cpp:35` and `test_ros2_publisher.cpp:37` gate on the count before publishing. Neither runs with a domain bridge today.

`agnocast::Node::count_subscribers()` has no in-tree caller, so the same-process fix is covered by no existing test.

The kernel module assumes the process asking is not a bridge (`agnocast_ioctl.c:1429`), so a bridge-owned publisher calling `get_subscription_count()` would over-count. No bridge code calls it.

`get_publisher_count()` cannot be made symmetric here: the kernel module has no `ret_other_domain_publisher_num`.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-patch-update`
