### PR TITLE
feat(ros2agnocast_discovery_agent): honor bidirectional in the domain bridge config

### DIFF
--- a/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/ros2agnocast_discovery_agent/domain_bridge_config.py
@@ -30,6 +30,8 @@ def parse_domain_bridge_config(text):
     ``rules`` is a list of ``(from_topic, to_topic, from_domain, to_domain)``
     tuples. ``to_topic`` is the per-topic ``remap`` target (same ``domain_bridge``
     field the external node honors), or the source name when ``remap`` is absent.
+    A ``bidirectional`` topic yields two tuples; the kmod folds them into one rule
+    with both directions enabled.
     ``skipped`` lists the topic names dropped for lack of a resolvable domain
     pair, so the caller can surface them instead of dropping them silently.
     ``from_domain`` / ``to_domain`` are taken from the top level and may be
@@ -70,8 +72,16 @@ def parse_domain_bridge_config(text):
         to_topic = spec.get('remap', str(topic_name))
         if not isinstance(to_topic, str):
             raise ValueError(f"'remap' for topic {topic_name!r} must be a string")
-        rules.append(
-            (str(topic_name), to_topic, _as_domain_id(from_domain), _as_domain_id(to_domain)))
+        bidirectional = spec.get('bidirectional', False)
+        if not isinstance(bidirectional, bool):
+            raise ValueError(f"'bidirectional' for topic {topic_name!r} must be a boolean")
+        from_id = _as_domain_id(from_domain)
+        to_id = _as_domain_id(to_domain)
+        rules.append((str(topic_name), to_topic, from_id, to_id))
+        if bidirectional:
+            # The external node's reverse leg swaps the domain ids and nothing else, keeping the
+            # source name on the subscribe side and the remap on the publish side.
+            rules.append((str(topic_name), to_topic, to_id, from_id))
     return rules, skipped
 
 

--- a/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
+++ b/src/ros2agnocast_discovery_agent/test/test_domain_bridge_config.py
@@ -167,3 +167,54 @@ topics:
   chatter:
 """
     assert parse_domain_bridge_config(text) == ([('chatter', 'chatter', 1, 2)], [])
+
+
+def test_bidirectional_topic_yields_both_directions():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: true
+"""
+    rules, skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/chatter', 1, 2), ('/chatter', '/chatter', 2, 1)]
+    assert skipped == []
+
+
+def test_bidirectional_reverse_leg_swaps_only_the_domains():
+    """Mirrors the external node, whose reverse leg keeps the source and remap names."""
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    remap: /renamed
+    bidirectional: true
+"""
+    rules, _skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/renamed', 1, 2), ('/chatter', '/renamed', 2, 1)]
+
+
+def test_bidirectional_false_yields_one_direction():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: false
+"""
+    rules, _skipped = parse_domain_bridge_config(text)
+    assert rules == [('/chatter', '/chatter', 1, 2)]
+
+
+def test_non_boolean_bidirectional_is_rejected():
+    text = """
+from_domain: 1
+to_domain: 2
+topics:
+  /chatter:
+    bidirectional: yes please
+"""
+    with pytest.raises(ValueError):
+        parse_domain_bridge_config(text)


### PR DESCRIPTION
## Description

`bidirectional: true` in a `domain_bridge` YAML was read as one-way: `parse_domain_bridge_config` looked only at `from_domain` / `to_domain` / `remap`, so the reverse leg the external node creates had no Agnocast counterpart. A bidirectional entry now yields a second tuple with the domain ids swapped and nothing else, mirroring `DomainBridge::DomainBridge` (`domain_bridge.cpp:598-605`), which keeps the source name on the subscribe side and the remap on the publish side.

Both consumers pick this up unchanged: `register_domain_bridge` registers both, which the kmod folds into one rule with both directions enabled (already covered by `test_case_domain_bridge_bidirectional_delivers`), and the discovery agent sees the reverse `from` side as its own. A non-boolean value is now rejected, like `remap`.

## Related links

#1558 forces the A2R bridge on a rule's `from` side; with this, a bidirectional entry forces both sides instead of silently only one.

## How was this PR tested?

- [ ] Autoware
- [ ] `bash scripts/test/e2e_test_1to1.bash` (required)
- [ ] `bash scripts/test/e2e_test_2to2.bash` (required)
- [ ] kunit tests (required when modifying the kernel module)
- [ ] `bash scripts/test/run_requires_kernel_module_tests.bash` (required)
- [ ] sample application

`pytest` in `src/ros2agnocast_discovery_agent`: 80 passed. Dropping the reverse tuple fails two tests.

## Notes for reviewers

- No kernel module change: the kmod already accepts the reversed pair and folds it.
- The reverse leg is deliberately not a true inverse under a `remap`. That is the external node's behavior, and this file exists to describe what that node relays.

## Post-merge checklist

- [ ] Reflect the changes in [`agnocast_doc`](https://github.com/autowarefoundation/agnocast_doc) after merging (if documentation needs updating)
