### PR TITLE
fix(agnocast)[need-minor-update]: keep a service response prefix from covering another service

### DIFF
--- a/agnocast_kmod/agnocast.h
+++ b/agnocast_kmod/agnocast.h
@@ -17,11 +17,11 @@
 #define TOPIC_NAME_BUFFER_SIZE 256  // Maximum length of topic name: 256 characters
 #define VERSION_BUFFER_LEN 32       // Maximum size of version number represented as a string
 
-// Must match create_service_{request,response}_topic_name in
-// src/agnocastlib/src/agnocast_utils.cpp, which owns the naming.
+// Must match agnocast::SRV_SEP and create_service_{request,response}_topic_name in
+// src/agnocastlib, which own the naming.
 #define SRV_REQUEST_PREFIX "/AGNOCAST_SRV_REQUEST"
 #define SRV_RESPONSE_PREFIX "/AGNOCAST_SRV_RESPONSE"
-#define SRV_RESPONSE_SEP "_SEP_"
+#define SRV_RESPONSE_SEP "%"
 
 typedef int32_t topic_local_id_t;
 struct publisher_shm_info

--- a/agnocast_kmod/agnocast_ioctl.c
+++ b/agnocast_kmod/agnocast_ioctl.c
@@ -2513,33 +2513,26 @@ static int check_prefix_domain_rule(
   {
     if (ipc_ns != rule->ipc_ns) continue;
 
+    // A service name cannot contain the separator, so no prefix can start with another.
     if (rule->is_prefix) {
-      const size_t len = strlen(rule->topic_name_a);
-      const bool nests = (len <= prefix_len) ? strncmp(rule->topic_name_a, prefix, len) == 0
-                                             : strncmp(prefix, rule->topic_name_a, prefix_len) == 0;
-      // find_domain_rule filters by domain before testing the name, so two prefix rules can both
-      // match a lookup only if their pairs share a domain; over disjoint pairs nesting is harmless.
-      const bool shares_domain = rule->domain_a == domain_a || rule->domain_a == domain_b ||
-                                 rule->domain_b == domain_a || rule->domain_b == domain_b;
-      if (!nests || !shares_domain) continue;
+      if (strcmp(rule->topic_name_a, prefix) != 0) continue;
 
-      if (len == prefix_len) {
-        if (rule->domain_a == domain_a && rule->domain_b == domain_b) {
-          same = rule;
-          continue;
-        }
-        dev_warn(
-          agnocast_device,
-          "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: the prefix is already paired with "
-          "another domain. (%s)\n",
-          prefix, from_domain, prefix, to_domain, __func__);
-        return -EBUSY;
+      if (rule->domain_a == domain_a && rule->domain_b == domain_b) {
+        same = rule;
+        continue;
       }
+
+      // find_domain_rule filters by domain before testing the name, so the same prefix over a
+      // disjoint pair can never be the other candidate for a lookup.
+      if (
+        rule->domain_a != domain_a && rule->domain_a != domain_b && rule->domain_b != domain_a &&
+        rule->domain_b != domain_b)
+        continue;
 
       dev_warn(
         agnocast_device,
-        "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: it nests with an existing prefix "
-        "rule. (%s)\n",
+        "Domain bridge prefix rule (%s@%u -> %s@%u) rejected: the prefix is already paired with "
+        "another domain. (%s)\n",
         prefix, from_domain, prefix, to_domain, __func__);
       return -EBUSY;
     }
@@ -2613,6 +2606,10 @@ int agnocast_ioctl_add_domain_bridge_service(
   if (from_domain == to_domain) return -EINVAL;
   if (service_name_from[0] != '/' || service_name_from[1] == '\0') return -EINVAL;
   if (service_name_to[0] != '/' || service_name_to[1] == '\0') return -EINVAL;
+  // A ROS name cannot contain the separator, so a caller passing one has bypassed ROS validation.
+  // Such a name would put its response topics under another service's response prefix.
+  if (strstr(service_name_from, SRV_RESPONSE_SEP) || strstr(service_name_to, SRV_RESPONSE_SEP))
+    return -EINVAL;
 
   char request_from[TOPIC_NAME_BUFFER_SIZE];
   char request_to[TOPIC_NAME_BUFFER_SIZE];

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_service.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_service.c
@@ -9,19 +9,18 @@
 // naming scheme shows up here as a failing test.
 //
 // SVC is the name the clients call; SVC_RENAMED is what the server offers when the two differ.
-// SVC_NESTED embeds _SEP_ in the service name itself -- the only way one service's response
-// prefix can nest inside another's.
 static const char * SVC = "/kunit_svc";
 static const char * SVC_RENAMED = "/kunit_svc_renamed";
 static const char * SVC_OTHER = "/kunit_svc_other";
-static const char * SVC_NESTED = "/kunit_svc_SEP_nested";
+// A name no ROS node can resolve to, so it only reaches the ioctl from an unvalidated caller.
+static const char * SVC_WITH_SEP = "/kunit_svc%nested";
 
 static const char * REQ = "/AGNOCAST_SRV_REQUEST/kunit_svc";
 static const char * REQ_RENAMED = "/AGNOCAST_SRV_REQUEST/kunit_svc_renamed";
 // A response topic of one client: the prefix plus the per-client suffix the client appends.
-static const char * RES_A = "/AGNOCAST_SRV_RESPONSE/kunit_svc_SEP_/nodeA_SEP_0";
+static const char * RES_A = "/AGNOCAST_SRV_RESPONSE/kunit_svc%/nodeA%0";
 // Beyond the response prefix by its last component only.
-static const char * OUTSIDE = "/AGNOCAST_SRV_RESPONSE/kunit_svc_outside_SEP_/nodeA_SEP_0";
+static const char * OUTSIDE = "/AGNOCAST_SRV_RESPONSE/kunit_svc_outside%/nodeA%0";
 
 static int add_service(
   const char * from, const char * to, const uint32_t from_domain, const uint32_t to_domain)
@@ -98,8 +97,7 @@ void test_case_add_domain_bridge_service_renames_only_the_request(struct kunit *
   // The response prefix keeps the caller-side name on both sides, so the server's domain reaches
   // it under the *client's* service name and not under the renamed one.
   KUNIT_EXPECT_TRUE(test, has_rule(RES_A, 2));
-  KUNIT_EXPECT_FALSE(
-    test, has_rule("/AGNOCAST_SRV_RESPONSE/kunit_svc_renamed_SEP_/nodeA_SEP_0", 2));
+  KUNIT_EXPECT_FALSE(test, has_rule("/AGNOCAST_SRV_RESPONSE/kunit_svc_renamed%/nodeA%0", 2));
 }
 
 void test_case_add_domain_bridge_service_same_domain_rejected(struct kunit * test)
@@ -142,6 +140,15 @@ void test_case_add_domain_bridge_service_relative_target_rejected(struct kunit *
 {
   // Act: the rename target is the one missing its leading '/'.
   const int ret = add_service(SVC, SVC_RENAMED + 1, 1, 2);
+
+  // Assert
+  KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+}
+
+void test_case_add_domain_bridge_service_separator_in_name_rejected(struct kunit * test)
+{
+  // Act
+  const int ret = add_service(SVC_WITH_SEP, SVC_WITH_SEP, 1, 2);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EINVAL);
@@ -247,14 +254,14 @@ void test_case_add_domain_bridge_service_accepted_with_a_client_elsewhere(struct
   KUNIT_EXPECT_EQ(test, ret, 0);
 }
 
-void test_case_add_domain_bridge_service_nested_over_disjoint_domains(struct kunit * test)
+void test_case_add_domain_bridge_service_accepted_over_a_disjoint_pair(struct kunit * test)
 {
   // Arrange
   KUNIT_ASSERT_EQ(test, add_service(SVC, SVC, 1, 2), 0);
 
-  // Act: a service whose response prefix nests inside the first one's, over a disjoint domain
-  // pair. Nesting is harmless there, because a lookup filters by domain before the name.
-  const int ret = add_service(SVC_NESTED, SVC_NESTED, 3, 4);
+  // Act: the same service between two other domains. A lookup filters by domain before the name,
+  // so the two registrations never compete.
+  const int ret = add_service(SVC, SVC, 3, 4);
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, 0);
@@ -270,31 +277,6 @@ void test_case_add_domain_bridge_service_repointed_pair_rejected(struct kunit * 
 
   // Assert
   KUNIT_EXPECT_EQ(test, ret, -EBUSY);
-}
-
-void test_case_add_domain_bridge_service_nested_rejected(struct kunit * test)
-{
-  // Arrange
-  KUNIT_ASSERT_EQ(test, add_service(SVC, SVC, 1, 2), 0);
-
-  // Act: a service whose response prefix nests inside the one already registered.
-  const int ret = add_service(SVC_NESTED, SVC_NESTED, 1, 2);
-
-  // Assert
-  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
-}
-
-void test_case_add_domain_bridge_service_nested_rejected_either_order(struct kunit * test)
-{
-  // Arrange: the nested service first, so the outer one is the newcomer.
-  KUNIT_ASSERT_EQ(test, add_service(SVC_NESTED, SVC_NESTED, 1, 2), 0);
-
-  // Act
-  const int ret = add_service(SVC, SVC, 1, 2);
-
-  // Assert: rejected, and the request rule is never inserted.
-  KUNIT_EXPECT_EQ(test, ret, -EBUSY);
-  KUNIT_EXPECT_FALSE(test, has_rule(REQ, 1));
 }
 
 void test_case_add_domain_bridge_service_late_reverse_direction_rejected(struct kunit * test)

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_service.h
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_add_domain_bridge_service.h
@@ -10,6 +10,7 @@
     KUNIT_CASE(test_case_add_domain_bridge_service_root_rejected),                     \
     KUNIT_CASE(test_case_add_domain_bridge_service_relative_rejected),                 \
     KUNIT_CASE(test_case_add_domain_bridge_service_relative_target_rejected),          \
+    KUNIT_CASE(test_case_add_domain_bridge_service_separator_in_name_rejected),        \
     KUNIT_CASE(test_case_add_domain_bridge_service_too_long_rejected),                 \
     KUNIT_CASE(test_case_add_domain_bridge_service_redeclaration_is_idempotent),       \
     KUNIT_CASE(test_case_add_domain_bridge_service_reverse_direction),                 \
@@ -17,10 +18,8 @@
     KUNIT_CASE(test_case_add_domain_bridge_service_accepted_beside_an_exact_rule),     \
     KUNIT_CASE(test_case_add_domain_bridge_service_accepted_with_a_topic_outside_it),  \
     KUNIT_CASE(test_case_add_domain_bridge_service_accepted_with_a_client_elsewhere),  \
-    KUNIT_CASE(test_case_add_domain_bridge_service_nested_over_disjoint_domains),      \
+    KUNIT_CASE(test_case_add_domain_bridge_service_accepted_over_a_disjoint_pair),     \
     KUNIT_CASE(test_case_add_domain_bridge_service_repointed_pair_rejected),           \
-    KUNIT_CASE(test_case_add_domain_bridge_service_nested_rejected),                   \
-    KUNIT_CASE(test_case_add_domain_bridge_service_nested_rejected_either_order),      \
     KUNIT_CASE(test_case_add_domain_bridge_service_late_reverse_direction_rejected),   \
     KUNIT_CASE(test_case_add_domain_bridge_service_rejected_when_client_joined),       \
     KUNIT_CASE(test_case_add_domain_bridge_service_rejected_when_response_joined),     \
@@ -36,6 +35,7 @@ void test_case_add_domain_bridge_service_empty_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_root_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_relative_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_relative_target_rejected(struct kunit * test);
+void test_case_add_domain_bridge_service_separator_in_name_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_too_long_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_redeclaration_is_idempotent(struct kunit * test);
 void test_case_add_domain_bridge_service_reverse_direction(struct kunit * test);
@@ -43,10 +43,8 @@ void test_case_add_domain_bridge_service_accepted_beside_another_service(struct 
 void test_case_add_domain_bridge_service_accepted_beside_an_exact_rule(struct kunit * test);
 void test_case_add_domain_bridge_service_accepted_with_a_topic_outside_it(struct kunit * test);
 void test_case_add_domain_bridge_service_accepted_with_a_client_elsewhere(struct kunit * test);
-void test_case_add_domain_bridge_service_nested_over_disjoint_domains(struct kunit * test);
+void test_case_add_domain_bridge_service_accepted_over_a_disjoint_pair(struct kunit * test);
 void test_case_add_domain_bridge_service_repointed_pair_rejected(struct kunit * test);
-void test_case_add_domain_bridge_service_nested_rejected(struct kunit * test);
-void test_case_add_domain_bridge_service_nested_rejected_either_order(struct kunit * test);
 void test_case_add_domain_bridge_service_late_reverse_direction_rejected(struct kunit * test);
 void test_case_add_domain_bridge_service_rejected_when_client_joined(struct kunit * test);
 void test_case_add_domain_bridge_service_rejected_when_response_joined(struct kunit * test);

--- a/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
+++ b/agnocast_kmod/agnocast_kunit/agnocast_kunit_domain_bridge.c
@@ -19,10 +19,10 @@ static const char * RN_DST = "/kunit_test_domain_bridge_rename_dst";
 // two callers' response topics under one service; OUTSIDE lies beyond it by its last component
 // only.
 static const char * SVC = "/kunit_test_domain_bridge_prefix";
-static const char * PFX_A = "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix_SEP_/clientA";
-static const char * PFX_B = "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix_SEP_/clientB";
+static const char * PFX_A = "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix%/clientA";
+static const char * PFX_B = "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix%/clientB";
 static const char * OUTSIDE =
-  "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix_other_SEP_/clientA";
+  "/AGNOCAST_SRV_RESPONSE/kunit_test_domain_bridge_prefix_other%/clientA";
 
 #define KUNIT_PUB_SHM_BUF_SIZE 4
 

--- a/src/agnocastlib/include/agnocast/agnocast_utils.hpp
+++ b/src/agnocastlib/include/agnocast/agnocast_utils.hpp
@@ -89,6 +89,8 @@ std::string create_shm_name(const pid_t pid);
 // `${AGNOCAST_TMPFS_DIR:-/dev/shm}/agnocast_type_registry/<ipc_ns_inode>/`.
 uint64_t get_self_ipc_ns_inode();
 std::string create_service_request_topic_name(const std::string & service_name);
+// A character no ROS name can contain, so one service's response prefix cannot cover another's.
+inline constexpr char SRV_SEP[] = "%";
 // A domain bridge merges two domains, where the same fully qualified node name may legitimately
 // appear twice, into one response topic. The publisher id separates such clients: it comes from a
 // counter the kernel module keeps per request topic.

--- a/src/agnocastlib/src/agnocast_utils.cpp
+++ b/src/agnocastlib/src/agnocast_utils.cpp
@@ -117,7 +117,7 @@ std::string create_service_response_topic_name(
   const std::string & service_name, const std::string & client_node_name,
   const topic_local_id_t client_publisher_id)
 {
-  return "/AGNOCAST_SRV_RESPONSE" + service_name + "_SEP_" + client_node_name + "_SEP_" +
+  return "/AGNOCAST_SRV_RESPONSE" + service_name + SRV_SEP + client_node_name + SRV_SEP +
          std::to_string(client_publisher_id);
 }
 

--- a/src/agnocastlib/src/cie_client_utils.cpp
+++ b/src/agnocastlib/src/cie_client_utils.cpp
@@ -1,6 +1,7 @@
 #include "agnocast/cie_client_utils.hpp"
 
 #include "agnocast/agnocast_publisher.hpp"
+#include "agnocast/agnocast_utils.hpp"
 #include "agnocast/node/agnocast_node.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -63,7 +64,7 @@ std::string create_callback_group_id(
       entries.push_back("Service(" + topic.substr(SRV_REQUEST_PREFIX_LEN) + ")");
     } else if (topic.rfind("/AGNOCAST_SRV_RESPONSE", 0) == 0) {
       auto service_part = topic.substr(SRV_RESPONSE_PREFIX_LEN);
-      auto sep_pos = service_part.find("_SEP_");
+      auto sep_pos = service_part.find(SRV_SEP);
       entries.push_back("Client(" + service_part.substr(0, sep_pos) + ")");
     } else {
       entries.push_back("Subscription(" + topic + ")");

--- a/src/agnocastlib/test/unit/test_agnocast_utils.cpp
+++ b/src/agnocastlib/test/unit/test_agnocast_utils.cpp
@@ -240,5 +240,5 @@ TEST(AgnocastUtilsTest, create_service_response_topic_name_appends_client_identi
 {
   EXPECT_EQ(
     agnocast::create_service_response_topic_name("/srv/add", "/client_node", 7),
-    "/AGNOCAST_SRV_RESPONSE/srv/add_SEP_/client_node_SEP_7");
+    "/AGNOCAST_SRV_RESPONSE/srv/add%/client_node%7");
 }

--- a/src/agnocastlib/test/unit/test_cie_client_utils.cpp
+++ b/src/agnocastlib/test/unit/test_cie_client_utils.cpp
@@ -121,7 +121,7 @@ TEST_F(CreateCallbackGroupIdTest, AgnocastClient)
 {
   // Arrange
   auto group = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  std::vector<std::string> agnocast_topics = {"/AGNOCAST_SRV_RESPONSE/my_service_SEP_client_node"};
+  std::vector<std::string> agnocast_topics = {"/AGNOCAST_SRV_RESPONSE/my_service%client_node"};
 
   // Act
   auto id = agnocast::create_callback_group_id(group, node_, agnocast_topics);

--- a/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
+++ b/src/ros2agnocast/ros2agnocast/verb/node_info_agnocast.py
@@ -28,7 +28,7 @@ def service_name_from_response_topic(topic_name):
     prefix = '/AGNOCAST_SRV_RESPONSE'
     if not topic_name.startswith(prefix):
         return None
-    return topic_name[len(prefix):].split('_SEP_')[0]
+    return topic_name[len(prefix):].split('%')[0]
 
 class NodeInfoAgnocastVerb(VerbExtension):
     "Output information about a node including Agnocast"
@@ -59,7 +59,7 @@ class NodeInfoAgnocastVerb(VerbExtension):
             def get_agnocast_node_topics(target_node_name):
                 sub_topic_list = []
                 pub_topic_list = []
-                # service_name_from_response_topic strips the _SEP_<id> suffix,
+                # service_name_from_response_topic strips the caller's suffix,
                 # so multiple response topics can collapse to the same service name.
                 server_set = set()
                 client_set = set()


### PR DESCRIPTION
## Description

`_SEP_` is legal in a ROS service name, so the response prefix registered for `/foo` also covers the response topics of an unregistered `/foo_SEP_bar`. Those get grouped across the two domains while their request topic never was, so the publisher id in their names counts from zero in each domain and two clients sharing a node name land on one response topic. A response crosses to the wrong client and is accepted silently.

Separate the parts of a response topic name with a character a ROS name cannot contain (`%`). No service can then be named such that its response topics fall under another service's prefix, and the service ioctl rejects a name carrying the separator so the kernel module does not rely on ROS validation. Two prefixes are now either equal or disjoint, so the nesting case in `check_prefix_domain_rule` goes with it.

## Related links

Found in review of #1566, which this is stacked on -- it owns the service ioctl and `SRV_RESPONSE_SEP`, so merge that first. Needed before the `services:` config in #1548, which is what makes the hole reachable.

A name may contain alphanumerics, `_` and `/` and nothing else: [`validate_full_topic_name.c`](https://github.com/ros2/rmw/blob/jazzy/rmw/src/validate_full_topic_name.c). `_SEP_` passes that; `%` does not.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [x] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

## Notes for reviewers

The response topic name is a wire contract between a client and a server, and the kernel module builds the prefix from the same separator, so agnocastlib and the kernel module have to move together.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)

## Version Update Label (Required)

`need-minor-update`
